### PR TITLE
ccxt backtest and ccxt data cache, ccxt backtest example upload, _strategy.py, ccxt.py modified for ccxt backtest

### DIFF
--- a/lumibot/backtesting/__init__.py
+++ b/lumibot/backtesting/__init__.py
@@ -4,3 +4,4 @@ from .backtesting_broker import BacktestingBroker
 from .pandas_backtesting import PandasDataBacktesting
 from .polygon_backtesting import PolygonDataBacktesting
 from .yahoo_backtesting import YahooDataBacktesting
+from .ccxt_backtesting import CcxtBacktesting

--- a/lumibot/backtesting/ccxt_backtesting.py
+++ b/lumibot/backtesting/ccxt_backtesting.py
@@ -1,5 +1,5 @@
-from lumibot.data_sources import CcxtBactestingData
+from lumibot.data_sources import CcxtBacktestingData
 
-class CcxtBacktesting(CcxtBactestingData):
+class CcxtBacktesting(CcxtBacktestingData):
     def __init__(self, datetime_start, datetime_end, **kwargs):
-        CcxtBactestingData.__init__(self, datetime_start, datetime_end, **kwargs)
+        CcxtBacktestingData.__init__(self, datetime_start, datetime_end, **kwargs)

--- a/lumibot/backtesting/ccxt_backtesting.py
+++ b/lumibot/backtesting/ccxt_backtesting.py
@@ -1,0 +1,5 @@
+from lumibot.data_sources import CcxtBactestingData
+
+class CcxtBacktesting(CcxtBactestingData):
+    def __init__(self, datetime_start, datetime_end, **kwargs):
+        CcxtBactestingData.__init__(self, datetime_start, datetime_end, **kwargs)

--- a/lumibot/data_sources/__init__.py
+++ b/lumibot/data_sources/__init__.py
@@ -8,4 +8,4 @@ from .interactive_brokers_data import InteractiveBrokersData
 from .pandas_data import PandasData
 from .tradier_data import TradierData
 from .yahoo_data import YahooData
-from .ccxt_backtesting_data import CcxtBactestingData
+from .ccxt_backtesting_data import CcxtBacktestingData

--- a/lumibot/data_sources/__init__.py
+++ b/lumibot/data_sources/__init__.py
@@ -8,3 +8,4 @@ from .interactive_brokers_data import InteractiveBrokersData
 from .pandas_data import PandasData
 from .tradier_data import TradierData
 from .yahoo_data import YahooData
+from .ccxt_backtesting_data import CcxtBactestingData

