### PR TITLE
Tradier polling

### DIFF
--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -113,6 +113,8 @@ class Broker(ABC):
         """
         pass
 
+    # =========Streaming functions=======================
+
     @abstractmethod
     def _get_stream_object(self):
         """
@@ -166,6 +168,7 @@ class Broker(ABC):
         pass
 
     # =========Market functions=======================
+
     def get_last_price(self, asset: Asset, quote=None, exchange=None) -> float:
         """
         Takes an asset and returns the last known price

--- a/lumibot/entities/asset.py
+++ b/lumibot/entities/asset.py
@@ -1,5 +1,8 @@
+import logging
 from collections import UserDict
 from datetime import date, datetime
+
+from lumibot.tools import parse_symbol
 
 
 class Asset:
@@ -154,6 +157,40 @@ class Asset:
 
         self.asset_type_must_be_one_of(self.asset_type)
         self.right_must_be_one_of(self.right)
+
+    @classmethod
+    def symbol2asset(cls, symbol: str):
+        """
+        Convert a symbol string to an Asset object. This is particularly useful for converting option symbols.
+
+        Parameters
+        ----------
+        symbol : str
+            The symbol string to convert.
+
+        Returns
+        -------
+        Asset
+            The Asset object.
+        """
+        if not symbol:
+            raise ValueError("Cannot convert an empty symbol to an Asset object.")
+
+        symbol_info = parse_symbol(symbol)
+        if symbol_info["type"] == "option":
+            return Asset(
+                symbol=symbol_info["stock_symbol"],
+                asset_type="option",
+                expiration=symbol_info["expiration_date"],
+                strike=symbol_info["strike_price"],
+                right=symbol_info["option_type"],
+            )
+        elif symbol_info["type"] == "stock":
+            return Asset(symbol=symbol, asset_type="stock")
+        else:
+            # TODO: Handle Crypto and Forex Symbols
+            logging.info(f"Unknown symbol asset type {symbol_info['type']}, defaulting to stock.")
+            return Asset(symbol=symbol)
 
     def __hash__(self):
         return hash((self.symbol, self.asset_type, self.expiration, self.strike, self.right))

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -10,6 +10,20 @@ from lumibot.tools.types import check_positive, check_price, check_quantity
 SELL = "sell"
 BUY = "buy"
 
+VALID_STATUS = ["unprocessed", "new", "open", "submitted", "fill", "partial_fill", "canceled", "error", "cash_settled"]
+STATUS_ALIAS_MAP = {
+    "cancelled": "canceled",
+    "cancel": "canceled",
+    "cash": "cash_settled",
+    "expired": "canceled",  # Tradier status
+    "filled": "fill",
+    "partially_filled": "partial_filled",  # Tradier status
+    "pending": "open",  # Tradier status
+    "presubmitted": "new",  # IBKR status
+    "rejected": "error",  # Tradier status
+    "submit": "submitted"
+}
+
 
 class Order:
     Transaction = namedtuple("Transaction", ["quantity", "price"])
@@ -265,7 +279,7 @@ class Order:
         self._raw = None
         self._transmitted = False
         self._error = None
-        self._error_message = None
+        self.error_message = None
 
         self.quantity = quantity
 
@@ -495,7 +509,12 @@ class Order:
     @status.setter
     def status(self, value):
         if value and isinstance(value, str):
-            self._status = value
+            if value.lower() in VALID_STATUS:
+                self._status = value.lower()
+            elif value.lower() in STATUS_ALIAS_MAP:
+                self._status = STATUS_ALIAS_MAP[value.lower()]
+            else:
+                raise ValueError(f"Invalid status: {value}")
 
     @property
     def quantity(self):
@@ -630,14 +649,28 @@ class Order:
         else:
             return False
 
+    def equivalent_status(self, status) -> bool:
+        """Returns if the status is equivalent to the order status."""
+        status = status.status if isinstance(status, Order) else status
+
+        if not status:
+            return False
+        elif self.status.lower() in [status.lower(), STATUS_ALIAS_MAP.get(status.lower(), "")]:
+            return True
+        # open/new status is equivalent
+        elif {self.status.lower(), status.lower()}.issubset({"open", "new"}):
+            return True
+        else:
+            return False
+
     def set_error(self, error):
         self.status = "error"
         self._error = error
-        self._error_message = str(error)
+        self.error_message = str(error)
         self._closed_event.set()
 
     def was_transmitted(self):
-        return self._transmitted is True
+        return self._transmitted
 
     def update_raw(self, raw):
         if raw is not None:

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -244,6 +244,9 @@ class Order:
         self.custom_params = custom_params
         self._trail_stop_price = None
         self.tag = tag
+        self.avg_fill_price = 0.0  # The weighted average filled price for this order. Calculated if not given by broker
+        self.broker_create_date = None  # The datetime the order was created by the broker
+        self.broker_update_date = None  # The datetime the order was last updated by the broker
 
         # Options:
         self.exchange = exchange
@@ -476,6 +479,14 @@ class Order:
         elif self.type == "stop_limit":
             self.limit_price = check_price(limit_price, "limit_price must be positive float.")
             self.stop_price = check_price(stop_price, "stop_price must be positive float.")
+
+    @property
+    def avg_fill_price(self):
+        return self._avg_fill_price
+
+    @avg_fill_price.setter
+    def avg_fill_price(self, value):
+        self._avg_fill_price = round(float(value), 2) if value else 0.0
 
     @property
     def status(self):

--- a/lumibot/tools/__init__.py
+++ b/lumibot/tools/__init__.py
@@ -1,9 +1,30 @@
+# TODO: Using * is really bad and leads to random circular imports (especially in polygon_helper and indicators)
+# TODO: When using *, you have to ensure that the underlying module does not import ANYTHING from the lumibot package
+# TODO: This tools module is a bad place to auto import as a helper to the code because all of the modules and functions
+# TODO: are not related to each other. It's just a collection of random functions and classes and it is unclear what
+# TODO: is being loaded when simply trying to load anything from the tools module. It's better to import the specific
+# TODO: functions and classes that you need from the tools module. This has made everything from black_scholes to
+# TODO: yahoo_helper all interrelated and it's a mess.
 from .black_scholes import BS
 from .debugers import *
 from .decorators import append_locals, execute_after, snatch_locals, staticdecorator
 from .helpers import *
-from .indicators import *
+from .indicators import (
+    cagr,
+    calculate_returns,
+    create_tearsheet,
+    get_risk_free_rate,
+    get_symbol_returns,
+    max_drawdown,
+    performance,
+    plot_indicators,
+    plot_returns,
+    romad,
+    sharpe,
+    stats_summary,
+    total_return,
+    volatility,
+)
 from .pandas import *
-from .polygon_helper import *
 from .types import *
 from .yahoo_helper import YahooHelper

--- a/lumibot/tools/helpers.py
+++ b/lumibot/tools/helpers.py
@@ -1,7 +1,7 @@
 import os
 import re
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import pandas_market_calendars as mcal
 from termcolor import colored
@@ -12,7 +12,7 @@ from lumibot import LUMIBOT_DEFAULT_PYTZ
 def get_chunks(l, chunk_size):
     chunks = []
     for i in range(0, len(l), chunk_size):
-        chunks.append(l[i : i + chunk_size])
+        chunks.append(l[i: i + chunk_size])
     return chunks
 
 
@@ -140,6 +140,7 @@ def parse_symbol(symbol):
     For options, extract and return the stock symbol, expiration date (as a datetime.date object),
     type (call or put), and strike price.
     For stocks, simply return the stock symbol.
+    TODO: Crypto and Forex support
     """
     # Pattern to match the option symbol format
     option_pattern = r"([A-Z]+)(\d{6})([CP])(\d+)"
