### PR TITLE
Added tradier oco orders

### DIFF
--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -610,7 +610,7 @@ class Tradier(Broker):
 
         # Stoploss and limit orders are usually used to close positions, even if they are submitted "before" the
         # position is technically open (i.e. buy and stoploss order are submitted simultaneously)
-        if order.type in [Order.OrderType.STOP, Order.OrderType.TRAIL] and original_side == "buy" or original_side == "sell":
+        if order.type in [Order.OrderType.STOP, Order.OrderType.TRAIL] and (original_side == "buy" or original_side == "sell"):
             side = side.replace("to_open", "to_close")
 
         # Check if the side is a valid Tradier side

--- a/lumibot/entities/asset.py
+++ b/lumibot/entities/asset.py
@@ -140,7 +140,7 @@ class Asset:
         underlying_asset: "Asset" = None,
     ):
         # Capitalize the symbol because some brokers require it
-        self.symbol = symbol.upper()
+        self.symbol = symbol.upper() if symbol is not None else None
         self.asset_type = asset_type
         self.strike = strike
         self.multiplier = multiplier
@@ -197,10 +197,14 @@ class Asset:
             )
         elif symbol_info["type"] == "stock":
             return Asset(symbol=symbol, asset_type="stock")
+        elif symbol_info["type"] == "future":
+            return Asset(symbol=symbol, asset_type="future", expiration=symbol_info["expiration_date"])
+        elif symbol_info["type"] == "forex":
+            return Asset(symbol=symbol, asset_type="forex")
+        elif symbol_info["type"] == "crypto":
+            return Asset(symbol=symbol, asset_type="crypto")
         else:
-            # TODO: Handle Crypto and Forex Symbols
-            logging.info(f"Unknown symbol asset type {symbol_info['type']}, defaulting to stock.")
-            return Asset(symbol=symbol)
+            return Asset(symbol=None)
 
     def __hash__(self):
         return hash((self.symbol, self.asset_type, self.expiration, self.strike, self.right))

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -11,7 +11,7 @@ from lumibot.tools.types import check_positive, check_price, check_quantity
 SELL = "sell"
 BUY = "buy"
 
-VALID_STATUS = ["unprocessed", "new", "open", "submitted", "fill", "partial_fill", "canceled", "error", "cash_settled"]
+VALID_STATUS = ["unprocessed", "new", "open", "submitted", "fill", "partial_fill", "cancelling", "canceled", "error", "cash_settled"]
 STATUS_ALIAS_MAP = {
     "cancelled": "canceled",
     "cancel": "canceled",
@@ -69,7 +69,10 @@ class Order:
         SELL_TO_CLOSE = "sell_to_close"
 
     class OrderStatus:
+        UNPROCESSED = "unprocessed"
+        OPEN = "open"
         NEW = "new"
+        CANCELLING = "cancelling"
         CANCELED = "canceled"
         FILLED = "fill"
         PARTIALLY_FILLED = "partial_fill"
@@ -299,7 +302,7 @@ class Order:
         self.stop_loss_price = None # Used for bracket, OTO, and OCO orders TODO: Remove this because it is confusing (use child orders instead)
         self.stop_loss_limit_price = None
         self.transactions = []
-        self.order_class = None
+        self.order_class = order_class
         self.dependent_order = None
         self.dependent_order_filled = False
         self.type = type
@@ -478,7 +481,6 @@ class Order:
             # This is a "One-Cancel-Other" advanced order
             self.order_class = self.OrderType.OCO
             self.type = self.OrderType.OCO
-            self.position_filled = True
             if stop_loss_price is not None and take_profit_price is not None:
                 self.take_profit_price = check_price(take_profit_price, "take_profit_price must be positive float.")
                 self.stop_loss_price = check_price(stop_loss_price, "stop_loss_price must be positive float.")
@@ -673,7 +675,13 @@ class Order:
 
         # If there are child orders, list them in the repr
         if self.child_orders:
-            repr_str = f"{self.type} order |"
+            # If there is an order class, use that in the repr instead of the type
+            if self.order_class:
+                repr_str = f"{self.order_class} order |"
+            else:
+                repr_str = f"{self.type} order |"
+
+            # Add the child orders to the repr
             for child_order in self.child_orders:
                 repr_str = f"{repr_str} {child_order.type} {child_order.side} {child_order.quantity} {child_order.asset} |"
         else:

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -1750,6 +1750,10 @@ class Strategy(_Strategy):
         >>> self.cancel_order(order)
 
         """
+        # Set the status to CANCELLING
+        order.status = Order.OrderStatus.CANCELLING
+
+        # Cancel the order
         return self.broker.cancel_order(order)
 
     def cancel_orders(self, orders):

--- a/lumibot/tools/helpers.py
+++ b/lumibot/tools/helpers.py
@@ -159,6 +159,10 @@ def parse_symbol(symbol):
     For stocks, simply return the stock symbol.
     TODO: Crypto and Forex support
     """
+    # Check that the symbol is a string
+    if not isinstance(symbol, str):
+        return {"type": None}
+    
     # Pattern to match the option symbol format
     option_pattern = r"([A-Z]+)(\d{6})([CP])(\d+)"
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="3.7.3",
+    version="3.7.4",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",
@@ -48,7 +48,7 @@ setuptools.setup(
         "appdirs",
         "pyarrow",
         "tqdm",
-        "lumiwealth-tradier>=0.1.9",
+        "lumiwealth-tradier>=0.1.10",
         "pytz",
         "psycopg2-binary",
         "exchange_calendars>=4.5.2",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="3.7.4",
+    version="3.7.5",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add support for One-Cancels-Other (OCO) orders in the Tradier broker integration within the Lumibot trading library.

### Why are these changes being made?
The changes are being made to enhance the functionality of the Lumibot library by allowing users to submit and manage OCO orders through the Tradier broker. This feature is crucial for traders who want to automate complex order strategies, such as setting simultaneous stop-loss and take-profit orders, where the execution of one cancels the other. The implementation includes parsing and submitting OCO orders, handling asset types, and updating order statuses to ensure robust order management.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->