### PR TITLE
Fix the crash when running live trade mode

### DIFF
--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -570,7 +570,7 @@ class _Strategy:
             self._analysis = stats_summary(self._strategy_returns_df, self.risk_free_rate)
 
             # Getting performance for the benchmark asset
-            if self._backtesting_start is not None and self._backtesting_end is not None:
+            if self._is_backtesting and self._backtesting_start is not None and self._backtesting_end is not None:
                 # Need to adjust the backtesting end date because the data from Yahoo
                 # is at the start of the day, so the graph cuts short. This may be needed
                 # for other timeframes as well


### PR DESCRIPTION
In live trade mode, we have the following call stack:

```
strategy_executor.py : on_strategy_end() -> self.strategy._dump_stats()
_strategy.py : _dump_stats() -> self._backtesting_start is not None and self._backtesting_end is not None
```

It triggers the crash that says the object does not have `_backtesting_start` attribute. Because at [l195 - l198](https://github.com/Lumiwealth/lumibot/blame/efaa66facafbcc80d72dc9345b768c3758aed386/lumibot/strategies/_strategy.py#L195-L198), these attributes are only initialized when the strategy is running in backtest.

This PR fixes the crash by checking if the strategy is running in backtesting mode first.