@@ -154,7 +155,7 @@ def parse_symbol(symbol):
             "stock_symbol": stock_symbol,
             "expiration_date": expiration_date,
             "option_type": option_type,
-            "strike_price": float(strike_price) / 1000,  # assuming strike price is in thousandths
+            "strike_price": round(float(strike_price) / 1000, 3),  # assuming strike price is in thousandths
         }
     else:
         return {"type": "stock", "stock_symbol": symbol}

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -2,19 +2,14 @@ import logging
 import math
 import os
 import webbrowser
-from datetime import datetime, timedelta
+from datetime import datetime
 from decimal import Decimal
 
-import numpy as np
 import pandas as pd
-import plotly.express as px
 import plotly.graph_objects as go
 import quantstats as qs
 from plotly.subplots import make_subplots
 
-# import lumibot.data_sources.alpha_vantage as av
-from lumibot import LUMIBOT_DEFAULT_PYTZ
-from lumibot.entities.asset import Asset
 from lumibot.tools import to_datetime_aware
 
 from .yahoo_helper import YahooHelper as yh
@@ -678,7 +673,7 @@ def create_tearsheet(
     strat_name: str,
     tearsheet_file: str,
     benchmark_df: pd.DataFrame,
-    benchmark_asset: Asset,
+    benchmark_asset,  # This is causing a circular import: Asset,
     show_tearsheet: bool,
     risk_free_rate: float,
 ):

