### PR TITLE
Variable Backing Up/Restoring through a PostgreSQL DB

### DIFF
--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -4,6 +4,7 @@ from termcolor import colored
 from asyncio.log import logger
 from decimal import Decimal
 import os
+import pickle
 import string
 import random
 
@@ -313,7 +314,36 @@ class _Strategy:
 
         self._filled_order_callback = filled_order_callback
 
+        self.pickle_file = ".stored.pkl"
+
+        # Check if the .stored file exists
+        if os.path.exists(self.pickle_file):
+            self.load_variables_to_instance()
+            return
+
     # =============Internal functions===================
+    def store_variables(self, **kwargs):
+        """
+        Save variables to a pickle file.
+
+        :param kwargs: The variables to save (as keyword arguments).
+        """
+        with open(self.pickle_file, 'wb') as file:
+            pickle.dump(kwargs, file)
+        logger.debug(f"Variables saved to {self.pickle_file}")
+
+    def load_variables_to_instance(self):
+        """
+        Load variables stored in a pickle file and set them as instance variables.
+        """
+        with open(self.pickle_file, 'rb') as file:
+            data = pickle.load(file)
+        
+        for key, value in data.items():
+            setattr(self, key, value)
+        
+        logger.info(f"Variables loaded from {self.pickle_file}.")
+    
     def _copy_dict(self):
         result = {}
         ignored_fields = ["broker", "data_source", "trading_pairs", "asset_gen"]

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -336,9 +336,16 @@ class _Strategy:
         """
         Load variables stored in a JSON file and set them as instance variables.
         """
-        with open(self.pickle_file, 'r') as file:
-            data = json.load(file)
-        
+        try:
+            with open(self.pickle_file, 'r') as file:
+                data = json.load(file)
+        except json.JSONDecodeError:
+            logger.error(f"Error decoding JSON from file {self.pickle_file}.")
+            data = {}
+        except Exception as e:
+            logger.error(f"An unexpected error occurred: {e}")
+            data = {}
+            
         for key, value in data.items():
             setattr(self, key, value)
     

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -4,7 +4,7 @@ from termcolor import colored
 from asyncio.log import logger
 from decimal import Decimal
 import os
-import pickle
+import json
 import string
 import random
 
@@ -314,7 +314,7 @@ class _Strategy:
 
         self._filled_order_callback = filled_order_callback
 
-        self.pickle_file = ".stored.pkl"
+        self.pickle_file = ".stored.json"
 
         # Check if the .stored file exists
         if os.path.exists(self.pickle_file):
@@ -324,25 +324,23 @@ class _Strategy:
     # =============Internal functions===================
     def store_variables(self, **kwargs):
         """
-        Save variables to a pickle file.
+        Save variables to a JSON file.
 
         :param kwargs: The variables to save (as keyword arguments).
         """
-        with open(self.pickle_file, 'wb') as file:
-            pickle.dump(kwargs, file)
+        with open(self.pickle_file, 'w') as file:
+            json.dump(kwargs, file)
         logger.debug(f"Variables saved to {self.pickle_file}")
 
     def load_variables_to_instance(self):
         """
-        Load variables stored in a pickle file and set them as instance variables.
+        Load variables stored in a JSON file and set them as instance variables.
         """
-        with open(self.pickle_file, 'rb') as file:
-            data = pickle.load(file)
+        with open(self.pickle_file, 'r') as file:
+            data = json.load(file)
         
         for key, value in data.items():
             setattr(self, key, value)
-        
-        logger.info(f"Variables loaded from {self.pickle_file}.")
     
     def _copy_dict(self):
         result = {}

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -39,7 +39,6 @@ class CustomLoggerAdapter(logging.LoggerAdapter):
 class _Strategy:
     IS_BACKTESTABLE = True
 
-
     def __init__(
         self,
         *args,
@@ -63,6 +62,7 @@ class _Strategy:
         force_start_immediately=False,
         discord_webhook_url=None,
         account_history_db_connection_str=None,
+        db_connection_str=None,
         strategy_id=None,
         discord_account_summary_footer=None,
         should_backup_variables_to_database=False,
@@ -126,15 +126,15 @@ class _Strategy:
         discord_webhook_url : str
             The discord webhook url to use for sending alerts from the strategy. You can send alerts to a discord
             channel by setting broadcast=True in the log_message method. The strategy will also by default send
-            and account summary to the discord channel at the end of each day (account_history_db_connection_str
+            and account summary to the discord channel at the end of each day (db_connection_str
             must be set for this to work). Defaults to None (no discord alerts).
             For instructions on how to create a discord webhook url, see this link:
             https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
         discord_account_summary_footer : str
             The footer to use for the account summary sent to the discord channel if discord_webhook_url is set and the
-            account_history_db_connection_str is set.
+            db_connection_str is set.
             Defaults to None (no footer).
-        account_history_db_connection_str : str
+        db_connection_str : str
             The connection string to use for the account history database. This is used to store the account history
             for the strategy. The account history is sent to the discord channel at the end of each day. The connection
             string should be in the format: "sqlite:///path/to/database.db". The database should have a table named
@@ -192,7 +192,10 @@ class _Strategy:
         self.logger = CustomLoggerAdapter(logger, {'strategy_name': self._name})
 
         self.discord_webhook_url = discord_webhook_url
-        self.account_history_db_connection_str = account_history_db_connection_str
+        if account_history_db_connection_str: 
+            self.db_connection_str = account_history_db_connection_str  
+            logging.warning("account_history_db_connection_str is deprecated and will be removed in future versions, please use db_connection_str instead") 
+
         self.discord_account_summary_footer = discord_account_summary_footer
         self.should_send_summary_to_discord=should_send_summary_to_discord
 

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -3,6 +3,7 @@ import io
 import os
 import time
 import uuid
+import json
 from asyncio.log import logger
 from decimal import Decimal
 from typing import Union
@@ -4106,10 +4107,11 @@ class Strategy(_Strategy):
 
     def get_stats_from_database(self, stats_table_name):
         # Create a database connection
-        engine = create_engine(self.account_history_db_connection_str)
+        if not hasattr(self, 'engine') or not self.engine:
+            self.engine = create_engine(self.account_history_db_connection_str)
         
         # Check if the table exists
-        if not inspect(engine).has_table(stats_table_name):
+        if not inspect(self.engine).has_table(stats_table_name):
             # Log that the table does not exist and we are creating it
             self.logger.info(f"Table {stats_table_name} does not exist. Creating it now.")
 
@@ -4130,10 +4132,10 @@ class Strategy(_Strategy):
                 }
             )
             # Create the table by saving this empty DataFrame to the database
