### PR TITLE
populate avg_fill_price

### DIFF
--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -368,6 +368,7 @@ class Tradier(Broker):
             date_created=response["create_date"],
         )
         order.status = response["status"]
+        order.avg_fill_price = response.get("avg_fill_price", order.avg_fill_price)
         order.update_raw(response)  # This marks order as 'transmitted'
         return order
 


### PR DESCRIPTION
Tradier orders pulled from the broker are missing the average_fill_price property. This causes order.avg_fill_price and order.get_fil_price() to return 0.0. This PR fixes issue #436 .