### PR TITLE
enable logging during backtesting but default to quiet_logs=True

### DIFF
--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1337,7 +1337,7 @@ class _Strategy:
         thetadata_password=None,
         use_quote_data=False,
         show_progress_bar=True,
-        quiet_logs=False,
+        quiet_logs=True,
         **kwargs,
     ):
         """Backtest a strategy.

--- a/lumibot/traders/trader.py
+++ b/lumibot/traders/trader.py
@@ -189,11 +189,6 @@ class Trader:
 
         if self.debug:
             logger.setLevel(logging.DEBUG)
-        elif self.is_backtest_broker:
-            logger.setLevel(logging.INFO)
-            for handler in logger.handlers:
-                if handler.__class__.__name__ == "StreamHandler":
-                    handler.setLevel(logging.ERROR)
         else:
             logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
This feature enables the use of logger.info during backtests which will help developers when building strategies. It does so by removing the code that previously forced the logging level to ERROR when the backtest broker was in use.

To enable logging in backtests, the developer simply passes quiet_logs=False to Strategy.backtest() and then they can see all the logs from their strategy. The quiet_logs parameter defaults to true in Strategy.backtest() but is false in the Trader init function.  This preserves the default behavior where there are lots of logs in live trading, but not many logs in local backtests.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enable logging during backtesting with the default setting of `quiet_logs=True` and remove specific logging level adjustments for backtest brokers.

### Why are these changes being made?

The change allows users to enable logging during backtesting if desired, while keeping the default behavior quiet to avoid unnecessary log clutter. The removal of specific logging level adjustments for backtest brokers simplifies the logging configuration, ensuring consistency and reducing potential confusion.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->