### PR TITLE
Added a check to see if both stock and option are entered with the sa…

### DIFF
--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1035,7 +1035,11 @@ class _Strategy:
         if isinstance(datasource_class, dict):
             optionsource_class = datasource_class["OPTION"]
             datasource_class = datasource_class["STOCK"]
-            use_other_option_source = True
+            # check if optionsource_class and datasource_class are the same type of class
+            if optionsource_class == datasource_class:
+                use_other_option_source = False
+            else:
+                use_other_option_source = True
         else:
             optionsource_class = None
             use_other_option_source = False


### PR DESCRIPTION
Added a check to see if both stock and option are entered with the same  data source
The run_backtest will run into error if both stock and option datasource are polygon without this change

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Added a check to determine if both `optionsource_class` and `datasource_class` are of the same type and set `use_other_option_source` accordingly.

### Why are these changes being made?
This change ensures that the system correctly identifies when to use a different option source, preventing potential conflicts or errors when both stock and option data sources are the same. This approach improves the robustness of the backtesting functionality.

<!-- Korbit AI PR Description End -->