### PR TITLE
Fixed risk_free_rate bug

### DIFF
--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -279,6 +279,7 @@ class _Strategy:
         self._minutes_before_closing = minutes_before_closing
         self._minutes_before_opening = minutes_before_opening
         self._sleeptime = sleeptime
+        self._risk_free_rate = risk_free_rate
         self._executor = StrategyExecutor(self)
         self.broker._add_subscriber(self._executor)
 

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -328,14 +328,16 @@ class Strategy(_Strategy):
 
     @property
     def risk_free_rate(self):
+        rfr = 0
         if self._risk_free_rate is not None:
-            return self._risk_free_rate
-        
-        # Get the current datetime
-        now = self.get_datetime()
+            rfr = self._risk_free_rate
+        else:
+            # Get the current datetime
+            now = self.get_datetime()
 
-        # Use the yahoo data to get the risk free rate
-        rfr = get_risk_free_rate(now)
+            # Use the yahoo data to get the risk free rate
+            rfr = get_risk_free_rate(now)
+        
         return rfr
 
     # ======= Helper Methods =======================

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -328,6 +328,9 @@ class Strategy(_Strategy):
 
     @property
     def risk_free_rate(self):
+        if self._risk_free_rate is not None:
+            return self._risk_free_rate
+        
         # Get the current datetime
         now = self.get_datetime()
 


### PR DESCRIPTION
If you provide a risk_free_rate to backtest() strategy class method it does not set the risk_free_rate instance variable, always tries to get data from yahoo finance.