### PR TITLE
Remove Yahoo data pickle cache file when it can't be read.

### DIFF
--- a/lumibot/tools/yahoo_helper.py
+++ b/lumibot/tools/yahoo_helper.py
@@ -73,6 +73,8 @@ class YahooHelper:
                         return pickle.load(f)
                 except Exception as e:
                     logging.error("Error while loading pickle file %s: %s" % (pickle_file_path, e))
+                    # Remove the file because it is corrupted.  This will enable re-download.
+                    os.remove(pickle_file_path)
                     return None
 
         return None


### PR DESCRIPTION
When the cache file can't be read because it is corrupted the backtest slows down instead of recovering (which depends on manual intervention after a super slow run).