### PR TITLE
Enabled big/ask for strategy to use. Removed slowdown backtesting

### DIFF
--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -1940,7 +1940,10 @@ class Strategy(_Strategy):
             self.log_message("Broker does not have a get_quote method.")
             return None
 
-        return self.broker.data_source.get_quote(asset)
+        if self.broker.option_source and asset.asset_type == "option":
+            return self.broker.option_source.get_quote(asset)
+        else:
+            return self.broker.data_source.get_quote(asset)
 
     def get_tick(self, asset):
         """Takes an Asset and returns the last known price"""
@@ -4182,6 +4185,9 @@ class Strategy(_Strategy):
                     raise
     
     def backup_variables_to_db(self):
+        if self.is_backtesting:
+            return
+
         if not hasattr(self, "db_connection_str") or self.db_connection_str is None or not self.should_backup_variables_to_database:
             return
 
@@ -4264,6 +4270,9 @@ class Strategy(_Strategy):
             logger.error(f"Error backing up variables to DB: {e}", exc_info=True)
 
     def load_variables_from_db(self):
+        if self.is_backtesting:
+            return
+
         if not hasattr(self, "db_connection_str") or self.db_connection_str is None or not self.should_backup_variables_to_database:
             return
 


### PR DESCRIPTION
Enabled get_quote for strategy to use. 
Removed slowdown backtesting issue

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enable the use of a specific quote source for options in the strategy and remove the database backup functionality during backtesting.

### Why are these changes being made?

The change allows the strategy to fetch quotes from a dedicated option source when dealing with options, improving accuracy and flexibility. The removal of database backup during backtesting is to enhance performance by avoiding unnecessary operations, as backtesting does not require persistent storage of variables.

<!-- Korbit AI PR Description End -->