### PR TITLE
Changed self.vars syntax and removed should_send_summary_to_discord

### DIFF
--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -38,16 +38,20 @@ class CustomLoggerAdapter(logging.LoggerAdapter):
 
 class Vars:
     def __init__(self):
-        self.__dict__ = {}
+        self._vars_dict = {}
 
     def __getattr__(self, name):
         try:
-            return self.__dict__[name]
+            return self._vars_dict[name]
         except KeyError:
             raise AttributeError(f"'Vars' object has no attribute '{name}'")
 
     def __setattr__(self, name, value):
-        self.__dict__[name] = value
+        self._vars_dict[name] = value
+
+    def get_all_attributes(self):
+        return self._vars_dict.copy()
+
 
 class _Strategy:
     IS_BACKTESTABLE = True

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -36,6 +36,19 @@ class CustomLoggerAdapter(logging.LoggerAdapter):
         except Exception as e:
             return msg, kwargs
 
+class Vars:
+    def __init__(self):
+        self.__dict__ = {}
+
+    def __getattr__(self, name):
+        try:
+            return self.__dict__[name]
+        except KeyError:
+            raise AttributeError(f"'Vars' object has no attribute '{name}'")
+
+    def __setattr__(self, name, value):
+        self.__dict__[name] = value
+
 class _Strategy:
     IS_BACKTESTABLE = True
 
@@ -312,7 +325,7 @@ class _Strategy:
         # Variable backup related variables
         self.should_backup_variables_to_database=should_backup_variables_to_database
         self._last_backup_state = None
-        self.vars = {}
+        self.vars = Vars()
 
         # Storing parameters for the initialize method
         if not hasattr(self, "parameters") or not isinstance(self.parameters, dict) or self.parameters is None:

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -83,7 +83,6 @@ class _Strategy:
         strategy_id=None,
         discord_account_summary_footer=None,
         should_backup_variables_to_database=False,
-        should_send_summary_to_discord=False,
         save_logfile=False,
         **kwargs,
     ):
@@ -214,7 +213,6 @@ class _Strategy:
             logging.warning("account_history_db_connection_str is deprecated and will be removed in future versions, please use db_connection_str instead") 
 
         self.discord_account_summary_footer = discord_account_summary_footer
-        self.should_send_summary_to_discord=should_send_summary_to_discord
 
         if strategy_id is None:
             self.strategy_id = self._name

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -4375,7 +4375,7 @@ class Strategy(_Strategy):
 
     def should_send_account_summary_to_discord(self):
         # Check if db_connection_str has been set, if not, return False
-        if not hasattr(self, "db_connection_str") or self.db_connection_str is None or not self.should_send_summary_to_discord:
+        if not hasattr(self, "db_connection_str") or self.db_connection_str is None or not self.discord_webhook_url:
             return False
 
         # Check if it has been at least 24 hours since the last account summary

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -4152,13 +4152,13 @@ class Strategy(_Strategy):
         if not hasattr(self, "db_connection_str") or self.db_connection_str is None or not self.should_backup_variables_to_database:
             return
     
-        current_state = json.dumps(self.vars.__dict__, sort_keys=True)
+        current_state = json.dumps(self.vars._vars_dict, sort_keys=True)
         if current_state == self._last_backup_state:
             self.logger.info("No variables changed. Not backing up.")
             return
 
         try:
-            data_to_save = self.vars.__dict__
+            data_to_save = self.vars._vars_dict
             if data_to_save:
                 json_data_to_save = json.dumps(data_to_save)
 
@@ -4210,9 +4210,9 @@ class Strategy(_Strategy):
 
                 # Update self.vars dictionary
                 for key, value in data.items():
-                    self.vars.__dict__[key] = value
+                    self.vars._vars_dict[key] = value
                 
-                current_state = json.dumps(self.vars.__dict__, sort_keys=True)
+                current_state = json.dumps(self.vars._vars_dict, sort_keys=True)
                 self._last_backup_state = current_state
 
                 logger.info("Variables loaded successfully from database")

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -4152,13 +4152,13 @@ class Strategy(_Strategy):
         if not hasattr(self, "db_connection_str") or self.db_connection_str is None or not self.should_backup_variables_to_database:
             return
     
-        current_state = json.dumps(self.vars, sort_keys=True)
+        current_state = json.dumps(self.vars.__dict__, sort_keys=True)
         if current_state == self._last_backup_state:
             self.logger.info("No variables changed. Not backing up.")
             return
 
         try:
-            data_to_save = self.vars
+            data_to_save = self.vars.__dict__
             if data_to_save:
                 json_data_to_save = json.dumps(data_to_save)
 
@@ -4210,9 +4210,9 @@ class Strategy(_Strategy):
 
                 # Update self.vars dictionary
                 for key, value in data.items():
-                    self.vars[key] = value
+                    self.vars.__dict__[key] = value
                 
-                current_state = json.dumps(self.vars, sort_keys=True)
+                current_state = json.dumps(self.vars.__dict__, sort_keys=True)
                 self._last_backup_state = current_state
 
                 logger.info("Variables loaded successfully from database")


### PR DESCRIPTION
Variables in self.vars can now be accessed by self.vars.varname instead of self.vars[varname]
self.should_send_summary_to_discord (added in my DB backup PR) proved to be useless. Now if a discord webhook is available, we send summary to discord.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI
> [!NOTE]
> This feature is in early access. You can enable or disable it in the [Korbit Console](https://app.korbit.ai/a18b7e63-743d-4f50-b9b5-cb58f1beb0f3/settings).

### What change is being made?
Refactor `self.vars` from a dictionary to an instance of the `Vars` class to encapsulate variable management within the `_Strategy` class.

### Why are these changes being made?
This change improves the encapsulation and management of strategy variables, providing a more robust and error-resistant way to handle dynamic attributes. The `Vars` class ensures that attribute access and assignment are handled gracefully, reducing the risk of runtime errors due to missing attributes.

<!-- Korbit AI PR Description End -->