### PR TITLE
When strategy parameters for live update implemented, lost kwargs argument

### DIFF
--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -287,7 +287,7 @@ class StrategyExecutor(Thread):
     @lifecycle_method
     def _initialize(self):
         self.strategy.log_message("Executing the initialize lifecycle method")
-        self.strategy.initialize()
+        self.strategy.initialize(**self.strategy.parameters)
 
     @lifecycle_method
     def _before_market_opens(self):


### PR DESCRIPTION
In `strategy_executor` lost the `**self.strategy.kwargs` parameter. This caused kwargs to not be loaded in `strategy.initialize`.

Added in new parameter now as `**self.strategy.parameters`. Now all keyword arguments running in strategies.