### PR TITLE
Fix get_historical_prices for PolygonDataBacktesting data source

### DIFF
--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -51,7 +51,7 @@ class PolygonDataBacktesting(PandasData):
             storage_used -= mu
             logging.info(f"Storage limit exceeded. Evicted LRU data: {k} used {mu:,} bytes")
 
-    def _update_pandas_data(self, asset, quote, length, timestep, start_dt=None, update_data_store=False):
+    def _update_pandas_data(self, asset, quote, length, timestep, start_dt=None, update_data_store=True):
         """
         Get asset data and update the self.pandas_data dictionary.
 


### PR DESCRIPTION
At head, `get_historical_prices` always returns None for Polygon data source. Here is a short snippet to reproduce:

```
from lumibot.backtesting import PolygonDataBacktesting
from lumibot.strategies import Strategy
from lumibot.entities import Asset
from datetime import datetime
import config
import pytz


tzinfo = pytz.timezone("America/New_York")
start = datetime(2024, 2, 5).astimezone(tzinfo)
end = datetime(2024, 2, 10).astimezone(tzinfo)

data_source = PolygonDataBacktesting(
    start, end, api_key=config.POLYGON_API_KEY, has_paid_subscription=True
)
prices = data_source.get_historical_prices("AAPL", 5, "minute")
prices  # None
```

The reason is that `get_historical_prices` internally calls [_pull_source_symbol_bars](https://github.com/Lumiwealth/lumibot/blob/96d73cd69f4b0c525e33668b1983b1a001a8059b/lumibot/data_sources/pandas_data.py#L247), which tries to retrieve the data from `self._data_store`. Without updating the data store, above script will always return None. 

Note that [get_last_price](https://github.com/Lumiwealth/lumibot/blob/96d73cd69f4b0c525e33668b1983b1a001a8059b/lumibot/backtesting/polygon_backtesting.py#L258) explicitly sets `update_data_store=True`. So that method works. I don't see a reason to have different treatment for the 2 methods.

I hope the explanation makes sense. Please let me know if I'm missing some key design decisions.
