### PR TITLE
Invalidate Polygon cache for options of a stock when its splits have changed.

### DIFF
--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -173,7 +173,7 @@ def validate_cache(force_cache_update: bool, asset: Asset, cache_file: Path, api
     Use the timestamp on the splits feather file to determine if we need to get the splits again.
     When invalidating we delete the cache file and return force_cache_update=True too.
     """
-    if asset.asset_type != Asset.AssetType.STOCK:
+    if asset.asset_type not in [Asset.AssetType.STOCK, Asset.AssetType.OPTION]:
         return force_cache_update
     cached_splits = pd.DataFrame()
     splits_file_stale = True


### PR DESCRIPTION
Fix for https://github.com/Lumiwealth/lumibot/issues/401.  Check for whether stock splits have changed for options when validating Polygon cache.

This turned out to be trivial since the logic is identical to what was done for stocks (https://github.com/Lumiwealth/lumibot/issues/390).
