### PR TITLE
yfinance optimize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Cache files
 lumibot/cache
+**/*.pkl
 
 # Development files
 venv

--- a/lumibot/__init__.py
+++ b/lumibot/__init__.py
@@ -1,0 +1,9 @@
+import os
+import pickle
+
+LUMIBOT_SOURCE_PATH = os.path.abspath(os.path.dirname(__file__))
+LUMIBOT_CACHE_FOLDER = os.path.join(LUMIBOT_SOURCE_PATH, "cache")
+LUMIBOT_DATE_INDEX_FILE = os.path.join(LUMIBOT_CACHE_FOLDER, "date_index.pkl")
+
+if not os.path.exists(LUMIBOT_CACHE_FOLDER):
+    os.makedirs(LUMIBOT_CACHE_FOLDER)

--- a/lumibot/data_sources/yahoo.py
+++ b/lumibot/data_sources/yahoo.py
@@ -46,9 +46,11 @@ class YahooData(DataSource):
         if symbol in self._data_store:
             data = self._data_store[symbol]
         else:
-            data = yf.Ticker(symbol).history(start=self.datetime_start,
-                end=self.datetime_end + timedelta(days=7), auto_adjust=self.auto_adjust)
-            data = data.loc[data.index <= self.datetime_end, :]
+            data = yf.Ticker(symbol).history(
+                start=self.datetime_start,
+                end=self.datetime_end + timedelta(seconds=1),
+                auto_adjust=self.auto_adjust,
+            )
             if data.shape[0] == 0:
                 raise NoDataFound(self.SOURCE, symbol)
             data = self._append_data(symbol, data)
@@ -72,13 +74,12 @@ class YahooData(DataSource):
             tickers = yf.Tickers(" ".join(missing_symbols))
             df_yf = tickers.history(
                 start=self.datetime_start,
-                end=self.datetime_end + timedelta(days=7),
+                end=self.datetime_end + timedelta(seconds=1),
                 thread=True,
                 group_by="ticker",
                 auto_adjust=self.auto_adjust,
                 progress=False,
             )
-            df_yf = df_yf.loc[df_yf.index <= self.datetime_end, :]
 
             dfs = {}
             for i in df_yf.columns.levels[0]:

--- a/lumibot/data_sources/yahoo.py
+++ b/lumibot/data_sources/yahoo.py
@@ -48,7 +48,7 @@ class YahooData(DataSource):
         else:
             data = yf.Ticker(symbol).history(
                 start=self.datetime_start,
-                end=self.datetime_end + timedelta(seconds=1),
+                end=self.datetime_end + timedelta(days=1),
                 auto_adjust=self.auto_adjust,
             )
             if data.shape[0] == 0:
@@ -74,7 +74,7 @@ class YahooData(DataSource):
             tickers = yf.Tickers(" ".join(missing_symbols))
             df_yf = tickers.history(
                 start=self.datetime_start,
-                end=self.datetime_end + timedelta(seconds=1),
+                end=self.datetime_end + timedelta(days=1),
                 thread=True,
                 group_by="ticker",
                 auto_adjust=self.auto_adjust,

--- a/lumibot/data_sources/yahoo.py
+++ b/lumibot/data_sources/yahoo.py
@@ -1,7 +1,4 @@
 from datetime import datetime, timedelta
-from contextlib import contextmanager
-import os
-import sys
 
 import yfinance as yf
 
@@ -73,14 +70,14 @@ class YahooData(DataSource):
 
         if missing_symbols:
             tickers = yf.Tickers(" ".join(missing_symbols))
-            with self.suppress_stdout():
-                df_yf = tickers.history(
-                    start=self.datetime_start,
-                    end=self.datetime_end + timedelta(days=7),
-                    thread=True,
-                    group_by="ticker",
-                    auto_adjust=self.auto_adjust,
-                )
+            df_yf = tickers.history(
+                start=self.datetime_start,
+                end=self.datetime_end + timedelta(days=7),
+                thread=True,
+                group_by="ticker",
+                auto_adjust=self.auto_adjust,
+                progress=False,
+            )
             df_yf = df_yf.loc[df_yf.index <= self.datetime_end, :]
 
             dfs = {}
@@ -100,13 +97,3 @@ class YahooData(DataSource):
     def _parse_source_symbol_bars(self, response, symbol):
         bars = Bars(response, self.SOURCE, symbol, raw=response)
         return bars
-
-    @contextmanager
-    def suppress_stdout(self):
-        with open(os.devnull, "w") as devnull:
-            old_stdout = sys.stdout
-            sys.stdout = devnull
-            try:
-                yield
-            finally:
-                sys.stdout = old_stdout

--- a/lumibot/data_sources/yahoo.py
+++ b/lumibot/data_sources/yahoo.py
@@ -1,4 +1,7 @@
 from datetime import datetime, timedelta
+from contextlib import contextmanager
+import os
+import sys
 
 import yfinance as yf
 
@@ -70,13 +73,14 @@ class YahooData(DataSource):
 
         if missing_symbols:
             tickers = yf.Tickers(" ".join(missing_symbols))
-            df_yf = tickers.history(
-                start=self.datetime_start,
-                end=self.datetime_end + timedelta(days=7),
-                thread=True,
-                group_by="ticker",
-                auto_adjust=self.auto_adjust,
-            )
+            with self.suppress_stdout():
+                df_yf = tickers.history(
+                    start=self.datetime_start,
+                    end=self.datetime_end + timedelta(days=7),
+                    thread=True,
+                    group_by="ticker",
+                    auto_adjust=self.auto_adjust,
+                )
             df_yf = df_yf.loc[df_yf.index <= self.datetime_end, :]
 
             dfs = {}
@@ -96,3 +100,13 @@ class YahooData(DataSource):
     def _parse_source_symbol_bars(self, response, symbol):
         bars = Bars(response, self.SOURCE, symbol, raw=response)
         return bars
+
+    @contextmanager
+    def suppress_stdout(self):
+        with open(os.devnull, "w") as devnull:
+            old_stdout = sys.stdout
+            sys.stdout = devnull
+            try:
+                yield
+            finally:
+                sys.stdout = old_stdout

--- a/lumibot/tools/helpers.py
+++ b/lumibot/tools/helpers.py
@@ -5,6 +5,8 @@ import sys
 
 import yfinance as yf
 
+from lumibot import LUMIBOT_DATE_INDEX_FILE
+
 
 def get_chunks(l, chunk_size):
     chunks = []
@@ -42,9 +44,8 @@ def get_trading_days():
     logger.setLevel(logging.INFO)
     logging.info("Fetching past trading days")
 
-    filename = "lumibot/tools/date_index.pkl"
     try:
-        with open(filename, "rb") as f:
+        with open(LUMIBOT_DATE_INDEX_FILE, "rb") as f:
             dates_saved = pickle.load(f)
     except:
         dates_saved = list()
@@ -56,7 +57,7 @@ def get_trading_days():
 
     dates_update = list(dates_update.date)
     days = sorted(list(set(dates_saved + dates_update)))
-    with open(filename, "wb") as f:
+    with open(LUMIBOT_DATE_INDEX_FILE, "wb") as f:
         pickle.dump(days, f)
     return days
 

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -132,7 +132,7 @@ def performance(_df, risk_free, prefix=""):
 
 def calculate_returns(symbol, start=datetime(1900, 1, 1), end=datetime.now()):
     benchmark = yf.Ticker(symbol)
-    benchmark_df = benchmark.history(start=start, end=end + timedelta(days=7))
+    benchmark_df = benchmark.history(start=start, end=end + timedelta(seconds=1))
     benchmark_df = benchmark_df.loc[
         (benchmark_df.index >= start) & (benchmark_df.index <= end)
     ]

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -132,7 +132,7 @@ def performance(_df, risk_free, prefix=""):
 
 def calculate_returns(symbol, start=datetime(1900, 1, 1), end=datetime.now()):
     benchmark = yf.Ticker(symbol)
-    benchmark_df = benchmark.history(start=start, end=end + timedelta(seconds=1))
+    benchmark_df = benchmark.history(start=start, end=end + timedelta(days=1))
     benchmark_df = benchmark_df.loc[
         (benchmark_df.index >= start) & (benchmark_df.index <= end)
     ]

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -1,6 +1,6 @@
 import logging
 import math
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import yfinance as yf
 
@@ -132,7 +132,7 @@ def performance(_df, risk_free, prefix=""):
 
 def calculate_returns(symbol, start=datetime(1900, 1, 1), end=datetime.now()):
     benchmark = yf.Ticker(symbol)
-    benchmark_df = benchmark.history(period="max")
+    benchmark_df = benchmark.history(start=start, end=end + timedelta(days=7))
     benchmark_df = benchmark_df.loc[
         (benchmark_df.index >= start) & (benchmark_df.index <= end)
     ]


### PR DESCRIPTION
A few areas in yfinance that we could pick up some speed with. Results in backtesting match master using diversification. 

Commit message: 
- Optimizing adding start and end dates, and threading, download multiple stocks all at once.

Downloading reduces time about 2 seconds for from 11.5 to 9.5 on average for one year backtest with five tickers.

When downloading in bulk, not using max, yf will return dates not including the last. To compensate, seven days were added and then refiltered.

For the historical datetime index, the latest index will be pickled locally, and retrieved for subsequent test, and saved each test. This will illiminate the need for a max download with all ohlc for each backtest. Also dropped the ohlcv info right away and managed the datetimes in a list/set for performance.