### PR TITLE
Fix get_historical_prices for PolygonDataBacktesting data source

### DIFF
--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -51,7 +51,7 @@ class PolygonDataBacktesting(PandasData):
             storage_used -= mu
             logging.info(f"Storage limit exceeded. Evicted LRU data: {k} used {mu:,} bytes")
 
-    def _update_pandas_data(self, asset, quote, length, timestep, start_dt=None, update_data_store=False):
+    def _update_pandas_data(self, asset, quote, length, timestep, start_dt=None):
         """
         Get asset data and update the self.pandas_data dictionary.
 
@@ -67,10 +67,6 @@ class PolygonDataBacktesting(PandasData):
             The timestep to use. For example, "1minute" or "1hour" or "1day".
         start_dt : datetime
             The start datetime to use. If None, the current self.start_datetime will be used.
-        update_data_store : bool
-            If True, the data will also be added to the self._data_store dictionary.
-            That update will not include the adjustments made by PandasData.load_data.
-            See https://github.com/Lumiwealth/lumibot/issues/391 and its PR for further discussion.
         """
         search_asset = asset
         asset_separated = asset
@@ -202,11 +198,6 @@ class PolygonDataBacktesting(PandasData):
         self.pandas_data.update(pandas_data_update)
         if PolygonDataBacktesting.MAX_STORAGE_BYTES:
             self._enforce_storage_limit(self.pandas_data)
-        if update_data_store:
-            # TODO: Why do we have both self.pandas_data and self._data_store?
-            self._data_store.update(pandas_data_update)
-            if PolygonDataBacktesting.MAX_STORAGE_BYTES:
-                self._enforce_storage_limit(self._data_store)
 
     def _pull_source_symbol_bars(
         self,
@@ -255,7 +246,7 @@ class PolygonDataBacktesting(PandasData):
     def get_last_price(self, asset, timestep="minute", quote=None, exchange=None, **kwargs):
         try:
             dt = self.get_datetime()
-            self._update_pandas_data(asset, quote, 1, timestep, dt, update_data_store=True)
+            self._update_pandas_data(asset, quote, 1, timestep, dt)
         except Exception as e:
             print(f"Error get_last_price from Polygon: {e}")
             print(f"Error get_last_price from Polygon: {asset=} {quote=} {timestep=} {dt=} {e}")

--- a/lumibot/data_sources/pandas_data.py
+++ b/lumibot/data_sources/pandas_data.py
@@ -24,11 +24,10 @@ class PandasData(DataSourceBacktesting):
         self.name = "pandas"
         self.pandas_data = self._set_pandas_data_keys(pandas_data)
         self.auto_adjust = auto_adjust
-        self._data_store = OrderedDict()
+        self._data_store = self.pandas_data
         self._date_index = None
         self._date_supply = None
         self._timestep = "minute"
-        self._expiries_exist = False
 
     @staticmethod
     def _set_pandas_data_keys(pandas_data):
@@ -65,9 +64,6 @@ class PandasData(DataSourceBacktesting):
     
     def load_data(self):
         self._data_store = self.pandas_data
-        self._expiries_exist = (
-            len([v.asset.expiration for v in self._data_store.values() if v.asset.expiration is not None]) > 0
-        )
         self._date_index = self.update_date_index()
 
         if len(self._data_store.values()) > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,11 +17,11 @@ marshmallow-sqlalchemy
 email_validator
 bcrypt
 pytest
-scipy==1.10.1  # Newer versions of scipy are currently causing issues
+scipy>=1.13.0
 ipython  # required for quantstats, but not in their dependency list for some reason
 quantstats-lumi
 python-dotenv  # Secret Storage
-ccxt==4.2.22
+ccxt==4.2.85
 termcolor
 jsonpickle
 apscheduler

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
         "email_validator",
         "bcrypt",
         "pytest",
-        "scipy>=1.13.0",  # Newer versions of scipy are currently causing issues
+        "scipy>=1.13.0",
         "ipython",  # required for quantstats, but not in their dependency list for some reason
         "quantstats-lumi>=0.2.0",
         "python-dotenv",  # Secret Storage

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 import pandas_market_calendars as mcal
 
+import pytz
 from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting
 from lumibot.entities import Asset
 from lumibot.strategies import Strategy
@@ -272,3 +273,18 @@ class TestPolygonBacktestFull:
             polygon_has_paid_subscription=True,
         )
         assert results
+
+
+class TestPolygonDataSource:
+
+    def test_get_historical_prices_is_not_none(self):
+        tzinfo = pytz.timezone("America/New_York")
+        start = datetime.datetime(2024, 2, 5).astimezone(tzinfo)
+        end = datetime.datetime(2024, 2, 10).astimezone(tzinfo)
+
+        data_source = PolygonDataBacktesting(
+            start, end, api_key=POLYGON_API_KEY, has_paid_subscription=True
+        )
+        data_source._datetime = datetime.datetime(2024, 2, 7, 10).astimezone(tzinfo)
+        prices = data_source.get_historical_prices("SPY", 1, "day")
+        assert prices is not None


### PR DESCRIPTION
At head, `get_historical_prices` always returns None for Polygon data source. The reason is that `get_historical_prices` internally calls [_pull_source_symbol_bars](https://github.com/Lumiwealth/lumibot/blob/96d73cd69f4b0c525e33668b1983b1a001a8059b/lumibot/data_sources/pandas_data.py#L247), which tries to retrieve the data from `self._data_store`. Without updating the data store, above script will always return None. 

Per discussion in https://github.com/Lumiwealth/lumibot/pull/430, this PR merges data_store and pandas_data. It also removes the `update_data_store` argument and simplifies the code logic.