### PR TITLE
Fix ccxt binance price precision

### DIFF
--- a/lumibot/brokers/ccxt.py
+++ b/lumibot/brokers/ccxt.py
@@ -469,10 +469,11 @@ class Ccxt(Broker):
             "stop_price",
         ]:
             if hasattr(order, price_type) and getattr(order, price_type) is not None:
+                precision_price = Decimal(str(10 ** -precision["price"])) if self.api.exchangeId == "binance" else precision["price"]
                 setattr(
                     order,
                     price_type,
-                    Decimal(getattr(order, price_type)).quantize(Decimal(str(precision["price"]))),
+                    Decimal(getattr(order, price_type)).quantize(Decimal(str(precision_price))),
                 )
             else:
                 continue


### PR DESCRIPTION
In ccxt, the price precision returned by Binance is different from other exchanges, which leads to limit orders rounding off decimals, and this always causes issues with the prices.

Binance market data like:
```json
{
  'precision': {'amount': 5, 'price': 2, 'cost': None, 'base': 8, 'quote': 8}
}
```