-            stats_new.to_sql(stats_table_name, engine, if_exists='replace', index=False)
+            stats_new.to_sql(stats_table_name, self.engine, if_exists='replace', index=False)
         
         # Load the stats dataframe from the database
-        stats_df = pd.read_sql_table(stats_table_name, engine)
+        stats_df = pd.read_sql_table(stats_table_name, self.engine)
 
         return stats_df
 
@@ -4145,6 +4147,78 @@ class Strategy(_Strategy):
             if_exists=if_exists,
             index=index,
         )
+    
+    def backup_variables_to_db(self):
+        if not hasattr(self, "account_history_db_connection_str") or self.account_history_db_connection_str is None or not self.should_backup_variables_to_database:
+            return
+    
+        current_state = json.dumps(self.vars, sort_keys=True)
+        if current_state == self._last_backup_state:
+            self.logger.info("No variables changed. Not backing up.")
+            return
+
+        try:
+            data_to_save = self.vars
+            if data_to_save:
+                json_data_to_save = json.dumps(data_to_save)
+
+                ny_tz = pytz.timezone("America/New_York")
+                now = datetime.datetime.now(ny_tz)
+
+                df = pd.DataFrame(
+                    {
+                        "id": [str(uuid.uuid4())],
+                        "last_updated": [now],
+                        "variables": [json_data_to_save]
+                    }
+                )
+
+                self.to_sql(df, self.name, self.account_history_db_connection_str, 'replace', False)
+                self._last_backup_state = current_state
+
+                logger.info("Variables backed up successfully")
+            else:
+                logger.info("No variables to back up")
+
+        except Exception as e:
+            logger.error(f"Error backing up variables to DB: {e}", exc_info=True)
+
+    def load_variables_from_db(self):
+        if not self.should_backup_variables_to_database:
+            return
+        
+        try:
+            # Query the latest entry from the backup table
+            query = f'SELECT * FROM "{self.name}" ORDER BY last_updated DESC LIMIT 1'
+            if not hasattr(self, 'engine') or not self.engine:
+                self.engine = create_engine(self.account_history_db_connection_str)
+
+            # Check if backup table exists
+            inspector = inspect(self.engine)
+            if not inspector.has_table(self.name):
+                logger.info(f"Backup for {self.name} does not exist in the database. Not restoring")
+                return
+            
+            df = pd.read_sql_query(query, self.engine)
+        
+            if df.empty:
+                logger.warning("No data found in the backup")
+            else:
+                # Parse the JSON data
+                json_data = df['variables'].iloc[0]
+                data = json.loads(json_data)
+
+                # Update self.vars dictionary
+                for key, value in data.items():
+                    self.vars[key] = value
+                
+                current_state = json.dumps(self.vars, sort_keys=True)
+                self._last_backup_state = current_state
+
+                logger.info("Variables loaded successfully from database")
+
+        except Exception as e:
+            logger.error(f"Error loading variables from database: {e}", exc_info=True)
 
     def calculate_returns(self):
         # Check if we are in backtesting mode, if so, don't send the message
@@ -4301,7 +4375,7 @@ class Strategy(_Strategy):
 
     def should_send_account_summary_to_discord(self):
         # Check if account_history_db_connection_str has been set, if not, return False
-        if not hasattr(self, "account_history_db_connection_str") or self.account_history_db_connection_str is None:
+        if not hasattr(self, "account_history_db_connection_str") or self.account_history_db_connection_str is None or not self.should_send_summary_to_discord:
             return False
 
         # Check if it has been at least 24 hours since the last account summary


### PR DESCRIPTION
Implemented strategy.vars dictionary. All variables in it can optionally be backed up/restored through an SQL DB. Useful for when a strategy that is dependant on past variables needs to be restarted/crashes. 

Introduced new strategy initialization flags:
        should_backup_variables_to_database-enables the db backing up feature
        should_send_summary_to_discord-enables the discord summary functionality (which was enabled by default before) 



