### PR TITLE
Adjust test valid values for the Momentum Test

### DIFF
--- a/lumibot/tests/test_strategies.py
+++ b/lumibot/tests/test_strategies.py
@@ -16,14 +16,14 @@ def test_momentum_strategy():
         risk_free_rate = 0
 
         valid_result = {
-            "cagr": 0.06808194998616934,
-            "volatility": 0.24666811122617535,
-            "sharpe": 0.2760062889675412,
+            "cagr": 0.08524645028981514,
+            "volatility": 0.24632330496590924,
+            "sharpe": 0.3460754568132038,
             "max_drawdown": {
-                "drawdown": 0.2670117192959624,
+                "drawdown": 0.2669783424180549,
                 "date": pd.Timestamp("2020-03-16 16:00:00-0400", tz="America/New_York"),
             },
-            "romad": 0.2549773851338174,
+            "romad": 0.3193009946714322,
         }
 
         stats = Momentum.backtest(


### PR DESCRIPTION
This accounts for the one day lag introduced by Yahoo Finance when filtering for start date instead of max.