### PR TITLE
process_pending_orders in self.sleep() method

### DIFF
--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -716,10 +716,7 @@ class Strategy(_Strategy):
             start_time = time.time()
             if process_pending_orders:
                 self.broker.process_pending_orders(strategy=self)
-
-                while time.time() - start_time < sleeptime:
-                    # Sleep for the the sleeptime in seconds.
-                    pass
+                time.sleep(time.time() - start_time)
 
         return self.broker.sleep(sleeptime)
 

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -716,7 +716,9 @@ class Strategy(_Strategy):
             start_time = time.time()
             if process_pending_orders:
                 self.broker.process_pending_orders(strategy=self)
-                time.sleep(time.time() - start_time)
+                remaining_time = time.time() - start_time
+                if remaining_time > 0:
+                    time.sleep(remaining_time)
 
         return self.broker.sleep(sleeptime)
 

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -687,7 +687,7 @@ class Strategy(_Strategy):
 
     # ======= Broker Methods ============
 
-    def sleep(self, sleeptime=0, process_pending_orders=False):
+    def sleep(self, sleeptime=0, process_pending_orders=True):
         """Sleep for sleeptime seconds.
 
         Use to pause the execution of the program. This should be used instead of `time.sleep` within the strategy. Also processes pending orders in the meantime.

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -687,15 +687,17 @@ class Strategy(_Strategy):
 
     # ======= Broker Methods ============
 
-    def sleep(self, sleeptime):
+    def sleep(self, sleeptime=0, process_pending_orders=False):
         """Sleep for sleeptime seconds.
 
-        Use to pause the execution of the program. This should be used instead of `time.sleep` within the strategy.
+        Use to pause the execution of the program. This should be used instead of `time.sleep` within the strategy. Also processes pending orders in the meantime.
 
         Parameters
         ----------
         sleeptime : float
             Time in seconds the program will be paused.
+        process_pending_orders : bool
+            If true, all pending orders will be processed.
 
         Returns
         -------
@@ -706,11 +708,21 @@ class Strategy(_Strategy):
         >>> # Sleep for 5 seconds
         >>> self.sleep(5)
         """
-        if not self.is_backtesting:
-            # Sleep for the the sleeptime in seconds.
-            time.sleep(sleeptime)
+
+        # Process pending orders and keep track of time 
+        if self.is_backtesting:
+            self.broker.process_pending_orders(strategy=self)
+        else:
+            start_time = time.time()
+            if process_pending_orders:
+                self.broker.process_pending_orders(strategy=self)
+
+                while time.time() - start_time < sleeptime:
+                    # Sleep for the the sleeptime in seconds.
+                    pass
 
         return self.broker.sleep(sleeptime)
+
 
     def get_selling_order(self, position):
         """Get the selling order for a position.


### PR DESCRIPTION
Process pending orders whenever self.sleep() is called. Off by default as to not break any current strategies. 

Could be useful, for example, after running self.sell_all() to ensure all positions execute before your strategy continues (and potentially opens new positions)
