### PR TITLE
Adding order.get_filled_price() and enabling pytest coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ todos.txt
 *.pem
 test_bot.py
 .vscode
+.coverage*
 
 # Pypi deployment
 build

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -471,7 +471,7 @@ class Order:
         else:
             return -cash_value
 
-    def get_filled_price(self) -> float:
+    def get_fill_price(self) -> float:
         """
         Get the weighted average filled price for this order. Option contracts often encounter partial fills,
         so the weighted average is the only valid price that can be used for PnL calculations.
@@ -483,7 +483,7 @@ class Order:
             has not yet been filled.
         """
         # Only calculate on filled orders
-        if not self.transactions or not self.position_filled or not self.quantity:
+        if not self.transactions or not self.quantity:
             return 0.0
 
         # calculate the weighted average filled price since options often encounter partial fills

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -471,6 +471,24 @@ class Order:
         else:
             return -cash_value
 
+    def get_filled_price(self) -> float:
+        """
+        Get the weighted average filled price for this order. Option contracts often encounter partial fills,
+        so the weighted average is the only valid price that can be used for PnL calculations.
+
+        Returns
+        -------
+        float
+            The weighted average filled price for this order. 0.0 will be returned if the order
+            has not yet been filled.
+        """
+        # Only calculate on filled orders
+        if not self.transactions or not self.position_filled:
+            return 0.0
+
+        # calculate the weighted average filled price since options often encounter partial fills
+        return round(sum([x.price * x.quantity for x in self.transactions]) / self.quantity, 2)
+
     def update_status(self, status):
         self.status = status
 

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -483,7 +483,7 @@ class Order:
             has not yet been filled.
         """
         # Only calculate on filled orders
-        if not self.transactions or not self.position_filled:
+        if not self.transactions or not self.position_filled or not self.quantity:
             return 0.0
 
         # calculate the weighted average filled price since options often encounter partial fills

--- a/lumibot/entities/trading_fee.py
+++ b/lumibot/entities/trading_fee.py
@@ -2,41 +2,43 @@ from decimal import Decimal
 
 
 class TradingFee:
-    """TradingFee class. Used to define the trading fees for a broker in a strategy/backtesting.
+    """TradingFee class. Used to define the trading fees for a broker in a strategy/backtesting."""
 
