### PR TITLE
Change some prints to logger; use logger instead of logging;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ test_bot.py
 *secret*/**.env
 lumi_tradier
 lumiwealth_tradier
+ThetaTerminal.jar
 
 # Pypi deployment
 build

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -11,6 +11,9 @@ from lumibot.data_sources import DataSourceBacktesting
 from lumibot.entities import Asset, Order, Position, TradingFee
 from lumibot.trading_builtins import CustomStream
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 
 class BacktestingBroker(Broker):
     # Metainfo
@@ -43,7 +46,7 @@ class BacktestingBroker(Broker):
                 if result.was_transmitted() and result.order_class and result.order_class == "oco":
                     orders = broker._flatten_order(result)
                     for order in orders:
-                        logging.info(f"{order} was sent to broker {self.name}")
+                        logger.info(f"{order} was sent to broker {self.name}")
                         broker._new_orders.append(order)
 
                     # Remove the original order from the list of new orders because
@@ -96,7 +99,7 @@ class BacktestingBroker(Broker):
         self.data_source._update_datetime(new_datetime, cash=cash, portfolio_value=portfolio_value)
         if self.option_source:
             self.option_source._update_datetime(new_datetime, cash=cash, portfolio_value=portfolio_value)
-        logging.info(f"Current backtesting datetime {self.datetime}")
+        logger.info(f"Current backtesting datetime {self.datetime}")
 
     # =========Clock functions=====================
 
@@ -359,7 +362,7 @@ class BacktestingBroker(Broker):
         if existing_position:
             position.add_order(order, quantity)  # Add will update quantity, but not double count the order
             if position.quantity == 0:
-                logging.info(f"Position {position} liquidated")
+                logger.info(f"Position {position} liquidated")
                 self._filled_positions.remove(position)
         else:
             self._filled_positions.append(position)  # New position, add it to the tracker
@@ -385,7 +388,7 @@ class BacktestingBroker(Broker):
         if existing_position:
             existing_position.add_order(order, quantity)  # Add will update quantity, but not double count the order
             if existing_position.quantity == 0:
-                logging.info("Position %r liquidated" % existing_position)
+                logger.info("Position %r liquidated" % existing_position)
                 self._filled_positions.remove(existing_position)
 
     def submit_order(self, order):
@@ -545,7 +548,7 @@ class BacktestingBroker(Broker):
                 if position.asset.expiration == self.datetime.date() and time_to_close > seconds_before_closing:
                     continue
 
-                logging.info(f"Automatically selling expired contract for asset {position.asset}")
+                logger.info(f"Automatically selling expired contract for asset {position.asset}")
 
                 # Cash settle the options contract
                 self.cash_settle_options_contract(position, strategy)
@@ -738,7 +741,7 @@ class BacktestingBroker(Broker):
                 if order.order_class in ["bracket", "oto"]:
                     orders = self._flatten_order(order)
                     for flat_order in orders:
-                        logging.info(f"{order} was sent to broker {self.name}")
+                        logger.info(f"{order} was sent to broker {self.name}")
                         self._new_orders.append(flat_order)
 
                 trade_cost = self.calculate_trade_cost(order, strategy, price)

--- a/lumibot/data_sources/data_source_backtesting.py
+++ b/lumibot/data_sources/data_source_backtesting.py
@@ -17,7 +17,14 @@ class DataSourceBacktesting(DataSource, ABC):
     IS_BACKTESTING_DATA_SOURCE = True
 
     def __init__(
-        self, datetime_start, datetime_end, backtesting_started=None, config=None, api_key=None, pandas_data=None
+        self,
+        datetime_start,
+        datetime_end,
+        backtesting_started=None,
+        config=None,
+        api_key=None,
+        pandas_data=None,
+        show_progress_bar=True
     ):
         super().__init__(api_key=api_key)
 
@@ -38,6 +45,9 @@ class DataSourceBacktesting(DataSource, ABC):
         # Legacy strategy.backtest code will always pass in a config even for DataSources that don't need it, so
         # catch it here and ignore it in this class. Child classes that need it should error check it themselves.
         self._config = config
+
+        # If false, we don't show the progress bar
+        self._show_progress_bar = show_progress_bar
 
     def get_datetime(self, adjust_for_delay=False):
         """
@@ -72,11 +82,12 @@ class DataSourceBacktesting(DataSource, ABC):
 
     def _update_datetime(self, new_datetime, cash=None, portfolio_value=None):
         self._datetime = new_datetime
-        print_progress_bar(
-            new_datetime,
-            self.datetime_start,
-            self.datetime_end,
-            self.backtesting_started,
-            cash=cash,
-            portfolio_value=portfolio_value,
-        )
+        if self._show_progress_bar:
+            print_progress_bar(
+                new_datetime,
+                self.datetime_start,
+                self.datetime_end,
+                self.backtesting_started,
+                cash=cash,
+                portfolio_value=portfolio_value,
+            )

--- a/lumibot/data_sources/yahoo_data.py
+++ b/lumibot/data_sources/yahoo_data.py
@@ -8,6 +8,9 @@ from lumibot.data_sources import DataSourceBacktesting
 from lumibot.entities import Asset, Bars
 from lumibot.tools import YahooHelper
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 
 class YahooData(DataSourceBacktesting):
     SOURCE = "YAHOO"
@@ -59,12 +62,12 @@ class YahooData(DataSourceBacktesting):
         self, asset, length, timestep=MIN_TIMESTEP, timeshift=None, quote=None, exchange=None, include_after_hours=True
     ):
         if exchange is not None:
-            logging.warning(
+            logger.warning(
                 f"the exchange parameter is not implemented for YahooData, but {exchange} was passed as the exchange"
             )
 
         if quote is not None:
-            logging.warning(f"quote is not implemented for YahooData, but {quote} was passed as the quote")
+            logger.warning(f"quote is not implemented for YahooData, but {quote} was passed as the quote")
 
         interval = self._parse_source_timestep(timestep, reverse=True)
         if asset in self._data_store:
@@ -104,7 +107,7 @@ class YahooData(DataSourceBacktesting):
         """pull broker bars for a list assets"""
 
         if quote is not None:
-            logging.warning(f"quote is not implemented for YahooData, but {quote} was passed as the quote")
+            logger.warning(f"quote is not implemented for YahooData, but {quote} was passed as the quote")
 
         interval = self._parse_source_timestep(timestep, reverse=True)
         missing_assets = [asset.symbol for asset in assets if asset not in self._data_store]
@@ -121,7 +124,7 @@ class YahooData(DataSourceBacktesting):
 
     def _parse_source_symbol_bars(self, response, asset, quote=None, length=None):
         if quote is not None:
-            logging.warning(f"quote is not implemented for YahooData, but {quote} was passed as the quote")
+            logger.warning(f"quote is not implemented for YahooData, but {quote} was passed as the quote")
 
         bars = Bars(response, self.SOURCE, asset, raw=response)
         return bars

--- a/lumibot/example_strategies/stock_buy_and_hold.py
+++ b/lumibot/example_strategies/stock_buy_and_hold.py
@@ -68,6 +68,8 @@ if __name__ == "__main__":
             backtesting_start,
             backtesting_end,
             benchmark_asset="SPY",
+            # show_progress_bar=False,
+            # quiet_logs=False,
         )
 
         # Print the results

--- a/lumibot/tools/__init__.py
+++ b/lumibot/tools/__init__.py
@@ -29,3 +29,4 @@ from .pandas import *
 from .types import *
 from .yahoo_helper import YahooHelper
 from .ccxt_data_store import CcxtCacheDB
+

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -18,6 +18,9 @@ from plotly.subplots import make_subplots
 
 from .yahoo_helper import YahooHelper as yh
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 
 def total_return(_df):
     """Calculate the cumulative return in a dataframe
@@ -220,10 +223,10 @@ def plot_indicators(
 ):
     # If show plot is False, then we don't want to open the plot in the browser
     if not show_indicators:
-        print("show_indicators is False, not creating the plot file.")
+        logger.debug("show_indicators is False, not creating the plot file.")
         return
 
-    print("\nCreating indicators plot...")
+    logger.info("\nCreating indicators plot...")
 
     fig = make_subplots(specs=[[{"secondary_y": True}]])
 
@@ -368,10 +371,10 @@ def plot_returns(
 ):
     # If show plot is False, then we don't want to open the plot in the browser
     if not show_plot:
-        print("show_plot is False, not creating the plot file.")
+        logging.info("show_plot is False, not creating the plot file.")
         return
 
-    print("\nCreating trades plot...")
+    logging.info("\nCreating trades plot...")
 
     dfs_concat = []
 
@@ -685,10 +688,10 @@ def create_tearsheet(
     # If show tearsheet is False, then we don't want to open the tearsheet in the browser
     # IMS create the tearsheet even if we are not showinbg it
     if not save_tearsheet:
-        print("save_tearsheet is False, not creating the tearsheet file.")
+        logging.info("save_tearsheet is False, not creating the tearsheet file.")
         return
 
-    print("\nCreating tearsheet...")
+    logging.info("\nCreating tearsheet...")
 
     # Check if df1 or df2 are empty and return if they are
     if strategy_df is None or benchmark_df is None or strategy_df.empty or benchmark_df.empty:

--- a/lumibot/traders/trader.py
+++ b/lumibot/traders/trader.py
@@ -8,9 +8,12 @@ import appdirs
 
 # Overloading time.sleep to warn users against using it
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 
 class Trader:
-    def __init__(self, logfile="", backtest=False, debug=False, strategies=None):
+    def __init__(self, logfile="", backtest=False, debug=False, strategies=None, quiet_logs=True):
         """
 
         Parameters
@@ -24,6 +27,8 @@ class Trader:
             Whether to run the strategies in debug mode or not. This will set the log level to DEBUG.
         strategies: list
             A list of strategies to run. If not specified, you must add strategies using trader.add_strategy(strategy)
+        quiet_logs: bool
+            Whether to quiet noisy logs by setting the log level to ERROR. Defaults to True.
         """
         # Check if the logfile is a valid path
         if logfile:
@@ -33,7 +38,8 @@ class Trader:
         # Setting debug and _logfile parameters and setting global log format
         self.debug = debug
         self.backtest = backtest
-        self.log_format = logging.Formatter("%(asctime)s: %(name)s: %(levelname)s: %(message)s")
+        self.log_format = logging.Formatter("%(asctime)s | %(name)s | %(levelname)s | %(message)s")
+        self.quiet_logs = quiet_logs
 
         if logfile:
             self.logfile = Path(logfile)
@@ -127,7 +133,7 @@ class Trader:
         strat = self._strategies[0]
         if self.is_backtest_broker:
             strat.verify_backtest_inputs(strat.backtesting_start, strat.backtesting_end)
-            logging.info("Backtesting starting...")
+            logger.info("Backtesting starting...")
 
         signal.signal(signal.SIGINT, self._stop_pool)
         self._set_logger()
@@ -138,7 +144,7 @@ class Trader:
         result = self._collect_analysis()
 
         if self.is_backtest_broker:
-            logging.info("Backtesting finished")
+            logger.info("Backtesting finished")
             strat.backtest_analysis(
                 logdir=self.logdir,
                 show_plot=show_plot,
@@ -168,6 +174,11 @@ class Trader:
         logging.getLogger("apscheduler.scheduler").setLevel(logging.ERROR)
         logging.getLogger("apscheduler.executors.default").setLevel(logging.ERROR)
 
+        if self.quiet_logs:
+            logging.getLogger("asyncio").setLevel(logging.ERROR)
+            logging.getLogger("lumibot.backtesting.backtesting_broker").setLevel(logging.ERROR)
+            logging.getLogger("lumibot.data_sources.yahoo_data").setLevel(logging.ERROR)
+
         logger = logging.getLogger()
 
         for handler in logger.handlers:
@@ -182,9 +193,9 @@ class Trader:
             logger.setLevel(logging.DEBUG)
         elif self.is_backtest_broker:
             logger.setLevel(logging.INFO)
-            for handler in logger.handlers:
-                if handler.__class__.__name__ == "StreamHandler":
-                    handler.setLevel(logging.ERROR)
+            # for handler in logger.handlers:
+            #     if handler.__class__.__name__ == "StreamHandler":
+            #         handler.setLevel(logging.ERROR)
         else:
             logger.setLevel(logging.INFO)
 

--- a/lumibot/traders/trader.py
+++ b/lumibot/traders/trader.py
@@ -193,9 +193,6 @@ class Trader:
             logger.setLevel(logging.DEBUG)
         elif self.is_backtest_broker:
             logger.setLevel(logging.INFO)
-            # for handler in logger.handlers:
-            #     if handler.__class__.__name__ == "StreamHandler":
-            #         handler.setLevel(logging.ERROR)
         else:
             logger.setLevel(logging.INFO)
 

--- a/tests/backtest/test_thetadata.py
+++ b/tests/backtest/test_thetadata.py
@@ -15,6 +15,8 @@ import pytest
 keyword = 'ThetaTerminal.jar'
 
 
+
+
 def find_git_root(path):
     # Traverse the directories upwards until a .git directory is found
     original_path = path


### PR DESCRIPTION
1. many calls were being made to the root logger using ‘logging.info’ instead of ‘logger.info’
2. Noisy modules like trader and yahoo did not register themselves with the logger so they couldn’t be individually quieted.
3. There were some print statements sprinkled around too
4. Added option to not show the progress bar (useful when using not using quiet_logs for debugging strategies)

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace `print` statements and `logging` calls with a unified `logger` instance across multiple modules, introduce a `quiet_logs` option to suppress noisy logs, and add a `show_progress_bar` option to control progress bar visibility during backtesting.

### Why are these changes being made?

These changes improve the logging consistency and configurability of the codebase by using a dedicated logger instance, which allows for better log management and filtering. The `quiet_logs` option provides flexibility to reduce log verbosity, enhancing user experience during backtesting, while the `show_progress_bar` option allows users to toggle the visibility of progress bars, catering to different user preferences.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->