### PR TITLE
Fix custom tearsheet name

### DIFF
--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1008,6 +1008,7 @@ class _Strategy:
             show_tearsheet=show_tearsheet,
             save_tearsheet=save_tearsheet,
             show_indicators=show_indicators,
+            tearsheet_file=tearsheet_file,
         )
 
         end = datetime.datetime.now()

--- a/lumibot/traders/trader.py
+++ b/lumibot/traders/trader.py
@@ -54,7 +54,7 @@ class Trader:
         """Adds a strategy to the trader"""
         self._strategies.append(strategy)
 
-    def run_all(self, async_=False, show_plot=True, show_tearsheet=True, save_tearsheet=True, show_indicators=True):
+    def run_all(self, async_=False, show_plot=True, show_tearsheet=True, save_tearsheet=True, show_indicators=True, tearsheet_file=""):
         """
         run all strategies
 
@@ -125,6 +125,7 @@ class Trader:
                 show_tearsheet=show_tearsheet,
                 save_tearsheet=save_tearsheet,
                 show_indicators=show_indicators,
+                tearsheet_file=tearsheet_file,
             )
 
         return result

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -215,7 +215,7 @@ class TestPolygonBacktestFull:
         )
         trader = Trader(logfile="", backtest=True)
         trader.add_strategy(poly_strat_obj)
-        results = trader.run_all(show_plot=False, show_tearsheet=False, save_tearsheet=False)
+        results = trader.run_all(show_plot=False, show_tearsheet=False, save_tearsheet=False, tearsheet_file="")
 
         assert results
         self.verify_backtest_results(poly_strat_obj)

--- a/tests/backtest/test_yahoo.py
+++ b/tests/backtest/test_yahoo.py
@@ -51,7 +51,7 @@ class TestYahooBacktestFull:
 
         trader = Trader(logfile="", backtest=True)
         trader.add_strategy(poly_strat_obj)
-        results = trader.run_all(show_plot=False, show_tearsheet=False, save_tearsheet=False)
+        results = trader.run_all(show_plot=False, show_tearsheet=False, save_tearsheet=False, tearsheet_file="")
 
         assert results
 


### PR DESCRIPTION
An anomalous behaviour concerning the saving of a tearsheet file with a custom name was fixed. Previously, even if a custom name was entered when launching a backtest, the file name was not used.