### PR TITLE
daily backtests with pandas didnt work. now they do

### DIFF
--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -192,9 +192,6 @@ class BacktestingBroker(Broker):
         return delta.total_seconds()
 
     def _await_market_to_open(self, timedelta=None, strategy=None):
-        if self.data_source.SOURCE == "PANDAS" and self.data_source._timestep == "day":
-            return
-
         # Process outstanding orders first before waiting for market to open
         # or else they don't get processed until the next day
         self.process_pending_orders(strategy=strategy)
@@ -205,9 +202,6 @@ class BacktestingBroker(Broker):
         self._update_datetime(time_to_open)
 
     def _await_market_to_close(self, timedelta=None, strategy=None):
-        if self.data_source.SOURCE == "PANDAS" and self.data_source._timestep == "day":
-            return
-
         # Process outstanding orders first before waiting for market to close
         # or else they don't get processed until the next day
         self.process_pending_orders(strategy=strategy)

--- a/tests/backtest/fixtures.py
+++ b/tests/backtest/fixtures.py
@@ -1,6 +1,17 @@
+from typing import Dict
+import os
 import pytest
+import logging
 import datetime
+
+import pandas as pd
+
+from lumibot.entities import Data, Asset
 from lumibot.backtesting import PolygonDataBacktesting
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 
 @pytest.fixture
 def polygon_data_backtesting():
@@ -17,3 +28,50 @@ def polygon_data_backtesting():
     )
     
     return polygon_data_instance
+
+
+@pytest.fixture(scope="function")
+def pandas_data_fixture() -> Dict[Asset, Data]:
+    """
+    Get a dictionary of Lumibot Data objects from the test data in tests/data folder
+    """
+    symbols = ["SPY", "TLT", "GLD"]
+    pandas_data = dict()
+    data_dir = os.getcwd() + "/data"
+    print(data_dir)
+    for symbol in symbols:
+        csv_path = data_dir + f"/{symbol}.csv"
+        asset = Asset(
+            symbol=symbol,
+            asset_type="stock",
+        )
+        df = pd.read_csv(
+            csv_path,
+            parse_dates=True,
+            index_col=0,
+            header=0,
+            usecols=[0, 1, 2, 3, 4, 6],
+            names=["Date", "Open", "High", "Low", "Close", "Volume"],
+        )
+        df = df.rename(
+            columns={
+                "Date": "date",
+                "Open": "open",
+                "High": "high",
+                "Low": "low",
+                "Close": "close",
+                "Volume": "volume",
+            }
+        )
+        df = df[["open", "high", "low", "close", "volume"]]
+        df.index.name = "datetime"
+
+        data = Data(
+            asset,
+            df,
+            date_start=datetime.datetime(2019, 1, 6),
+            date_end=datetime.datetime(2019, 12, 15),
+            timestep="day",
+        )
+        pandas_data[asset] = data
+    return pandas_data

--- a/tests/backtest/test_pandas_backtest.py
+++ b/tests/backtest/test_pandas_backtest.py
@@ -1,0 +1,78 @@
+import logging
+from datetime import datetime as DateTime
+
+from lumibot.backtesting import PandasDataBacktesting
+from lumibot.strategies.strategy import Strategy
+
+from tests.backtest.fixtures import pandas_data_fixture
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class LifecycleLogger(Strategy):
+
+    parameters = {
+        "sleeptime": "1D",
+        "market": "NYSE",
+    }
+
+    def initialize(self, symbol=""):
+        self.sleeptime = self.parameters["sleeptime"]
+        self.set_market(self.parameters["market"])
+
+    def before_market_opens(self):
+        dt = self.get_datetime()
+        logger.info(f"{dt} before_market_opens called")
+
+    def before_starting_trading(self):
+        dt = self.get_datetime()
+        logger.info(f"{dt} before_starting_trading called")
+
+    def on_trading_iteration(self):
+        dt = self.get_datetime()
+        logger.info(f"{dt} on_trading_iteration called")
+
+    def before_market_closes(self):
+        dt = self.get_datetime()
+        logger.info(f"{dt} before_market_closes called")
+
+    def after_market_closes(self):
+        dt = self.get_datetime()
+        logger.info(f"{dt} after_market_closes called")
+
+
+class TestPandasBacktest:
+
+    def test_pandas_data_fixture(self, pandas_data_fixture):
+        assert pandas_data_fixture is not None
+
+    def test_pandas_datasource_with_daily_data_in_backtest(self, pandas_data_fixture):
+        strategy_name = "LifecycleLogger"
+        strategy_class = LifecycleLogger
+        backtesting_start = DateTime(2019, 1, 14)
+        backtesting_end = DateTime(2019, 1, 20)
+
+        # Replace the strategy name now that it's known.
+        for data in pandas_data_fixture.values():
+            data.strategy = strategy_name
+
+        result = strategy_class.backtest(
+            datasource_class=PandasDataBacktesting,
+            backtesting_start=backtesting_start,
+            backtesting_end=backtesting_end,
+            pandas_data=list(pandas_data_fixture.values()),
+            risk_free_rate=0,
+            show_plot=False,
+            save_tearsheet=False,
+            show_tearsheet=False,
+            show_indicators=False,
+            save_logfile=False,
+            name=strategy_name,
+            budget=40000,
+            show_progress_bar=False,
+            quiet_logs=False,
+        )
+        logger.info(f"Result: {result}")
+        assert result is not None


### PR DESCRIPTION
The previous backtest broker didnt call update_datetime for daily runs (for some reason). Therefore it never changed the data of the backtest and it ran forever using the startdate. You can see this not working by running test_pandas_backtest.py using the original backtest broker before my changes. With my changes backtesting daily strategies with pandas now works.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove conditions that bypass awaiting market open and close logic for "PANDAS" data source with daily timestep.

### Why are these changes being made?

The bypassing conditions prevented the daily backtests using Pandas from executing properly, leading to incomplete simulation scenarios. Removing these conditions ensures that the backtesting process accurately processes pending orders, resulting in more realistic and robust simulation outcomes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->