### PR TITLE
fix tearsheet_file error when using run_all()

### DIFF
--- a/lumibot/traders/trader.py
+++ b/lumibot/traders/trader.py
@@ -54,7 +54,7 @@ class Trader:
         """Adds a strategy to the trader"""
         self._strategies.append(strategy)
 
-    def run_all(self, async_=False, show_plot=True, show_tearsheet=True, save_tearsheet=True, show_indicators=True, tearsheet_file=""):
+    def run_all(self, async_=False, show_plot=True, show_tearsheet=True, save_tearsheet=True, show_indicators=True, tearsheet_file=None):
         """
         run all strategies
 


### PR DESCRIPTION
This was giving an error when trying to backtest with run_all():

FileNotFoundError: [Errno 2] No such file or directory: ''