### PR TITLE
Better rate limited RESTClient

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,5 +1,16 @@
 name: LumiBot CI/CD
 on: [pull_request]
+# permissions:
+#   # Gives the action the necessary permissions for publishing new
+#   # comments in pull requests.
+#   pull-requests: write
+#   # Gives the action the necessary permissions for editing existing
+#   # comments (to avoid publishing multiple comments in the same PR)
+#   contents: write
+#   # Gives the action the necessary permissions for looking up the
+#   # workflow that launched this workflow, and download the related
+#   # artifact that contains the comment to be published
+#   actions: read
 jobs:
   LintAndTest:
     runs-on: ubuntu-latest
@@ -32,6 +43,12 @@ jobs:
           coverage run
           coverage report
           coverage html
-      - name: Python Coverage Comment
-          uses: py-cov-action/python-coverage-comment-action@v3.23
+      #     coverage xml -o coverage.xml 
+      # - name: Verify Coverage File
+      #   run: ls -l coverage.xml
+      # - name: Python Coverage Comment
+      #   uses: py-cov-action/python-coverage-comment-action@v3.23
+      #   with:
+      #     GITHUB_TOKEN: ${{ github.token }}
+      #     coverage_path: coverage.xml
             

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -19,6 +19,7 @@ jobs:
     env: 
       AIOHTTP_NO_EXTENSIONS: 1
       POLYGON_API_KEY: ${{secrets.POLYGON_API_KEY}}  # Required for Polygon API BackTests
+      POLYGON_IS_PAID_SUBSCRIPTION: ${{secrets.POLYGON_IS_PAID_SUBSCRIPTION}}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.11

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -19,7 +19,7 @@ jobs:
     env: 
       AIOHTTP_NO_EXTENSIONS: 1
       POLYGON_API_KEY: ${{secrets.POLYGON_API_KEY}}  # Required for Polygon API BackTests
-      POLYGON_IS_PAID_SUBSCRIPTION: ${{variables.POLYGON_IS_PAID_SUBSCRIPTION}}
+      POLYGON_IS_PAID_SUBSCRIPTION: $POLYGON_IS_PAID_SUBSCRIPTION
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.11

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -19,7 +19,7 @@ jobs:
     env: 
       AIOHTTP_NO_EXTENSIONS: 1
       POLYGON_API_KEY: ${{secrets.POLYGON_API_KEY}}  # Required for Polygon API BackTests
-      POLYGON_IS_PAID_SUBSCRIPTION: ${{secrets.POLYGON_IS_PAID_SUBSCRIPTION}}
+      POLYGON_IS_PAID_SUBSCRIPTION: ${{variables.POLYGON_IS_PAID_SUBSCRIPTION}}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.11

--- a/assets.json
+++ b/assets.json
@@ -1,0 +1,1 @@
+["VRT", "CNM", "SPY", "GOOG"]

--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -39,7 +39,7 @@ class PolygonDataBacktesting(PandasData):
         self.has_paid_subscription = has_paid_subscription
 
         # RESTClient API for Polygon.io polygon-api-client
-        self.polygon_client = PolygonClient.create(api_key=self._api_key, paid=self.has_paid_subscription)
+        self.polygon_client = PolygonClient.create(api_key=api_key, paid=has_paid_subscription)
 
     @staticmethod
     def _enforce_storage_limit(pandas_data: OrderedDict):

--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -39,7 +39,7 @@ class PolygonDataBacktesting(PandasData):
         self.has_paid_subscription = has_paid_subscription
 
         # RESTClient API for Polygon.io polygon-api-client
-        self.polygon_client = PolygonClient(self._api_key, paid=self.has_paid_subscription)
+        self.polygon_client = PolygonClient(api_key=self._api_key, paid=self.has_paid_subscription)
 
     @staticmethod
     def _enforce_storage_limit(pandas_data: OrderedDict):

--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -3,7 +3,6 @@ import traceback
 from collections import OrderedDict, defaultdict
 from datetime import date, timedelta
 
-from polygon import RESTClient
 from polygon.exceptions import BadResponse
 from termcolor import colored
 from urllib3.exceptions import MaxRetryError
@@ -11,6 +10,7 @@ from urllib3.exceptions import MaxRetryError
 from lumibot.data_sources import PandasData
 from lumibot.entities import Asset, Data
 from lumibot.tools import polygon_helper
+from lumibot.tools.polygon_helper import RLRESTClient
 
 START_BUFFER = timedelta(days=5)
 
