### PR TITLE
re removed deprecated polygon options

### DIFF
--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -841,8 +841,6 @@ class _Strategy:
         buy_trading_fees=[],
         sell_trading_fees=[],
         api_key=None,
-        polygon_api_key=None,
-        polygon_has_paid_subscription=None,  # Depricated, this is now automatic. Remove in future versions.
         use_other_option_source=False,
         thetadata_username=None,
         thetadata_password=None,
@@ -1006,9 +1004,6 @@ class _Strategy:
         if name is None:
             name = cls.__name__
 
-        if not api_key and polygon_api_key:
-            api_key = polygon_api_key
-
         # check if datasource_class is a class or a dictionary
         if isinstance(datasource_class, dict):
             optionsource_class = datasource_class["OPTION"]
@@ -1044,11 +1039,11 @@ class _Strategy:
 
         cls.verify_backtest_inputs(backtesting_start, backtesting_end)
 
-        # Make sure polygon_api_key is set if using PolygonDataBacktesting
+        # Make sure api_key is set if using PolygonDataBacktesting
         cls.api_key = api_key if api_key is not None else credentials['POLYGON_API_KEY']
         if datasource_class == PolygonDataBacktesting and cls.api_key is None:
             raise ValueError(
-                "Please set `api_key` to your API key from polygon.io as an environment variable if "
+                "Please set `POLYGON_API_KEY` to your API key from polygon.io as an environment variable if "
                 "you are using PolygonDataBacktesting. If you don't have one, you can get a free API key "
                 "from https://polygon.io/."
             )
@@ -1285,8 +1280,6 @@ class _Strategy:
         buy_trading_fees=[],
         sell_trading_fees=[],
         api_key=None,
-        polygon_api_key=None,
-        polygon_has_paid_subscription=None,  # Depricated, this is now automatic. Remove in future versions.
         indicators_file=None,
         show_indicators=True,
         save_logfile=False,
@@ -1357,9 +1350,6 @@ class _Strategy:
         api_key : str
             The polygon api key to use for polygon data. Only required if you are using PolygonDataBacktesting as
             the datasource_class.
-        polygon_api_key : str
-            The polygon api key to use for polygon data. Only required if you are using PolygonDataBacktesting as
-            the datasource_class. Depricated, please use 'api_key' instead.
         indicators_file : str
             The file to write the indicators to.
         show_indicators : bool
@@ -1428,8 +1418,6 @@ class _Strategy:
             buy_trading_fees=buy_trading_fees,
             sell_trading_fees=sell_trading_fees,
             api_key=api_key,
-            polygon_api_key=polygon_api_key,
-            polygon_has_paid_subscription=polygon_has_paid_subscription,
             indicators_file=indicators_file,
             show_indicators=show_indicators,
             save_logfile=save_logfile,

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1013,7 +1013,7 @@ class _Strategy:
         # Make sure polygon_api_key is set if using PolygonDataBacktesting
         if datasource_class == PolygonDataBacktesting and api_key is None:
             raise ValueError(
-                "Please set `api_key` to your API key from polygon.io in the backtest() function if "
+                "Please set `api_key` to your API key from polygon.io as an environment variable if "
                 "you are using PolygonDataBacktesting. If you don't have one, you can get a free API key "
                 "from https://polygon.io/."
             )

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -840,7 +840,7 @@ class _Strategy:
         parameters={},
         buy_trading_fees=[],
         sell_trading_fees=[],
-        api_key=None,
+        polygon_api_key=None,
         use_other_option_source=False,
         thetadata_username=None,
         thetadata_password=None,
@@ -911,7 +911,7 @@ class _Strategy:
             A list of TradingFee objects to apply to the buy orders during backtests.
         sell_trading_fees : list of TradingFee objects
             A list of TradingFee objects to apply to the sell orders during backtests.
-        api_key : str
+        polygon_api_key : str
             The polygon api key to use for polygon data. Only required if you are using PolygonDataBacktesting as
             the datasource_class.
         indicators_file : str
@@ -1039,9 +1039,9 @@ class _Strategy:
 
         cls.verify_backtest_inputs(backtesting_start, backtesting_end)
 
-        # Make sure api_key is set if using PolygonDataBacktesting
-        cls.api_key = api_key if api_key is not None else credentials['POLYGON_API_KEY']
-        if datasource_class == PolygonDataBacktesting and cls.api_key is None:
+        # Make sure polygon_api_key is set if using PolygonDataBacktesting
+        polygon_api_key = polygon_api_key if polygon_api_key is not None else credentials['POLYGON_API_KEY']
+        if datasource_class == PolygonDataBacktesting and polygon_api_key is None:
             raise ValueError(
                 "Please set `POLYGON_API_KEY` to your API key from polygon.io as an environment variable if "
                 "you are using PolygonDataBacktesting. If you don't have one, you can get a free API key "
@@ -1079,7 +1079,7 @@ class _Strategy:
             backtesting_end,
             config=config,
             auto_adjust=auto_adjust,
-            api_key=api_key,
+            api_key=polygon_api_key,
             pandas_data=pandas_data,
             **kwargs,
         )
@@ -1279,7 +1279,7 @@ class _Strategy:
         parameters={},
         buy_trading_fees=[],
         sell_trading_fees=[],
-        api_key=None,
+        polygon_api_key=None,
         indicators_file=None,
         show_indicators=True,
         save_logfile=False,
@@ -1347,7 +1347,7 @@ class _Strategy:
             A list of TradingFee objects to apply to the buy orders during backtests.
         sell_trading_fees : list of TradingFee objects
             A list of TradingFee objects to apply to the sell orders during backtests.
-        api_key : str
+        polygon_api_key : str
             The polygon api key to use for polygon data. Only required if you are using PolygonDataBacktesting as
             the datasource_class.
         indicators_file : str
@@ -1417,7 +1417,7 @@ class _Strategy:
             parameters=parameters,
             buy_trading_fees=buy_trading_fees,
             sell_trading_fees=sell_trading_fees,
-            api_key=api_key,
+            polygon_api_key=polygon_api_key,
             indicators_file=indicators_file,
             show_indicators=show_indicators,
             save_logfile=save_logfile,


### PR DESCRIPTION
Caused issues after thetadata was merged

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI
> [!NOTE]
> This feature is in early access. You can enable or disable it in the [Korbit Console](https://app.korbit.ai/a18b7e63-743d-4f50-b9b5-cb58f1beb0f3/settings).

### Remove deprecated polygon options.

This change removes the deprecated `polygon_api_key` and `polygon_has_paid_subscription` options from the `run_backtest` and `backtest` functions. These options are no longer necessary as the functionality is now handled automatically, and the `api_key` parameter should be used instead. This cleanup helps to simplify the code and avoid confusion for users.

<!-- Korbit AI PR Description End -->