### PR TITLE
Fixing IBKR Live Trading runs continuously re-canceling 

### DIFF
--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -744,8 +744,10 @@ class Broker:
             stored_order = self._process_new_order(stored_order)
             self._on_new_order(stored_order)
         elif type_event == self.CANCELED_ORDER:
-            stored_order = self._process_canceled_order(stored_order)
-            self._on_canceled_order(stored_order)
+            # Do not cancel or re-cancel already completed orders
+            if stored_order.is_active():
+                stored_order = self._process_canceled_order(stored_order)
+                self._on_canceled_order(stored_order)
         elif type_event == self.PARTIALLY_FILLED_ORDER:
             stored_order, position = self._process_partially_filled_order(
                 stored_order, price, filled_quantity

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -514,6 +514,16 @@ class Order:
         # Some Backtest runs are using a Decimal for the Transaction quantity, so we need to convert to float
         return round(sum([float(x.price) * float(x.quantity) for x in self.transactions]) / self.quantity, 2)
 
+    def is_active(self):
+        """
+        Returns whether this order is active.
+        Returns
+        -------
+        bool
+            True if the order is active, False otherwise.
+        """
+        return not self.is_filled() and not self.is_canceled()
+
     def is_canceled(self):
         """
         Returns whether this order has been cancelled.

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -69,3 +69,14 @@ class TestOrderBasics:
         assert order.is_canceled()
         order.status = 'cancel'
         assert order.is_canceled()
+
+    def test_active(self):
+        asset = Asset("SPY")
+        order = Order(strategy='abc', asset=asset, side="buy", quantity=100)
+        assert order.is_active()
+        order.status = 'filled'
+        assert not order.is_active()
+        order.status = 'cancelled'
+        assert not order.is_active()
+        order.status = 'submitted'
+        assert order.is_active()


### PR DESCRIPTION
Filled and Cancelled orders are getting re-cancelled every iteration because the orders no longer map properly to the list of InteractiveBroker orders.