### PR TITLE
BackTest Multi Min TimeStep

### DIFF
--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -84,8 +84,9 @@ class PolygonDataBacktesting(PandasData):
         # Download data from Polygon
         try:
             # Convert timestep string to timedelta and get start datetime
-            td = self.convert_timestep_str_to_timedelta(timestep) * length
+            td, ts_unit = self.convert_timestep_str_to_timedelta(timestep)
             # Multiply td by length to get the end datetime
+            td *= length
             start_datetime = self.datetime_start - td
 
             # Subtract an extra 5 days to the start datetime to make sure we have enough
@@ -98,7 +99,7 @@ class PolygonDataBacktesting(PandasData):
                 asset_separated,
                 start_datetime,
                 self.datetime_end,
-                timespan=timestep,
+                timespan=ts_unit,
                 quote_asset=quote_asset,
                 has_paid_subscription=self.has_paid_subscription,
             )
@@ -110,7 +111,7 @@ class PolygonDataBacktesting(PandasData):
             return None
 
         pandas_data = []
-        data = Data(asset_separated, df, timestep=timestep, quote=quote_asset)
+        data = Data(asset_separated, df, timestep=ts_unit, quote=quote_asset)
         pandas_data.append(data)
         pandas_data_updated = self._set_pandas_data_keys(pandas_data)
 

--- a/lumibot/data_sources/alpaca_data.py
+++ b/lumibot/data_sources/alpaca_data.py
@@ -21,6 +21,48 @@ class AlpacaData(DataSource):
             "representations": [TimeFrame.Minute, "minute"],
         },
         {
+            "timestep": "5 minutes",
+            "representations": [
+                [f"5{TimeFrame.Minute}", "minute"],
+            ],
+        },
+        {
+            "timestep": "10 minutes",
+            "representations": [
+                [f"10{TimeFrame.Minute}", "minute"],
+            ],
+        },
+        {
+            "timestep": "15 minutes",
+            "representations": [
+                [f"15{TimeFrame.Minute}", "minute"],
+            ],
+        },
+        {
+            "timestep": "30 minutes",
+            "representations": [
+                [f"30{TimeFrame.Minute}", "minute"],
+            ],
+        },
+        {
+            "timestep": "1 hour",
+            "representations": [
+                [f"{TimeFrame.Hour}", "hour"],
+            ],
+        },
+        {
+            "timestep": "2 hours",
+            "representations": [
+                [f"2{TimeFrame.Hour}", "hour"],
+            ],
+        },
+        {
+            "timestep": "4 hours",
+            "representations": [
+                [f"4{TimeFrame.Hour}", "hour"],
+            ],
+        },
+        {
             "timestep": "day",
             "representations": [TimeFrame.Day, "day"],
         },

--- a/lumibot/data_sources/data_source.py
+++ b/lumibot/data_sources/data_source.py
@@ -170,6 +170,8 @@ class DataSource(ABC):
         -------
         timedelta
             A timedelta object representing the timestep.
+        unit : str
+            The unit of the timestep. For example, "minute" or "hour" or "day".
         """
         timestep = timestep.lower()
 
@@ -194,7 +196,9 @@ class DataSource(ABC):
                     # Get the quantity (number of units)
                     quantity = int(timestep[:i])
                     # Get the unit (minute, hour, or day)
-                    unit = timestep[i:]
+                    # IBRK uses "minutes" instead of "minute" when 'quantity' > 1, for some reason, so handle
+                    # that behavior here so backtest is comptiable with IBRK
+                    unit = timestep[i:].strip().rstrip('s')  # Remove extra whitespace and IBKR's extra pluralization
                     break
         else:
             unit = timestep
@@ -205,7 +209,7 @@ class DataSource(ABC):
             quantity_in_minutes = quantity * time_unit_map[unit]
             # Convert minutes to timedelta
             delta = timedelta(minutes=quantity_in_minutes)
-            return delta
+            return delta, unit
         else:
             raise ValueError(
                 f"Unknown unit: {unit}. Valid units are minute, hour, day, M, H, D"

--- a/lumibot/entities/bars.py
+++ b/lumibot/entities/bars.py
@@ -259,7 +259,7 @@ class Bars:
         volume = df_copy["volume"].sum()
         return volume
 
-    def aggregate_bars(self, frequency):
+    def aggregate_bars(self, frequency, **grouper_kwargs):
         """
         Will convert a set of bars to a different timeframe (eg. 1 min to 15 min)
         frequency (string): The new timeframe that the bars should be in, eg. "15Min", "1H", or "1D"
@@ -280,7 +280,7 @@ class Bars:
         >>> bars = self.get_historical_prices("AAPL", 60, "minute")
         >>> bars_agg = bars.aggregate_bars("15Min")
         """
-        new_df = self.df.groupby(pd.Grouper(freq=frequency)).agg(
+        new_df = self.df.groupby(pd.Grouper(freq=frequency, **grouper_kwargs)).agg(
             {
                 "open": "first",
                 "close": "last",

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -2789,7 +2789,8 @@ class Strategy(_Strategy):
         timestep : str
             Either ``"minute"`` for minutes data or ``"day"``
             for days data default value depends on the data_source (minute
-            for alpaca, day for yahoo, ...)
+            for alpaca, day for yahoo, ...).  If you need, you can specify the width of the bars by adding a number
+            before the timestep (e.g. "5 minutes", "15 minutes", "1 day", "2 weeks", "1month", ...)
         timeshift : timedelta
             ``None`` by default. If specified indicates the time shift from
             the present. If  backtesting in Pandas, use integer representing
@@ -2935,7 +2936,8 @@ class Strategy(_Strategy):
         timestep : str
             Either ``"minute"`` for minutes data or ``"day"``
             for days data default value depends on the data_source (minute
-            for alpaca, day for yahoo, ...)
+            for alpaca, day for yahoo, ...). If you need, you can specify the width of the bars by adding a number
+            before the timestep (e.g. "5 minutes", "15 minutes", "1 day", "2 weeks", "1month", ...)
         timeshift : timedelta
             ``None`` by default. If specified indicates the time shift from
             the present. If  backtesting in Pandas, use integer representing


### PR DESCRIPTION
Issue during Live Trading:
- IBKR couldn't return 10days worth of history in 1m bars. 
  - Need to use ```timestep='10 minutes'``` as an input
- BackTest doesn't handle "10 minutes" as a valid timestep