-    Parameters
-    ----------
-    flat_fee : Decimal, float, or None
-        Flat fee to pay for each order. This is a fixed fee that is paid for each order in the quote currency.
-    percentage_fee : Decimal, float, or None
-        Percentage fee to pay for each order. This is a percentage of the order value that is paid for each order in the quote currency.
-    maker : bool
-        Whether this fee is a maker fee (applies to limit orders).
-        Default is True, which means that this fee will be used on limit orders.
-    taker : bool
-        Whether this fee is a taker fee (applies to market orders).
-        Default is True, which means that this fee will be used on market orders.
+    def __init__(self, flat_fee=0.0, percent_fee=0.0, maker=True, taker=True):
+        """
+        Parameters
+        ----------
+        flat_fee : Decimal, float, or None
+            Flat fee to pay for each order. This is a fixed fee that is paid for each order in the quote currency.
+        percent_fee : Decimal, float, or None
+            Percentage fee to pay for each order. This is a percentage of the order value that is paid for each order in the quote currency.
+        maker : bool
+            Whether this fee is a maker fee (applies to limit orders).
+            Default is True, which means that this fee will be used on limit orders.
+        taker : bool
+            Whether this fee is a taker fee (applies to market orders).
+            Default is True, which means that this fee will be used on market orders.
 
-    Example
-    --------
-    >>> trading_fee_1 = TradingFee(flat_fee=5) # $5 flat fee
-    >>> trading_fee_2 = TradingFee(percent_fee=0.01) # 1% fee
-    >>> backtesting_start = datetime(2022, 1, 1)
-    >>> backtesting_end = datetime(2022, 6, 1)
-    >>> result = MyStrategy.backtest(
-    >>>     YahooDataBacktesting,
-    >>>     backtesting_start,
-    >>>     backtesting_end,
-    >>>     buy_trading_fees=[trading_fee_1, trading_fee_2],
-    >>> )
-    """
-
-    flat_fee: Decimal = 0
-    percent_fee: Decimal = 0
-    maker: bool = False
-    taker: bool = False
-
-    def __init__(self, flat_fee=0, percent_fee=0, maker=True, taker=True):
+        Example
+        --------
+        >>> from datetime import datetime
+        >>> from lumibot.entities import TradingFee
+        >>> from lumibot.strategies import Strategy
+        >>> from lumibot.backtesting import YahooDataBacktesting
+        >>> class MyStrategy(Strategy):
+        >>>     pass
+        >>>
+        >>> trading_fee_1 = TradingFee(flat_fee=5.2) # $5.20 flat fee
+        >>> trading_fee_2 = TradingFee(percent_fee=0.01) # 1% fee
+        >>> backtesting_start = datetime(2022, 1, 1)
+        >>> backtesting_end = datetime(2022, 6, 1)
+        >>> result = MyStrategy.backtest(
+        >>>     YahooDataBacktesting,
+        >>>     backtesting_start,
+        >>>     backtesting_end,
+        >>>     buy_trading_fees=[trading_fee_1, trading_fee_2],
+        >>> )
+        """
         self.flat_fee = Decimal(flat_fee)
         self.percent_fee = Decimal(percent_fee)
         self.maker = maker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,37 @@
+# Additional items here based on your project needs.
+# How this is different from setup.py is ... complicated.
+#    StackOverflow Answer: https://stackoverflow.com/a/33685899
+#
+# The short version is that setup.py is for installing the package
+# and requirements.txt is for installing the dependencies and that these are
+# meant for different audiences. So we duplicate the lists of modules :(
+#
+# More Long Answer:
+#   https://towardsdatascience.com/requirements-vs-setuptools-python-ae3ee66e28af
+
+### ----- Requirements for the package ----- ###
+polygon==1.1.0
+alpaca_trade_api==2.3.0
+alpha_vantage
+ibapi==9.81.1.post1
+yfinance>=0.2.18
+matplotlib>=3.3.3
+quandl
+pandas>=1.4.0<2.0.0  # pandas v2 currently causing issues with quant stats (v0.0.59)
+pandas_datareader
+pandas_market_calendars>=4.1.2
+plotly
+flask-socketio
+flask-sqlalchemy
+flask-marshmallow
+marshmallow-sqlalchemy
+flask-security
+email_validator
+bcrypt
+pytest
+scipy
+quantstats==0.0.59
+ccxt==3.0.61
+termcolor
+jsonpickle
+apscheduler==3.10.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,15 @@
+# Include the main project requirements
+-r requirements.txt
+
+# Unit Test modules
+pytest
+pytest-mock
+coverage
+
+# Linting modules
+flake8
+isort
+
+# Security checkers
+bandit
+safety

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,51 @@ filterwarnings =
 
 testpaths = tests
 norecursedirs = docs .* *.egg* appdir jupyter *pycache* venv* .cache* .coverage* .git data docs docsrc
+
+# .coveragerc to control coverag.py
+[coverage:run]
+command_line = -m pytest -vv
+branch = True
+omit =
+	# * so you can get all dirs
+	*__init__.py
+
+	# Dirs to ignore
+	tests/*
+	venv*
+	.cache/
+	.git/
+	.cache-directory
+	.pytest*
+	docs/
+	data/
+	docsrc/
+	example*
+	cache*
+
+[coverage:report]
+# Regexs for lines to exclude from consideration
+exclude_lines =
+	# Have to re-enable the standard pragma
+	pragma: no coverag
+
+	# Don't complain about missing debug-only code
+	def __repr__
+	if self\.debug-only
+
+	# Don't complain if tests don't hit defensive assertion code:
+	raise AssertionError
+	raise NotImplementedError
+
+	# Don't complain if non-runable code isn't run
+	if 0:
+	if __name__ == __main__:
+
+precision = 2
+ignore_errors = True
+show_missing = True
+# Add this back in when coverage is at an acceptable level
+# fail_under = 98
+
+[coverage:html]
+directory = .coverage.html_report

--- a/tests/test_alpaca.py
+++ b/tests/test_alpaca.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from pandas import Timestamp
 
-from credentials import ALPACA_CONFIG
+# from credentials import ALPACA_CONFIG  # Put back in when ready to test
 from lumibot.brokers.alpaca import Alpaca
 from lumibot.entities.asset import Asset
 from lumibot.entities.bars import Bars

--- a/tests/test_ccxt.py
+++ b/tests/test_ccxt.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
 import pytest
-from credentials import BINANCE_CONFIG
+# from credentials import BINANCE_CONFIG  # Put back in when ready to test
 
 from lumibot.brokers.ccxt import Ccxt
 from lumibot.entities.asset import Asset

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -27,23 +27,18 @@ class TestOrderBasics:
         buy_order = Order(strategy='abc', asset=asset, side="buy", quantity=100)
 
         # No transactions
-        assert buy_order.get_filled_price() == 0
+        assert buy_order.get_fill_price() == 0
 
         buy_order.transactions = [
             Order.Transaction(quantity=50, price=20.0),
             Order.Transaction(quantity=50, price=30.0)
         ]
 
-        # Order not yet filled
-        assert buy_order.get_filled_price() == 0
-
-        # Order filled
-        buy_order.position_filled = True
-        assert buy_order.get_filled_price() == 25.0
+        assert buy_order.get_fill_price() == 25.0
 
         # Error case where quantity is not set
         buy_order._quantity = 0
-        assert buy_order.get_filled_price() == 0
+        assert buy_order.get_fill_price() == 0
 
         # Ensure Weighted Average used
         sell_order = Order(strategy='abc', asset=asset, side="sell", quantity=100)
@@ -52,4 +47,4 @@ class TestOrderBasics:
             Order.Transaction(quantity=20, price=40.0)
         ]
         sell_order.position_filled = True
-        assert sell_order.get_filled_price() == 32.0
+        assert sell_order.get_fill_price() == 32.0

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -25,6 +25,10 @@ class TestOrderBasics:
     def test_get_filled_price(self):
         asset = Asset("SPY")
         buy_order = Order(strategy='abc', asset=asset, side="buy", quantity=100)
+
+        # No transactions
+        assert buy_order.get_filled_price() == 0
+
         buy_order.transactions = [
             Order.Transaction(quantity=50, price=20.0),
             Order.Transaction(quantity=50, price=30.0)
@@ -36,6 +40,10 @@ class TestOrderBasics:
         # Order filled
         buy_order.position_filled = True
         assert buy_order.get_filled_price() == 25.0
+
+        # Error case where quantity is not set
+        buy_order._quantity = 0
+        assert buy_order.get_filled_price() == 0
 
         # Ensure Weighted Average used
         sell_order = Order(strategy='abc', asset=asset, side="sell", quantity=100)

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -21,3 +21,27 @@ class TestOrderBasics:
         asset = Asset("SPY", asset_type="option")
         order = Order(asset=asset, quantity=10, side="buy", strategy='abc')
         assert order.is_option()
+
+    def test_get_filled_price(self):
+        asset = Asset("SPY")
+        buy_order = Order(strategy='abc', asset=asset, side="buy", quantity=100)
+        buy_order.transactions = [
+            Order.Transaction(quantity=50, price=20.0),
+            Order.Transaction(quantity=50, price=30.0)
+        ]
+
+        # Order not yet filled
+        assert buy_order.get_filled_price() == 0
+
+        # Order filled
+        buy_order.position_filled = True
+        assert buy_order.get_filled_price() == 25.0
+
+        # Ensure Weighted Average used
+        sell_order = Order(strategy='abc', asset=asset, side="sell", quantity=100)
+        sell_order.transactions = [
+            Order.Transaction(quantity=80, price=30.0),
+            Order.Transaction(quantity=20, price=40.0)
+        ]
+        sell_order.position_filled = True
+        assert sell_order.get_filled_price() == 32.0

--- a/tests/test_tradingfee.py
+++ b/tests/test_tradingfee.py
@@ -1,0 +1,7 @@
+from lumibot.entities import TradingFee
+
+
+class TestTradingFee:
+    def test_init(self):
+        fee = TradingFee(flat_fee=5.2)
+        assert fee.flat_fee == 5.2


### PR DESCRIPTION
Main purpose is to add a new function to lumibot.entities.order and provide the testing.  As per our agreement, I also added some additional tests to TradingFee to incrementally improve coverage in some other area of the repository.

---
### Side note on coverage
To run coverage:
```
- Install requirements file:
  pip install -r requirements_dev.txt
- 3 step command to generate a full coverage report
  coverage run
  coverage report
  coverage html
- open the generated ".coverage.html_report/index.html" file in your browser
```
You will get a coverage report in the terminal that looks like:
![image](https://github.com/Lumiwealth/lumibot/assets/139159438/86c4dd89-3323-4314-aa96-1adb899f8014)

And the same data in a nice HTML version:
![image](https://github.com/Lumiwealth/lumibot/assets/139159438/50717dae-14df-4811-9c9a-1ca03fdb1bdc)

---
### Back to My code changes
![image](https://github.com/Lumiwealth/lumibot/assets/139159438/8d5bf312-8d8f-48ab-8511-2ca58aa5e657)
![image](https://github.com/Lumiwealth/lumibot/assets/139159438/1069cb98-dd63-4cb0-8175-b8855ac5ee6a)
```diff
+ New code is all Green -- Fully Covered!
```

---
### Incremental Coverage Improvement
Sorted by the coverage column!
![image](https://github.com/Lumiwealth/lumibot/assets/139159438/3c2ac9e7-e944-44a4-bc57-e0ac6963718d)
We now have a fully covered module!! 🎉 🥳 
