### PR TITLE
Prepare to merge thetadata feature into Lumibot 

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -20,6 +20,8 @@ jobs:
       AIOHTTP_NO_EXTENSIONS: 1
       POLYGON_API_KEY: ${{secrets.POLYGON_API_KEY}}  # Required for Polygon API BackTests
       POLYGON_IS_PAID_SUBSCRIPTION: $POLYGON_IS_PAID_SUBSCRIPTION
+      THETADATA_USERNAME: ${{secrets.THETADATA_USERNAME}} 
+      THETADATA_PASSWORD: ${{secrets.THETADATA_PASSWORD}} 
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.11

--- a/lumibot/backtesting/__init__.py
+++ b/lumibot/backtesting/__init__.py
@@ -3,5 +3,6 @@ from .alpha_vantage_backtesting import AlphaVantageBacktesting
 from .backtesting_broker import BacktestingBroker
 from .pandas_backtesting import PandasDataBacktesting
 from .polygon_backtesting import PolygonDataBacktesting
+from .thetadata_backtesting import ThetaDataBacktesting
 from .yahoo_backtesting import YahooDataBacktesting
 from .ccxt_backtesting import CcxtBacktesting

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -348,7 +348,7 @@ class BacktestingBroker(Broker):
         # Currently perfect fill price in backtesting!
         order.avg_fill_price = price
 
-        position = super()._process_filled_order(order, order.avg_fill_price, quantity)
+        position = super()._process_filled_order(order, price, quantity)
         if existing_position:
             position.add_order(order, quantity)  # Add will update quantity, but not double count the order
             if position.quantity == 0:

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -16,11 +16,13 @@ class BacktestingBroker(Broker):
     # Metainfo
     IS_BACKTESTING_BROKER = True
 
-    def __init__(self, data_source, connect_stream=True, max_workers=20, config=None, **kwargs):
-        super().__init__(name="backtesting", data_source=data_source, connect_stream=connect_stream, **kwargs)
+    def __init__(self, data_source, option_source=None, connect_stream=True, max_workers=20, config=None, **kwargs):
+        super().__init__(name="backtesting", data_source=data_source,
+                         option_source=option_source, connect_stream=connect_stream, **kwargs)
         # Calling init methods
         self.max_workers = max_workers
         self.market = "NASDAQ"
+        self.option_source = option_source
 
         # Legacy strategy.backtest code will always pass in a config even for Brokers that don't need it, so
         # catch it here and ignore it in this class. Child classes that need it should error check it themselves.
@@ -91,8 +93,9 @@ class BacktestingBroker(Broker):
             new_datetime = self.datetime + timedelta(seconds=update_dt)
         else:
             new_datetime = update_dt
-
         self.data_source._update_datetime(new_datetime, cash=cash, portfolio_value=portfolio_value)
+        if self.option_source:
+            self.option_source._update_datetime(new_datetime, cash=cash, portfolio_value=portfolio_value)
         logging.info(f"Current backtesting datetime {self.datetime}")
 
     # =========Clock functions=====================
@@ -166,10 +169,10 @@ class BacktestingBroker(Broker):
     def get_time_to_close(self):
         """Return the remaining time for the market to close in seconds"""
         now = self.datetime
-        
+
         # Use searchsorted for efficient searching and reduce unnecessary DataFrame access
         idx = self._trading_days.index.searchsorted(now, side='left')
-        
+
         if idx >= len(self._trading_days):
             logging.error("Cannot predict future")
             return 0
