### PR TITLE
Pandas Deprecation warning for append, code modified to pd.concat.

### DIFF
--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -637,8 +637,8 @@ class Broker:
                 "multiplier": multiplier,
             }
             # append row to the dataframe
-            self._trade_event_log_df = self._trade_event_log_df.append(
-                new_row, ignore_index=True
+            self._trade_event_log_df = pd.concat(
+                [self._trade_event_log_df, pd.DataFrame(new_row, index=[0])], axis=0
             )
 
         return

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -261,7 +261,7 @@ class _Strategy:
     # =============Stats functions=====================
 
     def _append_row(self, row):
-        self._stats = self._stats.append(row, ignore_index=True)
+        self._stats = pd.concat([self._stats, pd.DataFrame(row, index=[0])])
 
     def _format_stats(self):
         self._stats = self._stats.set_index("datetime")


### PR DESCRIPTION
stats rows are added to dataframes previously using .append. This is deprecated. Convert the dictionaries to new single row dataframes and concat.