--- a/lumibot/data_sources/ccxt_backtesting_data.py
+++ b/lumibot/data_sources/ccxt_backtesting_data.py
@@ -258,7 +258,7 @@ class CcxtBacktestingData(DataSourceBacktesting):
         historical options data."""
 
         raise NotImplementedError(
-            "Lumibot BinanceData does not support historical options data. If you need this "
+            "CcxtBactestingData does not support historical options data. If you need this "
             "feature, please use a different data source."
         )
 

--- a/lumibot/data_sources/ccxt_backtesting_data.py
+++ b/lumibot/data_sources/ccxt_backtesting_data.py
@@ -14,7 +14,7 @@ from pandas import DataFrame
 
 from typing import Union,Any
 
-class CcxtBactestingData(DataSourceBacktesting):
+class CcxtBacktestingData(DataSourceBacktesting):
     """Use CcxtCacheDB to download and cache data.
     """
     # SOURCE must be `CCXT` for the DataSourceBacktesting to work
@@ -278,7 +278,7 @@ if __name__ == "__main__":
     end_date = datetime(2023,12,31)
 
     # b = BinanceData(start_date,end_date, **kwargs)
-    b = CcxtBactestingData(start_date,end_date)
+    b = CcxtBacktestingData(start_date,end_date)
     r = b.get_historical_prices(
         asset=(Asset(symbol="SOL",asset_type="crypto"),Asset(symbol="USDT",asset_type="crypto")),
         length=20,

--- a/lumibot/data_sources/ccxt_backtesting_data.py
+++ b/lumibot/data_sources/ccxt_backtesting_data.py
@@ -265,7 +265,7 @@ class CcxtBacktestingData(DataSourceBacktesting):
 
     def get_strikes(self, asset):
         raise NotImplementedError(
-            "Lumibot BinanceData does not support historical options data. If you need this "
+            "CcxtBactestingData does not support historical options data. If you need this "
             "feature, please use a different data source."
         )
 

--- a/lumibot/data_sources/ccxt_backtesting_data.py
+++ b/lumibot/data_sources/ccxt_backtesting_data.py
@@ -1,0 +1,292 @@
+import logging
+from decimal import Decimal
+
+import numpy as np
+import pytz
+from datetime import timedelta,datetime
+
+from lumibot import LUMIBOT_DEFAULT_PYTZ
+from lumibot.data_sources import DataSourceBacktesting
+from lumibot.entities import Asset, Bars
+
+from lumibot.tools import CcxtCacheDB
+from pandas import DataFrame
+
+from typing import Union,Any
+
+class CcxtBactestingData(DataSourceBacktesting):
+    """Use CcxtCacheDB to download and cache data.
+    """
+    # SOURCE must be `CCXT` for the DataSourceBacktesting to work
+    # `CCXT` is used in DataSource name
+    SOURCE = "CCXT"
+    MIN_TIMESTEP = "day"
+    TIMESTEP_MAPPING = [
+        {"timestep": "minute", "representations": ["1m"]},
+        {"timestep": "day", "representations": ["1d"]},
+    ]
+
+    def __init__(self, *args, auto_adjust:bool=False, **kwargs):
+        # max data download limit
+        # from current date to max data download limit
+        download_limit = None
+        exchange_id = "binance"
+        if kwargs:
+            download_limit = kwargs.pop("max_data_download_limit", download_limit)
+            exchange_id = kwargs.pop("exchange_id", exchange_id)
+
+        super().__init__(*args, **kwargs)
+        self.name = exchange_id
+        self.auto_adjust = auto_adjust
+        self._data_store = {}
+        # The number of historical data is downloaded earlier than the start date when downloading historical data.
+        self._download_start_dt_prebuffer = 300
+
+        self.cache_db = CcxtCacheDB(self.name,max_download_limit=download_limit)
+
+
+    def _to_utc_timezone(self, dt:datetime)->datetime:
+        if not dt.tzinfo is None:
+            dt = dt.astimezone(pytz.utc)
+        else:
+            dt = pytz.utc.localize(dt)
+        return dt
+
+
+    def _append_data(self, key:str, data:DataFrame)->DataFrame:
+        """Adds data to a dict and returns the data.
+
+        Args:
+            key (str): BTC_USDT_1d, ETH_USDT_1d, etc
+            data (DataFrame): ohlcv data (datetime, open, high, low, close, volume)
+
+        Returns:
+            DataFrame: ohlcv data
+        """
+        data["price_change"] = data["close"].pct_change()
+        data["dividend_yield"] = 0
+        data["return"] = data["dividend_yield"] + data["price_change"]
+        self._data_store[key] = data
+        return data
+
+
+    def _pull_source_symbol_bars(
+        self, asset:tuple[Asset,Asset], length:int = None, timestep:str=MIN_TIMESTEP,
+            timeshift:int=None, quote=Asset, exchange:Any=None, include_after_hours:bool=True
+    )->Union[DataFrame,None]:
+        """Gets the OHCLV data for a specific asset.
+
+        Args:
+            asset (tuple[Asset,Asset]): base asset and quote asset
+                                        ex) (Asset(symbol="SOL",asset_type="crypto"),Asset(symbol="USDT",asset_type="crypto"))
+            length (int, optional): Number of data to import. Defaults to None.
+            timestep (str, optional): "day", "minute". Defaults to "minute".
+            timeshift (int, optional): The amount of shit for a given datetime. Defaults to None.
+            quote (Asset, optional): quote asset. Defaults to Asset.
+            exchange (Any, optional): exchange. Defaults to None.
+            include_after_hours (bool, optional): include_after_hours. Defaults to True.
+
+        Returns:
+            DataFrame: candle data
+        """
+        if exchange is not None:
+            logging.warning(
+                f"the exchange parameter is not implemented for CcxtData, but {exchange} was passed as the exchange"
+            )
+
+        if isinstance(asset, tuple):
+            symbol = f"{asset[0].symbol.upper()}/{asset[1].symbol.upper()}"
+        elif quote is not None:
+            symbol = f"{asset.symbol.upper()}/{quote.symbol.upper()}"
+        else:
+            symbol = asset
+
+        parsed_timestep = self._parse_source_timestep(timestep, reverse=True)
+        symbol_timestep = f"{symbol}_{parsed_timestep}"
+        if symbol_timestep in self._data_store:
+            data = self._data_store[symbol_timestep]
+        else:
+            data = self._pull_source_bars([asset],length,timestep,timeshift,quote,include_after_hours)
+            if data is None or len(data) == 0:
+                message = f"{self.SOURCE} did not return data for asset {symbol}. Make sure this symbol is valid."
+                logging.error(message)
+                return None
+            data = self._append_data(symbol_timestep, data[symbol])
+
+        end = self.get_datetime()
+        if timeshift:
+            end = end - timeshift
+
+        end = self.to_default_timezone(end)
+        result_data = data[data.index <= end]
+
+        if length is None:
+            return result_data
+
+        return result_data.tail(length)
+
+
+    def _pull_source_bars(self, assets:tuple[Asset,Asset], length:int, timestep:str=MIN_TIMESTEP,
+        timeshift:int=None, quote:Asset=None, include_after_hours:bool=False
+    )->DataFrame:
+        """pull broker bars for a list assets"""
+        parsed_timestep = self._parse_source_timestep(timestep, reverse=True)
+
+        result = {}
+        for asset in assets:
+            if isinstance(asset, tuple):
+                symbol = f"{asset[0].symbol.upper()}/{asset[1].symbol.upper()}"
+            elif quote is not None:
+                symbol = f"{asset.symbol.upper()}/{quote.symbol.upper()}"
+            else:
+                symbol = asset
+
+            # convert native timezone aware
+            start_dt = self._to_utc_timezone(self.datetime_start)
+            end_dt = self._to_utc_timezone(self.datetime_end)
+
+            if parsed_timestep == "1d":
+                start_dt = start_dt - timedelta(days=self._download_start_dt_prebuffer)
+            else:
+                start_dt = start_dt - timedelta(minutes=self._download_start_dt_prebuffer)
+
+
+            data = self.cache_db.download_ohlcv(symbol,parsed_timestep,
+                                                start_dt,end_dt)
+
+            data.index  = data.index.tz_localize("UTC")
+            data.index = data.index.tz_convert(LUMIBOT_DEFAULT_PYTZ)
+            result[symbol] = data
+
+        return result
+
+
+    def get_historical_prices(self, asset:tuple[Asset,Asset], length:int, timestep:str=None,
+            timeshift:int=None, quote:Asset=None, exchange:Any=None, include_after_hours:bool=True
+    )->Bars:
+        """Get bars for a given asset"""
+        if isinstance(asset, str):
+            asset = Asset(symbol=asset,asset_type="crypto")
+
+        if not timestep:
+            timestep = self.get_timestep()
+
+        response = self._pull_source_symbol_bars(
+            asset,
+            length,
+            timestep=timestep,
+            timeshift=timeshift,
+            quote=quote,
+            exchange=exchange,
+            include_after_hours=include_after_hours,
+        )
+        if isinstance(response, float):
+            return response
+        elif response is None:
+            return None
+
+        bars = self._parse_source_symbol_bars(response, asset, quote=quote, length=length)
+        return bars
+
+    # Get pricing data for an asset for the entire backtesting period
+    def get_historical_prices_between_dates(
+        self,
+        asset:tuple[Asset,Asset],
+        timestep:str="minute",
+        quote:Asset=None,
+        exchange:Any=None,
+        include_after_hours:bool=True,
+        start_date:datetime=None,
+        end_date:datetime=None,
+    )->Bars:
+        parsed_timestep = self._parse_source_timestep(timestep, reverse=True)
+
+        if isinstance(asset, tuple):
+            symbol = f"{asset[0].symbol.upper()}/{asset[1].symbol.upper()}"
+        elif quote is not None:
+            symbol = f"{asset.symbol.upper()}/{quote.symbol.upper()}"
+        else:
+            symbol = asset
+
+        # convert utc timezone
+        start_dt = self._to_utc_timezone(start_date)
+        end_dt = self._to_utc_timezone(end_date)
+
+        # Cache data is stored in UTC time
+        data = self.cache_db.get_data_from_cache(symbol, parsed_timestep, start_dt, end_dt)
+        if data is None or data.empty:
+            return None
+
+        # convert to lumibot default timezone
+        data.index  = data.index.tz_localize("UTC")
+        data.index = data.index.tz_convert(LUMIBOT_DEFAULT_PYTZ)
+
+        bars = self._parse_source_symbol_bars(data, asset, quote=quote)
+        return bars
+
+
+    def _parse_source_symbol_bars(self, response:DataFrame, asset:tuple[Asset,Asset],
+                                  quote:Asset=None, length:int=None)->Bars:
+        # Parse the dataframe returned from CCXT.
+        if "return" not in response.columns:
+            response["return"] = response["close"].pct_change()
+        bars = Bars(response, self.SOURCE, asset, quote=quote, raw=response)
+        return bars
+
+
+    def get_last_price(self, asset, timestep=None, quote=None, exchange=None, **kwargs):
+        """Takes an asset and returns the last known price of close"""
+        if timestep is None:
+            timestep = self.get_timestep()
+
+        bars = self.get_historical_prices(asset, 1, timestep=timestep, quote=quote, timeshift=None)
+
+        if isinstance(bars, float):
+            return bars
+        elif bars is None or bars.df.empty:
+            return None
+
+        close_ = bars.df.iloc[0].close
+        if isinstance(close_, np.int64):
+            close_ = Decimal(close_.item())
+        return close_
+
+
+    def get_chains(self, asset):
+        """
+        Get the chains for a given asset.  This is not implemented for BinanceData becuase Yahoo does not support
+        historical options data."""
+
+        raise NotImplementedError(
+            "Lumibot BinanceData does not support historical options data. If you need this "
+            "feature, please use a different data source."
+        )
+
+
+    def get_strikes(self, asset):
+        raise NotImplementedError(
+            "Lumibot BinanceData does not support historical options data. If you need this "
+            "feature, please use a different data source."
+        )
+
+if __name__ == "__main__":
+    # kwargs = {
+    #     "max_data_download_limit":10000,
+    # }
+
+    start_date = datetime(2023,12,15)
+    end_date = datetime(2023,12,31)
+
+    # b = BinanceData(start_date,end_date, **kwargs)
+    b = CcxtBactestingData(start_date,end_date)
+    r = b.get_historical_prices(
+        asset=(Asset(symbol="SOL",asset_type="crypto"),Asset(symbol="USDT",asset_type="crypto")),
+        length=20,
+        timestep="day",
+    )
+    print(r)
+    r = b.get_last_price(
+        asset=(Asset(symbol="SOL",asset_type="crypto"),Asset(symbol="USDT",asset_type="crypto")),
+        timestep="day",
+    )
+    print(r)

--- a/lumibot/data_sources/ccxt_backtesting_data.py
+++ b/lumibot/data_sources/ccxt_backtesting_data.py
@@ -81,7 +81,7 @@ class CcxtBacktestingData(DataSourceBacktesting):
                                         ex) (Asset(symbol="SOL",asset_type="crypto"),Asset(symbol="USDT",asset_type="crypto"))
             length (int, optional): Number of data to import. Defaults to None.
             timestep (str, optional): "day", "minute". Defaults to "minute".
-            timeshift (int, optional): The amount of shit for a given datetime. Defaults to None.
+            timeshift (int, optional): The amount of shift for a given datetime. Defaults to None.
             quote (Asset, optional): quote asset. Defaults to Asset.
             exchange (Any, optional): exchange. Defaults to None.
             include_after_hours (bool, optional): include_after_hours. Defaults to True.

--- a/lumibot/example_strategies/ccxt_backtesting_example.py
+++ b/lumibot/example_strategies/ccxt_backtesting_example.py
@@ -1,0 +1,143 @@
+# ta-lib install : https://cloudstrata.io/install-ta-lib-on-ubuntu-server/
+# pip install pandas-ta
+
+from lumibot.brokers import Ccxt
+from lumibot.entities import Asset, Order
+from lumibot.backtesting import CcxtBacktesting
+from lumibot.strategies.strategy import Strategy
+from lumibot.example_strategies.crypto_important_functions import ImportantFunctions
+from datetime import datetime
+from pandas import DataFrame
+import pandas_ta
+
+# Save API_KEY, SECRET_KEY in the .env file and import it like below.
+
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+
+class MyStrategy(Strategy):
+    def initialize(self, asset:tuple[Asset,Asset] = None,
+                   cash_at_risk:float=.5,window:int=14):
+        if asset is None:
+            raise ValueError("You must provide a valid asset pair")
+        # for crypto, market is 24/7
+        self.set_market("24/7")
+        self.sleeptime = "1D"
+        self.asset = asset
+        self.base, self.quote = asset
+        self.window = window
+        self.symbol = f"{self.base.symbol}/{self.quote.symbol}"
+        self.last_trade = None
+        self.order_quantity = 0.0
+        self.cash_at_risk = cash_at_risk
+
+    def _position_sizing(self):
+        cash = self.get_cash()
+        last_price = self.get_last_price(asset=self.asset,quote=self.quote)
+        quantity = round(cash * self.cash_at_risk / last_price,0)
+        return cash, last_price, quantity
+
+    def _get_historical_prices(self):
+        return self.get_historical_prices(asset=self.asset,length=None,
+                                    timestep="day",quote=self.quote).df
+
+    def _get_bbands(self,history_df:DataFrame):
+        bbands = history_df.ta.bbands(close='close',length=self.window,std=2)
+        # BBL (Lower Bollinger Band): Can act as a support level based on price volatility, and can indicate an 'oversold' condition if the price falls below this line.
+        # BBM (Breaking Bollinger Bands): This is essentially a moving average over a selected period of time, used as a reference point for price trends.
+        # BBU (Upper Bollinger Band): Can act as a resistance level based on price volatility, and can indicate an 'overbought' condition if the price moves above this line.
+        # BBB (Bollinger Band Width): Indicates the distance between the upper and lower bands, with a higher value indicating a more volatile market.
+        # BBP (Bollinger Band Percentage): This shows where the current price is located within the Bollinger Bands as a percentage, where a value close to 0 means that the price is close to the lower band, and a value close to 1 means that the price is close to the upper band.
+        bbands.columns = ['bbl','bbm','bbu','bbb','bbp']
+        return bbands
+
+    def on_trading_iteration(self):
+        # backtest 진행시에는 self.get_datetime()으로 현재 시간을 가져온다.
+        # 시간 간격은 self.sleeptime 이다.
+        current_dt = self.get_datetime()
+        cash, last_price, quantity = self._position_sizing()
+        history_df = self._get_historical_prices()
+        bbands = self._get_bbands(history_df)
+        prev_bbp = bbands[bbands.index < current_dt].tail(1).bbp.values[0]
+
+        if prev_bbp < -0.13 and cash > 0 and self.last_trade != Order.OrderSide.BUY and quantity > 0.0:
+            order = self.create_order(self.base,
+                                    quantity,
+                                    side = Order.OrderSide.BUY,
+                                    type = Order.OrderType.MARKET,
+                                    quote=self.quote)
+            self.submit_order(order)
+            self.last_trade = Order.OrderSide.BUY
+            self.order_quantity = quantity
+            self.log_message(f"Last buy trade was at {current_dt}")
+        elif prev_bbp > 1.2 and self.last_trade != Order.OrderSide.SELL and self.order_quantity > 0.0:
+            order = self.create_order(self.base,
+                                    self.order_quantity,
+                                    side = Order.OrderSide.SELL,
+                                    type = Order.OrderType.MARKET,
+                                    quote=self.quote)
+            self.submit_order(order)
+            self.last_trade = Order.OrderSide.SELL
+            self.order_quantity = 0.0
+            self.log_message(f"Last sell trade was at {current_dt}")
+
+exchange_id = "binance" #"bitmex"
+
+if exchange_id == "binance":
+    CCXT_CONFIG = {
+        "exchange_id": exchange_id,
+        "apiKey": os.getenv("B_API_KEY"),
+        "secret": os.getenv("B_SECRET_KEY"),
+        "sandbox": True,
+        'options': {
+            'defaultType': 'spot', # 'margine' or 'spot'
+        },
+    }
+elif exchange_id == "bitmex":
+    CCXT_CONFIG = {
+        "exchange_id": exchange_id,
+        "apiKey": os.getenv("BITMEX_API_KEY"),
+        "secret": os.getenv("BITMEX_SECRET_KEY"),
+        "sandbox": True,
+        'options': {
+            'defaultType': 'spot', # 'margine' or 'spot'
+        },
+    }
+else:
+    raise ValueError("Invalid exchange_id")
+
+base_symbol = "ETH"
+quote_symbol = "USDT"
+start_date = datetime(2023,1,1)
+end_date = datetime(2024,2,12)
+asset = (Asset(symbol=base_symbol, asset_type="crypto"),
+         Asset(symbol=quote_symbol, asset_type="crypto"))
+
+broker = Ccxt(CCXT_CONFIG)
+strategy = MyStrategy(name='mystrategy',
+                    broker=broker,
+                    quote_asset=Asset(symbol=quote_symbol, asset_type="crypto"),
+                    )
+
+# BinanceDataBacktesting default data download limit is 50,000
+# If you want to change the maximum data download limit, you can do so by using 'max_data_download_limit'.
+kwargs = {
+    "max_data_download_limit":10000,
+    "exchange_id":exchange_id, # bitmex
+}
+CcxtBacktesting.MIN_TIMESTEP = "day"
+strategy.backtest(
+    CcxtBacktesting,
+    start_date,
+    end_date,
+    benchmark_asset=f"{base_symbol}/{quote_symbol}",
+    quote_asset=Asset(symbol=quote_symbol, asset_type="crypto"),
+    parameters={
+            "asset":asset,
+            "cash_at_risk":.25,
+            "window":21},
+    **kwargs,
+)

--- a/lumibot/example_strategies/ccxt_backtesting_example.py
+++ b/lumibot/example_strategies/ccxt_backtesting_example.py
@@ -55,8 +55,8 @@ class MyStrategy(Strategy):
         return bbands
 
     def on_trading_iteration(self):
-        # backtest 진행시에는 self.get_datetime()으로 현재 시간을 가져온다.
-        # 시간 간격은 self.sleeptime 이다.
+        # During the backtest, we get the current time with self.get_datetime().
+        # The time interval is self.sleeptime.
         current_dt = self.get_datetime()
         cash, last_price, quantity = self._position_sizing()
         history_df = self._get_historical_prices()
@@ -89,8 +89,8 @@ exchange_id = "binance" #"bitmex"
 if exchange_id == "binance":
     CCXT_CONFIG = {
         "exchange_id": exchange_id,
-        "apiKey": os.getenv("B_API_KEY"),
-        "secret": os.getenv("B_SECRET_KEY"),
+        "apiKey": os.getenv("BINANCE_API_KEY"),
+        "secret": os.getenv("BINANCE_SECRET_KEY"),
         "sandbox": True,
         'options': {
             'defaultType': 'spot', # 'margine' or 'spot'

--- a/lumibot/example_strategies/ccxt_backtesting_example.py
+++ b/lumibot/example_strategies/ccxt_backtesting_example.py
@@ -1,26 +1,13 @@
-# ta-lib install : https://cloudstrata.io/install-ta-lib-on-ubuntu-server/
-# pip install pandas-ta
-
-from lumibot.brokers import Ccxt
 from lumibot.entities import Asset, Order
 from lumibot.backtesting import CcxtBacktesting
 from lumibot.strategies.strategy import Strategy
 from lumibot.example_strategies.crypto_important_functions import ImportantFunctions
 from datetime import datetime
 from pandas import DataFrame
-import pandas_ta
 
-# Save API_KEY, SECRET_KEY in the .env file and import it like below.
-
-from dotenv import load_dotenv
-import os
-
-load_dotenv()
-
-
-class MyStrategy(Strategy):
+class CcxtBacktestingExampleStrategy(Strategy):
     def initialize(self, asset:tuple[Asset,Asset] = None,
-                   cash_at_risk:float=.5,window:int=14):
+                   cash_at_risk:float=.25,window:int=21):
         if asset is None:
             raise ValueError("You must provide a valid asset pair")
         # for crypto, market is 24/7
@@ -45,14 +32,23 @@ class MyStrategy(Strategy):
                                     timestep="day",quote=self.quote).df
 
     def _get_bbands(self,history_df:DataFrame):
-        bbands = history_df.ta.bbands(close='close',length=self.window,std=2)
         # BBL (Lower Bollinger Band): Can act as a support level based on price volatility, and can indicate an 'oversold' condition if the price falls below this line.
         # BBM (Breaking Bollinger Bands): This is essentially a moving average over a selected period of time, used as a reference point for price trends.
         # BBU (Upper Bollinger Band): Can act as a resistance level based on price volatility, and can indicate an 'overbought' condition if the price moves above this line.
         # BBB (Bollinger Band Width): Indicates the distance between the upper and lower bands, with a higher value indicating a more volatile market.
         # BBP (Bollinger Band Percentage): This shows where the current price is located within the Bollinger Bands as a percentage, where a value close to 0 means that the price is close to the lower band, and a value close to 1 means that the price is close to the upper band.
-        bbands.columns = ['bbl','bbm','bbu','bbb','bbp']
-        return bbands
+        # return bbands
+        num_std_dev = 2.0
+        close = 'close'
+
+        df = DataFrame(index=history_df.index)
+        df[close] = history_df[close]
+        df['bbm'] = df[close].rolling(window=self.window).mean()
+        df['bbu'] = df['bbm'] + df[close].rolling(window=self.window).std() * num_std_dev
+        df['bbl'] = df['bbm'] - df[close].rolling(window=self.window).std() * num_std_dev
+        df['bbb'] = (df['bbu'] - df['bbl']) / df['bbm']
+        df['bbp'] = (df[close] - df['bbl']) / (df['bbu'] - df['bbl'])
+        return df
 
     def on_trading_iteration(self):
         # During the backtest, we get the current time with self.get_datetime().
@@ -84,60 +80,35 @@ class MyStrategy(Strategy):
             self.order_quantity = 0.0
             self.log_message(f"Last sell trade was at {current_dt}")
 
-exchange_id = "binance" #"bitmex"
 
-if exchange_id == "binance":
-    CCXT_CONFIG = {
-        "exchange_id": exchange_id,
-        "apiKey": os.getenv("BINANCE_API_KEY"),
-        "secret": os.getenv("BINANCE_SECRET_KEY"),
-        "sandbox": True,
-        'options': {
-            'defaultType': 'spot', # 'margine' or 'spot'
-        },
+if  __name__ == "__main__":
+
+    base_symbol = "ETH"
+    quote_symbol = "USDT"
+    start_date = datetime(2023,2,11)
+    end_date = datetime(2024,2,12)
+    asset = (Asset(symbol=base_symbol, asset_type="crypto"),
+            Asset(symbol=quote_symbol, asset_type="crypto"))
+
+    exchange_id = "kraken"  #"kucoin" #"bybit" #"okx" #"bitmex" # "binance"
+
+
+    # CcxtBacktesting default data download limit is 50,000
+    # If you want to change the maximum data download limit, you can do so by using 'max_data_download_limit'.
+    kwargs = {
+        # "max_data_download_limit":10000, # optional
+        "exchange_id":exchange_id,
     }
-elif exchange_id == "bitmex":
-    CCXT_CONFIG = {
-        "exchange_id": exchange_id,
-        "apiKey": os.getenv("BITMEX_API_KEY"),
-        "secret": os.getenv("BITMEX_SECRET_KEY"),
-        "sandbox": True,
-        'options': {
-            'defaultType': 'spot', # 'margine' or 'spot'
-        },
-    }
-else:
-    raise ValueError("Invalid exchange_id")
-
-base_symbol = "ETH"
-quote_symbol = "USDT"
-start_date = datetime(2023,1,1)
-end_date = datetime(2024,2,12)
-asset = (Asset(symbol=base_symbol, asset_type="crypto"),
-         Asset(symbol=quote_symbol, asset_type="crypto"))
-
-broker = Ccxt(CCXT_CONFIG)
-strategy = MyStrategy(name='mystrategy',
-                    broker=broker,
-                    quote_asset=Asset(symbol=quote_symbol, asset_type="crypto"),
-                    )
-
-# BinanceDataBacktesting default data download limit is 50,000
-# If you want to change the maximum data download limit, you can do so by using 'max_data_download_limit'.
-kwargs = {
-    "max_data_download_limit":10000,
-    "exchange_id":exchange_id, # bitmex
-}
-CcxtBacktesting.MIN_TIMESTEP = "day"
-strategy.backtest(
-    CcxtBacktesting,
-    start_date,
-    end_date,
-    benchmark_asset=f"{base_symbol}/{quote_symbol}",
-    quote_asset=Asset(symbol=quote_symbol, asset_type="crypto"),
-    parameters={
-            "asset":asset,
-            "cash_at_risk":.25,
-            "window":21},
-    **kwargs,
-)
+    CcxtBacktesting.MIN_TIMESTEP = "day"
+    results, strat_obj = CcxtBacktestingExampleStrategy.run_backtest(
+        CcxtBacktesting,
+        start_date,
+        end_date,
+        benchmark_asset=f"{base_symbol}/{quote_symbol}",
+        quote_asset=Asset(symbol=quote_symbol, asset_type="crypto"),
+        parameters={
+                "asset":asset,
+                "cash_at_risk":.25,
+                "window":21,},
+        **kwargs,
+    )

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -596,6 +596,37 @@ class _Strategy:
 
                     self._benchmark_returns_df = df
 
+                # For data sources of type CCXT, benchmark_asset gets bechmark_asset from the CCXT backtest data source.
+                elif self.broker.data_source.SOURCE.upper() == "CCXT":
+                    benchmark_asset = self._benchmark_asset
+                    # If the benchmark asset is a string, then convert it to an Asset object
+                    if isinstance(benchmark_asset, str):
+                        asset_quote = benchmark_asset.split("/")
+                        if len(asset_quote) == 2:
+                            benchmark_asset = (Asset(symbol=asset_quote[0], asset_type="crypto"),
+                                               Asset(symbol=asset_quote[1], asset_type="crypto"))
+                        else:
+                            benchmark_asset = Asset(symbol=benchmark_asset,asset_type="crypto")
+
+                    timestep = "minute"
+                    # If the strategy sleeptime is in days then use daily data, eg. "1D"
+                    if "D" in str(self._sleeptime):
+                        timestep = "day"
+
+                    bars = self.broker.data_source.get_historical_prices_between_dates(
+                        benchmark_asset,
+                        timestep,
+                        start_date=self._backtesting_start,
+                        end_date=backtesting_end_adjusted,
+                        quote=self._quote_asset,
+                    )
+                    df = bars.df
+
+                    # Add the symbol_cumprod column
+                    df["symbol_cumprod"] = (1 + df["return"]).cumprod()
+
+                    self._benchmark_returns_df = df
+
                 # If we are using any other data source, then get the benchmark returns from yahoo
                 else:
                     self._benchmark_returns_df = get_symbol_returns(

--- a/lumibot/tools/__init__.py
+++ b/lumibot/tools/__init__.py
@@ -28,3 +28,4 @@ from .indicators import (
 from .pandas import *
 from .types import *
 from .yahoo_helper import YahooHelper
+from .ccxt_data_store import CcxtCacheDB

--- a/lumibot/tools/ccxt_data_store.py
+++ b/lumibot/tools/ccxt_data_store.py
@@ -1,0 +1,509 @@
+import logging
+import time
+import duckdb
+import os
+import uuid
+import ccxt
+from datetime import datetime
+from tabulate import tabulate
+import pandas as pd
+from pandas import DataFrame
+from lumibot import LUMIBOT_CACHE_FOLDER
+import math
+import numpy as np
+from typing import Union
+
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s | %(name)s | %(levelname)s | %(message)s",
+                    datefmt="%Y-%m-%d %H:%M:%S")
+
+class CcxtCacheDB:
+    """A ccxt data cache class using duckdb.
+    The data being cached is OHLCV data and is stored in UTC.
+    After importing the data, you'll need to change the timezone if necessary.
+    Create an exchange_id folder in the cache folder, and create a symbol_timeframe.duckdb file under it.
+    ex) Create a BTC_USDT_1m.duckdb file in the binance folder.
+    If there is an existing cache file, it will use it to fetch the data, otherwise it will use ccxt to fetch the data.
+    If a cache file exists, but the requested data range is not in the cache file, the data will be fetched using ccxt.
+    For example, if the cache file contains data from 2023-01-01 to 2023-01-10, and you request data from 2023-01-05 to 2023-01-15,
+    the data from 2023-01-05 to 2023-01-10 will be fetched from the cache file, and the data from 2023-01-11 to 2023-01-15 will be fetched using ccxt.
+    The newly fetched data is stored in the cache file and the range of data stored in the cache file is updated to 2023-01-05 ~ 2023-01-15.
+    The cache file uses two tables to store the data using duckdb.
+    The candles table, which stores the OHLCV data, has the columns open, high, low, close, volume, and missing.
+    The cache_dt_ranges table, which stores the ranges of the cached data, has the following columns: id, start_dt, end_dt.
+    We use the missing column to fill in missing data in the time series data.
+    The missing column is 1 for missing data and 0 for non-missing data.
+
+    If max_download_limit is not set, both 1m and 1d will be set to 50000.
+    Raise an error if 'end_datetime - start_datetime' is greater than max_download_limit.
+    max_download_limit can be set in __init__.
+    """
+
+    def __init__(self, exchange_id:str,max_download_limit:int=None):
+        """Initialize the CcxtCacheDB class.
+
+        Args:
+            exchange_id (str): "binance","coinbase","kraken" etc.
+            max_download_limit (int, optional): Maximum number of data to be downloaded at once using CCXT. Defaults to None.
+
+        """
+        self.logger = logging.getLogger(self.__class__.__name__)
+        try:
+            exchange_class = getattr(ccxt, exchange_id)
+        except:
+            raise Exception(
+                "Could not find exchange named '{}'. Are you sure you are spelling the exchange_id correctly?".format(
+                    exchange_id
+                )
+            )
+
+        self.exchange_id = exchange_id
+        self.api = exchange_class()
+        self.api.load_markets()
+        # Recommended two or less api calls per second.
+        self.api.enableRateLimit = True
+        self.max_download_limit = 50000 if max_download_limit is None else max_download_limit
+
+
+    def get_cache_file_name(self, symbol:str, timeframe:str)->str:
+        """Returns the cache file name. If the cache folder does not exist, it is created.
+        cache folder is created under LUMIBOT_CACHE_FOLDER with exchange_id and symbol_timeframe.duckdb file.
+        e.g. BTC_USDT_1m.duckdb file is created under binance folder.
+
+        Args:
+            symbol (str): BTC/USDT, ETH/USDT etc.
+            timeframe (str): 1m, 1d etc.
+
+        Raises:
+            Exception: OSError if the cache folder cannot be created.
+
+        Returns:
+            str: cache full file name
+        """
+        cache_folder = os.path.join(LUMIBOT_CACHE_FOLDER,self.exchange_id)
+        try:
+            if not os.path.exists(cache_folder):
+                os.makedirs(cache_folder)
+        except OSError:
+            raise Exception("Could not create cache folder at {}".format(cache_folder))
+
+        cache_file = os.path.join(cache_folder,
+                                  f"{symbol.replace('/', '_')}_{timeframe}.duckdb")
+        return cache_file
+
+
+    def get_data_from_cache(self, symbol:str, timeframe:str,
+                            start:datetime, end:datetime)->DataFrame:
+        """Fetch data from cache. Raise an exception if the cache file does not exist.
+        Fetch data in the range start and end from the cache file.
+
+        Args:
+            symbol (str): BTC/USDT, ETH/USDT etc.
+            timeframe (str): 1m, 1d etc.
+            start (datetime): datetime object, ex) datetime(2023, 3, 2), datetime(2023, 3, 2, 12, 1, 0, 0)
+            end (datetime): datetime object, ex) datetime(2023, 3, 4), datetime(2023, 3, 4, 10, 14, 0, 0)
+
+        Raises:
+            Exception: cache file이 없으면 예외를 발생시킨다.
+
+        Returns:
+            DataFrame: Data fetched from cache.
+                       Use datetime as the index.
+                       datetime, open, high, low, close, volume, missing columns.
+        """
+
+        cache_file = self.get_cache_file_name(symbol, timeframe)
+        if not os.path.exists(cache_file):
+            raise Exception(f"Cache file {cache_file} does not exist")
+
+        start = start.replace(tzinfo=None)
+        end = end.replace(tzinfo=None)
+
+        with duckdb.connect(database = cache_file) as con:
+            df = con.execute("""select datetime, open, high, low, close, volume, missing
+                             from candles
+                             where datetime  between  ? and ?
+                             order by datetime asc
+                             """,(start,end)).fetch_df()
+        df.drop_duplicates(inplace=True,subset=['datetime'])
+        df.set_index("datetime", inplace=True)
+        return df
+
+
+    # timeframes: 1m, 1h, 1d
+    def download_ohlcv(self, symbol:str,timeframe:str,
+                       start:datetime, end:datetime,  limit:int=None)->DataFrame:
+        """Download data according to the given symbol, timeframe, start, end, and limit.
+        Store the downloaded data in a cache.
+        Data that is not in the cache is downloaded using CCXT.
+        If a cache file exists, but the requested data range is not in the cache file, the data will be fetched using ccxt.
+        For example, if the cache file contains data from 2023-01-01 to 2023-01-10, and you request data from 2023-01-05 to 2023-01-15,
+        the data from 2023-01-05 to 2023-01-10 will be fetched from the cache file, and the data from 2023-01-11 to 2023-01-15 will be fetched using ccxt.
+        The newly fetched data is stored in the cache file and the range of data stored in the cache file is updated to 2023-01-05 ~ 2023-01-15.
+
+        Args:
+            symbol (str):  BTC/USDT, ETH/USDT etc.
+            timeframe (str): 1m, 1d etc.
+            start (datetime): datetime object, ex) datetime(2023, 3, 2), datetime(2023, 3, 2, 12, 1, 0, 0)
+            end (datetime): datetime object, ex) datetime(2023, 3, 4), datetime(2023, 3, 4, 10, 14, 0, 0)
+            limit (int, optional): max download limit. Defaults to None.
+
+        Raises:
+            Exception: Raise an exception if the max download limit is exceeded.
+
+        Returns:
+            DataFrame: Data fetched from cache.
+                       Use datetime as the index.
+                       datetime, open, high, low, close, volume, missing columns.
+        """
+        if end is None:
+            end = datetime.utcnow()
+
+        if limit is None:
+            limit = self.max_download_limit
+
+        start_dt = start.replace(tzinfo=None)
+        end_dt = end.replace(tzinfo=None)
+
+        # set start_dt to 00:00:00 and end_dt to 23:59:59
+        start_dt = start_dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        end_dt = end_dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+
+        download_ranges,overap_range_ids,cache_range = self._calc_download_ranges(symbol, timeframe,start_dt, end_dt)
+
+        self.logger.info(f"download ranges :\n{self._table_str(download_ranges,headers=['from','to'])}")
+
+        for download_start,download_end in download_ranges:
+            range_cnt = download_end - download_start
+            if timeframe == "1m":
+                range_cnt = math.ceil(range_cnt.total_seconds() / 60)
+            elif timeframe == "1d":
+                range_cnt = range_cnt.days
+
+            if range_cnt > limit:
+                raise Exception(f"Request download range {range_cnt} is greater than download limit {limit}")
+
+            df = self._get_barset_from_api(symbol, timeframe,
+                                           range_cnt, download_start, download_end)
+            df = self._fill_missing_data(df, timeframe)
+            self._cache_ohlcv(symbol, df, timeframe)
+
+        cache_file = self.get_cache_file_name(symbol, timeframe)
+
+        if download_ranges:
+            if len(overap_range_ids) > 0:
+                start_dt = cache_range[0]
+                end_dt = cache_range[1]
+            else:
+                start_dt = df.datetime.min()
+                end_dt = df.datetime.max()
+
+            with duckdb.connect(cache_file) as con:
+                # insert new cache data range
+                con.execute("""INSERT INTO cache_dt_ranges VALUES (?, ?, ?)""",
+                            (str(uuid.uuid4().hex),start_dt,end_dt))
+                # delete overlapping ranges
+                if len(overap_range_ids) > 0:
+                    params = [(id,) for id in overap_range_ids]
+                    con.executemany("""DELETE FROM  cache_dt_ranges WHERE id = ?""", params)
+
+        with duckdb.connect(cache_file) as con:
+            df = con.execute("""select * from cache_dt_ranges""").fetch_df()
+        self.logger.info(f"cache ranges:\n{self._table_str(df[['start_dt', 'end_dt']],headers=['from','to'])}")
+
+        df_cache = self.get_data_from_cache(symbol, timeframe, start, end)
+        return df_cache
+
+
+    def _cache_ohlcv(self, symbol:str, df:DataFrame, timeframe:str)->None:
+        """ccxt에서 가져온 데이터를 cache에 저장한다.
+
+        Args:
+            symbol (str): BCH/USDT, ETH/USDT etc.
+            df (DataFrame): DataFrame to store in cache(datetime, open, high, low, close, volume, missing columns)
+            timeframe (str): 1m, 1d etc.
+        """
+        cache_file = self.get_cache_file_name(symbol, timeframe)
+
+        with duckdb.connect(cache_file) as con:
+            con.execute("""CREATE TABLE IF NOT EXISTS candles (
+                            datetime DATETIME,
+                            open FLOAT, high FLOAT, low FLOAT, close FLOAT, volume INTEGER, missing INTEGER)""")
+
+            # cache ranges table
+            con.execute("""CREATE TABLE  IF NOT EXISTS cache_dt_ranges (
+                            id STRING ,
+                            start_dt DATETIME ,
+                            end_dt DATETIME)""")
+            # insert df to cache db
+            con.execute("""INSERT INTO candles SELECT *  from df""")
+
+
+    def _calc_download_ranges(self,symbol:str,timeframe:str,
+                             start:datetime,
+                             end:datetime)->tuple[list[tuple[datetime, datetime]],list[str]]:
+        """Checks for duplicates between the data stored in the cache and the requested data,
+        and returns a range of non-duplicate download data ranges, overap ranges ids, new cache range.
+        For example, suppose you have the following data ranges stored in cache
+        ----------------------------------
+        | id |   start_dt   |   end_dt   |
+        ----------------------------------
+        | id1 | 2023-01-01 | 2023-01-10  |
+        | id2 | 2023-02-03 | 2023-03-11  |
+        | id3 | 2023-05-01 | 2023-06-07  |
+        ----------------------------------
+
+        If the requested data is 2023-01-05 to 2023-03-07, return 2023-01-11 to 2023-02-02 as the new download range,
+        overlapping range ids returns [id1,id2].
+        And the new cache_range returns (2023-01-01,2023-03-11).
+
+        Args:
+            symbol (str): BTC/USDT, ETH/USDT etc.
+            timeframe (str): 1m, 1d etc.
+            start (datetime): datetime object,
+                  ex) datetime(2023, 1, 5), datetime(2023, 1, 5, 12, 1, 0, 0)
+            end (datetime): datetime object,
+                  ex) datetime(2023, 3, 7), datetime(2023, 3, 7, 10, 14, 0, 0)
+
+        Returns:
+            tuple[list[tuple[datetime, datetime]],list[str]]: (new download ranges,overap range ids,new cache range)
+        """
+        cache_file = self.get_cache_file_name(symbol, timeframe)
+        if not os.path.exists(cache_file):
+            return [(start, end)],[],(start, end)
+        if os.path.exists(cache_file):
+            # get cache data ranges (id, start_dt, end_dt)
+            with duckdb.connect(cache_file) as con:
+                df = con.execute("""select * from cache_dt_ranges""").fetch_df()
+        if len(df) > 0:
+            return self._find_non_overlapping_range(df,start, end)
+        else:
+            return [(start, end)],[],(start, end)
+
+
+    def _find_non_overlapping_range(self,df:DataFrame,
+                                    new_start:datetime, new_end:datetime)->list[list,list,tuple]:
+        """Checks for duplicates between the data stored in the cache and the requested data,
+        and returns a range of non-duplicate download data ranges, overap ranges ids, new cache range.
+
+        Args:
+            df (DataFrame): data ranges stored in cache (id, start_dt, end_dt)
+            new_start (datetime): Data request start date time,ex) datetime(2023, 1, 5), datetime(2023, 1, 5, 12, 1, 0, 0)
+            new_end (datetime): Data request end date time, ex) datetime(2023, 3, 7), datetime(2023, 3, 7, 10, 14, 0, 0)
+
+        Returns:
+            list[list,list,tuple]: (new download ranges,overap range ids,new cache range)
+        """
+
+        # find overlapping ranges
+        def find_overlapping_range(row):
+            id=row['id']
+            e=row['end_dt']
+            s=row['start_dt']
+            if (s < new_start and new_start < e) or (new_start < s and e < new_end) or (s < new_end and new_end < e):
+                return  id, s, e
+            else:
+                return pd.NaT,pd.NaT,pd.NaT
+
+        overap = df.apply(find_overlapping_range, axis=1)
+        df['id'], df['start_dt'],df['end_dt'] = zip(*overap)
+        df.dropna(inplace=True)
+
+        if len(df) == 0:
+            return [(new_start,new_end)],[], (new_start,new_end)
+
+        df.sort_values(by='start_dt', inplace=True)
+        df.reset_index(drop=True, inplace=True)
+        dt_start,dt_end = df.start_dt.min(),df.end_dt.max()
+
+        ranges = []
+
+        start = new_start
+        end = new_end
+
+        if new_start < dt_start:
+            ranges.append((new_start,df.start_dt.iloc[0]))
+        else:
+            start = dt_start
+
+        if len(df) > 1:
+            for i in  range(0,len(df)-1):
+                ranges.append((df.end_dt.iloc[i], df.start_dt.iloc[i+1]))
+
+        if new_end > dt_end:
+            ranges.append((df.end_dt.iloc[-1],new_end))
+        else:
+            end = dt_end
+
+        return ranges, df.id.tolist(), (start,end)
+
+
+    def _get_barset_from_api(self, symbol:str, timeframe:str,
+                             limit:int=None, start:datetime=None, end:datetime=None)->Union[DataFrame ,None]:
+        """Use CCXT to get historical candle data for a given cryptocurrency symbol and time parameters.
+        Outputs a dataframe open, high, low, close columns and a native timezone index.
+
+        Args:
+            symbol (str): BTC/USDT, ETH/USDT etc.
+            timeframe (str): 1m, 1d etc.
+            limit (int, optional): max download limit. Defaults to None.
+            start (datetime, optional): When to start downloading data. Defaults to None.
+            end (datetime, optional): When the data download ends. Defaults to None.
+
+        Raises:
+            Exception: Raise an exception if there is no start or end date.
+        Returns:
+            DataFrame: candle data (datetime, open, high, low, close, volume)
+        """
+
+        if not self.api.has["fetchOHLCV"]:
+            logging.error("Exchange does not support fetching OHLCV data")
+
+        market = self.api.markets.get(symbol, None)
+        if market is None:
+            logging.error(
+                f"A request for market data for {symbol} was submitted. " f"The market for that pair does not exist"
+            )
+            return None
+
+        if end is None or start is None:
+            raise Exception("Start and end must be specified")
+
+        if limit is None:
+            limit = self.max_download_limit
+
+        endunix = self.api.parse8601(end.strftime("%Y-%m-%d %H:%M:%S"))
+
+        df_ret = None
+        curr_start = self.api.parse8601(start.strftime("%Y-%m-%d %H:%M:%S"))
+        curr_start = curr_start if curr_start > 0 else 0
+
+        cnt = 0
+        last_curr_end = None
+
+        loop_limit = 300
+        rate_limit = 10  # Requests per second in burst.
+
+        while True:
+            cnt += 1
+            candles = self.api.fetch_ohlcv(symbol, timeframe,
+                                           since=curr_start, limit=loop_limit, params={})
+
+            df = pd.DataFrame(candles, columns=["datetime",
+                                                "open", "high", "low", "close", "volume"])
+            df["datetime"] = pd.to_datetime(df["datetime"], unit="ms")
+            df = df.set_index("datetime")
+            if df_ret is None:
+                df_ret = df
+            else:
+                df_ret = pd.concat([df_ret, df])
+
+            df_ret = df_ret.sort_index()
+
+            if len(df) > 0:
+                last_curr_end = self.api.parse8601(df.index[-1].strftime("%Y-%m-%d %H:%M:%S"))
+            else:
+                last_curr_end = None
+
+            if len(df_ret) >= limit:
+                break
+            elif last_curr_end is None:
+                break
+            elif last_curr_end > endunix:
+                break
+
+            if curr_start == last_curr_end:
+                break
+            else:
+                curr_start = last_curr_end
+
+            # Sleep for half a second every rate_limit requests to prevent rate limiting issues
+            if cnt % rate_limit == 0:
+                time.sleep(1)
+
+            # Catch if endless loop.
+            if cnt > 500:
+                break
+
+
+        df_ret.drop_duplicates(inplace=True)
+        df_ret.reset_index(inplace=True)
+
+        return df_ret
+
+
+    def _fill_missing_data(self, df:DataFrame, freq:str)->DataFrame:
+        """If datetime is missing from the candle data, fill in the missing data.
+        Missing data is marked with a 1 in the missing column and 0 for the rest.
+
+        Args:
+            df (DataFrame): candle data (datetime, open, high, low, close, volume)
+            freq (str): 1m, 1d etc.
+
+        Returns:
+            DataFrame: candle data (datetime, open, high, low, close, volume, missing)
+        """
+        df.set_index("datetime", inplace=True)
+        if freq == "1d":
+            dt_range = pd.date_range(start=df.index.min(), end=df.index.max(), freq="D")
+        else:
+            dt_range = pd.date_range(start=df.index.min(), end=df.index.max(), freq="T")
+
+        df_complete = df.reindex(dt_range).fillna(method='ffill')
+        df_complete['missing'] = np.where(df_complete.index.isin(df.index), 0, 1)
+        #  Change "datetime" to come to the front
+        #  When inserting DB, make sure that the datetime comes to the first colmun.
+        df_complete.insert(0,"datetime", df_complete.index)
+        df_complete.reset_index(drop=True, inplace=True)
+        return df_complete
+
+
+    def _table_str(self, df, headers="keys"):
+        return tabulate(df, headers=headers, tablefmt='psql')
+
+if __name__ == "__main__":
+    exchange_id = "binance"
+    symbol = "SOL/USDT"
+    timeframe = "1m"
+
+    cache = CcxtCacheDB(exchange_id)
+
+    cache_file_path = cache.get_cache_file_name(symbol,timeframe)
+     # Remove cache file if exists.
+    if os.path.exists(cache_file_path):
+        os.remove(cache_file_path)
+
+    # no overap new download range
+    start = datetime(2023, 3, 1)
+    end = datetime(2023, 3, 11)
+    df = cache.download_ohlcv(symbol,timeframe,start,end)
+    print(f"data length: {len(df)}")
+
+    # no overap new download range
+    start = datetime(2023, 3, 13)
+    end = datetime(2023, 3, 15)
+    df = cache.download_ohlcv(symbol,timeframe,start,end)
+    print(f"data length: {len(df)}")
+
+    # fully overap download range, no download
+    start = datetime(2023, 3, 13)
+    end = datetime(2023, 3, 14)
+    df = cache.download_ohlcv(symbol,timeframe,start,end)
+    print(f"data length: {len(df)}")
+
+    # no overap new download range
+    start = datetime(2023, 4, 5)
+    end = datetime(2023, 4, 7)
+    df = cache.download_ohlcv(symbol,timeframe,start,end)
+    print(f"data length: {len(df)}")
+
+    # Partially nested download ranges
+    # cache ranges updated
+    start = datetime(2023, 3, 9)
+    end = datetime(2023, 3, 17)
+    df = cache.download_ohlcv(symbol,timeframe,start,end)
+    print(f"data length: {len(df)}")
+
+    df = cache.get_data_from_cache("SOL/USDT","1m",datetime(2000,1,1),datetime(2025,1,1))
+    print(f"total data length: {len(df)}")

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -9,6 +9,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import quantstats_lumi as qs
 from lumibot.tools import to_datetime_aware
+from lumibot import LUMIBOT_DEFAULT_TIMEZONE
 from plotly.subplots import make_subplots
 
 from .yahoo_helper import YahooHelper as yh
@@ -392,6 +393,11 @@ def plot_returns(
     else:
         trades_df = trades_df.set_index("time")
         df_final = df_final.merge(trades_df, how="outer", left_index=True, right_index=True)
+
+    # Fix for minute timeframe backtests plotting
+    # Converted to DatetimeIndex because index becomes Index type and UTC timezone in pd.concat
+    # The x-axis is not displayed correctly in plotly when not converted to DatetimeIndex type
+    df_final.index = pd.to_datetime(df_final.index,utc=True).tz_convert(LUMIBOT_DEFAULT_TIMEZONE)
 
     # fig = go.Figure()
     fig = make_subplots(specs=[[{"secondary_y": True}]])

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,7 @@ pyarrow
 tqdm
 pytz
 lumiwealth-tradier
+tabulate
+duckdb
+uuid
+numpy

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,10 @@ setuptools.setup(
         "lumiwealth-tradier>=0.1.4",
         "pytz",
         "psycopg2-binary",
+        "duckdb",
+        "uuid",
+        "numpy",
+        "tabulate",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/backtest/test_example_strategies.py
+++ b/tests/backtest/test_example_strategies.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 
-from lumibot.backtesting import PolygonDataBacktesting, YahooDataBacktesting
+from lumibot.backtesting import PolygonDataBacktesting, YahooDataBacktesting, CcxtBacktesting
 from lumibot.example_strategies.options_hold_to_expiry import OptionsHoldToExpiry
 from lumibot.example_strategies.stock_bracket import StockBracket
 from lumibot.example_strategies.stock_buy_and_hold import BuyAndHold
@@ -10,6 +10,8 @@ from lumibot.example_strategies.stock_limit_and_trailing_stops import (
     LimitAndTrailingStop,
 )
 from lumibot.example_strategies.stock_oco import StockOco
+from lumibot.example_strategies.ccxt_backtesting_example import CcxtBacktestingExampleStrategy
+from lumibot.entities import Asset
 
 # Global parameters
 # API Key for testing Polygon.io
@@ -235,3 +237,53 @@ class TestExampleStrategies:
         # The first limit order should have filled at $399.71 and a quantity of 100
         assert round(cash_settled_orders.iloc[0]["price"], 0) == 0
         assert cash_settled_orders.iloc[0]["filled_quantity"] == 10
+
+    def test_ccxt_backtesting(self):
+        """
+        Test the example strategy StockBracket by running a backtest and checking that the strategy object is returned
+        along with the correct results
+        """
+
+        base_symbol = "ETH"
+        quote_symbol = "USDT"
+        backtesting_start = datetime.datetime(2023,2,11)
+        backtesting_end = datetime.datetime(2024,2,12)
+        asset = (Asset(symbol=base_symbol, asset_type="crypto"),
+                Asset(symbol=quote_symbol, asset_type="crypto"))
+
+        exchange_id = "kraken"  #"kucoin" #"bybit" #"okx" #"bitmex" # "binance"
+
+        # CcxtBacktesting default data download limit is 50,000
+        # If you want to change the maximum data download limit, you can do so by using 'max_data_download_limit'.
+        kwargs = {
+            # "max_data_download_limit":10000, # optional
+            "exchange_id":exchange_id,
+        }
+        CcxtBacktesting.MIN_TIMESTEP = "day"
+        results, strat_obj = CcxtBacktestingExampleStrategy.run_backtest(
+            CcxtBacktesting,
+            backtesting_start,
+            backtesting_end,
+            benchmark_asset=f"{base_symbol}/{quote_symbol}",
+            show_plot=False,
+            show_tearsheet=False,
+            save_tearsheet=False,
+            risk_free_rate=0.0,
+            parameters={
+            "asset":asset,
+            "cash_at_risk":.25,
+            "window":21},
+            **kwargs
+        )
+        assert results
+        assert isinstance(strat_obj, CcxtBacktestingExampleStrategy)
+
+        trades_df = strat_obj.broker._trade_event_log_df
+
+        # Get all the filled market orders
+        filled_orders = trades_df[(trades_df["status"] == "fill")]
+
+        # Check that the second order was a market order with a price of $1909 or more and a quantity of 17.0
+        assert filled_orders.iloc[1]["type"] == "market"
+        assert filled_orders.iloc[1]["filled_quantity"] == 17.0
+        assert filled_orders.iloc[1]["price"] >= 1909

--- a/tests/test_ccxt_store.py
+++ b/tests/test_ccxt_store.py
@@ -1,0 +1,105 @@
+from lumibot.tools import CcxtCacheDB
+import pytest
+import duckdb
+from datetime import datetime
+import os
+
+
+# PYTHONWARNINGS="ignore::DeprecationWarning"; pytest test/test_ccxt_cache.py
+
+@pytest.mark.parametrize("exchange_id,symbol,timeframe,start,end",
+                         [ ("binance","BTC/USDT","1m",datetime(2023, 3, 2),datetime(2023, 3, 4))
+                         ])
+def test_cache_download_data(exchange_id:str, symbol:str, timeframe:str, start:datetime, end:datetime)->None:
+    cache = CcxtCacheDB(exchange_id)
+    cache_file_path = cache.get_cache_file_name(symbol,timeframe)
+
+    # Remove cache file if exists.
+    if os.path.exists(cache_file_path):
+        os.remove(cache_file_path)
+
+    # Download data and store in cache.
+    df1 = cache.download_ohlcv(symbol,timeframe,start,end)
+
+    assert os.path.exists(cache_file_path)
+
+    # Counting data for the requested time period.
+    dt = end - start
+    if timeframe == "1d":
+        request_data_length = dt.days
+    else:
+        request_data_length = dt.total_seconds() / 60
+
+    # The cached data must be greater than or equal to the requested data.
+    assert len(df1) >= request_data_length
+    # The last time of the cached data must be equal to or greater than the requested time.
+    assert df1.index.max() >= end
+    # The first time of the cached data must be equal to or less than the requested time.
+    assert df1.index.min() <= start
+
+    # Fetch data stored in cache.
+    df2 = cache.get_data_from_cache(symbol,timeframe,start,end)
+    assert len(df2) >= request_data_length
+    assert df2.index.max() >= end
+    assert df2.index.min() <= start
+
+
+
+@pytest.mark.parametrize("exchange_id,symbol,timeframe,start,end",
+                         [ ("binance","BTC/USDT","1m",datetime(2023, 3, 3),datetime(2023, 3, 6))
+                         ])
+def test_cache_download_data_without_overap(exchange_id:str, symbol:str, timeframe:str, start:datetime, end:datetime)->None:
+    """Test for cases where the requested time range is partially covered by cache, but not partially covered by cache, if cache already exists.
+    In this case, you need to combine the data in the cache with the newly downloaded data to create the data for the requested time range.
+    Therefore, the existing start range must be larger than the requested start range and the existing end range must be smaller than the requested end range.
+    The final range of updated data should be from the existing start range to the requested end range.
+    """
+
+    cache = CcxtCacheDB(exchange_id)
+    cache_file_path = cache.get_cache_file_name(symbol,timeframe)
+
+    # Read the cache_dt_ranges table before caching new data to duckdb
+    with duckdb.connect(cache_file_path) as con:
+        df_down_range = con.execute("SELECT * from cache_dt_ranges").fetch_df()
+    prev_start_dt = df_down_range.iloc[0].start_dt
+    prev_end_dt = df_down_range.iloc[0].end_dt
+
+    # Download data and store in cache.
+    df_cache = cache.download_ohlcv(symbol,timeframe,start,end)
+
+    # Read the cache_dt_ranges table after caching new data to duckdb
+    with duckdb.connect(cache_file_path) as con:
+        df_down_range = con.execute("SELECT * from cache_dt_ranges").fetch_df()
+
+    # 기존 데이터 범위가 새로운 데이터 범위로 업데이트 되었는지 확인
+    # 데이터 범위의 개수는 1개여야 한다.
+    assert len(df_down_range) == 1
+
+    cur_start_dt = df_down_range.iloc[0].start_dt
+    cur_end_dt = df_down_range.iloc[0].end_dt
+
+    # 새로운 데이터 범위는 기존 데이터 범위보다 커야 한다.
+    assert cur_start_dt <= prev_start_dt
+    assert cur_end_dt >= prev_end_dt
+
+    # 새로운 데이터 범위는 요청한 데이터 범위보다 커야 한다.
+    assert cur_end_dt >= end
+    assert cur_start_dt <= start
+
+    # Counting data for the requested time period.
+    dt = end - start
+    if timeframe == "1d":
+        request_data_length = dt.days
+    else:
+        request_data_length = dt.total_seconds() / 60
+
+    # The cached data must be greater than or equal to the requested data.
+    assert len(df_cache) >= request_data_length
+    # The last time of the cached data must be equal to or greater than the requested time.
+    assert df_cache.index.max() >= end
+    # The first time of the cached data must be equal to or less than the requested time.
+    assert df_cache.index.min() <= start
+
+    # Remove cache file if exists.
+    if os.path.exists(cache_file_path):
+        os.remove(cache_file_path)

--- a/tests/test_ccxt_store.py
+++ b/tests/test_ccxt_store.py
@@ -5,10 +5,10 @@ from datetime import datetime
 import os
 
 
-# PYTHONWARNINGS="ignore::DeprecationWarning"; pytest test/test_ccxt_cache.py
+# PYTHONWARNINGS="ignore::DeprecationWarning"; pytest test/test_ccxt_store.py
 
 @pytest.mark.parametrize("exchange_id,symbol,timeframe,start,end",
-                         [ ("binance","BTC/USDT","1m",datetime(2023, 3, 2),datetime(2023, 3, 4))
+                         [ ("bitmex","ETH/USDT","1d",datetime(2022, 8, 1),datetime(2022, 10, 30))
                          ])
 def test_cache_download_data(exchange_id:str, symbol:str, timeframe:str, start:datetime, end:datetime)->None:
     cache = CcxtCacheDB(exchange_id)
@@ -46,7 +46,7 @@ def test_cache_download_data(exchange_id:str, symbol:str, timeframe:str, start:d
 
 
 @pytest.mark.parametrize("exchange_id,symbol,timeframe,start,end",
-                         [ ("binance","BTC/USDT","1m",datetime(2023, 3, 3),datetime(2023, 3, 6))
+                         [ ("bitmex","ETH/USDT","1d",datetime(2022, 9, 1),datetime(2024, 1, 30))
                          ])
 def test_cache_download_data_without_overap(exchange_id:str, symbol:str, timeframe:str, start:datetime, end:datetime)->None:
     """Test for cases where the requested time range is partially covered by cache, but not partially covered by cache, if cache already exists.