@@ -493,14 +496,14 @@ class BacktestingBroker(Broker):
         """
         if self.data_source.SOURCE != "PANDAS":
             return
-        
+
         # If it's the same day as the expiration, we need to check the time to see if it's after market close
         time_to_close = self.get_time_to_close()
 
         # If the time to close is None, then the market is not open so we should not sell the contracts
         if time_to_close is None:
             return
-        
+
         # Calculate the number of seconds before market close
         seconds_before_closing = strategy.minutes_before_closing * 60
 
@@ -634,6 +637,8 @@ class BacktestingBroker(Broker):
                 low = df["low"].iloc[0]
                 close = df["close"].iloc[0]
                 volume = df["volume"].iloc[0]
+                print(f"in BacktestingBroker, asset: {asset}")
+                print(f"in BacktestingBroker, OHLCV: {open}, {high}, {low}, {close}, {volume}")
 
             #############################
             # Determine transaction price.

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -637,8 +637,6 @@ class BacktestingBroker(Broker):
                 low = df["low"].iloc[0]
                 close = df["close"].iloc[0]
                 volume = df["volume"].iloc[0]
-                print(f"\nin BacktestingBroker, asset: {asset}, dt: {dt}")
-                print(f"in BacktestingBroker, OHLCV: {open}, {high}, {low}, {close}, {volume}")
 
             #############################
             # Determine transaction price.

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -637,7 +637,7 @@ class BacktestingBroker(Broker):
                 low = df["low"].iloc[0]
                 close = df["close"].iloc[0]
                 volume = df["volume"].iloc[0]
-                print(f"in BacktestingBroker, asset: {asset}")
+                print(f"\nin BacktestingBroker, asset: {asset}, dt: {dt}")
                 print(f"in BacktestingBroker, OHLCV: {open}, {high}, {low}, {close}, {volume}")
 
             #############################

--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -139,25 +139,25 @@ class PolygonDataBacktesting(PandasData):
             formatted_end_datetime = self.datetime_end.strftime("%Y-%m-%d")
             if "Your plan doesn't include this data timeframe" in str(e):
                 error_message = colored(
-                                "Polygon Access Denied: Your subscription does not allow you to backtest that far back in time. "
-                                f"You requested data for {asset_separated} {ts_unit} bars "
-                                f"from {formatted_start_datetime} to {formatted_end_datetime}. "
-                                "Please consider either changing your backtesting timeframe to start later since your "
-                                "subscription does not allow you to backtest that far back or upgrade your Polygon "
-                                "subscription."
-                                "You can upgrade your Polygon subscription at at https://polygon.io/?utm_source=affiliate&utm_campaign=lumi10 "
-                                "Please use the full link to give us credit for the sale, it helps support this project. "
-                                "You can use the coupon code 'LUMI10' for 10% off. ",
-                                color="red")
+                    "Polygon Access Denied: Your subscription does not allow you to backtest that far back in time. "
+                    f"You requested data for {asset_separated} {ts_unit} bars "
+                    f"from {formatted_start_datetime} to {formatted_end_datetime}. "
+                    "Please consider either changing your backtesting timeframe to start later since your "
+                    "subscription does not allow you to backtest that far back or upgrade your Polygon "
+                    "subscription."
+                    "You can upgrade your Polygon subscription at at https://polygon.io/?utm_source=affiliate&utm_campaign=lumi10 "
+                    "Please use the full link to give us credit for the sale, it helps support this project. "
+                    "You can use the coupon code 'LUMI10' for 10% off. ",
+                    color="red")
                 raise Exception(error_message) from e
             elif "Unknown API Key" in str(e):
                 error_message = colored(
-                                "Polygon Access Denied: Your API key is invalid. "
-                                "Please check your API key and try again. "
-                                "You can get an API key at https://polygon.io/?utm_source=affiliate&utm_campaign=lumi10 "
-                                "Please use the full link to give us credit for the sale, it helps support this project. "
-                                "You can use the coupon code 'LUMI10' for 10% off. ",
-                                color="red")
+                    "Polygon Access Denied: Your API key is invalid. "
+                    "Please check your API key and try again. "
+                    "You can get an API key at https://polygon.io/?utm_source=affiliate&utm_campaign=lumi10 "
+                    "Please use the full link to give us credit for the sale, it helps support this project. "
+                    "You can use the coupon code 'LUMI10' for 10% off. ",
+                    color="red")
                 raise Exception(error_message) from e
             else:
                 # Handle other BadResponse exceptions not related to plan limitations

--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -78,7 +78,6 @@ class PolygonDataBacktesting(PandasData):
         start_datetime, ts_unit = self.get_start_datetime_and_ts_unit(
             length, timestep, start_dt, start_buffer=START_BUFFER
         )
-
         # Check if we have data for this asset
         if search_asset in self.pandas_data:
             asset_data = self.pandas_data[search_asset]
@@ -170,10 +169,8 @@ class PolygonDataBacktesting(PandasData):
 
         if (df is None) or df.empty:
             return
-
         data = Data(asset_separated, df, timestep=ts_unit, quote=quote_asset)
         pandas_data_update = self._set_pandas_data_keys([data])
-
         # Add the keys to the self.pandas_data dictionary
         self.pandas_data.update(pandas_data_update)
         if PolygonDataBacktesting.MAX_STORAGE_BYTES:
@@ -191,10 +188,8 @@ class PolygonDataBacktesting(PandasData):
     ):
         # Get the current datetime and calculate the start datetime
         current_dt = self.get_datetime()
-
         # Get data from Polygon
         self._update_pandas_data(asset, quote, length, timestep, current_dt)
-
         return super()._pull_source_symbol_bars(
             asset, length, timestep, timeshift, quote, exchange, include_after_hours
         )

--- a/lumibot/backtesting/thetadata_backtesting.py
+++ b/lumibot/backtesting/thetadata_backtesting.py
@@ -141,7 +141,7 @@ class ThetaDataBacktesting(PandasData):
                 dt=self.get_datetime()
             )
             # save df to csv file
-            # df.to_csv(f"theta_csv/wrong{date_time_now}_{asset.strike}_{asset.expiration}_{asset.right}.csv")
+            # df.to_csv(f"theta_csv/{date_time_now}_{asset.strike}_{asset.expiration}_{asset.right}.csv")
         except Exception as e:
             logging.info(traceback.format_exc())
             raise Exception("Error getting data from ThetaData") from e

--- a/lumibot/backtesting/thetadata_backtesting.py
+++ b/lumibot/backtesting/thetadata_backtesting.py
@@ -1,0 +1,292 @@
+import logging
+import re
+import traceback
+from datetime import date, timedelta
+
+from lumibot.data_sources import PandasData
+from lumibot.entities import Asset, Data
+from lumibot.tools import thetadata_helper
+
+START_BUFFER = timedelta(days=5)
+
+
+class ThetaDataBacktesting(PandasData):
+    """
+    Backtesting implementation of Polygon
+    """
+
+    def __init__(
+        self,
+        datetime_start,
+        datetime_end,
+        pandas_data=None,
+        username=None,
+        password=None,
+        **kwargs,
+    ):
+        super().__init__(datetime_start=datetime_start, datetime_end=datetime_end, pandas_data=pandas_data, **kwargs)
+
+        self._username = username
+        self._password = password
+
+        # # RESTClient API for Polygon.io polygon-api-client
+        # self.polygon_client = RESTClient(self._api_key)
+
+    def get_start_datetime_and_ts_unit(self, length, timestep, start_dt=None):
+        """
+        Get the start datetime for the data.
+
+        Parameters
+        ----------
+        length : int
+            The number of data points to get.
+        timestep : str
+            The timestep to use. For example, "1minute" or "1hour" or "1day".
+
+
+        Returns
+        -------
+        datetime
+            The start datetime.
+        str
+            The timestep unit.
+        """
+        # Convert timestep string to timedelta and get start datetime
+        td, ts_unit = self.convert_timestep_str_to_timedelta(timestep)
+
+        # Multiply td by length to get the end datetime
+        td *= length
+
+        if start_dt is not None:
+            start_datetime = start_dt - td
+        else:
+            start_datetime = self.datetime_start - td
+
+        # Subtract an extra 5 days to the start datetime to make sure we have enough
+        # data when it's a sparsely traded asset, especially over weekends
+        start_datetime = start_datetime - START_BUFFER
+
+        return start_datetime, ts_unit
+
+    def update_pandas_data(self, asset, quote, length, timestep, start_dt=None):
+        """
+        Get asset data and update the self.pandas_data dictionary.
+
+        Parameters
+        ----------
+        asset : Asset
+            The asset to get data for.
+        quote : Asset
+            The quote asset to use. For example, if asset is "SPY" and quote is "USD", the data will be for "SPY/USD".
+        length : int
+            The number of data points to get.
+        timestep : str
+            The timestep to use. For example, "1minute" or "1hour" or "1day".
+
+        Returns
+        -------
+        dict
+            A dictionary with the keys being the asset and the values being the PandasData objects.
+        """
+        search_asset = asset
+        asset_separated = asset
+        quote_asset = quote if quote is not None else Asset("USD", "forex")
+
+        if isinstance(search_asset, tuple):
+            asset_separated, quote_asset = search_asset
+        else:
+            search_asset = (search_asset, quote_asset)
+
+        # Get the start datetime and timestep unit
+        start_datetime, ts_unit = self.get_start_datetime_and_ts_unit(length, timestep, start_dt)
+
+        # Check if we have data for this asset
+        if search_asset in self.pandas_data:
+            asset_data = self.pandas_data[search_asset]
+            asset_data_df = asset_data.df
+            data_start_datetime = asset_data_df.index[0]
+
+            # Get the timestep of the data
+            data_timestep = asset_data.timestep
+
+            # If the timestep is the same, we don't need to update the data
+            if data_timestep == ts_unit:
+                # Check if we have enough data (5 days is the buffer we subtracted from the start datetime)
+                if (data_start_datetime - start_datetime) < START_BUFFER:
+                    return None
+
+            # Always try to get the lowest timestep possible because we can always resample
+            # If day is requested then make sure we at least have data that's less than a day
+            if ts_unit == "day":
+                if data_timestep == "minute":
+                    # Check if we have enough data (5 days is the buffer we subtracted from the start datetime)
+                    if (data_start_datetime - start_datetime) < START_BUFFER:
+                        return None
+                    else:
+                        # We don't have enough data, so we need to get more (but in minutes)
+                        ts_unit = "minute"
+                elif data_timestep == "hour":
+                    # Check if we have enough data (5 days is the buffer we subtracted from the start datetime)
+                    if (data_start_datetime - start_datetime) < START_BUFFER:
+                        return None
+                    else:
+                        # We don't have enough data, so we need to get more (but in hours)
+                        ts_unit = "hour"
+
+            # If hour is requested then make sure we at least have data that's less than an hour
+            if ts_unit == "hour":
+                if data_timestep == "minute":
+                    # Check if we have enough data (5 days is the buffer we subtracted from the start datetime)
+                    if (data_start_datetime - start_datetime) < START_BUFFER:
+                        return None
+                    else:
+                        # We don't have enough data, so we need to get more (but in minutes)
+                        ts_unit = "minute"
+
+        # Download data from Polygon
+        try:
+            # Get data from Polygon
+            df = thetadata_helper.get_price_data(
+                self._username,
+                self._password,
+                asset_separated,
+                start_datetime,
+                self.datetime_end,
+                timespan=ts_unit,
+                quote_asset=quote_asset,
+            )
+        except Exception as e:
+            logging.error(traceback.format_exc())
+            raise Exception("Error getting data from ThetaData") from e
+
+        if df is None:
+            return None
+
+        pandas_data = []
+        data = Data(asset_separated, df, timestep=ts_unit, quote=quote_asset)
+        pandas_data.append(data)
+        pandas_data_updated = self._set_pandas_data_keys(pandas_data)
+
+        return pandas_data_updated
+
+    def _pull_source_symbol_bars(
+        self,
+        asset,
+        length,
+        timestep=None,
+        timeshift=None,
+        quote=None,
+        exchange=None,
+        include_after_hours=True,
+    ):
+        pandas_data_update = self.update_pandas_data(asset, quote, length, timestep)
+
+        if pandas_data_update is not None:
+            # Add the keys to the self.pandas_data dictionary
+            self.pandas_data.update(pandas_data_update)
+
+        return super()._pull_source_symbol_bars(
+            asset, length, timestep, timeshift, quote, exchange, include_after_hours
+        )
+
+    # Get pricing data for an asset for the entire backtesting period
+    def get_historical_prices_between_dates(
+        self,
+        asset,
+        timestep="minute",
+        quote=None,
+        exchange=None,
+        include_after_hours=True,
+        start_date=None,
+        end_date=None,
+    ):
+        pandas_data_update = self.update_pandas_data(asset, quote, 1, timestep)
+        if pandas_data_update is not None:
+            # Add the keys to the self.pandas_data dictionary
+            self.pandas_data.update(pandas_data_update)
+
+        response = super()._pull_source_symbol_bars_between_dates(
+            asset, timestep, quote, exchange, include_after_hours, start_date, end_date
+        )
+
+        if response is None:
+            return None
+
+        bars = self._parse_source_symbol_bars(response, asset, quote=quote)
+        return bars
+
+    def get_last_price(self, asset, timestep="minute", quote=None, exchange=None, **kwargs):
+        try:
+            dt = self.get_datetime()
+            pandas_data_update = self.update_pandas_data(asset, quote, 1, timestep, dt)
+            if pandas_data_update is not None:
+                # Add the keys to the self.pandas_data dictionary
+                self.pandas_data.update(pandas_data_update)
+                self._data_store.update(pandas_data_update)
+        except Exception as e:
+            print(f"Error get_last_price from Polygon: {e}")
+
+        return super().get_last_price(asset=asset, quote=quote, exchange=exchange)
+
+    def get_chains(self, asset):
+        """
+        Integrates the Polygon client library into the LumiBot backtest for Options Data in the same
+        structure as Interactive Brokers options chain data
+
+        Parameters
+        ----------
+        asset : Asset
+            The asset to get data for.
+
+        Returns
+        -------
+        dictionary:
+            A dictionary nested with a dictionarty of Polygon Option Contracts information broken out by Exchange,
+            with embedded lists for Expirations and Strikes.
+            {'SMART': {'TradingClass': 'SPY', 'Multiplier': 100, 'Expirations': [], 'Strikes': []}}
+
+            - `TradingClass` (str) eg: `FB`
+            - `Multiplier` (str) eg: `100`
+            - `Expirations` (list of str) eg: [`20230616`, ...]
+            - `Strikes` (list of floats) eg: [`100.0`, ...]
+        """
+
+        # All Option Contracts | get_chains matching IBKR |
+        # {'SMART': {'TradingClass': 'SPY', 'Multiplier': 100, 'Expirations': [], 'Strikes': []}}
+        option_contracts = {"SMART": {"TradingClass": None, "Multiplier": None, "Expirations": [], "Strikes": []}}
+        contracts = option_contracts["SMART"]  # initialize contracts
+        today = self.get_datetime().date()
+        real_today = date.today()
+
+        # All Contracts | to match lumitbot, more inputs required from get_chains()
+        # If the strategy is using a recent backtest date, some contracts might not be expired yet, query those too
+        expired_list = [True, False] if real_today - today <= timedelta(days=31) else [True]
+        polygon_contracts = []
+        for expired in expired_list:
+            polygon_contracts.extend(
+                list(
+                    self.polygon_client.list_options_contracts(
+                        underlying_ticker=asset.symbol,
+                        expiration_date_gte=today,
+                        expired=expired,  # Needed so BackTest can look at old contracts to find the expirations/strikes
+                        limit=1000,
+                    )
+                )
+            )
+
+        for polygon_contract in polygon_contracts:
+            # Return to Loop and Skip if Multipler is not 100 because non-standard contracts are not supported
+            if polygon_contract.shares_per_contract != 100:
+                continue
+
+            # Contract Data | Attributes
+            exchange = polygon_contract.primary_exchange
+            contracts["TradingClass"] = polygon_contract.underlying_ticker
+            contracts["Multiplier"] = polygon_contract.shares_per_contract
+            contracts["Expirations"].append(polygon_contract.expiration_date)
+            contracts["Strikes"].append(polygon_contract.strike_price)
+
+            option_contracts["SMART"] = contracts
+            option_contracts[exchange] = contracts
+
+        return option_contracts

--- a/lumibot/backtesting/thetadata_backtesting.py
+++ b/lumibot/backtesting/thetadata_backtesting.py
@@ -138,7 +138,7 @@ class ThetaDataBacktesting(PandasData):
                 self.datetime_end,
                 timespan=ts_unit,
                 quote_asset=quote_asset,
-                dt=self.get_datetime()
+                dt=date_time_now
             )
             # save df to csv file
             # df.to_csv(f"theta_csv/{date_time_now}_{asset.strike}_{asset.expiration}_{asset.right}.csv")
@@ -211,7 +211,7 @@ class ThetaDataBacktesting(PandasData):
                 self.pandas_data.update(pandas_data_update)
                 self._data_store.update(pandas_data_update)
         except Exception as e:
-            print(f"Error get_last_price from ThetaData: {e}")
+            logging.info(f"\nError get_last_price from ThetaData: {e}, {dt}, asset:{asset}")
 
         return super().get_last_price(asset=asset, quote=quote, exchange=exchange)
 

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -566,7 +566,6 @@ class Broker(ABC):
 
     def _process_partially_filled_order(self, order, price, quantity):
         self._new_orders.remove(order.identifier, key="identifier")
-
         order.add_transaction(price, quantity)
         order.status = self.PARTIALLY_FILLED_ORDER
         order.set_partially_filled()
@@ -590,7 +589,6 @@ class Broker(ABC):
         self._new_orders.remove(order.identifier, key="identifier")
         self._unprocessed_orders.remove(order.identifier, key="identifier")
         self._partially_filled_orders.remove(order.identifier, key="identifier")
-
         order.add_transaction(price, quantity)
         order.status = self.FILLED_ORDER
         order.set_filled()
@@ -630,7 +628,6 @@ class Broker(ABC):
         self._new_orders.remove(order.identifier, key="identifier")
         self._unprocessed_orders.remove(order.identifier, key="identifier")
         self._partially_filled_orders.remove(order.identifier, key="identifier")
-
         order.add_transaction(price, quantity)
         order.status = self.CASH_SETTLED
         order.set_filled()

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -17,6 +17,7 @@ from lumibot.data_sources import DataSource
 from lumibot.entities import Asset, Order, Position
 from lumibot.trading_builtins import SafeList
 
+
 class CustomLoggerAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):
         # Check if the level is enabled to avoid formatting costs if not necessary
@@ -31,6 +32,7 @@ class CustomLoggerAdapter(logging.LoggerAdapter):
         # Pre-format part of the log message that's static or changes infrequently
         self.formatted_prefix = f'[{new_strategy_name}]'
 
+
 class Broker(ABC):
     # Metainfo
     IS_BACKTESTING_BROKER = False
@@ -43,7 +45,7 @@ class Broker(ABC):
     CASH_SETTLED = "cash_settled"
     ERROR_ORDER = "error"
 
-    def __init__(self, name="", connect_stream=True, data_source: DataSource = None, config=None, max_workers=20):
+    def __init__(self, name="", connect_stream=True, data_source: DataSource = None, option_source: DataSource = None, config=None, max_workers=20):
         """Broker constructor"""
         # Shared Variables between threads
         self.name = name
@@ -63,6 +65,7 @@ class Broker(ABC):
         self._config = config
         self._strategy_name = ""
         self.data_source = data_source
+        self.option_source = option_source
         self.max_workers = min(max_workers, 200)
         self.quote_assets = set()  # Quote positions will never be removed from tracking during sync operations
 
@@ -273,7 +276,10 @@ class Broker(ABC):
         float
             The last known price of the asset.
         """
