### PR TITLE
:hammer:: Fix column with wrong types

### DIFF
--- a/lumibot/tools/ccxt_data_store.py
+++ b/lumibot/tools/ccxt_data_store.py
@@ -229,7 +229,7 @@ class CcxtCacheDB:
         with duckdb.connect(cache_file) as con:
             con.execute("""CREATE TABLE IF NOT EXISTS candles (
                             datetime DATETIME,
-                            open FLOAT, high FLOAT, low FLOAT, close FLOAT, volume INTEGER, missing INTEGER)""")
+                            open DECIMAL, high DECIMAL, low DECIMAL, close DECIMAL, volume DECIMAL, missing INTEGER)""")
 
             # cache ranges table
             con.execute("""CREATE TABLE  IF NOT EXISTS cache_dt_ranges (


### PR DESCRIPTION
When running the code with crypto currencies, the table is created with a restrictive column type which does not play nice with the backtesting_broker. 

This change should address the above issue and ensure that the data will work with the backtesting_broker.