--- a/lumibot/trading_builtins/__init__.py
+++ b/lumibot/trading_builtins/__init__.py
@@ -1,2 +1,2 @@
-from .custom_stream import CustomStream
+from .custom_stream import CustomStream, PollingStream
 from .safe_list import SafeList

--- a/lumibot/trading_builtins/custom_stream.py
+++ b/lumibot/trading_builtins/custom_stream.py
@@ -34,9 +34,7 @@ class CustomStream:
             action(**payload)
 
     def run(self, name):
-        # Threads are spawned by the broker._launch_stream() code, not needed here.
-        # thread = Thread(target=self._run, daemon=True, name=name)
-        # thread.start()
+        # Threads are spawned by the broker._launch_stream() code
         self._run()
 
 
@@ -49,7 +47,7 @@ class PollingStream(CustomStream):
     """
     POLL_EVENT = "poll"
 
-    def __init__(self, polling_interval=10.0):
+    def __init__(self, polling_interval=5.0):
         """
         Parameters
         ----------

--- a/lumibot/trading_builtins/custom_stream.py
+++ b/lumibot/trading_builtins/custom_stream.py
@@ -1,8 +1,10 @@
+import queue
 from queue import Queue
 from threading import Thread
 
 
 class CustomStream:
+
     def __init__(self):
         self._queue = Queue(1)
         self._actions_mapping = {}
@@ -20,14 +22,58 @@ class CustomStream:
 
     def _run(self):
         while True:
-            event, payload = self._queue.get()
-            if payload is None:
-                payload = {}
-            if event in self._actions_mapping:
-                action = self._actions_mapping[event]
-                action(**payload)
+            event, payload = self._queue.get()  # This is a blocking operation.
+            self._process_queue_event(event, payload)
             self._queue.task_done()
 
+    def _process_queue_event(self, event, payload):
+        if payload is None:
+            payload = {}
+        if event in self._actions_mapping:
+            action = self._actions_mapping[event]
+            action(**payload)
+
     def run(self, name):
-        thread = Thread(target=self._run, daemon=True, name=name)
-        thread.start()
+        # Threads are spawned by the broker._launch_stream() code, not needed here.
+        # thread = Thread(target=self._run, daemon=True, name=name)
+        # thread.start()
+        self._run()
+
+
+class PollingStream(CustomStream):
+    """
+    A stream that polls an API endpoint at a regular interval and dispatches events based on the response. It is
+    required that a polling action is registered with the stream using add_action(). The polling action should make a
+    request to the API and dispatch events based on the response. A user can also dispatch events to the stream manually
+    using dispatch(), including the poll event to force an off-cycle poll action to occur.
+    """
+    POLL_EVENT = "poll"
+
+    def __init__(self, polling_interval=10.0):
+        """
+        Parameters
+        ----------
+        polling_interval: float
+            Number of seconds to wait between polling the API.
+        """
+        super().__init__()
+        self.polling_interval = polling_interval
+
+    def _run(self):
+        while True:
+            try:
+                # This is a blocking operation until an item is available in the queue or the timeout is reached.
+                event, payload = self._queue.get(timeout=self.polling_interval)
+                self._process_queue_event(event, payload)
+                self._queue.task_done()
+            except queue.Empty:
+                # If the queue is empty, it means the polling interval has been reached.
+                self._poll()
+                continue
+
+    def _poll(self):
+        if self.POLL_EVENT not in self._actions_mapping:
+            raise ValueError("No action is defined for the poll event. You must register a polling action with "
+                             "add_action()")
+        self._process_queue_event(self.POLL_EVENT, {})
+        raise NotImplementedError

--- a/lumibot/trading_builtins/custom_stream.py
+++ b/lumibot/trading_builtins/custom_stream.py
@@ -76,4 +76,3 @@ class PollingStream(CustomStream):
             raise ValueError("No action is defined for the poll event. You must register a polling action with "
                              "add_action()")
         self._process_queue_event(self.POLL_EVENT, {})
-        raise NotImplementedError

