### PR TITLE
Bug: With updated Pandas, IBKR data is being returned with invalid index

### DIFF
--- a/lumibot/data_sources/interactive_brokers_data.py
+++ b/lumibot/data_sources/interactive_brokers_data.py
@@ -230,7 +230,7 @@ class InteractiveBrokersData(DataSource):
 
                 if "min" in parsed_timestep or "hour" in parsed_timestep:
                     df["date"] = (
-                        pd.to_datetime(df["date"], unit="s", origin="unix")
+                        pd.to_datetime(df["date"].astype(int), unit="s", origin="unix")
                         .dt.tz_localize("UTC")
                         .dt.tz_convert(self.DEFAULT_TIMEZONE)
                     )


### PR DESCRIPTION
datetime index where minutes are being repeated.

![94i72uiNY9](https://github.com/Lumiwealth/lumibot/assets/139159438/7a9b9d6a-c98c-41f2-b087-319bce3e89d6)

_Should show_
Red box: min=43,44
Yellow Box: min=45,46
Green Box: min=47,48,49