### PR TITLE
fixed edge case where we first get day data, then request minute data

### DIFF
--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 
 import pandas as pd
+
 from lumibot import LUMIBOT_DEFAULT_PYTZ as DEFAULT_PYTZ
 from lumibot.tools.helpers import to_datetime_aware
 
@@ -323,7 +324,7 @@ class Data:
         # Check if the date is in the dataframe, if not then get the last
         # known data (this speeds up the process)
         i = None
-        
+
         # Check if we have the iter_index_dict, if not then repair the times and fill (which will create the iter_index_dict)
         if getattr(self, "iter_index_dict", None) is None:
             self.repair_times_and_fill(self.df.index)
@@ -371,8 +372,8 @@ class Data:
             if not is_data:
                 # Log a warning
                 logging.warning(
-                    f"The date you are looking for ({dt}) is outside of the data's date range ({self.datetime_start} to {self.datetime_end}) after accounting for a length of {kwargs.get('length', 1)} and a timeshift of {kwargs.get('timeshift', 0)}. Keep in mind that the length you are requesting must also be available in your data, in this case we are {data_index} rows away from the data you need."                
-                    )
+                    f"The date you are looking for ({dt}) is outside of the data's date range ({self.datetime_start} to {self.datetime_end}) after accounting for a length of {kwargs.get('length', 1)} and a timeshift of {kwargs.get('timeshift', 0)}. Keep in mind that the length you are requesting must also be available in your data, in this case we are {data_index} rows away from the data you need."
+                )
 
             res = func(self, *args, **kwargs)
             # print(f"Results last price: {res}")
@@ -448,10 +449,10 @@ class Data:
         # Get bars.
         end_row = self.get_iter_count(dt) - timeshift
         start_row = end_row - length
-        
+
         if start_row < 0:
             start_row = 0
-            
+
         # Cast both start_row and end_row to int
         start_row = int(start_row)
         end_row = int(end_row)
@@ -461,10 +462,10 @@ class Data:
             dict[dl_name] = dl.dataline[start_row:end_row]
 
         return dict
-    
+
     def _get_bars_between_dates_dict(self, timestep=None, start_date=None, end_date=None):
         """Returns a dictionary of all the data available between the start and end dates.
-        
+
         Parameters
         ----------
         timestep : str
@@ -473,26 +474,26 @@ class Data:
             The start date to get the data for.
         end_date : datetime.datetime
             The end date to get the data for.
-            
+
         Returns
         -------
         dict
         """
-        
+
         end_row = self.get_iter_count(end_date)
         start_row = self.get_iter_count(start_date)
-        
+
         if start_row < 0:
             start_row = 0
-            
+
         # Cast both start_row and end_row to int
         start_row = int(start_row)
         end_row = int(end_row)
-        
+
         dict = {}
         for dl_name, dl in self.datalines.items():
             dict[dl_name] = dl.dataline[start_row:end_row]
-            
+
         return dict
 
     def get_bars(self, dt, length=1, timestep=MIN_TIMESTEP, timeshift=0, exchange=None):
@@ -547,6 +548,9 @@ class Data:
                 }
             )
 
+            # Drop any rows that have NaN values (this can happen if the data is not complete, eg. weekends)
+            df_result = df_result.dropna()
+
             return df_result
         else:
             dict = self._get_bars_dict(
@@ -558,10 +562,10 @@ class Data:
 
             df = pd.DataFrame(dict).set_index("datetime")
             return df
-        
+
     def get_bars_between_dates(self, timestep=MIN_TIMESTEP, exchange=None, start_date=None, end_date=None):
         """Returns a dataframe of all the data available between the start and end dates.
-        
+
         Parameters
         ----------
         timestep : str
@@ -572,22 +576,22 @@ class Data:
             The start date to get the data for.
         end_date : datetime.datetime
             The end date to get the data for.
-            
+
         Returns
         -------
         pandas.DataFrame
         """
-        
+
         if timestep == "minute" and self.timestep == "day":
             raise ValueError(
                 "You are requesting minute data from a daily data source. This is not supported."
             )
-            
+
         if timestep != "minute" and timestep != "day":
             raise ValueError(
                 f"Only minute and day are supported for timestep. You provided: {timestep}"
             )
-            
+
         if timestep == "day" and self.timestep == "minute":
 
             dict = self._get_bars_between_dates_dict(
@@ -595,12 +599,12 @@ class Data:
                 start_date=start_date,
                 end_date=end_date
             )
-            
+
             if dict is None:
                 return None
-            
+
             df = pd.DataFrame(dict).set_index("datetime")
-            
+
             df_result = df.resample("D").agg(
                 {
                     "open": "first",
@@ -610,22 +614,18 @@ class Data:
                     "volume": "sum",
                 }
             )
-            
+
             return df_result
-        
+
         else:
             dict = self._get_bars_between_dates_dict(
                 timestep=timestep,
                 start_date=start_date,
                 end_date=end_date
             )
-            
+
             if dict is None:
                 return None
-            
+
             df = pd.DataFrame(dict).set_index("datetime")
             return df
-        
-        
-
-   

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -512,7 +512,7 @@ class Order:
 
         # calculate the weighted average filled price since options often encounter partial fills
         # Some Backtest runs are using a Decimal for the Transaction quantity, so we need to convert to float
-        return round(sum([float(x.price) * float(x.quantity) for x in self.transactions]) / self.quantity, 2)
+        return round(sum([float(x.price) * float(x.quantity) for x in self.transactions]) / float(self.quantity), 2)
 
     def is_active(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "polygon-api-client",
-        "alpaca-py<=0.10.0",
+        "alpaca-py<=0.12.0",
         "alpha_vantage",
         "ibapi==9.81.1.post1",
         "yfinance>=0.2.18",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="2.8.5",
+    version="2.8.6",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="2.8.6",
+    version="2.8.7",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",


### PR DESCRIPTION
basically the issue was that if we got day data first, then the data store would never attempt to get minute data. that has now been changed so that we always try to keep the minimum timestep in the data store