--- a/lumibot/trading_builtins/safe_list.py
+++ b/lumibot/trading_builtins/safe_list.py
@@ -14,6 +14,14 @@ class SafeList:
     def __repr__(self):
         return repr(self.__items)
 
+    def __bool__(self):
+        with self.__lock:
+            return bool(self.__items)
+
+    def __len__(self):
+        with self.__lock:
+            return len(self.__items) if self.__items else 0
+
     def __iter__(self):
         with self.__lock:
             return iter(self.__items)
@@ -46,10 +54,7 @@ class SafeList:
                 self.__items.remove(value)
             else:
                 if not isinstance(key, str):
-                    raise ValueError(
-                        "key must be a string, received %r of type %s"
-                        % (key, type(key))
-                    )
+                    raise ValueError(f"key must be a string, received {key} of type {type(key)}")
                 self.__items = [
                     item for item in self.__items if getattr(item, key) != value
                 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ norecursedirs = docs .* *.egg* appdir jupyter *pycache* venv* .cache* .coverage*
 
 # .coveragerc to control coverag.py
 [coverage:run]
-command_line = -m pytest -vv -m "not apitest" --ignore-glob="*test_tradier.py"
+command_line = -m pytest -m "not apitest"
 branch = True
 omit =
 	# * so you can get all dirs

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -57,6 +57,19 @@ def test_instances_equal():
     assert a == b
 
 
+def test_symbol2asset():
+    asset = Asset.symbol2asset("ABC")
+    assert asset.symbol == "ABC"
+    assert asset.asset_type == "stock"
+
+    asset = Asset.symbol2asset("ABC200101C00150000")
+    assert asset.symbol == "ABC"
+    assert asset.asset_type == "option"
+    assert asset.expiration == datetime.date(2020, 1, 1)
+    assert asset.strike == 150
+    assert asset.right == "CALL"
+
+
 @pytest.mark.parametrize("param", ["not_call_or_CALL", "not_put_or_PUT", "CALLS", "PUTS"])
 def test_right_validator(param):
     with pytest.raises(Exception):

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -80,3 +80,45 @@ class TestOrderBasics:
         assert not order.is_active()
         order.status = 'submitted'
         assert order.is_active()
+
+    def test_status(self):
+        asset = Asset("SPY")
+        order = Order(strategy='abc', asset=asset, side="buy", quantity=100)
+        assert order.status == "unprocessed"
+        order.status = "filled"
+        assert order.status == "fill"
+        order.status = "canceled"
+        assert order.status == "canceled"
+        order.status = "submit"
+        assert order.status == "submitted"
+        order.status = "cancel"
+        assert order.status == "canceled"
+
+        with pytest.raises(ValueError):
+            order.status = "blah"
+
+    def test_equivalent_status(self):
+        asset = Asset("SPY")
+        order1 = Order(strategy='abc', asset=asset, side="buy", quantity=100)
+        order2 = Order(strategy='abc', asset=asset, side="buy", quantity=100)
+        assert order1.equivalent_status(order2)
+        order2.status = "filled"
+        assert not order1.equivalent_status(order2)
+        order1.status = "filled"
+        assert order1.equivalent_status(order2)
+
+        order1.status = "canceled"
+        order2.status = "cancelled"
+        assert order1.equivalent_status(order2)
+
+        order1.status = "submit"
+        order2.status = "submitted"
+        assert order1.equivalent_status(order2)
+
+        order1.status = "open"
+        order2.status = "new"
+        assert order1.equivalent_status(order2)
+
+        order1.status = "open"
+        order2.status = ""
+        assert not order1.equivalent_status("")

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -1,5 +1,7 @@
+import datetime as dt
 import os
 
+import pandas as pd
 import pytest
 
 from lumibot.brokers.tradier import Tradier
@@ -117,3 +119,303 @@ class TestTradierBroker:
         mock_pull_positions.return_value = Position(strategy=strategy, asset=option_asset, quantity=0)
         option_order.side = "buy"
         assert broker._lumi_side2tradier(option_order) == "buy_to_open"
+
+    def test_parse_broker_order(self):
+        broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True)
+        strategy = "strat_unittest"
+        stock_symbol = "SPY"
+        option_symbol = "SPY200101C00150000"
+
+        response = {
+            "id": 123,
+            "type": "market",
+            "side": "buy",
+            "symbol": stock_symbol,
+            "quantity": 1,
+            "status": "submitted",
+            "tag": strategy,
+            "duration": "day",
+            "create_date": dt.datetime.today(),
+        }
+        stock_order = broker._parse_broker_order(response, "")
+        assert stock_order.identifier == 123
+        assert stock_order.strategy == strategy
+        assert stock_order.asset.symbol == stock_symbol
+        assert stock_order.quantity == 1
+        assert stock_order.side == "buy"
+        assert stock_order.status == "submitted"
+        assert stock_order.type == "market"
+
+        # Test with an option and stop order
+        response = {
+            "id": 123,
+            "type": "stop",
+            "side": "sell",
+            "symbol": option_symbol,
+            "quantity": 1,
+            "status": "submitted",
+            "tag": strategy,
+            "duration": "gtc",
+            "create_date": dt.datetime.today(),
+            "stop_price": 1.0,
+        }
+        option_order = broker._parse_broker_order(response, "lumi_strat")
+        assert option_order.identifier == 123
+        assert option_order.strategy == "lumi_strat"
+        assert option_order.asset.symbol == "SPY"
+        assert option_order.asset.asset_type == "option"
+        assert option_order.asset.expiration == dt.date(2020, 1, 1)
+        assert option_order.asset.strike == 150
+        assert option_order.asset.right == "CALL"
+        assert option_order.quantity == 1
+        assert option_order.side == "sell"
+        assert option_order.status == "submitted"
+        assert option_order.type == "stop"
+        assert option_order.stop_price == 1.0
+
+    def test_do_polling(self, mocker):
+        broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True)
+        strategy = "strat_unittest"
+        mock_get_orders = mocker.patch.object(broker.tradier.orders, 'get_orders', return_value=pd.DataFrame())
+        submit_response = {'id': 123, 'status': 'ok'}
+        mock_submit_order = mocker.patch.object(broker.tradier.orders, 'order', return_value=submit_response)
+
+        # Test polling with no orders
+        broker.do_polling()
+        known_orders = broker.get_all_orders()
+        tracked_orders = broker.get_tracked_orders()
+        assert not known_orders
+        assert not tracked_orders
+
+        # Submit an order to test polling with
+        stock_asset = Asset("SPY")
+        stock_qty = 10
+        order = Order(strategy, stock_asset, stock_qty, 'buy', type='market')
+        sub_order = broker._submit_order(order)
+        assert sub_order.status == "submitted"
+        assert sub_order.identifier == 123
+        assert sub_order.was_transmitted()
+        assert broker.get_all_orders()
+        assert broker.get_tracked_orders()
+        assert broker._unprocessed_orders
+        assert not broker._new_orders
+
+        # Test polling with the order
+        first_response = {
+            "id": 123,
+            "type": "market",
+            "side": "buy",
+            "symbol": "SPY",
+            "quantity": stock_qty,
+            "status": "pending",
+            "duration": "day",
+            "create_date": dt.datetime.today(),
+            "avg_fill_price": 0.0,
+            "exec_quantity": 0,
+            "tag": strategy,
+        }
+        mock_get_orders.return_value = pd.DataFrame([first_response])
+        broker.do_polling()
+        known_orders = broker.get_tracked_orders(strategy=strategy)
+        assert known_orders
+        assert not broker._unprocessed_orders
+        assert broker._new_orders
+        order1 = known_orders[0]
+        assert order1.identifier == 123
+        assert order1.status == "new"
+        assert not order1.get_fill_price()
+
+        # Poll again, nothing changes
+        broker.do_polling()
+        known_orders = broker.get_tracked_orders(strategy=strategy)
+        order1 = known_orders[0]
+        assert len(known_orders) == 1, "No duplicate orders were created."
+        assert not broker._unprocessed_orders
+        assert len(broker._new_orders) == 1
+        assert order1.status == "new"
+
+        # Add a 2nd order: stop loss
+        mock_submit_order.return_value = {'id': 124, 'status': 'ok'}
+        stop_order = Order(strategy, stock_asset, 1, 'sell', type='stop', stop_price=100.0)
+        sub_order = broker._submit_order(stop_order)
+        assert sub_order.status == "submitted"
+        assert sub_order.identifier == 124
+        assert sub_order.was_transmitted()
+        assert len(broker._unprocessed_orders) == 1
+        assert len(broker._new_orders) == 1
+        assert len(broker.get_all_orders()) == 2
+        assert len(broker.get_tracked_orders()) == 2
+
+        second_response = {
+            "id": 124,
+            "type": "stop",
+            "side": "sell",
+            "symbol": "SPY",
+            "quantity": stock_qty,
+            "status": "open",
+            "duration": "gtc",
+            "create_date": dt.datetime.today(),
+            "stop_price": 100.0,
+            "avg_fill_price": 0.0,
+            "exec_quantity": 0,
+            "tag": strategy,
+        }
+        mock_get_orders.return_value = pd.DataFrame([first_response, second_response])
+        broker.do_polling()
+        known_orders = broker.get_tracked_orders(strategy=strategy)
+        assert known_orders
+        assert not broker._unprocessed_orders
+        assert len(broker._new_orders) == 2
+        assert len(known_orders) == 2
+        order2 = known_orders[1]
+        assert order2.identifier == 124
+        assert order2.status == "new"
+        assert not order2.get_fill_price()
+
+        # Fill the first order (market)
+        first_response["status"] = "filled"
+        first_response["avg_fill_price"] = 101.0
+        first_response["exec_quantity"] = stock_qty
+        mock_get_orders.return_value = pd.DataFrame([first_response, second_response])
+        broker.do_polling()
+        known_orders = broker.get_tracked_orders(strategy=strategy)
+        positions = broker.get_tracked_positions(strategy=strategy)
+        assert len(known_orders) == 1, "Filled orders no longer tracked."
+        assert len(positions) == 1
+        assert len(positions[0].orders) == 1
+        order1 = positions[0].orders[0]
+        assert order1.identifier == 123
+        assert order1.type == "market"
+        assert order1.is_filled()
+        assert order1.get_fill_price() == 101.0
+        assert len(broker._new_orders) == 1
+        assert not broker._unprocessed_orders
+        assert len(broker.get_all_orders()) == 2
+        assert len(broker.get_tracked_positions()) == 1
+
+        # Cancel the 2nd order (stoploss)
+        second_response["status"] = "canceled"
+        mock_get_orders.return_value = pd.DataFrame([first_response, second_response])
+        broker.do_polling()
+        known_orders = broker.get_tracked_orders(strategy=strategy)
+        assert len(known_orders) == 0, "Canceled orders no longer tracked."
+        assert len(broker._new_orders) == 0
+        assert not broker._unprocessed_orders
+        assert len(broker.get_all_orders()) == 2
+        assert len(broker.get_tracked_positions()) == 1
+        assert len(broker._canceled_orders) == 1
+        order2 = broker._canceled_orders[0]
+        assert order2.identifier == 124
+        assert order2.type == "stop"
+        assert order2.is_canceled()
+        assert not order2.get_fill_price()
+
+        # Poll again, nothing changes
+        broker.do_polling()
+        known_orders = broker.get_tracked_orders(strategy=strategy)
+        assert len(known_orders) == 0, "Canceled orders no longer tracked."
+        assert len(broker._new_orders) == 0
+        assert not broker._unprocessed_orders
+        assert len(broker.get_all_orders()) == 2
+        assert len(broker.get_tracked_positions()) == 1
+        assert len(broker._canceled_orders) == 1
+
+        # Submit an order that causes a broker error
+        mock_submit_order.return_value = {'id': 125, 'status': 'ok'}
+        stop_order = Order(strategy, stock_asset, stock_qty, 'sell', type='limit', limit_price=1000.0)
+        sub_order = broker._submit_order(stop_order)
+        assert sub_order.status == "submitted"
+        assert sub_order.identifier == 125
+        assert sub_order.was_transmitted()
+        assert len(broker._unprocessed_orders) == 1
+        assert len(broker._new_orders) == 0
+        assert len(broker.get_all_orders()) == 3
+        assert len(broker.get_tracked_orders()) == 1
+
+        third_response = {
+            "id": 125,
+            "type": "limit",
+            "side": "sell",
+            "symbol": "SPY",
+            "quantity": stock_qty,
+            "status": "rejected",
+            "reason_description": "API Error Msg",
+            "duration": "gtc",
+            "create_date": dt.datetime.today(),
+            "avg_fill_price": 0.0,
+            "exec_quantity": 0,
+            "tag": strategy,
+        }
+        mock_get_orders.return_value = pd.DataFrame([first_response, second_response, third_response])
+        broker.do_polling()
+        known_orders = broker.get_tracked_orders(strategy=strategy)
+        assert len(known_orders) == 0, "Rejected orders no longer tracked. They get canceled and set with error msg."
+        assert len(broker._new_orders) == 0
+        assert not broker._unprocessed_orders
+        assert len(broker._canceled_orders) == 2
+        assert len(broker.get_all_orders()) == 3
+        assert len(broker.get_tracked_positions()) == 1
+        error_order = broker._canceled_orders[1]
+        assert error_order.identifier == 125
+        assert error_order.type == "limit"
+        assert error_order.status == "error"
+        assert not error_order.get_fill_price()
+        assert error_order.error_message == "API Error Msg"
+
+        # There is a Lumibot order that is not tracked by the broker, so it should be canceled.
+        mock_submit_order.return_value = {'id': 126, 'status': 'ok'}
+        drop_order = Order(strategy, stock_asset, stock_qty, 'sell', type='market')
+        broker._submit_order(drop_order)
+        assert len(broker._unprocessed_orders) == 1
+        assert len(broker._new_orders) == 0
+        assert len(broker.get_all_orders()) == 4
+
+        # Poll, but broker returns no info on the Lumibot order so it should be canceled.
+        mock_get_orders.return_value = pd.DataFrame([first_response, second_response, third_response])
+        broker.do_polling()
+        known_orders = broker.get_tracked_orders(strategy=strategy)
+        assert len(known_orders) == 0, "Untracked orders no longer tracked."
+        assert len(broker._new_orders) == 0
+        assert not broker._unprocessed_orders
+        assert len(broker._canceled_orders) == 3
+        order = broker._canceled_orders[2]
+        assert order.identifier == 126
+        assert order.is_canceled()
+
+        # Broker returns an order that Lumibot doesn't know about, so it should be added to Lumibot.
+        fourth_response = {
+            "id": 127,
+            "type": "market",
+            "side": "buy",
+            "symbol": "SPY",
+            "quantity": stock_qty,
+            "status": "filled",
+            "duration": "day",
+            "create_date": dt.datetime.today(),
+            "avg_fill_price": 102.0,
+            "exec_quantity": stock_qty,
+            "tag": strategy,
+        }
+        mock_get_orders.return_value = pd.DataFrame([first_response, second_response, third_response, fourth_response])
+        broker.do_polling()
+        known_orders = broker.get_tracked_orders(strategy=strategy)
+        assert len(known_orders) == 1, "New orders are tracked."
+        assert len(broker._new_orders) == 1
+        assert not broker._unprocessed_orders
+        order = known_orders[0]
+        assert order.identifier == 127
+        assert order.status == "new"
+        assert not order.get_fill_price()
+
+        # Poll again, order fill will now be processed
+        mock_get_orders.return_value = pd.DataFrame([first_response, second_response, third_response, fourth_response])
+        broker.do_polling()
+        known_orders = broker.get_tracked_orders(strategy=strategy)
+        assert not known_orders, "Filled orders no longer tracked."
+        assert len(broker._new_orders) == 0
+        assert not broker._unprocessed_orders
+        assert len(broker.get_all_orders()) == 5
+        order = broker.get_order(127)
+        assert order.identifier == 127
+        assert order.is_filled()
+        assert order.get_fill_price() == 102.0

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -4,7 +4,7 @@ import pytest
 
 from lumibot.brokers.tradier import Tradier
 from lumibot.data_sources.tradier_data import TradierData
