### PR TITLE
Correct show_plot to also control the indicator.html file display in a browser.

### DIFF
--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import jsonpickle
 import pandas as pd
+
 from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting
 from lumibot.entities import Asset, Position
 from lumibot.tools import (
@@ -996,7 +997,7 @@ class _Strategy:
                 chart_markers_df,
                 chart_lines_df,
                 f"{self._log_strat_name()}Strategy Indicators",
-                show_plot=show_indicators,
+                show_indicators=show_indicators,
             )
         self.tearsheet(
             save_tearsheet=save_tearsheet,

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -7,7 +7,6 @@ from decimal import Decimal
 
 import jsonpickle
 import pandas as pd
-
 from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting
 from lumibot.entities import Asset, Position
 from lumibot.tools import (
@@ -607,28 +606,6 @@ class _Strategy:
                 initial_budget=self._initial_budget,
             )
 
-    def plot_indicators(
-        self,
-        plot_file_html="indicators.html",
-        chart_markers_df=None,
-        chart_lines_df=None,
-        show_plot=True,
-        show_indicators=True,
-    ):
-        # Check if we have at least one indicator to plot
-        if chart_markers_df is None and chart_lines_df is None:
-            return None
-
-        # Plot the indicators
-        plot_indicators(
-            plot_file_html,
-            chart_markers_df,
-            chart_lines_df,
-            f"{self._log_strat_name()}Strategy Indicators",
-            show_plot,
-            show_indicators,
-        )
-
     def tearsheet(
         self,
         save_tearsheet=True,
@@ -1011,13 +988,16 @@ class _Strategy:
         chart_lines_df = pd.DataFrame(self._chart_lines_list)
         # Create chart markers dataframe
         chart_markers_df = pd.DataFrame(self._chart_markers_list)
-        self.plot_indicators(
-            indicators_file,
-            chart_markers_df,
-            chart_lines_df,
-            show_indicators,
-            show_plot=show_plot,
-        )
+
+        # Check if we have at least one indicator to plot
+        if chart_markers_df is not None and chart_lines_df is not None:
+            plot_indicators(
+                indicators_file,
+                chart_markers_df,
+                chart_lines_df,
+                f"{self._log_strat_name()}Strategy Indicators",
+                show_plot=show_indicators,
+            )
         self.tearsheet(
             save_tearsheet=save_tearsheet,
             tearsheet_file=tearsheet_file,

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -612,6 +612,7 @@ class _Strategy:
         plot_file_html="indicators.html",
         chart_markers_df=None,
         chart_lines_df=None,
+        show_plot=True
     ):
         # Check if we have at least one indicator to plot
         if chart_markers_df is None and chart_lines_df is None:
@@ -623,6 +624,7 @@ class _Strategy:
             chart_markers_df,
             chart_lines_df,
             f"{self._log_strat_name()}Strategy Indicators",
+            show_plot,
         )
 
     def tearsheet(
@@ -1002,6 +1004,7 @@ class _Strategy:
             indicators_file,
             chart_markers_df,
             chart_lines_df,
+            show_plot=show_plot,
         )
         self.tearsheet(
             save_tearsheet=save_tearsheet,

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import jsonpickle
 import pandas as pd
+
 from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting
 from lumibot.entities import Asset, Position
 from lumibot.tools import (
@@ -611,7 +612,7 @@ class _Strategy:
         plot_file_html="indicators.html",
         chart_markers_df=None,
         chart_lines_df=None,
-        show_plot=True
+        show_plot=True,
         show_indicators=True,
     ):
         # Check if we have at least one indicator to plot

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -8,8 +8,9 @@ from decimal import Decimal
 import pandas as pd
 import plotly.graph_objects as go
 import quantstats_lumi as qs
-from lumibot.tools import to_datetime_aware
 from plotly.subplots import make_subplots
+
+from lumibot.tools import to_datetime_aware
 
 from .yahoo_helper import YahooHelper as yh
 
@@ -204,7 +205,7 @@ def plot_indicators(
 ):
     # If show plot is False, then we don't want to open the plot in the browser
     if not show_indicators:
-        print("show_plot is False, not creating the plot file.")
+        print("show_indicators is False, not creating the plot file.")
         return
 
     print("\nCreating indicators plot...")

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -8,9 +8,8 @@ from decimal import Decimal
 import pandas as pd
 import plotly.graph_objects as go
 import quantstats_lumi as qs
-from plotly.subplots import make_subplots
-
 from lumibot.tools import to_datetime_aware
+from plotly.subplots import make_subplots
 
 from .yahoo_helper import YahooHelper as yh
 
@@ -201,10 +200,10 @@ def plot_indicators(
     chart_markers_df=None,
     chart_lines_df=None,
     strategy_name=None,
-    show_plot=True,
+    show_indicators=True,
 ):
     # If show plot is False, then we don't want to open the plot in the browser
-    if not show_plot:
+    if not show_indicators:
         print("show_plot is False, not creating the plot file.")
         return
 


### PR DESCRIPTION
Currently, the show_plot flag is ignored by the indicators.html file.  This file is opened in a browser every time.

The " fig.write_html(plot_file_html, auto_open=show_plot)" invocation to create the file references the flag, but since it was not properly passed along the call tree, it always defaulted to "True."

This pull request corrects this behavior.