### PR TITLE
Lifecycle fixes

### DIFF
--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -747,6 +747,9 @@ class Broker(ABC):
     def market_close_time(self):
         return self.utc_to_local(self.market_hours(close=True))
 
+    def market_open_time(self):
+        return self.utc_to_local(self.market_hours(close=False))
+
     def is_market_open(self):
         """Determines if the market is open.
 

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -76,6 +76,7 @@ class _Strategy:
         broker=None,
         minutes_before_closing=1,
         minutes_before_opening=60,
+        minutes_after_closing=0,
         sleeptime="1M",
         stats_file=None,
         risk_free_rate=None,
@@ -374,6 +375,7 @@ class _Strategy:
         self._initial_budget = budget
         self._minutes_before_closing = minutes_before_closing
         self._minutes_before_opening = minutes_before_opening
+        self._minutes_after_closing = minutes_after_closing
         self._sleeptime = sleeptime
         self._risk_free_rate = risk_free_rate
         self._executor = StrategyExecutor(self)

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -156,6 +156,33 @@ class Strategy(_Strategy):
         self._minutes_before_closing = value
 
     @property
+    def minutes_after_closing(self):
+        """Get or set the number of minutes that the strategy will continue executing after market closes.
+
+        The lifecycle method after_market_closes is executed minutes_after_closing minutes after the market closes. By default, equals to 0 minutes.
+
+        Returns
+        -------
+        int
+            The number of minutes after the market closes that the strategy will continue executing.
+
+        Example
+        -------
+        >>> # Set the number of minutes after the market closes
+        >>> self.minutes_after_closing = 10
+
+        >>> # Set the number of minutes after the market closes to 0 in the initialize method
+        >>> def initialize(self):
+        >>>     self.minutes_after_closing = 0
+
+        """
+        return self._minutes_after_closing
+
+    @minutes_after_closing.setter
+    def minutes_after_closing(self, value):
+        self._minutes_after_closing = value
+
+    @property
     def sleeptime(self):
         """Get or set the current sleep time for the strategy.
 

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -944,10 +944,10 @@ class StrategyExecutor(Thread):
                 current_date = current_datetime.date()
                 min_before_closing = timedelta(minutes=self.strategy.minutes_before_closing)
                 min_before_open = timedelta(minutes=self.strategy.minutes_before_opening)
-                min_after_open = timedelta(minutes=self.strategy.minutes_after_opening)
+                min_after_close = timedelta(minutes=self.strategy.minutes_after_closing)
 
                 # After market closes