-from lumibot.entities import Asset, Order
+from lumibot.entities import Asset, Order, Position
 
 TRADIER_ACCOUNT_ID_PAPER = os.getenv("TRADIER_ACCOUNT_ID_PAPER")
 TRADIER_TOKEN_PAPER = os.getenv("TRADIER_TOKEN_PAPER")
@@ -19,8 +19,13 @@ def tradier_ds():
 def tradier():
     return Tradier(account_number=TRADIER_ACCOUNT_ID_PAPER, access_token=TRADIER_TOKEN_PAPER, paper=True)
 
+
 @pytest.mark.apitest
-class TestTradierData:
+class TestTradierDataAPI:
+    """
+    API Tests skipped by default. To run all API tests, use the following command:
+    python -m pytest -m apitest
+    """
     def test_basics(self):
         tdata = TradierData(account_number="1234", access_token="a1b2c3", paper=True)
         assert tdata._account_number == "1234"
@@ -33,12 +38,11 @@ class TestTradierData:
 
 
 @pytest.mark.apitest
-class TestTradierBroker:
-    def test_basics(self):
-        broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True)
-        assert broker.name == "Tradier"
-        assert broker._tradier_account_number == "1234"
-
+class TestTradierBrokerAPI:
+    """
+    API Tests skipped by default. To run all API tests, use the following command:
+    python -m pytest -m apitest
+    """
     def test_get_last_price(self, tradier):
         asset = Asset("AAPL")
         price = tradier.get_last_price(asset)
