### PR TITLE
fix empty tearsheet_file for trader.run_all

### DIFF
--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1047,15 +1047,15 @@ class _Strategy:
 
         datestring = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         basename = f"{name + '_' if name is not None else ''}{datestring}"
-        if plot_file_html is None:
+        if not plot_file_html:
             plot_file_html = f"{logdir}/{basename}_trades.html"
-        if trades_file is None:
+        if not trades_file:
             trades_file = f"{logdir}/{basename}_trades.csv"
-        if tearsheet_file is None:
+        if not tearsheet_file:
             tearsheet_file = f"{logdir}/{basename}_tearsheet.html"
-        if settings_file is None:
+        if not settings_file:
             settings_file = f"{logdir}/{basename}_settings.json"
-        if indicators_file is None:
+        if not indicators_file:
             indicators_file = f"{logdir}/{basename}_indicators.html"
 
         self.write_backtest_settings(settings_file)

--- a/lumibot/traders/trader.py
+++ b/lumibot/traders/trader.py
@@ -54,7 +54,7 @@ class Trader:
         """Adds a strategy to the trader"""
         self._strategies.append(strategy)
 
-    def run_all(self, async_=False, show_plot=True, show_tearsheet=True, save_tearsheet=True, show_indicators=True, tearsheet_file=""):
+    def run_all(self, async_=False, show_plot=True, show_tearsheet=True, save_tearsheet=True, show_indicators=True, tearsheet_file=None):
         """
         run all strategies
 

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -221,7 +221,7 @@ class TestPolygonBacktestFull:
         )
         trader = Trader(logfile="", backtest=True)
         trader.add_strategy(poly_strat_obj)
-        results = trader.run_all(show_plot=False, show_tearsheet=False, save_tearsheet=False, tearsheet_file="")
+        results = trader.run_all(show_plot=False, show_tearsheet=False, save_tearsheet=True)
 
         assert results
         self.verify_backtest_results(poly_strat_obj)


### PR DESCRIPTION
Since https://github.com/Lumiwealth/lumibot/commit/7d072abd72b1197215cd7e50ae5ad9043d2a36e2, `trader.run_all(save_tearsheet=True)` no longer works, because `tearsheet_file` defaults to empty string (which is not None), and the downstream does not update its value.

This change does the following:

- update a test to make sure `trader.run_all(save_tearsheet=True)` can run without any crash
- update `tearsheet_file=None`
- update downstream (_strategy.py) to handle both empty string and None


Before the change we will get the following error and stack trace:

```
FAILED tests/backtest/test_polygon.py::TestPolygonBacktestFull::test_polygon_restclient - FileNotFoundError: [Errno 2] No such file or directory: ''

lumibot/traders/trader.py:122: in run_all
    strat.backtest_analysis(
lumibot/strategies/_strategy.py:1084: in backtest_analysis
    self.tearsheet(
lumibot/strategies/_strategy.py:699: in tearsheet
    create_tearsheet(
lumibot/tools/indicators.py:717: in create_tearsheet
    qs.reports.html(
```
