### PR TITLE
Pandas iteration to groupby

### DIFF
--- a/lumibot/tools/pandas.py
+++ b/lumibot/tools/pandas.py
@@ -5,18 +5,8 @@ import pandas as pd
 
 def day_deduplicate(df_):
     df_copy = df_.copy()
-    df_copy["should_keep"] = True
-    n_rows = len(df_copy.index)
-    for index, row in df_copy.iterrows():
-        position = df_copy.index.get_loc(index)
-        if position + 1 == n_rows:
-            break
+    df_copy = df_copy.groupby(level=0).head(1)
 
-        if index.date() == df_copy.index[position + 1].date():
-            df_copy.loc[index, "should_keep"] = False
-
-    df_copy = df_copy[df_copy["should_keep"]]
-    df_copy = df_copy.drop(["should_keep"], axis=1)
     return df_copy
 
 


### PR DESCRIPTION
In the pandas `tools` helper, the method `day_deduplicate` is using iterations to create a final dataframe without duplicate dates. Proposing using groupby which is vectorized.

Checked the original vs. the groupby function with log files and trace_stats. Results are identical. 