@@ -55,3 +59,61 @@ class TestTradierBroker:
         # Cancel the testing order once we are done
         # How do we check this? Who changes the Lumibot order status to "canceled"?
         tradier.cancel_order(submitted_order)
+
+
+class TestTradierBroker:
+    """
+    Unit tests for the Tradier broker. These tests do not require any API calls.
+    """
+    def test_basics(self):
+        broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True)
+        assert broker.name == "Tradier"
+        assert broker._tradier_account_number == "1234"
+
+    def test_tradier_side2lumi(self):
+        broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True)
+        assert broker._tradier_side2lumi("buy") == "buy"
+        assert broker._tradier_side2lumi("sell") == "sell"
+        assert broker._tradier_side2lumi("buy_to_cover") == "buy"
+        assert broker._tradier_side2lumi("sell_short") == "sell"
+
+        with pytest.raises(ValueError):
+            broker._tradier_side2lumi("blah")
+
+    def test_lumi_side2tradier(self, mocker):
+        broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True)
+        mock_pull_positions = mocker.patch.object(broker, '_pull_position', return_value=None)
+        strategy = "strat_unittest"
+        stock_asset = Asset("SPY")
+        option_asset = Asset("SPY", asset_type='option')
+        stock_order = Order(strategy, stock_asset, 1, 'buy', type='market')
+        option_order = Order(strategy, option_asset, 1, 'buy', type='market')
+
+        assert broker._lumi_side2tradier(stock_order) == "buy"
+        stock_order.side = "sell"
+        assert broker._lumi_side2tradier(stock_order) == "sell"
+
+        assert broker._lumi_side2tradier(option_order) == "buy_to_open"
+        option_order.side = "sell"
+        assert broker._lumi_side2tradier(option_order) == "sell_to_open"
+        option_order.side = "blah"
+        assert not broker._lumi_side2tradier(option_order)
+
+        mock_pull_positions.return_value = Position(strategy=strategy, asset=option_asset, quantity=1)
+        option_order.side = "buy"
+        assert broker._lumi_side2tradier(option_order) == "buy_to_open"
+        option_order.side = "sell"
+        assert broker._lumi_side2tradier(option_order) == "sell_to_close"
+
+        mock_pull_positions.return_value = Position(strategy=strategy, asset=option_asset, quantity=-1)
+        option_order.side = "buy"
+        assert broker._lumi_side2tradier(option_order) == "buy_to_close"
+        option_order.side = "sell"
+        assert broker._lumi_side2tradier(option_order) == "sell_to_open"
+        option_order.side = "blah"
+        assert not broker._lumi_side2tradier(option_order)
+
+        # Sanity check case where we have an empty position
+        mock_pull_positions.return_value = Position(strategy=strategy, asset=option_asset, quantity=0)
+        option_order.side = "buy"
+        assert broker._lumi_side2tradier(option_order) == "buy_to_open"


