### PR TITLE
Change log level of unnecessary logs to debug

### DIFF
--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -99,7 +99,7 @@ class BacktestingBroker(Broker):
         self.data_source._update_datetime(new_datetime, cash=cash, portfolio_value=portfolio_value)
         if self.option_source:
             self.option_source._update_datetime(new_datetime, cash=cash, portfolio_value=portfolio_value)
-        logger.info(f"Current backtesting datetime {self.datetime}")
+        logger.debug(f"Current backtesting datetime {self.datetime}")
 
     # =========Clock functions=====================
 

--- a/lumibot/data_sources/interactive_brokers_rest_data.py
+++ b/lumibot/data_sources/interactive_brokers_rest_data.py
@@ -162,9 +162,9 @@ class InteractiveBrokersRESTData(DataSource):
                     and "id" in response[0]
                 ):
                     self.account_id = response[0]["id"]
-                    logging.info(
+                    logging.debug(
                         colored(
-                            f"Successfully retrieved Account ID: {self.account_id}",
+                            f"Retrieved Account ID",
                             "green",
                         )
                     )

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -199,19 +199,24 @@ class _Strategy:
         self.sell_trading_fees = sell_trading_fees
         self.save_logfile = save_logfile
         self.broker = broker
-        self._name = name
+
+        if name is not None:
+            self._name = name
+
+        elif STRATEGY_NAME is not None:
+            self._name = STRATEGY_NAME
+        
+        else:
+            self._name = self.__class__.__name__
 
         # Create an adapter with 'strategy_name' set to the instance's name
         self.logger = CustomLoggerAdapter(logger, {'strategy_name': self._name})
-
+        logging.info(self.__class__.__name__)
         # Set the log level to INFO so that all logs INFO and above are displayed
         self.logger.setLevel(logging.INFO)
         
         if self.broker == None:
             self.broker = BROKER
-        
-        if self._name == None:
-            self._name = STRATEGY_NAME
 
         self.hide_positions = HIDE_POSITIONS
         self.hide_trades = HIDE_TRADES

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -3098,7 +3098,7 @@ class Strategy(_Strategy):
         if quote is None:
             quote = self.quote_asset
 
-        self.logger.info(f"Getting historical prices for {asset}, {length} bars, {timestep}")
+        self.logger.debug(f"Getting historical prices for {asset}, {length} bars, {timestep}")
 
         asset = self._sanitize_user_asset(asset)
 
@@ -4114,12 +4114,12 @@ class Strategy(_Strategy):
 
     def send_account_summary_to_discord(self):
         # Log that we are sending the account summary to Discord
-        self.logger.info("Considering to send account summary to Discord")
+        self.logger.debug("Considering sending account summary to Discord")
 
         # Check if we are in backtesting mode, if so, don't send the message
         if self.is_backtesting:
             # Log that we are not sending the account summary to Discord
-            self.logger.info("Not sending account summary to Discord because we are in backtesting mode")
+            self.logger.debug("Not sending account summary to Discord because we are in backtesting mode")
             return
 
         # Check if last_account_summary_dt has been set, if not, set it to None

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -3098,7 +3098,7 @@ class Strategy(_Strategy):
         if quote is None:
             quote = self.quote_asset
 
-        self.logger.debug(f"Getting historical prices for {asset}, {length} bars, {timestep}")
+        self.logger.info(f"Getting historical prices for {asset}, {length} bars, {timestep}")
 
         asset = self._sanitize_user_asset(asset)
 

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -93,7 +93,7 @@ class StrategyExecutor(Thread):
 
     def sync_broker(self):
         # Log that we are syncing the broker.
-        self.strategy.logger.info("Syncing the broker.")
+        self.strategy.logger.debug("Syncing the broker.")
 
         # Only audit the broker positions during live trading.
         if self.broker.IS_BACKTESTING_BROKER:

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -135,7 +135,7 @@ class StrategyExecutor(Thread):
                 cash_balance = broker_balances[0]
                 portfolio_value = broker_balances[2]
                 self.strategy._set_cash_position(cash_balance)
-                self.strategy.logger.info(f"Got Cash Balance: ${cash_balance:.2f}, Portfolio: ${portfolio_value:.2f}")
+                self.strategy.logger.debug(f"Got Cash Balance: ${cash_balance:.2f}, Portfolio: ${portfolio_value:.2f}")
 
 
             held_trades_len = len(self.broker._held_trades)


### PR DESCRIPTION
This pull request changes the log level of some unnecessary logs from info to debug. The logs affected are related to backtesting datetime, getting historical prices, sending account summary to Discord, and syncing the broker. This change will help reduce the noise in the logs and make it easier to focus on important information.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Change log level of specific log messages from `info` to `debug` across several modules within the codebase.

### Why are these changes being made?

The affected log messages are deemed unnecessary for regular informational logging, potentially cluttering logs with less critical information. By switching these messages to `debug`, the logs will remain clearer and focused on more significant events unless debugging is specifically required. This adjustment aids in maintaining log clarity and efficiency.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->