### PR TITLE
Support Yahoo data at 1 minute and 15 minute intervals

### DIFF
--- a/lumibot/data_sources/yahoo_data.py
+++ b/lumibot/data_sources/yahoo_data.py
@@ -13,7 +13,9 @@ class YahooData(DataSourceBacktesting):
     SOURCE = "YAHOO"
     MIN_TIMESTEP = "day"
     TIMESTEP_MAPPING = [
-        {"timestep": "day", "representations": ["1D", "day"]},
+        {"timestep": "day", "representations": ["1d", "day"]},
+        {"timestep": "15 minutes", "representations": ["15m", "15 minutes"]},
+        {"timestep": "minute", "representations": ["1m", "1 minute"]},
     ]
 
     def __init__(self, *args, auto_adjust=True, **kwargs):
@@ -64,12 +66,13 @@ class YahooData(DataSourceBacktesting):
         if quote is not None:
             logging.warning(f"quote is not implemented for YahooData, but {quote} was passed as the quote")
 
-        self._parse_source_timestep(timestep, reverse=True)
+        interval = self._parse_source_timestep(timestep, reverse=True)
         if asset in self._data_store:
             data = self._data_store[asset]
         else:
             data = YahooHelper.get_symbol_data(
                 asset.symbol,
+                interval=interval,
                 auto_adjust=self.auto_adjust,
                 last_needed_datetime=self.datetime_end,
             )
@@ -79,11 +82,13 @@ class YahooData(DataSourceBacktesting):
                 return None
             data = self._append_data(asset, data)
 
-        # Get the last minute of self._datetime to get the current bar
-        dt = self._datetime.replace(hour=23, minute=59, second=59, microsecond=999999)
+        if timestep == "day":
+            # Get the last minute of self._datetime to get the current bar
+            dt = self._datetime.replace(hour=23, minute=59, second=59, microsecond=999999)
+            end = dt - timedelta(days=1)
+        else:
+            end = self._datetime.replace(second=59, microsecond=999999)
 
-        # End should be yesterday because otherwise you can see the future
-        end = dt - timedelta(days=1)
         if timeshift:
             end = end - timeshift
 
@@ -101,11 +106,11 @@ class YahooData(DataSourceBacktesting):
         if quote is not None:
             logging.warning(f"quote is not implemented for YahooData, but {quote} was passed as the quote")
 
-        self._parse_source_timestep(timestep, reverse=True)
+        interval = self._parse_source_timestep(timestep, reverse=True)
         missing_assets = [asset.symbol for asset in assets if asset not in self._data_store]
 
         if missing_assets:
-            dfs = YahooHelper.get_symbols_data(missing_assets, auto_adjust=self.auto_adjust)
+            dfs = YahooHelper.get_symbols_data(missing_assets, interval=interval, auto_adjust=self.auto_adjust)
             for symbol, df in dfs.items():
                 self._append_data(symbol, df)
 

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 
 import pandas as pd
 import plotly.graph_objects as go
+import pytz
 import quantstats_lumi as qs
 from plotly.subplots import make_subplots
 
@@ -47,8 +48,8 @@ def cagr(_df):
     df = df.sort_index(ascending=True)
     df["cum_return"] = (1 + df["return"]).cumprod()
     total_ret = df["cum_return"].iloc[-1]
-    start = datetime.utcfromtimestamp(df.index.values[0].astype("O") / 1e9)
-    end = datetime.utcfromtimestamp(df.index.values[-1].astype("O") / 1e9)
+    start = datetime.fromtimestamp(df.index.values[0].astype("O") / 1e9, pytz.UTC)
+    end = datetime.fromtimestamp(df.index.values[-1].astype("O") / 1e9, pytz.UTC)
     period_years = (end - start).days / 365.25
     if period_years == 0:
         return 0
@@ -62,8 +63,8 @@ def volatility(_df):
     has the return for that time period (eg. daily)
     """
     df = _df.copy()
-    start = datetime.utcfromtimestamp(df.index.values[0].astype("O") / 1e9)
-    end = datetime.utcfromtimestamp(df.index.values[-1].astype("O") / 1e9)
+    start = datetime.fromtimestamp(df.index.values[0].astype("O") / 1e9, pytz.UTC)
+    end = datetime.fromtimestamp(df.index.values[-1].astype("O") / 1e9, pytz.UTC)
     period_years = (end - start).days / 365.25
     if period_years == 0:
         return 0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="3.3.1",
+    version="3.4.0",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",
@@ -35,7 +35,7 @@ setuptools.setup(
         "email_validator",
         "bcrypt",
         "pytest",
-        "scipy==1.10.1",  # Newer versions of scipy are currently causing issues
+        "scipy==1.13.0",  # Newer versions of scipy are currently causing issues
         "ipython",  # required for quantstats, but not in their dependency list for some reason
         "quantstats-lumi>=0.2.0",
         "python-dotenv",  # Secret Storage


### PR DESCRIPTION
Updated Yahoo backtesting data to support 1 minute and 15 minute intervals.  Yahoo supports 1 minute intervals for past 7 days and 15 minute intervals for past 60 days.

In setup.py, there is a dependency on scipy==1.10.1.  That version appears to have been yanked.  I set to 1.13.0 but please change is that is not correct.