### PR TITLE
Fixed IB reconnect issues

### DIFF
--- a/lumibot/brokers/interactive_brokers.py
+++ b/lumibot/brokers/interactive_brokers.py
@@ -25,7 +25,7 @@ class InteractiveBrokers(Broker):
     """Inherit InteractiveBrokerData first and all the price market
     methods than inherits broker"""
 
-    def __init__(self, config, max_workers=20, chunk_size=100, data_source=None, max_connection_retries=0, **kwargs):
+    def __init__(self, config, max_workers=20, chunk_size=100, data_source=None, max_connection_retries=1000, **kwargs):
         if data_source is None:
             data_source = InteractiveBrokersData(config, max_workers=max_workers, chunk_size=chunk_size)
 
@@ -53,8 +53,9 @@ class InteractiveBrokers(Broker):
         self.ip = ip
         self.socket_port = socket_port
         self.client_id = client_id
+        self.max_connection_retries = max_connection_retries
 
-        self.start_ib(ip, socket_port, client_id, max_connection_retries)
+        self.start_ib(ip, socket_port, client_id, self.max_connection_retries)
 
     def start_ib(self, ip, socket_port, client_id, max_connection_retries):
         # Connect to interactive brokers.
@@ -275,7 +276,7 @@ class InteractiveBrokers(Broker):
             # Delete the ib object and create a new one
             del self.ib
             self.ib = None
-            self.start_ib(self.ip, self.socket_port, self.client_id, max_connection_retries=1000)
+            self.start_ib(self.ip, self.socket_port, self.client_id, max_connection_retries=self.max_connection_retries)
 
             return True
 

--- a/lumibot/brokers/interactive_brokers.py
+++ b/lumibot/brokers/interactive_brokers.py
@@ -295,7 +295,7 @@ class InteractiveBrokers(Broker):
             (cash, positions_value, total_liquidation_value)
         """
 
-try:
+        try:
             # First make sure that we are connected to the broker.
             needed_reconnect = self._reconnect_if_not_connected()
 

--- a/lumibot/brokers/interactive_brokers.py
+++ b/lumibot/brokers/interactive_brokers.py
@@ -295,16 +295,19 @@ class InteractiveBrokers(Broker):
             (cash, positions_value, total_liquidation_value)
         """
 
-        try:
+try:
             # First make sure that we are connected to the broker.
             needed_reconnect = self._reconnect_if_not_connected()
 
             # If we needed a reconnect, then sleep for a bit to make sure that the connection is established.
             if needed_reconnect:
-                # Log that we needed to reconnect to the broker.
+                # Log that we needed to reconnect to the broker and sleep to make sure the connection is established.
+                sleeplen = 5
                 logging.warning(
-                    f"Had to reconnect to the broker."
+                    f"Had to reconnect to the broker. Sleeping for {sleeplen} seconds to make sure the connection is established."
                 )
+                # Sleep to make sure the connection is established.
+                time.sleep(sleeplen)
 
             # Get the account summary from the broker.
             summary = self.ib.get_account_summary()

--- a/lumibot/brokers/interactive_brokers.py
+++ b/lumibot/brokers/interactive_brokers.py
@@ -275,7 +275,7 @@ class InteractiveBrokers(Broker):
             # Delete the ib object and create a new one
             del self.ib
             self.ib = None
-            self.start_ib(self.ip, self.socket_port, self.client_id, max_connection_retries=0)
+            self.start_ib(self.ip, self.socket_port, self.client_id, max_connection_retries=1000)
 
             return True
 
@@ -300,13 +300,10 @@ class InteractiveBrokers(Broker):
 
             # If we needed a reconnect, then sleep for a bit to make sure that the connection is established.
             if needed_reconnect:
-                # Log that we needed to reconnect to the broker and sleep to make sure the connection is established.
-                sleeplen = 5
+                # Log that we needed to reconnect to the broker.
                 logging.warning(
-                    f"Had to reconnect to the broker. Sleeping for {sleeplen} seconds to make sure the connection is established."
+                    f"Had to reconnect to the broker."
                 )
-                # Sleep to make sure the connection is established.
-                time.sleep(sleeplen)
 
             # Get the account summary from the broker.
             summary = self.ib.get_account_summary()


### PR DESCRIPTION
Added max_connection_retries to reconnect function
Removed sleeplen as it is now obsolete

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI
> [!NOTE]
> This feature is in early access. You can enable or disable it in the [Korbit Console](https://app.korbit.ai/settings).

### What change is being made?
Increase the maximum connection retries to 1000 and remove the sleep delay after reconnecting in the Interactive Brokers broker implementation.

### Why are these changes being made?
The previous limit of zero retries was insufficient for maintaining a stable connection, leading to frequent disconnections. Increasing the retries to 1000 ensures more robust reconnection attempts. The sleep delay was removed to streamline the reconnection process, as it was deemed unnecessary for ensuring connection stability.

<!-- Korbit AI PR Description End -->