### PR TITLE
Fix miscalculated start datetime in _pull_source_symbol_bars

### DIFF
--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -220,10 +220,9 @@ class PolygonDataBacktesting(PandasData):
     ):
         # Get the current datetime and calculate the start datetime
         current_dt = self.get_datetime()
-        start_dt, ts_unit = self.get_start_datetime_and_ts_unit(length, timestep, current_dt, start_buffer=START_BUFFER)
 
         # Get data from Polygon
-        self._update_pandas_data(asset, quote, length, timestep, start_dt)
+        self._update_pandas_data(asset, quote, length, timestep, current_dt)
 
         return super()._pull_source_symbol_bars(
             asset, length, timestep, timeshift, quote, exchange, include_after_hours

--- a/tests/backtest/fixtures.py
+++ b/tests/backtest/fixtures.py
@@ -1,0 +1,20 @@
+import pytest
+import datetime
+from lumibot.backtesting import PolygonDataBacktesting
+
+@pytest.fixture
+def polygon_data_backtesting():
+    datetime_start = datetime.datetime(2023, 1, 1)
+    datetime_end = datetime.datetime(2023, 2, 1)
+    api_key = "fake_api_key"
+    pandas_data = {}
+    
+    polygon_data_instance = PolygonDataBacktesting(
+        datetime_start=datetime_start,
+        datetime_end=datetime_end,
+        pandas_data=pandas_data,
+        api_key=api_key,
+        has_paid_subscription=False
+    )
+    
+    return polygon_data_instance

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -4,10 +4,15 @@ from collections import defaultdict
 
 import pandas_market_calendars as mcal
 
+from tests.backtest.fixtures import polygon_data_backtesting
 from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting
+from lumibot.tools import polygon_helper
 from lumibot.entities import Asset
 from lumibot.strategies import Strategy
 from lumibot.traders import Trader
+
+from unittest.mock import MagicMock, patch
+from datetime import timedelta
 
 # Global parameters
 # API Key for testing Polygon.io
@@ -272,3 +277,45 @@ class TestPolygonBacktestFull:
             polygon_has_paid_subscription=True,
         )
         assert results
+
+    def test_pull_source_symbol_bars_with_api_call(self, polygon_data_backtesting, mocker):
+        """Test that polygon_helper.get_price_data_from_polygon() is called with the right parameters"""
+        
+        # Only simulate first date
+        mocker.patch.object(
+            polygon_data_backtesting,
+            'get_datetime',
+            return_value=polygon_data_backtesting.datetime_start
+        )
+
+        mocked_get_price_data = mocker.patch(
+            'lumibot.tools.polygon_helper.get_price_data_from_polygon',
+            return_value=MagicMock()
+        )
+        
+        asset = Asset(symbol="AAPL", asset_type="stock")
+        quote = Asset(symbol="USD", asset_type="forex")
+        length = 10
+        timestep = "day"
+        START_BUFFER = timedelta(days=5)
+
+        with patch('lumibot.backtesting.polygon_backtesting.START_BUFFER', new=START_BUFFER):
+            polygon_data_backtesting._pull_source_symbol_bars(
+                asset=asset,
+                length=length,
+                timestep=timestep,
+                quote=quote
+            )
+
+            mocked_get_price_data.assert_called_once()
+            call_args = mocked_get_price_data.call_args
+            
+            expected_start_date = polygon_data_backtesting.datetime_start - datetime.timedelta(days=length) - START_BUFFER
+            
+            assert call_args[0][0] == polygon_data_backtesting._api_key
+            assert call_args[0][1] == asset
+            assert call_args[0][2] == expected_start_date
+            assert call_args[0][3] == polygon_data_backtesting.datetime_end
+            assert call_args[1]["timespan"] == timestep
+            assert call_args[1]["quote_asset"] == quote
+            assert call_args[1]["has_paid_subscription"] == polygon_data_backtesting.has_paid_subscription


### PR DESCRIPTION
- Removed duplicate calls to self.get_start_datetime_and_ts_unit within _update_pandas_data to prevent exceeding API limits.
- Added unit test to verify correct data handling in Polygon API calls.