### PR TITLE
Enable info logs in backtests

### DIFF
--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1337,7 +1337,7 @@ class _Strategy:
         thetadata_password=None,
         use_quote_data=False,
         show_progress_bar=True,
-        quiet_logs=False,
+        quiet_logs=True,
         **kwargs,
     ):
         """Backtest a strategy.

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -103,7 +103,6 @@ class _Strategy:
         should_send_summary_to_discord=True,
         save_logfile=False,
         lumiwealth_api_key=None,
-        quiet_logs=False,
         **kwargs,
     ):
         """Initializes a Strategy object.
@@ -189,8 +188,6 @@ class _Strategy:
             Turning on this option will slow down the backtest.
         lumiwealth_api_key : str
             The API key to use for the LumiWealth data source. Defaults to None (saving to the cloud is off).
-        quiet_logs : bool
-            Whether to quiet noisy logs by setting the log level to ERROR. Defaults to True.
         kwargs : dict
             A dictionary of additional keyword arguments to pass to the strategy.
 

--- a/lumibot/traders/trader.py
+++ b/lumibot/traders/trader.py
@@ -171,11 +171,11 @@ class Trader:
         logging.getLogger("requests").setLevel(logging.ERROR)
         logging.getLogger("apscheduler.scheduler").setLevel(logging.ERROR)
         logging.getLogger("apscheduler.executors.default").setLevel(logging.ERROR)
+        logging.getLogger("lumibot.data_sources.yahoo_data").setLevel(logging.ERROR)
 
         if self.quiet_logs:
             logging.getLogger("asyncio").setLevel(logging.ERROR)
             logging.getLogger("lumibot.backtesting.backtesting_broker").setLevel(logging.ERROR)
-            logging.getLogger("lumibot.data_sources.yahoo_data").setLevel(logging.ERROR)
 
         logger = logging.getLogger()
 

--- a/lumibot/traders/trader.py
+++ b/lumibot/traders/trader.py
@@ -189,11 +189,6 @@ class Trader:
 
         if self.debug:
             logger.setLevel(logging.DEBUG)
-        elif self.is_backtest_broker:
-            logger.setLevel(logging.INFO)
-            for handler in logger.handlers:
-                if handler.__class__.__name__ == "StreamHandler":
-                    handler.setLevel(logging.ERROR)
         else:
             logger.setLevel(logging.INFO)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 polygon-api-client
 alpha_vantage
 ibapi==9.81.1.post1
-yfinance
+yfinance==0.2.44
 matplotlib>=3.3.3
 quandl
 pandas>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 polygon-api-client
 alpha_vantage
 ibapi==9.81.1.post1
-yfinance==0.2.44
+yfinance
 matplotlib>=3.3.3
 quandl
 pandas>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         "alpaca-py>=0.28.1",
         "alpha_vantage",
         "ibapi==9.81.1.post1",
-        "yfinance>=0.2.37",
+        "yfinance>=0.2.46",
         "matplotlib>=3.3.3",
         "quandl",
         # Numpy over 1.2 but below 2 since v2 is not supported by several libraries yet


### PR DESCRIPTION
This feature enables the use of logger.info during backtests which will help developers when building strategies. It does so by removing the code that previously forced the logging level to ERROR when the backtest broker was in use.

To enable logging in backtests, the developer simply passes quiet_logs=False to Strategy.backtest() and then they can see all the logs from their strategy. The quiet_logs parameter defaults to true in Strategy.backtest() but is false in the Trader init function. This preserves the default behavior where there are lots of logs in live trading, but not many logs in local backtests.

This also fixes an issue with a recent deployment of yfinance

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the backtest logging settings to enable more info logs by default and update the `yfinance` library version in the dependencies.

### Why are these changes being made?

The quiet_logs parameter for backtests is set to True by default to provide more detailed logging information, facilitating debugging and analysis. Additionally, updating the `yfinance` library version ensures compatibility with recent features and bug fixes. This approach balances verbosity and information density during backtesting while keeping dependencies up-to-date.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->