--- a/tests/test_ccxt_store.py
+++ b/tests/test_ccxt_store.py
@@ -71,18 +71,18 @@ def test_cache_download_data_without_overap(exchange_id:str, symbol:str, timefra
     with duckdb.connect(cache_file_path) as con:
         df_down_range = con.execute("SELECT * from cache_dt_ranges").fetch_df()
 
-    # 기존 데이터 범위가 새로운 데이터 범위로 업데이트 되었는지 확인
-    # 데이터 범위의 개수는 1개여야 한다.
+    # Verify that the existing data range has been updated with the new data range
+    # The number of data ranges should be 1.
     assert len(df_down_range) == 1
 
     cur_start_dt = df_down_range.iloc[0].start_dt
     cur_end_dt = df_down_range.iloc[0].end_dt
 
-    # 새로운 데이터 범위는 기존 데이터 범위보다 커야 한다.
+    # The new data range must be larger than the existing data range.
     assert cur_start_dt <= prev_start_dt
     assert cur_end_dt >= prev_end_dt
 
-    # 새로운 데이터 범위는 요청한 데이터 범위보다 커야 한다.
+    # The new data range must be larger than the requested data range.
     assert cur_end_dt >= end
     assert cur_start_dt <= start
 


### PR DESCRIPTION
● ccxt data cache :  lumibot/tools/ccxt_data_store.py
 - This module used duckdb to cache the ccxt data, see the in-source documentation for details.
 - Used when backtesting CCXT.
 
● ccxt data cache test module: tests/test_ccxt_store.py
 
● ccxt backtesting data source : lumibot/data_sources/ccxt_backtesting_data.py
 - This module is similar to the structure of yahoo_data.py.
 - The ccxt data cache module is used here.
 
● ccxt backtesting : lumibot/backtesting/ccxt_backtesting.py
 - This module is similar to the structure of yahoo_backtesting.py.

● ccxt backtesting example : lumibot/example_strategies/ccxt_backtesting_example.py
 - binance, bitmex backtesting example
 - Use `ccxt backtesting data source` as the benchmark data source.

● _strategy.py, ccxt.py  modified for ccxt backtesting