-        return self.data_source.get_last_price(asset, quote=quote, exchange=exchange)
+        if self.option_source and asset.asset_type == "option":
+            return self.option_source.get_last_price(asset, quote=quote, exchange=exchange)
+        else:
+            return self.data_source.get_last_price(asset, quote=quote, exchange=exchange)
 
     def get_last_prices(self, assets, quote=None, exchange=None):
         """
@@ -1116,7 +1122,8 @@ class Broker(ABC):
             )
 
         if filled_quantity is not None:
-            error = ValueError(f"filled_quantity must be a positive integer or float, received {filled_quantity} instead")
+            error = ValueError(
+                f"filled_quantity must be a positive integer or float, received {filled_quantity} instead")
             try:
                 if not isinstance(filled_quantity, float):
                     filled_quantity = float(filled_quantity)

--- a/lumibot/brokers/ccxt.py
+++ b/lumibot/brokers/ccxt.py
@@ -182,10 +182,10 @@ class Ccxt(Broker):
                 f"Please check the symbol and the exchange currencies list."
             )
             precision = None
-        
+
         elif self.api.exchangeId == "binance":
             precision = str(10 ** -self.api.currencies[symbol]["precision"])
-            
+
         else:
             precision = str(self.api.currencies[symbol]["precision"])
 
@@ -253,7 +253,7 @@ class Ccxt(Broker):
             # Check if the position is not None
             if new_pos is not None:
                 result.append(new_pos)
-                
+
         return result
 
     def _pull_positions(self, strategy):
@@ -482,7 +482,8 @@ class Ccxt(Broker):
             "stop_price",
         ]:
             if hasattr(order, price_type) and getattr(order, price_type) is not None:
-                precision_price = Decimal(str(10 ** -precision["price"])) if self.api.exchangeId == "binance" else precision["price"]
+                precision_price = Decimal(str(10 ** -precision["price"])
+                                          ) if self.api.exchangeId == "binance" else precision["price"]
                 setattr(
                     order,
                     price_type,

--- a/lumibot/data_sources/pandas_data.py
+++ b/lumibot/data_sources/pandas_data.py
@@ -249,7 +249,6 @@ class PandasData(DataSourceBacktesting):
         now = self.get_datetime()
         try:
             res = data.get_bars(now, length=length, timestep=timestep, timeshift=timeshift)
-            # print(f"\npandas_data.py:_pull_source_symbol_bars after data.get_bars, time:{now}")
         # Return None if data.get_bars returns a ValueError
         except ValueError as e:
             logging.info(f"Error getting bars for {asset}: {e}")

--- a/lumibot/data_sources/pandas_data.py
+++ b/lumibot/data_sources/pandas_data.py
@@ -249,7 +249,7 @@ class PandasData(DataSourceBacktesting):
         now = self.get_datetime()
         try:
             res = data.get_bars(now, length=length, timestep=timestep, timeshift=timeshift)
-            print(f"\npandas_data.py:_pull_source_symbol_bars after data.get_bars, time:{now}")
+            # print(f"\npandas_data.py:_pull_source_symbol_bars after data.get_bars, time:{now}")
         # Return None if data.get_bars returns a ValueError
         except ValueError as e:
             logging.info(f"Error getting bars for {asset}: {e}")

--- a/lumibot/data_sources/pandas_data.py
+++ b/lumibot/data_sources/pandas_data.py
@@ -3,6 +3,7 @@ from collections import defaultdict, OrderedDict
 from datetime import date, timedelta
 
 import pandas as pd
+
 from lumibot.data_sources import DataSourceBacktesting
 from lumibot.entities import Asset, AssetsMapping, Bars
 
@@ -61,7 +62,7 @@ class PandasData(DataSourceBacktesting):
                 new_pandas_data[key] = data
 
         return new_pandas_data
-    
+
     def load_data(self):
         self._data_store = self.pandas_data
         self._date_index = self.update_date_index()
@@ -387,6 +388,43 @@ class PandasData(DataSourceBacktesting):
         str
             The timestep unit.
         """
+
+
+<< << << < HEAD
+== == == =
+        strikes = []
+        for store_item, data in self._data_store.items():
+            store_asset = store_item[0]
+            if (
+                store_asset.asset_type == "option"
+                and store_asset.symbol == asset.symbol
+                and store_asset.expiration == asset.expiration
+                and store_asset.right == asset.right
+            ):
+                strikes.append(float(store_asset.strike))
+
+        return sorted(list(set(strikes)))
+
+    def get_start_datetime_and_ts_unit(self, length, timestep, start_dt=None, start_buffer=timedelta(days=5)):
+        """
+        Get the start datetime for the data.
+
+        Parameters
+        ----------
+        length : int
+            The number of data points to get.
+        timestep : str
+            The timestep to use. For example, "1minute" or "1hour" or "1day".
+
+
+        Returns
+        -------
+        datetime
+            The start datetime.
+        str
+            The timestep unit.
+        """
+>>>>>>> thetadata almost complete. tests passing
         # Convert timestep string to timedelta and get start datetime
         td, ts_unit = self.convert_timestep_str_to_timedelta(timestep)
 
@@ -403,6 +441,7 @@ class PandasData(DataSourceBacktesting):
         start_datetime = start_datetime - start_buffer
 
         return start_datetime, ts_unit
