### PR TITLE
data_source: added new function get_chain_full_info() 

### DIFF
--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -353,6 +353,40 @@ class Broker(ABC):
         """
         return chains[exchange] if exchange in chains else chains
 
+    def get_chain_full_info(self, asset: Asset, expiry: str, chains=None, underlying_price=None, risk_free_rate=None,
+                            strike_min=None, strike_max=None) -> pd.DataFrame:
+        """
+        Get the full chain information for an option asset, including: greeks, bid/ask, open_interest, etc. For
+        brokers that do not support this, greeks will be calculated locally. For brokers like Tradier this function
+        is much faster as only a single API call can be done to return the data for all options simultaneously.
+
+        Parameters
+        ----------
+        asset : Asset
+            The option asset to get the chain information for.
+        expiry
+            The expiry date of the option chain.
+        chains
+            The chains dictionary created by `get_chains` method. This is used
+            to get the list of strikes needed to calculate the greeks.
+        underlying_price
+            Price of the underlying asset.
+        risk_free_rate
+            The risk-free rate used in interest calculations.
+        strike_min
+            The minimum strike price to return in the chain. If None, will return all strikes.
+        strike_max
+            The maximum strike price to return in the chain. If None, will return all strikes.
+
+        Returns
+        -------
+        pd.DataFrame
+            A DataFrame containing the full chain information for the option asset. Greeks columns will be named as
+            'greeks.delta', 'greeks.theta', etc.
+        """
+        return self.data_source.get_chain_full_info(asset, expiry, chains, underlying_price, risk_free_rate,
+                                                    strike_min, strike_max)
+
     def get_greeks(self, asset, asset_price, underlying_price, risk_free_rate, query_greeks=False):
         """
         Get the greeks of an option asset.

--- a/tests/test_data_source.py
+++ b/tests/test_data_source.py
@@ -1,6 +1,45 @@
 from lumibot.data_sources.data_source import DataSource
+from lumibot.entities import Asset
+
+
+class DataSourceTestable(DataSource):
+    def __init__(self, api_key):
+        super().__init__(api_key=api_key)
+
+    def get_chains(self, asset: Asset, quote: Asset = None) -> dict:
+        return {}
+
+    def get_last_price(self, asset, quote=None, exchange=None):
+        return 0.0
+
+    def get_historical_prices(
+        self, asset, length, timestep="", timeshift=None, quote=None, exchange=None, include_after_hours=True
+    ):
+        pass
 
 
 class TestDataSource:
-    def test_code(self):
-        assert True
+    def test_get_chain_full_info(self, mocker):
+        ds = DataSourceTestable(api_key='test')
+        chains = {'Chains': {
+            "PUT": {
+                "2023-12-01": [101, 102, 103],
+            },
+            "CALL": {
+                "2023-12-01": [101, 102, 103],
+            },
+        }}
+        mocker.patch.object(ds, 'get_chains', return_value=chains)
+        mocker.patch.object(ds, 'get_last_price', return_value=1.0)
+
+        asset = Asset("SPY")
+        df_chain = ds.get_chain_full_info(asset, '2023-12-01', underlying_price=102, risk_free_rate=0.01)
+        assert len(df_chain) == 6
+        assert 'last' in df_chain.columns
+        assert 'bid' in df_chain.columns
+        assert 'greeks.delta' in df_chain.columns
+
+        # Test with strike filters
+        df_chain = ds.get_chain_full_info(asset, '2023-12-01', chains=chains, underlying_price=102,
+                                          risk_free_rate=0.01, strike_min=102, strike_max=102)
+        assert len(df_chain) == 2

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -78,6 +78,18 @@ class TestTradierDataAPI:
         assert 'low' in quote
         assert 'close' in quote
 
+    def test_get_chain_full_info(self, tradier_ds):
+        asset = Asset("SPY")
+        chains = tradier_ds.get_chains(asset)
+        expir_date = list(chains['Chains']['CALL'].keys())[0]
+
+        df = tradier_ds.get_chain_full_info(asset, expir_date)
+        assert isinstance(df, pd.DataFrame)
+        assert 'strike' in df.columns
+        assert 'last' in df.columns
+        assert 'greeks.delta' in df.columns
+        assert len(df)
+
 
 @pytest.mark.apitest
 class TestTradierBrokerAPI:


### PR DESCRIPTION
All options for a given expiration date can have the full greeks, bid/ask, open_interest, etc. calculated in a single efficient execution.

For Tradier and Polygon-Live, all of the greeks for every option can be returned with a single API call.  This is much faster than looping and doing individual get_last_price() + calculate_greeks() calls.

For Polygon-BackTest and IBKR, we will have to continue to do the slow way of repeated queries.  Filtering options included to help speed this step up as well.