### PR TITLE
Keep track of what the split history is for each stock symbol's cache feather file.  Invalidate the (i.e. force redownload) when the splits change.

### DIFF
--- a/lumibot/data_sources/pandas_data.py
+++ b/lumibot/data_sources/pandas_data.py
@@ -67,7 +67,7 @@ class PandasData(DataSourceBacktesting):
 
     @staticmethod
     def _enforce_storage_limit(pandas_data: OrderedDict):
-        storage_used = sum([data.df.memory_usage().sum() for data in pandas_data.values()])
+        storage_used = sum(data.df.memory_usage().sum() for data in pandas_data.values())
         logging.info(f"{storage_used = :,} bytes for {len(pandas_data)} items")
         while storage_used > MAX_STORAGE_BYTES:
             k, d = pandas_data.popitem(last=False)

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -182,7 +182,7 @@ def validate_cache(force_cache_update: bool, asset: Asset, cache_file: Path, api
         splits_file_stale = datetime.fromtimestamp(splits_file_path.stat().st_mtime).date() != date.today()
         if splits_file_stale:
             cached_splits = pd.read_feather(splits_file_path)
-    if splits_file_stale:
+    if splits_file_stale or force_cache_update:
         polygon_client = RESTClient(api_key)
         # Need to get the splits in execution order to make the list comparable across invocations.
         splits = polygon_client.list_splits(ticker=asset.symbol, sort="execution_date", order="asc")

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -184,7 +184,8 @@ def validate_cache(force_cache_update: bool, asset: Asset, cache_file: Path, api
             cached_splits = pd.read_feather(splits_file_path)
     if splits_file_stale:
         polygon_client = RESTClient(api_key)
-        splits = polygon_client.list_splits(ticker=asset.symbol)
+        # Need to get the splits in execution order to make the list comparable across invocations.
+        splits = polygon_client.list_splits(ticker=asset.symbol, sort="execution_date", order="asc")
         if isinstance(splits, Iterator):
             # Convert the generator to a list so DataFrame will make a row per item.
             splits_df = pd.DataFrame(list(splits))


### PR DESCRIPTION
A fix for https://github.com/Lumiwealth/lumibot/issues/390.