### PR TITLE
get_datetime: added in optional delay accounting

### DIFF
--- a/lumibot/data_sources/data_source.py
+++ b/lumibot/data_sources/data_source.py
@@ -112,15 +112,23 @@ class DataSource(ABC):
 
     # ========Python datetime helpers======================
 
-    def get_datetime(self):
+    def get_datetime(self, adjust_for_delay=False):
         """
         Returns the current datetime in the default timezone
+
+        Parameters
+        ----------
+        adjust_for_delay : bool
+            Whether to adjust the current time for the delay. This is useful for paper trading data sources that
+            provide delayed data.
 
         Returns
         -------
         datetime
         """
         current_time = self.to_default_timezone(datetime.now())
+        if adjust_for_delay and self._delay:
+            current_time -= self._delay
         return current_time
 
     def get_timestamp(self):

--- a/lumibot/data_sources/data_source_backtesting.py
+++ b/lumibot/data_sources/data_source_backtesting.py
@@ -39,7 +39,20 @@ class DataSourceBacktesting(DataSource, ABC):
         # catch it here and ignore it in this class. Child classes that need it should error check it themselves.
         self._config = config
 
-    def get_datetime(self):
+    def get_datetime(self, adjust_for_delay=False):
+        """
+        Get the current datetime of the backtest.
+
+        Parameters
+        ----------
+        adjust_for_delay: bool
+            Not used for backtesting data sources.  This parameter is only used for live data sources.
+
+        Returns
+        -------
+        datetime
+            The current datetime of the backtest.
+        """
         return self._datetime
 
     def get_datetime_range(self, length, timestep="minute", timeshift=None):

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -2319,7 +2319,7 @@ class Strategy(_Strategy):
         """
         return self.broker.data_source.DEFAULT_PYTZ
 
-    def get_datetime(self):
+    def get_datetime(self, adjust_for_delay=False):
         """Returns the current datetime according to the data source. In a backtest this will be the current bar's datetime. In live trading this will be the current datetime on the exchange.
 
         Returns
@@ -2333,7 +2333,7 @@ class Strategy(_Strategy):
         >>> datetime = self.get_datetime()
         >>> self.log_message(f"The current datetime is {datetime}")
         """
-        return self.broker.data_source.get_datetime()
+        return self.broker.data_source.get_datetime(adjust_for_delay=adjust_for_delay)
 
     def get_timestamp(self):
         """Returns the current timestamp according to the data source. In a backtest this will be the current bar's timestamp. In live trading this will be the current timestamp on the exchange.


### PR DESCRIPTION
Allows the user to optionally adjust for delayed data timestamps with a new flag to pass to the get_datetime(adjust_for_delay=True) calls.