### PR TITLE
longer spark chart

### DIFF
--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -706,7 +706,11 @@ class Order:
         """
         # Only calculate on filled orders
         if not self.transactions or not self.quantity:
-            return 0.0
+            return None
+        
+        # Check if x.price is None
+        if any(x.price is None for x in self.transactions):
+            return None
 
         # calculate the weighted average filled price since options often encounter partial fills
         # Some Backtest runs are using a Decimal for the Transaction quantity, so we need to convert to float

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -3892,7 +3892,7 @@ class Strategy(_Strategy):
                 f"Failed to send message to Discord. Status code: {response.status_code}, message: {response.text}"
             )
 
-    def send_spark_chart_to_discord(self, stats_df, portfolio_value, now, days=180):
+    def send_spark_chart_to_discord(self, stats_df, portfolio_value, now, days=1095):
         # Check if we are in backtesting mode, if so, don't send the message
         if self.is_backtesting:
             return

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="3.6.0",
+    version="3.6.1",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI
> [!NOTE]
> This feature is in early access. You can enable or disable it in the [Korbit Console](https://app.korbit.ai/a18b7e63-743d-4f50-b9b5-cb58f1beb0f3/settings).

### What change is being made?
Extend the default duration for spark charts sent to Discord from 180 days to 1095 days and update the package version to 3.6.1.

### Why are these changes being made?
The extension to 1095 days provides a longer historical view of portfolio performance, which can be more insightful for users. The version bump reflects this enhancement in the package.

<!-- Korbit AI PR Description End -->