### PR TITLE
Correct date range for intra-day strategy

### DIFF
--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -768,6 +768,10 @@ class StrategyExecutor(Thread):
         if not is_247:
             # Set date to the start date, but account for minutes_before_opening
             self.strategy.await_market_to_open()  # set new time and bar length. Check if hit bar max or date max.
+            # Check if we should continue to run when we are in a new day.
+            broker_continue = self.broker.should_continue()
+            if not broker_continue:
+                return
 
             if not has_data_source or (has_data_source and self.broker.data_source.SOURCE != "PANDAS"):
                 self.strategy._update_cash_with_dividends()


### PR DESCRIPTION
When the strategy is intra-day (with sleeptime < 1D), the strategy executor will run one extra day after the `datetime_end`, which is incorrect. This change adds another `should_continue` check before the market opens, so it respects the `datetime_end` more rigorously.

For example, if the `datetime_end=2024-02-10`, which is a Saturday.

- The behavior at head will try to run the strategy on `2024-02-12` (a Monday). The executor stops at the market close time of `2024-02-12`.
- With this PR, the executor will run all the lifecycle methods on `2024-02-09` (Friday), and then sleep until before the market opens on `2024-02-12`, and stops there