@@ -39,7 +39,7 @@ class PolygonDataBacktesting(PandasData):
         self.has_paid_subscription = has_paid_subscription
 
         # RESTClient API for Polygon.io polygon-api-client
-        self.polygon_client = RESTClient(self._api_key)
+        self.polygon_client = RLRESTClient(self._api_key, paid=self.has_paid_subscription)
 
     @staticmethod
     def _enforce_storage_limit(pandas_data: OrderedDict):

--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -39,7 +39,7 @@ class PolygonDataBacktesting(PandasData):
         self.has_paid_subscription = has_paid_subscription
 
         # RESTClient API for Polygon.io polygon-api-client
-        self.polygon_client = PolygonClient(api_key=self._api_key, paid=self.has_paid_subscription)
+        self.polygon_client = PolygonClient.create(api_key=self._api_key, paid=self.has_paid_subscription)
 
     @staticmethod
     def _enforce_storage_limit(pandas_data: OrderedDict):

--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -10,7 +10,7 @@ from urllib3.exceptions import MaxRetryError
 from lumibot.data_sources import PandasData
 from lumibot.entities import Asset, Data
 from lumibot.tools import polygon_helper
-from lumibot.tools.polygon_helper import RLRESTClient
+from lumibot.tools.polygon_helper import PolygonClient
 
 START_BUFFER = timedelta(days=5)
 
@@ -39,7 +39,7 @@ class PolygonDataBacktesting(PandasData):
         self.has_paid_subscription = has_paid_subscription
 
         # RESTClient API for Polygon.io polygon-api-client
-        self.polygon_client = RLRESTClient(self._api_key, paid=self.has_paid_subscription)
+        self.polygon_client = PolygonClient(self._api_key, paid=self.has_paid_subscription)
 
     @staticmethod
     def _enforce_storage_limit(pandas_data: OrderedDict):

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -492,7 +492,7 @@ class PolygonClient(RESTClient):
         """
         Initialize the PolygonClient with rate limiting.
         """
-        self.seconds = 60
+        self.seconds = 12
         super().__init__(*args, **kwargs)
 
     def _get(self, *args, **kwargs):

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -479,17 +479,19 @@ class PolygonClient(RESTClient):
         client = PolygonClient(paid=False)  # For rate limited client
         client = PolygonClient(paid=True)   # For non-rate limited client (default)
         """
-    
+
         self.paid = kwargs.pop('paid', True)
         self.seconds = 60
         super().__init__(*args, **kwargs)
-
-    def _get(self, *args, **kwargs):
+        
         if not self.paid:
-            logging.info(
-                f"\nSleeping {self.seconds} seconds while getting data from Polygon "
-                 "to avoid hitting the rate limit; "
-                 "consider a paid Polygon subscription for faster results.\n"
-            )
-            time.sleep(self.seconds)
+            self._get = self._get_rate_limited
+
+    def _get_rate_limited(self, *args, **kwargs):
+        logging.info(
+            f"\nSleeping {self.seconds} seconds while getting data from Polygon "
+            "to avoid hitting the rate limit; "
+            "consider a paid Polygon subscription for faster results.\n"
+        )
+        time.sleep(self.seconds)
         return super()._get(*args, **kwargs)

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -466,6 +466,8 @@ def update_polygon_data(df_all, result):
 class PolygonClient(RESTClient):
     ''' Rate Limited RESTClient with factory method '''
 
+    WAIT_SECONDS = 12
+
     @classmethod
     def create(cls, *args, **kwargs) -> RESTClient:
         """
@@ -488,18 +490,11 @@ class PolygonClient(RESTClient):
             return cls(*args, **kwargs)
 
 
-    def __init__(self, *args, **kwargs):
-        """
-        Initialize the PolygonClient with rate limiting.
-        """
-        self.seconds = 12
-        super().__init__(*args, **kwargs)
-
     def _get(self, *args, **kwargs):
         logging.info(
-            f"\nSleeping {self.seconds} seconds while getting data from Polygon "
+            f"\nSleeping {PolygonClient.WAIT_SECONDS} seconds while getting data from Polygon "
             "to avoid hitting the rate limit; "
             "consider a paid Polygon subscription for faster results.\n"
         )
-        time.sleep(self.seconds)
+        time.sleep(PolygonClient.WAIT_SECONDS)
         return super()._get(*args, **kwargs)

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -465,7 +465,7 @@ def update_polygon_data(df_all, result):
 
 class PolygonClient(RESTClient):
     ''' Rate Limited RESTClient '''
