### PR TITLE
Fixed backtesting options on a recent real date where the options hav…

### DIFF
--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -464,11 +464,11 @@ class BacktestingBroker(Broker):
                     self.cancel_order(order)
                     continue
                 dt = ohlc.df.index[-1]
-                open = ohlc.df["open"][-1]
-                high = ohlc.df["high"][-1]
-                low = ohlc.df["low"][-1]
-                close = ohlc.df["close"][-1]
-                volume = ohlc.df["volume"][-1]
+                open = ohlc.df["open"].iloc[-1]
+                high = ohlc.df["high"].iloc[-1]
+                low = ohlc.df["low"].iloc[-1]
+                close = ohlc.df["close"].iloc[-1]
+                volume = ohlc.df["volume"].iloc[-1]
 
             #############################
             # Determine transaction price.

--- a/lumibot/brokers/interactive_brokers.py
+++ b/lumibot/brokers/interactive_brokers.py
@@ -136,7 +136,7 @@ class InteractiveBrokers(InteractiveBrokersData, Broker):
                 if position["position"] != 0:
                     positions.append(position)
         else:
-            logging.info("No positions found at interactive brokers.")
+            logging.debug("No positions found at interactive brokers.")
 
         return positions
 

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -812,9 +812,13 @@ class StrategyExecutor(Thread):
                 logging.error(traceback.format_exc())
                 try:
                     self._on_bot_crash(e)
-                except Exception as e:
-                    logging.error(e)
+                except Exception as e1:
+                    logging.error(e1)
                     logging.error(traceback.format_exc())
+
+                # In BackTesting, we want to stop the bot if it crashes so there isn't an infinite loop
+                if self.strategy.is_backtesting:
+                    raise RuntimeError("Exception encountered, stopping BackTest.") from e
 
                 # Only stop the strategy if it's time, otherwise keep running the bot
                 if not self._strategy_sleep():

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -28,7 +28,7 @@ def total_return(_df):
     df = df.sort_index(ascending=True)
     df["cum_return"] = (1 + df["return"]).cumprod()
 
-    total_ret = df["cum_return"][-1] - 1
+    total_ret = df["cum_return"].iloc[-1] - 1
 
     return total_ret
 
@@ -48,7 +48,7 @@ def cagr(_df):
     df = _df.copy()
     df = df.sort_index(ascending=True)
     df["cum_return"] = (1 + df["return"]).cumprod()
-    total_ret = df["cum_return"][-1]
+    total_ret = df["cum_return"].iloc[-1]
     start = datetime.utcfromtimestamp(df.index.values[0].astype("O") / 1e9)
     end = datetime.utcfromtimestamp(df.index.values[-1].astype("O") / 1e9)
     period_years = (end - start).days / 365.25

--- a/tests/test_backtest_polygon.py
+++ b/tests/test_backtest_polygon.py
@@ -17,7 +17,7 @@ class PolygonBacktestStrat(Strategy):
     parameters = {"symbol": "AMZN"}
 
     # Set the initial values for the strategy
-    def initialize(self):
+    def initialize(self, parameters=None):
         self.sleeptime = "1D"
         self.first_price = None
         self.first_option_price = None
@@ -232,18 +232,3 @@ class TestPolygonBacktestFull:
             polygon_has_paid_subscription=True,
         )
         assert results
-
-
-class TestPolygonBacktestBasics:
-    def test_polygon_basics(self):
-        asset = Asset("SPY")
-        now = datetime.datetime.now(pytz.utc)
-        start = now - datetime.timedelta(days=1)
-        end = now
-        polygon_backtest = PolygonDataBacktesting(
-            start,
-            end,
-            polygon_api_key=POLYGON_API_KEY,
-            has_paid_subscription=True,
-        )
-        assert polygon_backtest.get_last_price(asset)


### PR DESCRIPTION
…en't expired yet.  Need to do an additional query to Polygon.IO.

When doing a recent backtest, things failed because the closest options contracts were not yet expired so Polygon didn't return them when queried with "expired=True". Need an update for Backtest to also look for unexpired contracts when getting chains.

Example: TSLA has options every 2 weeks

Today is 2023-09-13
Backtest TSLA for 2023-09-09
Closest Option contract is 2023-09-15 --> Not Yet expired so currently can't be used in BackTest.