+<<<<<<< HEAD
 
     def get_historical_prices(
         self, asset, length, timestep="", timeshift=None, quote=None, exchange=None, include_after_hours=True
@@ -430,3 +469,5 @@ class PandasData(DataSourceBacktesting):
 
         bars = self._parse_source_symbol_bars(response, asset, quote=quote, length=length)
         return bars
+=======
+>>>>>>> thetadata almost complete. tests passing

--- a/lumibot/data_sources/pandas_data.py
+++ b/lumibot/data_sources/pandas_data.py
@@ -3,7 +3,6 @@ from collections import defaultdict, OrderedDict
 from datetime import date, timedelta
 
 import pandas as pd
-
 from lumibot.data_sources import DataSourceBacktesting
 from lumibot.entities import Asset, AssetsMapping, Bars
 
@@ -250,6 +249,7 @@ class PandasData(DataSourceBacktesting):
         now = self.get_datetime()
         try:
             res = data.get_bars(now, length=length, timestep=timestep, timeshift=timeshift)
+            print(f"\npandas_data.py:_pull_source_symbol_bars after data.get_bars, time:{now}")
         # Return None if data.get_bars returns a ValueError
         except ValueError as e:
             logging.info(f"Error getting bars for {asset}: {e}")
@@ -388,43 +388,6 @@ class PandasData(DataSourceBacktesting):
         str
             The timestep unit.
         """
-
-
-<< << << < HEAD
-== == == =
-        strikes = []
-        for store_item, data in self._data_store.items():
-            store_asset = store_item[0]
-            if (
-                store_asset.asset_type == "option"
-                and store_asset.symbol == asset.symbol
-                and store_asset.expiration == asset.expiration
-                and store_asset.right == asset.right
-            ):
-                strikes.append(float(store_asset.strike))
-
-        return sorted(list(set(strikes)))
-
-    def get_start_datetime_and_ts_unit(self, length, timestep, start_dt=None, start_buffer=timedelta(days=5)):
-        """
-        Get the start datetime for the data.
-
-        Parameters
-        ----------
-        length : int
-            The number of data points to get.
-        timestep : str
-            The timestep to use. For example, "1minute" or "1hour" or "1day".
-
-
-        Returns
-        -------
-        datetime
-            The start datetime.
-        str
-            The timestep unit.
-        """
->>>>>>> thetadata almost complete. tests passing
         # Convert timestep string to timedelta and get start datetime
         td, ts_unit = self.convert_timestep_str_to_timedelta(timestep)
 
@@ -441,7 +404,6 @@ class PandasData(DataSourceBacktesting):
         start_datetime = start_datetime - start_buffer
 
         return start_datetime, ts_unit
-<<<<<<< HEAD
 
     def get_historical_prices(
         self, asset, length, timestep="", timeshift=None, quote=None, exchange=None, include_after_hours=True
@@ -452,7 +414,6 @@ class PandasData(DataSourceBacktesting):
 
         if not timestep:
             timestep = self.get_timestep()
-
         response = self._pull_source_symbol_bars(
             asset,
             length,
@@ -469,5 +430,3 @@ class PandasData(DataSourceBacktesting):
 
         bars = self._parse_source_symbol_bars(response, asset, quote=quote, length=length)
         return bars
-=======
->>>>>>> thetadata almost complete. tests passing

--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -268,8 +268,8 @@ class Data:
             )
         return df
 
-    # ./lumibot/build/__editable__.lumibot-3.1.14-py3-none-any/lumibot/entities/data.py:280: 
-    # FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. 
+    # ./lumibot/build/__editable__.lumibot-3.1.14-py3-none-any/lumibot/entities/data.py:280:
+    # FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version.
     # Call result.infer_objects(copy=False) instead.
     # To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
 
@@ -402,7 +402,8 @@ class Data:
         float
         """
         iter_count = self.get_iter_count(dt)
-        return self.datalines["open"].dataline[iter_count]
+        price = self.datalines["open"].dataline[iter_count]
+        return price
 
     @check_data
     def _get_bars_dict(self, dt, length=1, timestep=None, timeshift=0):

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -9,7 +9,6 @@ import string
 import random
 
 import pandas as pd
-
 from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting
 from lumibot.entities import Asset, Position
 from lumibot.tools import (
@@ -608,6 +607,7 @@ class _Strategy:
         if "datetime" in self._stats.columns:
             self._stats = self._stats.set_index("datetime")
         self._stats["return"] = self._stats["portfolio_value"].pct_change()
+
         return self._stats
 
     def _dump_stats(self):

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -512,7 +512,6 @@ class _Strategy:
                 prices = self.broker.option_source.get_last_prices(assets)
             else:
                 prices = self.broker.data_source.get_last_prices(assets)
-            print(f"\n_strategy.py datetime:{self.broker.datetime} prices: {prices}\n")
             for position in positions:
                 # Turn the asset into a tuple if it's a crypto asset
                 asset = (
@@ -561,7 +560,6 @@ class _Strategy:
                 else:
                     multiplier = asset.multiplier if asset.asset_type in ["option", "future"] else 1
                 portfolio_value += float(quantity) * price * multiplier
-            print(f"portfolio_value: {portfolio_value}")
             self._portfolio_value = portfolio_value
         return portfolio_value
 

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -31,6 +31,7 @@ matplotlib.use("Agg")
 # Set the stats table name for when storing stats in a database, defined by db_connection_str
 STATS_TABLE_NAME = "strategy_tracker"
 
+
 class Strategy(_Strategy):
     @property
     def name(self):
@@ -369,11 +370,11 @@ class Strategy(_Strategy):
         if broadcast:
             # Send the message to Discord
             self.send_discord_message(message)
-        
+
         # If we are backtesting and we don't want to save the logfile, don't log (they're not displayed in the console anyway)
         if not self.save_logfile and self.is_backtesting:
             return
-        
+
         if color:
             colored_message = colored(message, color)
             self.logger.info(colored_message)
@@ -724,7 +725,6 @@ class Strategy(_Strategy):
             self.broker.process_pending_orders(strategy=self)
 
         return self.broker.sleep(sleeptime)
-
 
     def get_selling_order(self, position):
         """Get the selling order for a position.
@@ -1506,14 +1506,14 @@ class Strategy(_Strategy):
                 "Cannot submit a None order, please check to make sure that you have actually created an order before submitting."
             )
             return
-        
+
         # Check if the order is an Order object
         if not isinstance(order, Order):
             self.logger.error(
                 f"Order must be an Order object. You entered {order}."
             )
             return
-        
+
         # Check if the order does not have a quantity of zero
         if order.quantity == 0:
             self.logger.error(
@@ -1551,7 +1551,7 @@ class Strategy(_Strategy):
         tag : str
             Tradier only.
             A tag for the multileg order.
-        
+
         Returns
         -------
         list of Order objects
@@ -1936,17 +1936,17 @@ class Strategy(_Strategy):
             self.log_message(f"Could not get last price for {asset}", color="red")
             self.log_message(f"{e}")
             return None
-        
+
     def get_quote(self, asset):
         """Get a quote for the asset.
 
         NOTE: This currently only works with Tradier. It does not work with backtetsing or other brokers.
-        
+
         Parameters
         ----------
         asset : Asset object
             The asset for which the quote is needed.
-            
+
         Returns
         -------
         dict
@@ -2059,32 +2059,33 @@ class Strategy(_Strategy):
         """
         asset = self._sanitize_user_asset(asset)
         return self.broker.get_chains(asset)
-    
+
     def get_next_trading_day(self, date, exchange='NYSE'):
         """
         Finds the next trading day for the given date and exchange.
-        
+
         Parameters:
             date (str): The date from which to find the next trading day, in 'YYYY-MM-DD' format.
             exchange (str): The exchange calendar to use, default is 'NYSE'.
-            
+
         Returns:
             next_trading_day (datetime.date): The next trading day after the given date.
         """
-        
+
         # Load the specified market calendar
         calendar = mcal.get_calendar(exchange)
-        
+
         # Convert the input string date to pandas Timestamp
         date_timestamp = pd.Timestamp(date)
-        
+
         # Get the next trading day. The schedule is inclusive of the start_date when the market is open on this day.
         # Hence, we add 1 day to the start_date to ensure we start checking from the day after.
-        schedule = calendar.schedule(start_date=date_timestamp + pd.Timedelta(days=1), end_date=date_timestamp + pd.Timedelta(days=10))
-        
+        schedule = calendar.schedule(start_date=date_timestamp + pd.Timedelta(days=1),
+                                     end_date=date_timestamp + pd.Timedelta(days=10))
+
         # The next trading day is the first entry in the schedule
         next_trading_day = schedule.index[0].date()
-        
+
         return next_trading_day
 
     def get_chain(self, chains, exchange="SMART"):
@@ -3090,15 +3091,26 @@ class Strategy(_Strategy):
         asset = self.crypto_assets_to_tuple(asset, quote)
         if not timestep:
             timestep = self.broker.data_source.MIN_TIMESTEP
-        return self.broker.data_source.get_historical_prices(
-            asset,
-            length,
-            timestep=timestep,
-            timeshift=timeshift,
-            exchange=exchange,
-            include_after_hours=include_after_hours,
-            quote=quote,
-        )
+        if self.broker.option_source and asset.asset_type == "option":
+            return self.broker.option_source.get_historical_prices(
+                asset,
+                length,
+                timestep=timestep,
+                timeshift=timeshift,
+                exchange=exchange,
+                include_after_hours=include_after_hours,
+                quote=quote,
+            )
+        else:
+            return self.broker.data_source.get_historical_prices(
+                asset,
+                length,
+                timestep=timestep,
+                timeshift=timeshift,
+                exchange=exchange,
+                include_after_hours=include_after_hours,
+                quote=quote,
+            )
 
     def get_symbol_bars(
         self,
@@ -4091,7 +4103,7 @@ class Strategy(_Strategy):
         if not should_send_account_summary:
             # Log that we are not sending the account summary to Discord
             return
-        
+
         # Log that we are sending the account summary to Discord
         self.logger.info("Sending account summary to Discord")
 
@@ -4117,7 +4129,7 @@ class Strategy(_Strategy):
         # Create a database connection
         if not hasattr(self, 'db_engine') or not self.db_engine:
             self.db_engine = create_engine(self.db_connection_str)
-        
+
         # Check if the table exists
         if not inspect(self.db_engine).has_table(stats_table_name):
             # Log that the table does not exist and we are creating it
@@ -4136,12 +4148,12 @@ class Strategy(_Strategy):
                     "datetime": [now],
                     "portfolio_value": [0.0],  # Default or initial value
                     "cash": [0.0],             # Default or initial value
-                    "strategy_id": ["INITIAL VALUE"], # Default or initial value
+                    "strategy_id": ["INITIAL VALUE"],  # Default or initial value
                 }
             )
             # Create the table by saving this empty DataFrame to the database
             stats_new.to_sql(stats_table_name, self.db_engine, if_exists='replace', index=False)
-        
+
         # Load the stats dataframe from the database
         stats_df = pd.read_sql_table(stats_table_name, self.db_engine)
 
@@ -4155,7 +4167,7 @@ class Strategy(_Strategy):
             if_exists=if_exists,
             index=index,
         )
-    
+
     def backup_variables_to_db(self):
         if not hasattr(self, "db_connection_str") or self.db_connection_str is None or not self.should_backup_variables_to_database:
             return
@@ -4163,11 +4175,11 @@ class Strategy(_Strategy):
         # Ensure we have a self.db_engine
         if not hasattr(self, 'db_engine') or not self.db_engine:
             self.db_engine = create_engine(self.db_connection_str)
-        
+
         # Get the current time in New York
         ny_tz = pytz.timezone("America/New_York")
         now = datetime.datetime.now(ny_tz)
-        
+
         if not inspect(self.db_engine).has_table(self.backup_table_name):
             # Log that the table does not exist and we are creating it
             self.logger.info(f"Table {self.backup_table_name} does not exist. Creating it now.")
@@ -4226,7 +4238,7 @@ class Strategy(_Strategy):
                                 'variables': json_data_to_save,
                                 'strategy_id': self.name
                             })
-                            
+
                 self._last_backup_state = current_state
                 logger.info("Variables backed up successfully")
             else:
@@ -4238,7 +4250,7 @@ class Strategy(_Strategy):
     def load_variables_from_db(self):
         if not hasattr(self, "db_connection_str") or self.db_connection_str is None or not self.should_backup_variables_to_database:
             return
-        
+
         try:
             if not hasattr(self, 'db_engine') or not self.db_engine:
                 self.db_engine = create_engine(self.db_connection_str)
@@ -4248,10 +4260,11 @@ class Strategy(_Strategy):
             if not inspector.has_table(self.backup_table_name):
                 logger.info(f"Backup for {self.name} does not exist in the database. Not restoring")
                 return
-            
+
              # Query the latest entry from the backup table
-            query = text(f'SELECT * FROM {self.backup_table_name} WHERE strategy_id = :strategy_id ORDER BY last_updated DESC LIMIT 1')    
-            
+            query = text(
+                f'SELECT * FROM {self.backup_table_name} WHERE strategy_id = :strategy_id ORDER BY last_updated DESC LIMIT 1')
+
             params = {'strategy_id': self.name}
             df = pd.read_sql_query(query, self.db_engine, params=params)
 
@@ -4265,7 +4278,7 @@ class Strategy(_Strategy):
                 # Update self.vars dictionary
                 for key, value in data.items():
                     self.vars.set(key, value)
-                
+
                 current_state = json.dumps(self.vars.all(), sort_keys=True)
                 self._last_backup_state = current_state
 
@@ -4377,7 +4390,7 @@ class Strategy(_Strategy):
                     # Add the return to the results
                     results_text += f"**7 day Return:** {return_7_days:,.2f}% (${(portfolio_value - portfolio_value_7_days_ago):,.2f} change)\n"
 
-                    ## If we are up more than pct_up_threshold over the past 7 days, send a message to Discord
+                    # If we are up more than pct_up_threshold over the past 7 days, send a message to Discord
                     PERCENT_UP_THRESHOLD = 3
                     if return_7_days > PERCENT_UP_THRESHOLD:
                         # Create a message to send to Discord
@@ -4431,24 +4444,26 @@ class Strategy(_Strategy):
         # Check if db_connection_str has been set, if not, return False
         if not hasattr(self, "db_connection_str"):
             # Log that we are not sending the account summary to Discord
-            self.logger.info("Not sending account summary to Discord because self does not have db_connection_str attribute")
+            self.logger.info(
+                "Not sending account summary to Discord because self does not have db_connection_str attribute")
             return False
-        
+
         if self.db_connection_str is None:
             # Log that we are not sending the account summary to Discord
             self.logger.info("Not sending account summary to Discord because db_connection_str is not set")
             return False
-    
+
         # Check if discord_webhook_url has been set, if not, return False
         if not self.discord_webhook_url:
             # Log that we are not sending the account summary to Discord
             self.logger.info("Not sending account summary to Discord because discord_webhook_url is not set")
             return False
-        
+
         # Check if should_send_summary_to_discord has been set, if not, return False
         if not self.should_send_summary_to_discord:
             # Log that we are not sending the account summary to Discord
-            self.logger.info(f"Not sending account summary to Discord because should_send_summary_to_discord is False or not set. The value is: {self.should_send_summary_to_discord}")
+            self.logger.info(
+                f"Not sending account summary to Discord because should_send_summary_to_discord is False or not set. The value is: {self.should_send_summary_to_discord}")
             return False
 
         # Check if it has been at least 24 hours since the last account summary
@@ -4465,10 +4480,11 @@ class Strategy(_Strategy):
 
             # Return True because we should send the account summary to Discord
             return True
-        
+
         else:
             # Log that we are not sending the account summary to Discord
-            self.logger.info(f"Not sending account summary to Discord because it has not been at least 24 hours since the last account summary. Last account summary was at: {self.last_account_summary_dt}")
+            self.logger.info(
+                f"Not sending account summary to Discord because it has not been at least 24 hours since the last account summary. Last account summary was at: {self.last_account_summary_dt}")
 
             # Return False because we should not send the account summary to Discord
             return False

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -323,6 +323,19 @@ class StrategyExecutor(Thread):
         result["datetime"] = self.strategy.get_datetime()
         result["portfolio_value"] = self.strategy.portfolio_value
         result["cash"] = self.strategy.cash
+
+        # Add positions column
+        positions_list = []
+        positions = self.strategy.get_positions()
+        for position in positions:
+            pos_dict = {
+                "asset": position.asset,
+                "quantity": position.quantity,
+            }
+            positions_list.append(pos_dict)
+
+        result["positions"] = positions_list
+
         self.strategy._append_row(result)
         return result
 

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -253,7 +253,7 @@ class StrategyExecutor(Thread):
                 self.strategy._update_cash(order.side, quantity, price, multiplier)
 
             self._on_partially_filled_order(**payload)
-        
+
         else:
             self.strategy.logger.error(f"Event {event} not recognized. Payload: {payload}")
 
@@ -801,9 +801,9 @@ class StrategyExecutor(Thread):
                 self.broker.data_source._iter_count += 1
 
             dt = self.broker.data_source._date_index[self.broker.data_source._iter_count]
-
+            print(f"strategy_executor.py: _run_trading_session: before _update_datetime time: {self.broker.datetime}")
             self.broker._update_datetime(dt, cash=self.strategy.cash, portfolio_value=self.strategy.portfolio_value)
-
+            print(f"strategy_executor.py: _run_trading_session: after _update_datetime time: {self.broker.datetime}")
             self.strategy._update_cash_with_dividends()
 
             self._on_trading_iteration()
@@ -966,7 +966,7 @@ class StrategyExecutor(Thread):
 
         # Sort the trading days by market close time so that we can search them faster
         self.broker._trading_days.sort_values('market_close', inplace=True)  # Ensure sorted order
-        
+
         # Set DataFrame index to market_close for fast lookups
         self.broker._trading_days.set_index('market_close', inplace=True)
 

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -801,9 +801,7 @@ class StrategyExecutor(Thread):
                 self.broker.data_source._iter_count += 1
 
             dt = self.broker.data_source._date_index[self.broker.data_source._iter_count]
-            print(f"strategy_executor.py: _run_trading_session: before _update_datetime time: {self.broker.datetime}")
             self.broker._update_datetime(dt, cash=self.strategy.cash, portfolio_value=self.strategy.portfolio_value)
-            print(f"strategy_executor.py: _run_trading_session: after _update_datetime time: {self.broker.datetime}")
             self.strategy._update_cash_with_dividends()
 
             self._on_trading_iteration()

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -14,6 +14,7 @@ from plotly.subplots import make_subplots
 
 from lumibot import LUMIBOT_DEFAULT_TIMEZONE
 from lumibot.tools import to_datetime_aware
+from plotly.subplots import make_subplots
 
 from .yahoo_helper import YahooHelper as yh
 

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -9,6 +9,8 @@ from urllib.parse import urlparse, urlunparse
 
 import pandas as pd
 import pandas_market_calendars as mcal
+from lumibot import LUMIBOT_CACHE_FOLDER
+from lumibot.entities import Asset
 
 # noinspection PyPackageRequirements
 from polygon import RESTClient
@@ -26,6 +28,7 @@ MAX_POLYGON_DAYS = 30
 schedule_cache = {}
 buffered_schedules = {}
 
+
 def get_cached_schedule(cal, start_date, end_date, buffer_days=30):
     """
     Fetch schedule with a buffer at the end. This is done to reduce the number of calls to the calendar API (which is slow).
@@ -34,35 +37,38 @@ def get_cached_schedule(cal, start_date, end_date, buffer_days=30):
 
     buffer_end = end_date + timedelta(days=buffer_days)
     cache_key = (cal.name, start_date, end_date)
-    
+
     # Check if the required range is in the schedule cache
     if cache_key in schedule_cache:
         return schedule_cache[cache_key]
-    
+
     # Convert start_date and end_date to pd.Timestamp for comparison
     start_timestamp = pd.Timestamp(start_date)
     end_timestamp = pd.Timestamp(end_date)
-    
+
     # Check if we have the buffered schedule for this calendar
     if cal.name in buffered_schedules:
         buffered_schedule = buffered_schedules[cal.name]
         # Check if the current buffered schedule covers the required range
         if buffered_schedule.index.min() <= start_timestamp and buffered_schedule.index.max() >= end_timestamp:
-            filtered_schedule = buffered_schedule[(buffered_schedule.index >= start_timestamp) & (buffered_schedule.index <= end_timestamp)]
+            filtered_schedule = buffered_schedule[(buffered_schedule.index >= start_timestamp) & (
+                buffered_schedule.index <= end_timestamp)]
             schedule_cache[cache_key] = filtered_schedule
             return filtered_schedule
-    
+
     # Fetch and cache the new buffered schedule
     buffered_schedule = cal.schedule(start_date=start_date, end_date=buffer_end)
     buffered_schedules[cal.name] = buffered_schedule  # Store the buffered schedule for this calendar
-    
+
     # Filter the schedule to only include the requested date range
-    filtered_schedule = buffered_schedule[(buffered_schedule.index >= start_timestamp) & (buffered_schedule.index <= end_timestamp)]
-    
+    filtered_schedule = buffered_schedule[(buffered_schedule.index >= start_timestamp)
+                                          & (buffered_schedule.index <= end_timestamp)]
+
     # Cache the filtered schedule for quick lookup
     schedule_cache[cache_key] = filtered_schedule
-    
+
     return filtered_schedule
+
 
 def get_price_data_from_polygon(
     api_key: str,
@@ -111,9 +117,9 @@ def get_price_data_from_polygon(
     cache_file = build_cache_filename(asset, timespan)
     # Check whether it might be stale because of splits.
     force_cache_update = validate_cache(force_cache_update, asset, cache_file, api_key)
-    
+
     df_all = None
-    # Load from the cache file if it exists.  
+    # Load from the cache file if it exists.
     if cache_file.exists() and not force_cache_update:
         logging.debug(f"Loading pricing data for {asset} / {quote_asset} with '{timespan}' timespan from cache file...")
         df_all = load_cache(cache_file)
@@ -190,6 +196,7 @@ def get_price_data_from_polygon(
         df_all.dropna(how="all", inplace=True)
 
     return df_all
+
 
 def validate_cache(force_cache_update: bool, asset: Asset, cache_file: Path, api_key: str):
     """
@@ -507,6 +514,7 @@ def update_polygon_data(df_all, result):
 
     return df_all
 
+
 class PolygonClient(RESTClient):
     ''' Rate Limited RESTClient with factory method '''
 
@@ -534,24 +542,24 @@ class PolygonClient(RESTClient):
         Examples:
         ---------
         Using default environment variables:
-        
+
         >>> client = PolygonClient.create()
-        
+
         Providing an API key explicitly:
-        
+
         >>> client = PolygonClient.create(api_key='your_api_key_here')
-        
+
         """
         if 'api_key' not in kwargs:
             kwargs['api_key'] = os.environ.get("POLYGON_API_KEY")
-        
+
         return cls(*args, **kwargs)
 
     def _get(self, *args, **kwargs):
         while True:
             try:
                 return super()._get(*args, **kwargs)
-            
+
             except MaxRetryError as e:
                 url = urlunparse(urlparse(kwargs['path'])._replace(query=""))
 
@@ -565,7 +573,7 @@ class PolygonClient(RESTClient):
                 )
 
                 colored_message = colored(message, "red")
-                
+
                 logging.error(colored_message)
                 logging.debug(f"Error: {e}")
                 time.sleep(PolygonClient.WAIT_SECONDS_RETRY)

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -133,7 +133,6 @@ def get_price_data(
 
         else:
             df_all = update_df(df_all, result_df)
-            print(f"\ndf_all tail: \n{df_all.tail()}")
 
         start = end + timedelta(days=1)
         end = start + delta
@@ -142,13 +141,9 @@ def get_price_data(
             break
 
     update_cache(cache_file, df_all, df_feather)
-    # df_all.index = df_all.index + pd.Timedelta(hours=THETA_SUMMER_TIME_SHIFT) - pd.Timedelta(minutes=1)
-
     if is_summer_time(start):
-        print(f"Today's date is in Daylight Saving Time (Summer Time)")
         df_all.index = df_all.index + pd.Timedelta(hours=THETA_SUMMER_TIME_SHIFT) - pd.Timedelta(minutes=1)
     else:
-        print(f"Today's date is in Standard Time (Winter Time)")
         df_all.index = df_all.index + pd.Timedelta(hours=THETA_WINTER_TIME_SHIFT) - pd.Timedelta(minutes=1)
     return df_all
 
@@ -307,26 +302,14 @@ def update_df(df_all, result):
     if not df.empty:
         df = df.set_index("datetime").sort_index()
         if df_all is not None:
-            print(f"\n new loop df_all head: \n{df_all.head()}")
             # set "datetime" column as index of df_all
             df_all = df_all.set_index("datetime").sort_index()
-            print(f"\n after setting index df_all head: \n{df_all.head()}")
-        print(f"\nbefore utc: df head: \n{df.head()}")
         df.index = df.index.tz_localize("UTC")
-        print(f"\nafter utc: df head: \n{df.head()}")
         if df_all is None or df_all.empty:
             df_all = df
-            print(f"\nNo df_all, assign df_all=df")
         else:
-            print(f"\nInside update_df, df_all head: \n{df_all.head()}")
-            print(f"\nInside update_df, df head: \n{df.head()}")
             df_all = pd.concat([df_all, df]).sort_index()
             df_all = df_all[~df_all.index.duplicated(keep="first")]  # Remove any duplicate rows
-
-            print(f"\nafter concat df_all head: \n{df_all.head()}")
-        # df_all = df_all.reset_index()
-        print(f"\nafter concat reset index df_all head: \n{df_all.head()}")
-
     return df_all
 
 
@@ -401,7 +384,6 @@ def is_weekend(date):
 
 def get_request(url: str, headers: dict, querystring: dict, username: str, password: str):
     counter = 0
-    print(f"querystring: {querystring}")
     expiry = querystring['exp'] if 'exp' in querystring else None
 
     # Check if expiry date is a holiday or weekend, this part of the logic is currently
@@ -431,7 +413,6 @@ def get_request(url: str, headers: dict, querystring: dict, username: str, passw
                         f"Error getting data from Theta Data: {json_resp['header']['error_type']},\nquerystring: {querystring}")
                     check_connection(username=username, password=password)
                 else:
-                    # print(f"\nthe_helper: Found valid querystring: {querystring}")
                     break
 
         except Exception as e:

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -1,0 +1,467 @@
+# This file contains helper functions for getting data from Polygon.io
+import logging
+import time
+from datetime import date, datetime, timedelta
+from enum import Enum
+from pathlib import Path
+
+import pandas as pd
+import pandas_market_calendars as mcal
+import requests
+from thetadata import DateRange, OptionReqType, StockReqType, ThetaClient
+
+from lumibot import LUMIBOT_CACHE_FOLDER
+from lumibot.entities import Asset
+
+WAIT_TIME = 60
+MAX_DAYS = 30
+CACHE_SUBFOLDER = "thetadata"
+BASE_URL = "http://127.0.0.1:25510"
+
+
+# Create enum for request type
+class ReqType(Enum):
+    STOCK = "stock"
+    OPTION = "option"
+
+
+def get_price_data(
+    username: str,
+    password: str,
+    asset: Asset,
+    start: datetime,
+    end: datetime,
+    timespan: str = "minute",
+    quote_asset: Asset = None,
+):
+    """
+    Queries ThetaData for pricing data for the given asset and returns a DataFrame with the data. Data will be
+    cached in the LUMIBOT_CACHE_FOLDER/polygon folder so that it can be reused later and we don't have to query
+    ThetaData every time we run a backtest.
+
+    Parameters
+    ----------
+    username : str
+        Your ThetaData username
+    password : str
+        Your ThetaData password
+    asset : Asset
+        The asset we are getting data for
+    start : datetime
+        The start date/time for the data we want
+    end : datetime
+        The end date/time for the data we want
+    timespan : str
+        The timespan for the data we want. Default is "minute" but can also be "second", "hour", "day", "week",
+        "month", "quarter"
+    quote_asset : Asset
+        The quote asset for the asset we are getting data for. This is only needed for Forex assets.
+
+    Returns
+    -------
+    pd.DataFrame
+        A DataFrame with the pricing data for the asset
+
+    """
+
+    # Check if we already have data for this asset in the csv file
+    df_all = None
+    df_csv = None
+    cache_file = build_cache_filename(asset, timespan)
+    if cache_file.exists():
+        print(f"\nLoading pricing data for {asset} / {quote_asset} with '{timespan}' timespan from cache file...")
+        df_csv = load_cache(cache_file)
+        df_all = df_csv.copy()  # Make a copy so we can check the original later for differences
+
+    # Check if we need to get more data
+    missing_dates = get_missing_dates(df_all, asset, start, end)
+    if not missing_dates:
+        return df_all
+
+    print(f"\nGetting pricing data for {asset} / {quote_asset} with '{timespan}' timespan from ThetaData...")
+
+    start = missing_dates[0]  # Data will start at 8am UTC (4am EST)
+    end = missing_dates[-1]  # Data will end at 23:59 UTC (7:59pm EST)
+    delta = timedelta(days=MAX_DAYS)
+
+    interval_ms = None
+    # Calculate the interval in milliseconds
+    if timespan == "second":
+        interval_ms = 1000
+    elif timespan == "minute":
+        interval_ms = 60000
+    elif timespan == "hour":
+        interval_ms = 3600000
+    elif timespan == "day":
+        interval_ms = 86400000
+    else:
+        interval_ms = 60000
+        logging.warning(f"Unsupported timespan: {timespan}, using default of 1 minute")
+
+    while start <= missing_dates[-1]:
+        # If we don't have a paid subscription, we need to wait 1 minute between requests because of
+        # the rate limit. Wait every other query so that we don't spend too much time waiting.
+
+        if end > start + delta:
+            end = start + delta
+
+        result_df = get_historical_data(asset.symbol, start, end, interval_ms, ReqType.STOCK)
+
+        # result = polygon_client.get_aggs(
+        #     ticker=symbol,
+        #     from_=start,  # polygon-api-client docs say 'from' but that is a reserved word in python
+        #     to=end,
+        #     # In Polygon, multiplier is the number of "timespans" in each candle, so if you want 5min candles
+        #     # returned you would set multiplier=5 and timespan="minute". This is very different from the
+        #     # asset.multiplier setting for option contracts.
+        #     multiplier=1,
+        #     timespan=timespan,
+        #     limit=50000,  # Max limit for Polygon
+        # )
+
+        if result_df is None or len(result_df) == 0:
+            logging.warning(
+                f"No data returned for {asset} / {quote_asset} with '{timespan}' timespan between {start} and {end}"
+            )
+
+        else:
+            df_all = update_df(df_all, result_df)
+
+        start = end + timedelta(days=1)
+        end = start + delta
+
+    update_cache(cache_file, df_all, df_csv)
+    return df_all
+
+
+# TODO: Remove this? It's an exact copy of the function in polygon_helper.py
+def get_trading_dates(asset: Asset, start: datetime, end: datetime):
+    """
+    Get a list of trading days for the asset between the start and end dates
+    Parameters
+    ----------
+    asset : Asset
+        Asset we are getting data for
+    start : datetime
+        Start date for the data requested
+    end : datetime
+        End date for the data requested
+
+    Returns
+    -------
+
+    """
+    # Crypto Asset Calendar
+    if asset.asset_type == "crypto":
+        # Crypto trades every day, 24/7 so we don't need to check the calendar
+        return [start.date() + timedelta(days=x) for x in range((end.date() - start.date()).days + 1)]
+
+    # Stock/Option Asset for Backtesting - Assuming NYSE trading days
+    elif asset.asset_type == "stock" or asset.asset_type == "option":
+        cal = mcal.get_calendar("NYSE")
+
+    # Forex Asset for Backtesting - Forex trades weekdays, 24hrs starting Sunday 5pm EST
+    # Calendar: "CME_FX"
+    elif asset.asset_type == "forex":
+        cal = mcal.get_calendar("CME_FX")
+
+    else:
+        raise ValueError(f"Unsupported asset type for polygon: {asset.asset_type}")
+
+    # Get the trading days between the start and end dates
+    df = cal.schedule(start_date=start.date(), end_date=end.date())
+    trading_days = df.index.date.tolist()
+    return trading_days
+
+
+def get_polygon_symbol(asset, polygon_client, quote_asset=None):
+    """
+    Get the symbol for the asset in a format that Polygon will understand
+    Parameters
+    ----------
+    asset : Asset
+        Asset we are getting data for
+    polygon_client : RESTClient
+        The RESTClient connection for Polygon Stock-Equity API
+    quote_asset : Asset
+        The quote asset for the asset we are getting data for
+
+    Returns
+    -------
+    str
+        The symbol for the asset in a format that Polygon will understand
+    """
+    # Crypto Asset for Backtesting
+    if asset.asset_type == "crypto":
+        quote_asset_symbol = quote_asset.symbol if quote_asset else "USD"
+        symbol = f"X:{asset.symbol}{quote_asset_symbol}"
+
+    # Stock-Equity Asset for Backtesting
+    elif asset.asset_type == "stock":
+        symbol = asset.symbol
+
+    # Forex Asset for Backtesting
+    elif asset.asset_type == "forex":
+        # If quote_asset is None, throw an error
+        if quote_asset is None:
+            raise ValueError(f"quote_asset is required for asset type {asset.asset_type}")
+
+        symbol = f"C:{asset.symbol}{quote_asset.symbol}"
+
+    # Option Asset for Backtesting - Do a query to Polygon to get the ticker
+    elif asset.asset_type == "option":
+        # Needed so BackTest both old and existing contracts
+        real_today = date.today()
+        expired = True if asset.expiration < real_today else False
+
+        # Query for the historical Option Contract ticker backtest is looking for
+        contracts = list(
+            polygon_client.list_options_contracts(
+                underlying_ticker=asset.symbol,
+                expiration_date=asset.expiration,
+                contract_type=asset.right.lower(),
+                strike_price=asset.strike,
+                expired=expired,
+                limit=10,
+            )
+        )
+
+        if len(contracts) == 0:
+            raise LookupError(f"Unable to find option contract for {asset}")
+
+        # Example: O:SPY230802C00457000
+        symbol = contracts[0].ticker
+
+    else:
+        raise ValueError(f"Unsupported asset type for polygon: {asset.asset_type}")
+
+    return symbol
+
+
+def build_cache_filename(asset: Asset, timespan: str):
+    """Helper function to create the cache filename for a given asset and timespan"""
+
+    lumibot_cache_folder = Path(LUMIBOT_CACHE_FOLDER) / CACHE_SUBFOLDER
+
+    # If It's an option then also add the expiration date, strike price and right to the filename
+    if asset.asset_type == "option":
+        if asset.expiration is None:
+            raise ValueError(f"Expiration date is required for option {asset} but it is None")
+
+        # Make asset.expiration datetime into a string like "YYMMDD"
+        expiry_string = asset.expiration.strftime("%y%m%d")
+        uniq_str = f"{asset.symbol}_{expiry_string}_{asset.strike}_{asset.right}"
+    else:
+        uniq_str = asset.symbol
+
+    cache_filename = f"{asset.asset_type}_{uniq_str}_{timespan}.csv"
+    cache_file = lumibot_cache_folder / cache_filename
+    return cache_file
+
+
+def get_missing_dates(df_all, asset, start, end):
+    """
+    Check if we have data for the full range
+    Later Query to Polygon will pad an extra full day to start/end dates so that there should never
+    be any gap with intraday data missing.
+
+    Parameters
+    ----------
+    df_all : pd.DataFrame
+        Data loaded from the cache file
+    asset : Asset
+        Asset we are getting data for
+    start : datetime
+        Start date for the data requested
+    end : datetime
+        End date for the data requested
+
+    Returns
+    -------
+    list[datetime.date]
+        A list of dates that we need to get data for
+    """
+    trading_dates = get_trading_dates(asset, start, end)
+    if df_all is None or not len(df_all):
+        return trading_dates
+
+    # It is possible to have full day gap in the data if previous queries were far apart
+    # Example: Query for 8/1/2023, then 8/31/2023, then 8/7/2023
+    # Whole days are easy to check for because we can just check the dates in the index
+    dates = pd.Series(df_all.index.date).unique()
+    missing_dates = sorted(set(trading_dates) - set(dates))
+
+    # For Options, don't need any dates passed the expiration date
+    if asset.asset_type == "option":
+        missing_dates = [x for x in missing_dates if x <= asset.expiration]
+
+    return missing_dates
+
+
+def load_cache(cache_file):
+    """Load the data from the cache file and return a DataFrame with a DateTimeIndex"""
+    df_csv = pd.read_csv(cache_file, index_col="datetime")
+    df_csv.index = pd.to_datetime(
+        df_csv.index
+    )  # TODO: Is there some way to speed this up? It takes several times longer than just reading the csv file
+    df_csv = df_csv.sort_index()
+
+    # Check if the index is already timezone aware
+    if df_csv.index.tzinfo is None:
+        # Set the timezone to UTC
+        df_csv.index = df_csv.index.tz_localize("UTC")
+
+    return df_csv
+
+
+def update_cache(cache_file, df_all, df_csv):
+    """Update the cache file with the new data"""
+    # Check if df_all is different from df_csv (if df_csv exists)
+    if df_all is not None and len(df_all) > 0:
+        # Check if the dataframes are the same
+        if df_all.equals(df_csv):
+            return
+
+        # Create the directory if it doesn't exist
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+
+        # Save the data to a csv file
+        df_all.to_csv(cache_file)
+
+
+def update_df(df_all, result):
+    """
+    Update the DataFrame with the new data from ThetaData
+
+    Parameters
+    ----------
+    df_all : pd.DataFrame
+        A DataFrame with the data we already have
+    result : list
+        A List of dictionaries with the new data from Polygon
+        Format: [{'o': 1.0, 'h': 2.0, 'l': 3.0, 'c': 4.0, 'v': 5.0, 't': 116120000000}]
+    """
+
+    df = pd.DataFrame(result)
+    if not df.empty:
+        df = df.set_index("datetime").sort_index()
+
+        # Set the timezone to UTC
+        df.index = df.index.tz_localize("UTC")
+
+        if df_all is None or df_all.empty:
+            df_all = df
+        else:
+            df_all = pd.concat([df_all, df]).sort_index()
+            df_all = df_all[~df_all.index.duplicated(keep="first")]  # Remove any duplicate rows
+
+    return df_all
+
+
+def start_theta_data_client(username: str, password: str):
+    # First try shutting down any existing connection
+    try:
+        requests.get(f"{BASE_URL}/v2/system/terminal/shutdown")
+    except Exception:
+        pass
+
+    client = ThetaClient(username=username, passwd=password)
+
+    time.sleep(1)
+
+    return client
+
+
+def check_connection(username: str, password: str):
+    # Do endless while loop and check if connected every 100 milliseconds
+    MAX_RETRIES = 10
+    counter = 0
+    client = None
+    while True:
+        try:
+            res = requests.get(f"{BASE_URL}/v2/system/mdds/status", timeout=1)
+            con_text = res.text
+
+            if con_text == "CONNECTED":
+                print("Connected to Theta Data!")
+                break
+            elif con_text == "DISCONNECTED":
+                print("Disconnected from Theta Data!")
+                counter += 1
+            else:
+                print(f"Unknown connection status: {con_text}, starting theta data client")
+                client = start_theta_data_client(username=username, password=password)
+                counter += 1
+        except Exception:
+            client = start_theta_data_client(username=username, password=password)
+            counter += 1
+
+        if counter > MAX_RETRIES:
+            print("Cannot connect to Theta Data!")
+            break
+
+    return client
+
+
+def get_historical_data(ticker: str, start_dt: datetime, end_dt: datetime, ivl: int, req_type: ReqType):
+    """
+    Get data from ThetaData
+
+    Parameters
+    ----------
+    ticker : str
+        The ticker for the asset we are getting data for
+    start_dt : datetime
+        The start date/time for the data we want
+    end_dt : datetime
+        The end date/time for the data we want
+    ivl : int
+        The interval for the data we want in milliseconds (eg. 60000 for 1 minute)
+    req_type : ReqType
+        The type of data we are requesting (stock or option)
+    """
+
+    # Comvert start and end dates to strings
+    start_date = start_dt.strftime("%Y%m%d")
+    end_date = end_dt.strftime("%Y%m%d")
+
+    # Create the url based on the request type
+    if req_type == ReqType.STOCK:
+        url = f"{BASE_URL}/hist/stock/ohlc"
+    elif req_type == ReqType.OPTION:
+        url = f"{BASE_URL}/hist/option/ohlc"
+
+    querystring = {"root": ticker, "start_date": start_date, "end_date": end_date, "ivl": ivl}
+
+    headers = {"Accept": "application/json"}
+
+    try:
+        response = requests.get(url, headers=headers, params=querystring)
+    except Exception:
+        check_connection()
+
+    # If status code is not 200, then we are not connected
+    if response.status_code != 200:
+        check_connection()
+
+    json_resp = response.json()
+
+    # Convert to pandas dataframe
+    df = pd.DataFrame(json_resp["response"], columns=json_resp["header"]["format"])
+
+    # Combine ms_of_day and date columns into datetime (date is in the format YYYYMMDD, eg. '20220901')
+    df["datetime"] = pd.to_datetime(df["date"].astype(str) + df["ms_of_day"].astype(str), format="%Y%m%d%H%M%S%f")
+
+    # Function to combine ms_of_day and date into datetime
+    def combine_datetime(row):
+        # Ensure the date is in integer format and then convert to string
+        date_str = str(int(row["date"]))
+        base_date = datetime.strptime(date_str, "%Y%m%d")
+        # Adding the milliseconds of the day to the base date
+        datetime_value = base_date + timedelta(milliseconds=int(row["ms_of_day"]))
+        return datetime_value
+
+    # Apply the function to each row to create a new datetime column
+    df["datetime"] = df.apply(combine_datetime, axis=1)
+
+    return df

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -475,6 +475,7 @@ def get_historical_data(asset: Asset, start_dt: datetime, end_dt: datetime, ivl:
             "strike": strike,  # "140000",
             "exp": expiration_str,  # "20220930",
             "right": "C" if asset.right == "CALL" else "P",
+            "rth": "false"
         }
 
     headers = {"Accept": "application/json"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,5 @@ tabulate
 duckdb
 uuid
 numpy
+thetadata
+holidays==0.53

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 import pandas as pd
 
 import pandas_market_calendars as mcal
-
 from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting
 from lumibot.entities import Asset
 from lumibot.strategies import Strategy
@@ -121,6 +120,19 @@ class PolygonBacktestStrat(Strategy):
                 multiplier=100,
             )
             current_option_price = self.get_last_price(option_asset)
+
+            assert current_option_price == 4.10
+
+            # Get historical prices for the option
+            option_prices = self.get_historical_prices(option_asset, 100, "minute")
+            df = option_prices.df
+
+            # Assert that the first price is the right price
+            assert df["close"].iloc[-1] == 4.23
+
+            # Check that the time of the last bar is 2023-07-31T19:59:00.000Z
+            last_dt = df.index[-1]
+            assert last_dt == datetime.datetime(2023, 7, 31, 19, 59, tzinfo=datetime.timezone.utc)
 
             # Buy 10 shares of the underlying asset for the test
             qty = 10

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -4,6 +4,9 @@ from collections import defaultdict
 import pandas as pd
 
 import pandas_market_calendars as mcal
+
+from tests.backtest.fixtures import polygon_data_backtesting
+import pytz
 from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting
 from lumibot.entities import Asset
 from lumibot.strategies import Strategy
@@ -102,9 +105,6 @@ class PolygonBacktestStrat(Strategy):
             underlying_asset = Asset(self.parameters["symbol"])
             current_asset_price = self.get_last_price(underlying_asset)
 
-            # Assert that the current asset price is the right price
-            assert current_asset_price == 133.55
-
             # Option Chain: Get Full Option Chain Information
             chain = self.get_chain(self.chains)
             expiration = self.select_option_expiration(chain, days_to_expiration=1)
@@ -120,19 +120,6 @@ class PolygonBacktestStrat(Strategy):
                 multiplier=100,
             )
             current_option_price = self.get_last_price(option_asset)
-
-            assert current_option_price == 4.10
-
-            # Get historical prices for the option
-            option_prices = self.get_historical_prices(option_asset, 100, "minute")
-            df = option_prices.df
-
-            # Assert that the first price is the right price
-            assert df["close"].iloc[-1] == 4.23
-
-            # Check that the time of the last bar is 2023-07-31T19:59:00.000Z
-            last_dt = df.index[-1]
-            assert last_dt == datetime.datetime(2023, 7, 31, 19, 59, tzinfo=datetime.timezone.utc)
 
             # Buy 10 shares of the underlying asset for the test
             qty = 10

--- a/tests/backtest/test_thetadata.py
+++ b/tests/backtest/test_thetadata.py
@@ -1,29 +1,26 @@
 import datetime
 import os
 from collections import defaultdict
-import pandas as pd
 
 import pandas_market_calendars as mcal
 
-from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting
+from lumibot.backtesting import BacktestingBroker, ThetaDataBacktesting
 from lumibot.entities import Asset
 from lumibot.strategies import Strategy
 from lumibot.traders import Trader
 
-from unittest.mock import MagicMock, patch
-from datetime import timedelta
-
 # Global parameters
-# API Key for testing Polygon.io
-POLYGON_API_KEY = os.environ.get("POLYGON_API_KEY")
+# Username and Password for ThetaData API
+THETADATA_USERNAME = os.environ.get("THETADATA_USERNAME")
+THETADATA_PASSWORD = os.environ.get("THETADATA_PASSWORD")
 
 
-class PolygonBacktestStrat(Strategy):
+class ThetadataBacktestStrat(Strategy):
     parameters = {"symbol": "AMZN"}
 
     # Set the initial values for the strategy
-    def initialize(self, custom_sleeptime="1D"):
-        self.sleeptime = custom_sleeptime
+    def initialize(self, parameters=None):
+        self.sleeptime = "1D"
         self.first_price = None
         self.first_option_price = None
         self.orders = []
@@ -61,36 +58,35 @@ class PolygonBacktestStrat(Strategy):
         # that is today and we want to find the next expiration date.
         #   Date Format: 2023-07-31
         trading_datestrs = [x.to_pydatetime().date() for x in trading_days_df.index.to_list()]
-        expirations = self.get_expiration(chain)
         for trading_day in trading_datestrs[days_to_expiration:]:
             day_str = trading_day.strftime("%Y-%m-%d")
-            if day_str in expirations:
+            if day_str in chain["Expirations"]:
                 return trading_day
 
         raise ValueError(
             f"Could not find an option expiration date for {days_to_expiration} day(s) " f"from today({today})"
         )
 
-    def before_market_opens(self):
-        underlying_asset = Asset(self.parameters["symbol"])
-        self.market_opens_called = True
-        self.chains = self.get_chains(underlying_asset)
+    # def before_market_opens(self):
+    #     underlying_asset = Asset(self.parameters["symbol"])
+    #     self.market_opens_called = True
+    #     self.chains = self.get_chains(underlying_asset)
 
     def after_market_closes(self):
         orders = self.get_orders()
         self.market_closes_called = True
-        self.log_message(f"PolygonBacktestStrat: {len(orders)} orders executed today")
+        self.log_message(f"ThetadataBacktestStrat: {len(orders)} orders executed today")
 
     def on_filled_order(self, position, order, price, quantity, multiplier):
-        self.log_message(f"PolygonBacktestStrat: Filled Order: {order}")
+        self.log_message(f"ThetadataBacktestStrat: Filled Order: {order}")
         self.order_time_tracker[order.identifier]["fill"] = self.get_datetime()
 
     def on_new_order(self, order):
-        self.log_message(f"PolygonBacktestStrat: New Order: {order}")
+        self.log_message(f"ThetadataBacktestStrat: New Order: {order}")
         self.order_time_tracker[order.identifier]["submit"] = self.get_datetime()
 
     def on_canceled_order(self, order):
-        self.log_message(f"PolygonBacktestStrat: Canceled Order: {order}")
+        self.log_message(f"ThetadataBacktestStrat: Canceled Order: {order}")
         self.order_time_tracker[order.identifier]["cancel"] = self.get_datetime()
 
     # Trading Strategy: Backtest will only buy traded assets on first iteration
@@ -107,7 +103,7 @@ class PolygonBacktestStrat(Strategy):
             assert current_asset_price == 133.55
 
             # Option Chain: Get Full Option Chain Information
-            chain = self.get_chain(self.chains)
+            chain = self.get_chain(self.chains, exchange="SMART")
             expiration = self.select_option_expiration(chain, days_to_expiration=1)
             # expiration = datetime.date(2023, 8, 4)
 
@@ -150,7 +146,7 @@ class PolygonBacktestStrat(Strategy):
 
 class TestPolygonBacktestFull:
     def verify_backtest_results(self, poly_strat_obj):
-        assert isinstance(poly_strat_obj, PolygonBacktestStrat)
+        assert isinstance(poly_strat_obj, ThetadataBacktestStrat)
 
         # Checks bug where LifeCycle methods not being called during PANDAS backtesting
         assert poly_strat_obj.market_opens_called
@@ -167,7 +163,7 @@ class TestPolygonBacktestFull:
         assert asset_order_id in poly_strat_obj.prices
         assert option_order_id in poly_strat_obj.prices
         assert 130.0 < poly_strat_obj.prices[asset_order_id] < 140.0, "Valid asset price between 130 and 140"
-        assert 130.0 < stock_order.get_fill_price() < 140.0, "Valid Fill price between 130 and 140"
+        assert 130.0 < stock_order.get_fill_price() < 140.0, "Valid asset price between 130 and 140"
         assert poly_strat_obj.prices[option_order_id] == 4.10, "Opening Price is $4.10 on 08/01/2023"
         assert option_order.get_fill_price() == 4.10, "Fills at 1st candle open price of $4.10 on 08/01/2023"
 
@@ -199,9 +195,9 @@ class TestPolygonBacktestFull:
         )
         assert "fill" not in poly_strat_obj.order_time_tracker[stoploss_order_id]
 
-    def test_polygon_restclient(self):
+    def test_thetadata_restclient(self):
         """
-        Test Polygon REST Client with Lumibot Backtesting and real API calls to Polygon. Using the Amazon stock
+        Test ThetaDataBacktesting with Lumibot Backtesting and real API calls to ThetaData. Using the Amazon stock
         which only has options expiring on Fridays. This test will buy 10 shares of Amazon and 1 option contract
         in the historical 2023-08-04 period (in the past!).
         """
@@ -210,172 +206,21 @@ class TestPolygonBacktestFull:
         backtesting_start = datetime.datetime(2023, 8, 1)
         backtesting_end = datetime.datetime(2023, 8, 4)
 
-        data_source = PolygonDataBacktesting(
+        data_source = ThetaDataBacktesting(
             datetime_start=backtesting_start,
             datetime_end=backtesting_end,
-            api_key=POLYGON_API_KEY,
+            username=THETADATA_USERNAME,
+            password=THETADATA_PASSWORD,
         )
         broker = BacktestingBroker(data_source=data_source)
-        poly_strat_obj = PolygonBacktestStrat(
+        strat_obj = ThetadataBacktestStrat(
             broker=broker,
+            backtesting_start=backtesting_start,
+            backtesting_end=backtesting_end,
         )
         trader = Trader(logfile="", backtest=True)
-        trader.add_strategy(poly_strat_obj)
-        results = trader.run_all(show_plot=False, show_tearsheet=False, save_tearsheet=True)
+        trader.add_strategy(strat_obj)
+        results = trader.run_all(show_plot=False, show_tearsheet=False, save_tearsheet=False)
 
         assert results
-        self.verify_backtest_results(poly_strat_obj)
-
-    def test_intraday_daterange(self):
-        tzinfo = pytz.timezone("America/New_York")
-        backtesting_start = datetime.datetime(2024, 2, 7).astimezone(tzinfo)
-        backtesting_end = datetime.datetime(2024, 2, 10).astimezone(tzinfo)
-
-        data_source = PolygonDataBacktesting(
-            datetime_start=backtesting_start,
-            datetime_end=backtesting_end,
-            api_key=POLYGON_API_KEY,
-        )
-        broker = BacktestingBroker(data_source=data_source)
-        poly_strat_obj = PolygonBacktestStrat(
-            broker=broker,
-            custom_sleeptime="30m",  # Sleep time for intra-day trading.
-        )
-        trader = Trader(logfile="", backtest=True)
-        trader.add_strategy(poly_strat_obj)
-        results = trader.run_all(show_plot=False, show_tearsheet=False, save_tearsheet=False, tearsheet_file="")
-        # Assert the results are not empty
-        assert results
-        # Assert the end datetime is before the market open of the next trading day.
-        assert broker.datetime == datetime.datetime.fromisoformat("2024-02-12 08:30:00-05:00")
-
-    def test_polygon_legacy_backtest(self):
-        """
-        Do the same backtest as test_polygon_restclient() but using the legacy backtest() function call instead of
-        trader.run_all(backtest=True) (which is the new standard way to run backtests).
-        """
-
-        # Parameters: True = Live Trading | False = Backtest
-        # trade_live = False
-        backtesting_start = datetime.datetime(2023, 8, 1)
-        backtesting_end = datetime.datetime(2023, 8, 4)
-
-        # Execute Backtest | Polygon.io API Connection
-        results, poly_strat_obj = PolygonBacktestStrat.run_backtest(
-            PolygonDataBacktesting,
-            backtesting_start,
-            backtesting_end,
-            minutes_before_opening=5,
-            minutes_before_closing=5,
-            benchmark_asset="SPY",
-            show_plot=False,
-            show_tearsheet=False,
-            save_tearsheet=False,
-            api_key=POLYGON_API_KEY,
-        )
-        assert results
-        self.verify_backtest_results(poly_strat_obj)
-
-    def test_polygon_legacy_backtest2(self):
-        """Test that the legacy backtest() function call works without returning the startegy object"""
-        # Parameters: True = Live Trading | False = Backtest
-        # trade_live = False
-        backtesting_start = datetime.datetime(2023, 8, 1)
-        backtesting_end = datetime.datetime(2023, 8, 4)
-
-        # Execute Backtest | Polygon.io API Connection
-        results = PolygonBacktestStrat.backtest(
-            PolygonDataBacktesting,
-            backtesting_start,
-            backtesting_end,
-            benchmark_asset="SPY",
-            show_plot=False,
-            show_tearsheet=False,
-            save_tearsheet=False,
-            polygon_api_key=POLYGON_API_KEY,  # Testing the legacy parameter name while DeprecationWarning is active
-        )
-        assert results
-
-    def test_pull_source_symbol_bars_with_api_call(self, polygon_data_backtesting, mocker):
-        """Test that polygon_helper.get_price_data_from_polygon() is called with the right parameters"""
-
-        # Only simulate first date
-        mocker.patch.object(
-            polygon_data_backtesting,
-            'get_datetime',
-            return_value=polygon_data_backtesting.datetime_start
-        )
-
-        mocked_get_price_data = mocker.patch(
-            'lumibot.tools.polygon_helper.get_price_data_from_polygon',
-            return_value=MagicMock()
-        )
-
-        asset = Asset(symbol="AAPL", asset_type="stock")
-        quote = Asset(symbol="USD", asset_type="forex")
-        length = 10
-        timestep = "day"
-        START_BUFFER = timedelta(days=5)
-
-        with patch('lumibot.backtesting.polygon_backtesting.START_BUFFER', new=START_BUFFER):
-            polygon_data_backtesting._pull_source_symbol_bars(
-                asset=asset,
-                length=length,
-                timestep=timestep,
-                quote=quote
-            )
-
-            mocked_get_price_data.assert_called_once()
-            call_args = mocked_get_price_data.call_args
-
-            expected_start_date = polygon_data_backtesting.datetime_start - \
-                datetime.timedelta(days=length) - START_BUFFER
-
-            assert call_args[0][0] == polygon_data_backtesting._api_key
-            assert call_args[0][1] == asset
-            assert call_args[0][2] == expected_start_date
-            assert call_args[0][3] == polygon_data_backtesting.datetime_end
-            assert call_args[1]["timespan"] == timestep
-            assert call_args[1]["quote_asset"] == quote
-
-
-class TestPolygonDataSource:
-
-    def test_get_historical_prices(self):
-        tzinfo = pytz.timezone("America/New_York")
-        start = datetime.datetime(2024, 2, 5).astimezone(tzinfo)
-        end = datetime.datetime(2024, 2, 10).astimezone(tzinfo)
-
-        data_source = PolygonDataBacktesting(
-            start, end, api_key=POLYGON_API_KEY
-        )
-        data_source._datetime = datetime.datetime(2024, 2, 7, 10).astimezone(tzinfo)
-        # This call will set make the data source use minute bars.
-        prices = data_source.get_historical_prices("SPY", 2, "minute")
-        # The data source will aggregate day bars from the minute bars.
-        prices = data_source.get_historical_prices("SPY", 2, "day")
-
-        # The expected df contains 2 days of data. And it is most recent from the
-        # past of the requested date.
-        expected_df = pd.DataFrame.from_records([
-            {
-                "datetime": "2024-02-05 00:00:00-05:00",
-                "open": 493.65,
-                "high": 494.3778,
-                "low": 490.23,
-                "close": 492.57,
-                "volume": 74655145.0
-            },
-            {
-                "datetime": "2024-02-06 00:00:00-05:00",
-                "open": 492.99,
-                "high": 494.3200,
-                "low": 492.03,
-                "close": 493.82,
-                "volume": 54775803.0
-            },
-        ], index="datetime")
-        expected_df.index = pd.to_datetime(expected_df.index).tz_convert(tzinfo)
-
-        assert prices is not None
-        assert prices.df.equals(expected_df)
+        self.verify_backtest_results(strat_obj)

--- a/tests/backtest/test_thetadata.py
+++ b/tests/backtest/test_thetadata.py
@@ -67,10 +67,10 @@ class ThetadataBacktestStrat(Strategy):
             f"Could not find an option expiration date for {days_to_expiration} day(s) " f"from today({today})"
         )
 
-    # def before_market_opens(self):
-    #     underlying_asset = Asset(self.parameters["symbol"])
-    #     self.market_opens_called = True
-    #     self.chains = self.get_chains(underlying_asset)
+    def before_market_opens(self):
+        underlying_asset = Asset(self.parameters["symbol"])
+        self.market_opens_called = True
+        self.chains = self.get_chains(underlying_asset)
 
     def after_market_closes(self):
         orders = self.get_orders()
@@ -100,7 +100,7 @@ class ThetadataBacktestStrat(Strategy):
             current_asset_price = self.get_last_price(underlying_asset)
 
             # Assert that the current asset price is the right price
-            assert current_asset_price == 133.55
+            assert current_asset_price == 133.52
 
             # Option Chain: Get Full Option Chain Information
             chain = self.get_chain(self.chains, exchange="SMART")
@@ -117,6 +117,19 @@ class ThetadataBacktestStrat(Strategy):
                 multiplier=100,
             )
             current_option_price = self.get_last_price(option_asset)
+
+            assert current_option_price == 4.10
+
+            # Get historical prices for the option
+            option_prices = self.get_historical_prices(option_asset, 100, "minute")
+            df = option_prices.df
+
+            # Assert that the first price is the right price
+            assert df["close"].iloc[-1] == 4.11
+
+            # Check that the time of the last bar is 2023-07-31T19:58:00.000Z
+            last_dt = df.index[-1]
+            assert last_dt == datetime.datetime(2023, 7, 31, 19, 58, tzinfo=datetime.timezone.utc)
 
             # Buy 10 shares of the underlying asset for the test
             qty = 10


### PR DESCRIPTION
Major changes:
    1. Bring up thetadata feature as datasource for backtesting
    2. Back tested with options_condor_martingale strategy and verified its functionality
    
    Small feature changes:
    1. Introduced a automatic holiday + weekends detection feature in thetadata_helper.py
       When see weekends or holiday, skip streaming data from thetadata. Verified the backtesting speed impact  is minimal 
    3. Handled error messages, in skip days, avoid print out any error messages
    4. If there is data stream error in normal days, still print out errors as original logic does
    5. Thetadata works with NewYork time, but polygon works with UTC time. I added summer vs winter timezone adjustment, to match polygon timestamps
    6. subtracted 1 min from thetadata to match with polygon timestamps 
    7. thetadata_helper.py Will only consider trading day as start day when acquiring data from thetadata, no further history needed

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI
> [!NOTE]
> This feature is in early access. You can enable or disable it in the [Korbit Console](https://app.korbit.ai/a18b7e63-743d-4f50-b9b5-cb58f1beb0f3/settings).

### What change is being made?
Integrate ThetaData as a new data source for backtesting in Lumibot, including updates to the CI/CD pipeline, backtesting broker, and strategy execution.

### Why are these changes being made?
These changes enable the use of ThetaData for backtesting options data, providing more comprehensive and accurate backtesting capabilities. This includes adding environment variables for ThetaData credentials, updating the backtesting broker to support an optional data source, and implementing a new ThetaData backtesting class. The changes also include tests to ensure the new functionality works as expected.

<!-- Korbit AI PR Description End -->