-    
+
     def __init__(self, *args, **kwargs):
         """
         Initialize the PolygonClient with optional rate limiting.
@@ -474,6 +474,10 @@ class PolygonClient(RESTClient):
         paid : bool, optional
             If False, the client will sleep for 60 seconds before each request to avoid
             hitting the rate limit. Default is True.
+        
+        Usage:
+        client = PolygonClient(paid=False)  # For rate limited client
+        client = PolygonClient(paid=True)   # For non-rate limited client (default)
         """
     
         self.paid = kwargs.pop('paid', True)

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -89,7 +89,7 @@ def get_price_data_from_polygon(
     # print(f"\nGetting pricing data for {asset} / {quote_asset} with '{timespan}' timespan from Polygon...")
 
     # RESTClient connection for Polygon Stock-Equity API; traded_asset is standard
-    # Add "trace=True" to see the API capolygon_clientlls printed to the console for debugging
+    # Add "trace=True" to see the API calls printed to the console for debugging
     polygon_client = PolygonClient.create(api_key=api_key, paid=has_paid_subscription)
     symbol = get_polygon_symbol(asset, polygon_client, quote_asset)  # Will do a Polygon query for option contracts
 

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -90,7 +90,7 @@ def get_price_data_from_polygon(
 
     # RESTClient connection for Polygon Stock-Equity API; traded_asset is standard
     # Add "trace=True" to see the API capolygon_clientlls printed to the console for debugging
-    polygon_client = PolygonClient(api_key, paid=has_paid_subscription)
+    polygon_client = PolygonClient(api_key=api_key, paid=has_paid_subscription)
     symbol = get_polygon_symbol(asset, polygon_client, quote_asset)  # Will do a Polygon query for option contracts
 
     # To reduce calls to Polygon, we call on full date ranges instead of including hours/minutes
@@ -165,7 +165,7 @@ def validate_cache(force_cache_update: bool, asset: Asset, cache_file: Path, api
         if splits_file_stale:
             cached_splits = pd.read_feather(splits_file_path)
     if splits_file_stale or force_cache_update:
-        polygon_client = PolygonClient(api_key, paid=paid)
+        polygon_client = PolygonClient(api_key=api_key, paid=paid)
         # Need to get the splits in execution order to make the list comparable across invocations.
         splits = polygon_client.list_splits(ticker=asset.symbol, sort="execution_date", order="asc")
         if isinstance(splits, Iterator):
@@ -476,8 +476,8 @@ class PolygonClient(RESTClient):
             hitting the rate limit. Default is True.
         
         Usage:
-        client = PolygonClient(paid=False)  # For rate limited client
-        client = PolygonClient(paid=True)   # For non-rate limited client (default)
+        client = PolygonClient(api_key=<API_KEY>, paid=False)  # For rate limited client
+        client = PolygonClient(api_key=<API_KEY>, paid=True)   # For non-rate limited client (default)
         """
 
         self.paid = kwargs.pop('paid', True)

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -90,7 +90,7 @@ def get_price_data_from_polygon(
 
     # RESTClient connection for Polygon Stock-Equity API; traded_asset is standard
     # Add "trace=True" to see the API capolygon_clientlls printed to the console for debugging
-    polygon_client = RLRESTClient(api_key, paid=has_paid_subscription)
+    polygon_client = PolygonClient(api_key, paid=has_paid_subscription)
     symbol = get_polygon_symbol(asset, polygon_client, quote_asset)  # Will do a Polygon query for option contracts
 
     # To reduce calls to Polygon, we call on full date ranges instead of including hours/minutes
@@ -463,7 +463,7 @@ def update_polygon_data(df_all, result):
 
     return df_all
 
-class RLRESTClient(RESTClient):
+class PolygonClient(RESTClient):
     ''' Rate Limited RESTClient '''
     def __init__(self, *args, **kwargs):
         self.paid = kwargs.pop('paid', True)

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -472,13 +472,10 @@ class RLRESTClient(RESTClient):
 
     def _get(self, *args, **kwargs):
         if not self.paid:
-            print(
-                f"\nSleeping {self.seconds} seconds while getting data from Polygon because "
-                f"we don't want to hit the rate limit. IT IS NORMAL FOR THIS TEXT TO SHOW UP SEVERAL TIMES "
-                "and IT MAY TAKE UP TO 10 MINUTES PER ASSET while we download all the data from Polygon. The next "
-                "time you run this it should be faster because the data will be cached to your machine. \n"
-                "If you want this to go faster, you can get a paid Polygon subscription at https://polygon.io/pricing "
-                f"and set `polygon_has_paid_subscription=True` when starting the backtest.\n"
+            logging.info(
+                f"\nSleeping {self.seconds} seconds while getting data from Polygon "
+                 "to avoid hitting the rate limit; "
+                 "consider a paid Polygon subscription for faster results.\n"
             )
             time.sleep(self.seconds)
         return super()._get(*args, **kwargs)

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -465,7 +465,17 @@ def update_polygon_data(df_all, result):
 
 class PolygonClient(RESTClient):
     ''' Rate Limited RESTClient '''
+    
     def __init__(self, *args, **kwargs):
+        """
+        Initialize the PolygonClient with optional rate limiting.
+
+        Keyword Arguments:
+        paid : bool, optional
+            If False, the client will sleep for 60 seconds before each request to avoid
+            hitting the rate limit. Default is True.
+        """
+    
         self.paid = kwargs.pop('paid', True)
         self.seconds = 60
         super().__init__(*args, **kwargs)

--- a/tests/backtest/test_example_strategies.py
+++ b/tests/backtest/test_example_strategies.py
@@ -18,6 +18,7 @@ from lumibot.entities import Asset
 # Global parameters
 # API Key for testing Polygon.io
 POLYGON_API_KEY = os.environ.get("POLYGON_API_KEY")
+POLYGON_IS_PAID_SUBSCRIPTION = os.getenv("POLYGON_IS_PAID_SUBSCRIPTION", "true").lower() not in {'false', '0', 'f', 'n', 'no'}
 
 
 class TestExampleStrategies:
@@ -40,6 +41,8 @@ class TestExampleStrategies:
             show_plot=False,
             show_tearsheet=False,
             save_tearsheet=False,
+            polygon_api_key=POLYGON_API_KEY,
+            polygon_has_paid_subscription=POLYGON_IS_PAID_SUBSCRIPTION
         )
         assert results
         assert isinstance(strat_obj, StockBracket)

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -18,7 +18,7 @@ from datetime import timedelta
 # Global parameters
 # API Key for testing Polygon.io
 POLYGON_API_KEY = os.environ.get("POLYGON_API_KEY")
-POLYGON_IS_PAID_SUBSCRIPTION = os.environ.get("POLYGON_IS_PAID_SUBSCRIPTION") or True
+POLYGON_IS_PAID_SUBSCRIPTION = os.getenv("POLYGON_IS_PAID_SUBSCRIPTION", "true").lower() not in {'false', '0', 'f', 'n', 'no'}
 
 
 class PolygonBacktestStrat(Strategy):

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -18,6 +18,7 @@ from datetime import timedelta
 # Global parameters
 # API Key for testing Polygon.io
 POLYGON_API_KEY = os.environ.get("POLYGON_API_KEY")
+POLYGON_IS_PAID_SUBSCRIPTION = os.environ.get("POLYGON_IS_PAID_SUBSCRIPTION") or True
 
 
 class PolygonBacktestStrat(Strategy):
@@ -213,7 +214,7 @@ class TestPolygonBacktestFull:
             datetime_start=backtesting_start,
             datetime_end=backtesting_end,
             api_key=POLYGON_API_KEY,
-            has_paid_subscription=True,
+            has_paid_subscription=POLYGON_IS_PAID_SUBSCRIPTION,
         )
         broker = BacktestingBroker(data_source=data_source)
         poly_strat_obj = PolygonBacktestStrat(
@@ -235,7 +236,7 @@ class TestPolygonBacktestFull:
             datetime_start=backtesting_start,
             datetime_end=backtesting_end,
             api_key=POLYGON_API_KEY,
-            has_paid_subscription=True,
+            has_paid_subscription=POLYGON_IS_PAID_SUBSCRIPTION,
         )
         broker = BacktestingBroker(data_source=data_source)
         poly_strat_obj = PolygonBacktestStrat(
@@ -275,7 +276,7 @@ class TestPolygonBacktestFull:
             api_key=POLYGON_API_KEY,
             # Painfully slow with free subscription setting b/c lumibot is over querying and imposing a very
             # strict rate limit
-            polygon_has_paid_subscription=True,
+            polygon_has_paid_subscription=POLYGON_IS_PAID_SUBSCRIPTION,
         )
         assert results
         self.verify_backtest_results(poly_strat_obj)
@@ -299,7 +300,7 @@ class TestPolygonBacktestFull:
             polygon_api_key=POLYGON_API_KEY,  # Testing the legacy parameter name while DeprecationWarning is active
             # Painfully slow with free subscription setting b/c lumibot is over querying and imposing a very
             # strict rate limit
-            polygon_has_paid_subscription=True,
+            polygon_has_paid_subscription=POLYGON_IS_PAID_SUBSCRIPTION,
         )
         assert results
 
@@ -354,7 +355,7 @@ class TestPolygonDataSource:
         end = datetime.datetime(2024, 2, 10).astimezone(tzinfo)
 
         data_source = PolygonDataBacktesting(
-            start, end, api_key=POLYGON_API_KEY, has_paid_subscription=True
+            start, end, api_key=POLYGON_API_KEY, has_paid_subscription=POLYGON_IS_PAID_SUBSCRIPTION
         )
         data_source._datetime = datetime.datetime(2024, 2, 7, 10).astimezone(tzinfo)
         # This call will set make the data source use minute bars.

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -372,7 +372,7 @@ class TestPolygonDataSource:
                 "high": 494.3778,
                 "low": 490.23,
                 "close": 492.57,
-                "volume": 74655145.0
+                "volume": 74773591.0
             },
             {
                 "datetime": "2024-02-06 00:00:00-05:00",
@@ -380,7 +380,7 @@ class TestPolygonDataSource:
                 "high": 494.3200,
                 "low": 492.03,
                 "close": 493.82,
-                "volume": 54775803.0
+                "volume": 54891827.0
             },
         ], index="datetime")
         expected_df.index = pd.to_datetime(expected_df.index).tz_convert(tzinfo)

--- a/tests/test_polygon_helper.py
+++ b/tests/test_polygon_helper.py
@@ -292,7 +292,7 @@ class TestPolygonPriceData:
     def test_get_price_data_from_polygon(self, mocker, tmpdir):
         # Ensure we don't accidentally call the real Polygon API
         mock_polyclient = mocker.MagicMock()
-        mocker.patch.object(ph, "PolygonClient", mock_polyclient)
+        mocker.patch.object(ph, "RESTClient", mock_polyclient)
         #mocker.patch.object(ph, "WAIT_TIME", 0)
         mocker.patch.object(ph, "LUMIBOT_CACHE_FOLDER", tmpdir)
 
@@ -392,7 +392,7 @@ class TestPolygonPriceData:
     def test_polygon_missing_day_caching(self, mocker, tmpdir, timespan, force_cache_update):
         # Ensure we don't accidentally call the real Polygon API
         mock_polyclient = mocker.MagicMock()
-        mocker.patch.object(ph, "PolygonClient", mock_polyclient)
+        mocker.patch.object(ph, "RESTClient", mock_polyclient)
         #mocker.patch.object(ph, "WAIT_TIME", 0)
         mocker.patch.object(ph, "LUMIBOT_CACHE_FOLDER", tmpdir)
 

--- a/tests/test_polygon_helper.py
+++ b/tests/test_polygon_helper.py
@@ -292,8 +292,8 @@ class TestPolygonPriceData:
     def test_get_price_data_from_polygon(self, mocker, tmpdir):
         # Ensure we don't accidentally call the real Polygon API
         mock_polyclient = mocker.MagicMock()
-        mocker.patch.object(ph, "RESTClient", mock_polyclient)
-        mocker.patch.object(ph, "WAIT_TIME", 0)
+        mocker.patch.object(ph, "PolygonClient", mock_polyclient)
+        #mocker.patch.object(ph, "WAIT_TIME", 0)
         mocker.patch.object(ph, "LUMIBOT_CACHE_FOLDER", tmpdir)
 
         # Options Contracts to return
@@ -392,8 +392,8 @@ class TestPolygonPriceData:
     def test_polygon_missing_day_caching(self, mocker, tmpdir, timespan, force_cache_update):
         # Ensure we don't accidentally call the real Polygon API
         mock_polyclient = mocker.MagicMock()
-        mocker.patch.object(ph, "RESTClient", mock_polyclient)
-        mocker.patch.object(ph, "WAIT_TIME", 0)
+        mocker.patch.object(ph, "PolygonClient", mock_polyclient)
+        #mocker.patch.object(ph, "WAIT_TIME", 0)
         mocker.patch.object(ph, "LUMIBOT_CACHE_FOLDER", tmpdir)
 
         # Basic Setup


### PR DESCRIPTION
With the new rate limited RESTClient class (PolygonClient) all current and future polygon API calls will be rate limited if needed. This was not done before for list_option_contracts, for example.

This also enables local testing with a free polygon key (works but slow). For local testing with free account you have to add an environment variable called POLYGON_IS_PAID_SUBSCRIPTION=False