### PR DESCRIPTION
This is a big update that implements a Polling feature for handling Order Status Updates.  All current brokers (Alpaca, IBKR, etc) use websocket streaming to send status changes as they happen.  However, Tradier does not support websocket streaming on their paper accounts (Live accounts only).  To support his new methodology, a new CustomStream class has been created that will process polling results in a manner similar to how the websocket streaming works.  The main difference for the Polling process now is that the PollingSteam class itself will look for user issued poll events and if none are found after a timeout period, it will automatically do the polling itself.  This allows the user to "poke" the broker for more frequent updates if they desire.

This update is fairly complicated and deals with Threaded processing, so it can be pretty hard to track what is going on by merely looking at the Git change log.  Start with looking at:
1. new PollingStream class in custom_stream.py
     * in particular the _poll() method that uses timeouts for kicking off a new polling cycle. This same function also processes the "normal" stream events like NEW_ORDER, etc.
1. Tradier register_stream_events() function defines what items will be processed by the stream. 
    * Notice that there is a polling event defined here that enables the StreamThread to do polling as needed.  This combined with the timeout method are the only scheduling needed to enable polling to work.
1. Tradier do_polling() is the function that will get called every time the stream timeout is reached (or a user dispatches a polling event request)
   * This function should look very similar to what the backtesting_broker is doing for processing orders, but it is connecting to the TradierAPI instead of handling it all internally.