### PR TITLE
added child orders to order object for OCO, OTO, Bracket, etc

### DIFF
--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -397,6 +397,10 @@ class Alpaca(Broker):
         else:
             trade_symbol = order.asset.symbol
 
+        # If order type is OCO, set to limit (Alpaca wants this for OCO)
+        if order.type == Order.OrderType.OCO:
+            order.type = Order.OrderType.LIMIT
+
         kwargs = {
             "symbol": trade_symbol,
             "qty": qty,

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -418,23 +418,23 @@ class Order:
         if self.type is None:
             # Check if this is a trailing stop order
             if trail_price is not None or trail_percent is not None:
-                self.type = "trailing_stop"
+                self.type = self.OrderType.TRAIL
 
             # Check if this is a market order
             elif limit_price is None and stop_price is None:
-                self.type = "market"
+                self.type = self.OrderType.MARKET
 
             # Check if this is a stop order
             elif limit_price is None and stop_price is not None:
-                self.type = "stop"
+                self.type = self.OrderType.STOP
 
             # Check if this is a limit order
             elif limit_price is not None and stop_price is None:
-                self.type = "limit"
+                self.type = self.OrderType.LIMIT
 
             # Check if this is a stop limit order
             elif limit_price is not None and stop_price is not None:
-                self.type = "stop_limit"
+                self.type = self.OrderType.STOP_LIMIT
 
             else:
                 raise ValueError(
@@ -444,8 +444,8 @@ class Order:
 
         if self.type == "oco":
             # This is a "One-Cancel-Other" advanced order
-            self.order_class = "oco"
-            self.type = "limit"  # Needs to be set as limit order for Alpaca
+            self.order_class = self.OrderType.OCO
+            self.type = self.OrderType.OCO
             self.position_filled = True
             if stop_loss_price is not None and take_profit_price is not None:
                 self.take_profit_price = check_price(take_profit_price, "take_profit_price must be positive float.")
@@ -635,7 +635,7 @@ class Order:
         if self.is_filled():
             price = self.get_fill_price()
 
-        repr_str = f"{self.order_class} {self.type} order of | {self.quantity} {self.rep_asset} {self.side} |"
+        repr_str = f"{self.type} order of | {self.quantity} {self.rep_asset} {self.side} |"
         if price:
             repr_str = f"{repr_str} at price ${price}"
         if self.order_class:

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -33,7 +33,7 @@ class TestOrderBasics:
         # Assert that the child order does not have any child orders of its own
         assert child_order.child_orders == []
 
-        # Add another child order to the OCO order
+        # Add a child order to the OCO order
         order.child_orders.append(child_order)
 
         # Assert that the child order still does not have any child orders of its own

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -8,6 +8,48 @@ class TestOrderBasics:
         assert Order(asset=Asset("SPY"), quantity=10, side="buy", strategy='abc').side == 'buy'
         assert Order(asset=Asset("SPY"), quantity=10, side="sell", strategy='abc').side == 'sell'
 
+    def test_blank_oco(self):
+        # Create an OCO order without any child 
+        order = Order(
+            strategy="",
+            type=Order.OrderType.OCO,
+        )
+
+        assert order.avg_fill_price == None
+        assert order.quantity == None
+        assert order.status == "unprocessed"
+
+        # Add a child order
+        child_order = Order(
+            strategy="",
+            type=Order.OrderType.LIMIT,
+            side="buy",
+            asset=Asset("SPY"),
+            quantity=10,
+            limit_price=100,
+        )
+
+        order.add_child_order(child_order)
+
+        # Check that the original order did not change as a result of adding a child order
+        assert order.avg_fill_price == None
+        assert order.quantity == None
+        assert order.status == "unprocessed"
+        assert order.side == None
+        assert order.asset == None
+        assert order.child_orders == [child_order]
+
+    def test_price_doesnt_exist(self):
+        # Test that the price does not exist for any orders, we should be more specific such as limit_price, stop_price, fill_price, etc.
+        with pytest.raises(TypeError):
+            Order(
+                strategy="",
+                asset=Asset("SPY"),
+                quantity=10,
+                side="buy",
+                price=100,
+            )
+
     def test_is_option(self):
         # Standard stock order
         asset = Asset("SPY")


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI
> [!NOTE]
> This feature is in early access. You can enable or disable it in the [Korbit Console](https://app.korbit.ai/a18b7e63-743d-4f50-b9b5-cb58f1beb0f3/settings).

### What change is being made?
Add support for child orders to the `Order` object to handle OCO, OTO, and Bracket orders.

### Why are these changes being made?
This change allows for better management and tracking of complex order types by associating child orders with a parent order. This approach simplifies the handling of advanced order types and ensures that related orders are processed together. Additionally, it includes tests to verify the new functionality.

<!-- Korbit AI PR Description End -->