### PR TITLE
Proper handle "day" timestep in historical prices

### DIFF
--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -530,6 +530,14 @@ class Data:
         # Drop any rows that have NaN values (this can happen if the data is not complete, eg. weekends)
         df_result = df_result.dropna()
 
+        # Remove partial day data from the current day, which can happen if the data is in minute timestep.
+        if timestep == "day":
+            df_result = df_result[df_result.index < dt.replace(hour=0, minute=0, second=0, microsecond=0)]
+
+        # The original df_result may include more rows when timestep is day and self.timestep is minute.
+        # In this case, we only want to return the last n rows.
+        df_result = df_result.tail(n=num_periods)
+
         return df_result
 
     def get_bars_between_dates(self, timestep=MIN_TIMESTEP, exchange=None, start_date=None, end_date=None):

--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -496,6 +496,7 @@ class Data:
         """
         # Parse the timestep
         quantity, timestep = parse_timestep_qty_and_unit(timestep)
+        num_periods = length
 
         if timestep == "minute" and self.timestep == "day":
             raise ValueError("You are requesting minute data from a daily data source. This is not supported.")


### PR DESCRIPTION
There are 2 issues if the underlying data source contains `minute` timestep data, and the user calls `get_historical_prices` with `timestep=day`:

1. returns more days than requested
2. includes partial day data from the current day

### Test script

```python
from lumibot.backtesting import PolygonDataBacktesting
from lumibot.strategies import Strategy
from lumibot.entities import Asset
from datetime import datetime
import config
import pytz


tzinfo = pytz.timezone("America/New_York")
start = datetime(2024, 2, 5).astimezone(tzinfo)
end = datetime(2024, 2, 10).astimezone(tzinfo)

data_source = PolygonDataBacktesting(
    start, end, api_key=config.POLYGON_API_KEY, has_paid_subscription=True
)
data_source._datetime = datetime(2024, 2, 7, 10).astimezone(tzinfo)
prices = data_source.get_historical_prices("AAPL", 2, "minute")
prices = data_source.get_historical_prices("AAPL", 1, "day")
prices
```

### Before the PR

![image](https://github.com/Lumiwealth/lumibot/assets/8814693/faf145ab-a5ae-4b15-84b1-06c147ebb349)

### After the PR

![image](https://github.com/Lumiwealth/lumibot/assets/8814693/49dbd8b5-33bf-4fd4-9c1d-8ccabfcfbf5e)