-                if (current_datetime >= self.broker.market_close_time() + min_after_open and
+                if (current_datetime >= self.broker.market_close_time() + min_after_close and
                         current_date != self.lifecycle_last_date['after_market_closes']):
                     self._after_market_closes()
                     self.lifecycle_last_date['after_market_closes'] = current_date
@@ -959,7 +959,7 @@ class StrategyExecutor(Thread):
                     self.lifecycle_last_date['before_market_closes'] = current_date
 
                 # Before market opens
-                elif (current_datetime >= self.broker.market_open - min_before_open and
+                elif (current_datetime >= self.broker.market_open_time() - min_before_open and
                         current_date != self.lifecycle_last_date['before_market_opens']):
                     self._before_market_opens()
                     self.lifecycle_last_date['before_market_opens'] = current_date

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -55,6 +55,15 @@ class StrategyExecutor(Thread):
         # Keep track of Abrupt Closing method execution
         self.abrupt_closing = False
 
+        # Keep track of when LifCycle methods should be called.  This is important for Live trading sessions that
+        # run over multiple days and need to call the lifecycle methods at the correct time.
+        self.lifecycle_last_date = {
+            "after_market_closes": None,
+            "before_market_opens": None,
+            "before_market_closes": None,
+        }
+
+
     @property
     def name(self):
         return self.strategy._name
@@ -109,8 +118,8 @@ class StrategyExecutor(Thread):
         positions_broker = []
         while held_trades_len > 0:
             # Snapshot for the broker and lumibot:
-            cash_broker = self.broker._get_balances_at_broker(self.strategy.quote_asset)
-            if cash_broker is None:
+            broker_balances = self.broker._get_balances_at_broker(self.strategy.quote_asset)
+            if broker_balances is None:
                 if cash_broker_retries < cash_broker_max_retries:
                     self.strategy.logger.info("Unable to get cash from broker, trying again.")
                     cash_broker_retries += 1
@@ -120,11 +129,12 @@ class StrategyExecutor(Thread):
                         f"Unable to get the cash balance after {cash_broker_max_retries} "
                         f"tries, setting cash to zero."
                     )
-                    cash_broker = 0
+                    broker_balances = 0
             else:
-                cash_broker = cash_broker[0]
-                self.strategy._set_cash_position(cash_broker)
-                self.strategy.logger.info(f"Got Cash Balance: {cash_broker}")
+                cash_balance = broker_balances[0]
+                portfolio_value = broker_balances[2]
+                self.strategy._set_cash_position(cash_balance)
+                self.strategy.logger.info(f"Got Cash Balance: ${cash_balance:.2f}, Portfolio: ${portfolio_value:.2f}")
 
 
             held_trades_len = len(self.broker._held_trades)
@@ -851,10 +861,12 @@ class StrategyExecutor(Thread):
 
             if not self.broker.is_market_open():
                 self._before_market_opens()
+                self.lifecycle_last_date['before_market_opens'] = self.strategy.get_datetime().date()
 
             # Now go to the actual open without considering minutes_before_opening
             self.strategy.await_market_to_open(timedelta=0)
             self._before_starting_trading()
+            self.lifecycle_last_date['before_starting_trading'] = self.strategy.get_datetime().date()
 
             time_to_close = self.broker.get_time_to_close()
 
@@ -926,6 +938,31 @@ class StrategyExecutor(Thread):
                 if not is_247_or_should_we_stop:
                     print("Breaking loop because it's 24/7 and time to stop.")
                     break
+
+                # Handle LifeCycle methods
+                current_datetime = self.strategy.get_datetime()
+                current_date = current_datetime.date()
+                min_before_closing = timedelta(minutes=self.strategy.minutes_before_closing)
+                min_before_open = timedelta(minutes=self.strategy.minutes_before_opening)
+                min_after_open = timedelta(minutes=self.strategy.minutes_after_opening)
+
+                # After market closes
+                if (current_datetime >= self.broker.market_close_time() + min_after_open and
+                        current_date != self.lifecycle_last_date['after_market_closes']):
+                    self._after_market_closes()
+                    self.lifecycle_last_date['after_market_closes'] = current_date
+
+                # Before market closes
+                elif (current_datetime >= self.broker.market_close_time() - min_before_closing and
+                        current_date != self.lifecycle_last_date['before_market_closes']):
+                    self._before_market_closes()
+                    self.lifecycle_last_date['before_market_closes'] = current_date
+
+                # Before market opens
+                elif (current_datetime >= self.broker.market_open - min_before_open and
+                        current_date != self.lifecycle_last_date['before_market_opens']):
+                    self._before_market_opens()
+                    self.lifecycle_last_date['before_market_opens'] = current_date
 
                 time.sleep(1)  # Sleep to save CPU
 

--- a/lumibot/trading_builtins/custom_stream.py
+++ b/lumibot/trading_builtins/custom_stream.py
@@ -73,6 +73,10 @@ class PollingStream(CustomStream):
                 # If the queue is empty, it means the polling interval has been reached.
                 self._poll()
                 continue
+            # Ensure that the Polling thread does not die if an exception is raised in the event processing.
+            except Exception as e: # noqa
+                logging.exception(f"An error occurred while processing a queue event. {e}")
+                continue
 
     def _poll(self):
         if self.POLL_EVENT not in self._actions_mapping:


### PR DESCRIPTION
Market Lifecycle methods such as before_market_opens(), before_market_closes(), and after_market_closes() were not being called correctly during live/paper trading due to how threading is used to handle the entire run_session.  These lifecycle methods were called properly for backtesting because it does not use threads for run_session.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add lifecycle management improvements to the trading strategy execution, including new methods for handling market open and close times, and enhance logging and error handling in the broker and custom stream components.

### Why are these changes being made?

These changes address the need for more precise control over trading strategy execution around market open and close times, ensuring lifecycle methods are called correctly in live trading sessions. Additionally, improved logging and error handling enhance the robustness and maintainability of the system, particularly in scenarios where broker data may be incomplete or erroneous.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->