### PR TITLE
quiet_logs now works for realz. when no api keys, relevant tests are skipped.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ todos.txt
 test_bot.py
 .vscode
 .coverage*
-*secret*/**.env
+.env
 lumi_tradier
 lumiwealth_tradier
 ThetaTerminal.jar

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you want to contribute to Lumibot, you can check how to get started below. We
 
 ## Running Tests
 
-We use pytest for our testing framework. To run the tests, you can run the following command:
+We use pytest for our testing framework. Some tests require API keys to be in a `.env` file in the root directory. To run the tests, you can run the following command:
 
 ```bash
 pytest

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Our blog has lots of example strategies and shows you how to run a bot using Lum
 
 **https://lumiwealth.com/blog/**
 
+## Run a backtest
+
+To run a backtest, you can use the following code snippet:
+
+```bash
+python -m lumibot.example_strategies.stock_buy_and_hold
+```
+
 ## Run an Example Strategy
 
 We made a small example strategy to show you how to use Lumibot in this GitHub repository: [Example Algorithm GitHub](https://github.com/Lumiwealth-Strategies/stock_example_algo)

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -12,7 +12,6 @@ from lumibot.entities import Asset, Order, Position, TradingFee
 from lumibot.trading_builtins import CustomStream
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class BacktestingBroker(Broker):

--- a/lumibot/credentials.py
+++ b/lumibot/credentials.py
@@ -16,7 +16,6 @@ import termcolor
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def find_and_load_dotenv(base_dir) -> bool:

--- a/lumibot/data_sources/yahoo_data.py
+++ b/lumibot/data_sources/yahoo_data.py
@@ -9,7 +9,6 @@ from lumibot.entities import Asset, Bars
 from lumibot.tools import YahooHelper
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class YahooData(DataSourceBacktesting):

--- a/lumibot/example_strategies/lifecycle_logger.py
+++ b/lumibot/example_strategies/lifecycle_logger.py
@@ -1,9 +1,9 @@
 import logging
+import datetime
 
 from lumibot.strategies.strategy import Strategy
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class LifecycleLogger(Strategy):
@@ -37,3 +37,35 @@ class LifecycleLogger(Strategy):
         dt = self.get_datetime()
         logger.info(f"{dt} after_market_closes called")
 
+
+if __name__ == "__main__":
+    IS_BACKTESTING = True
+
+    if IS_BACKTESTING:
+        from lumibot.backtesting import YahooDataBacktesting
+
+        # Backtest this strategy
+        backtesting_start = datetime.datetime(2023, 1, 1)
+        backtesting_end = datetime.datetime(2024, 9, 1)
+
+        results = LifecycleLogger.backtest(
+            YahooDataBacktesting,
+            backtesting_start,
+            backtesting_end,
+            benchmark_asset="SPY",
+            # show_progress_bar=False,
+            # quiet_logs=False,
+        )
+
+        # Print the results
+        print(results)
+    else:
+        from lumibot.credentials import ALPACA_CONFIG
+        from lumibot.brokers import Alpaca
+        from lumibot.traders import Trader
+
+        trader = Trader()
+        broker = Alpaca(ALPACA_CONFIG)
+        strategy = LifecycleLogger(broker=broker)
+        trader.add_strategy(strategy)
+        strategy_executors = trader.run_all()

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1438,8 +1438,6 @@ class _Strategy:
             When set to true this requests Quote data in addition to OHLC which adds time to backtests.
         show_progress_bar : bool
             Whether to show the progress bar. Defaults to True.
-        trader_class : Trader class
-            The trader class to use. Defaults to Trader.
         quiet_logs : bool
             Whether to quiet noisy logs by setting the log level to ERROR. Defaults to True.
         trader_class : Trader class

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1013,9 +1013,6 @@ class _Strategy:
         if not hasattr(self, "logger") or self.logger is None:
             self.logger = CustomLoggerAdapter(logger, {'strategy_name': self._name})
 
-        # Print start message
-        print(f"Starting backtest for {datasource_class.__name__}...")
-
         # If show_plot is None, then set it to True
         if show_plot is None:
             show_plot = SHOW_PLOT

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -19,7 +19,6 @@ from plotly.subplots import make_subplots
 from .yahoo_helper import YahooHelper as yh
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def total_return(_df):

--- a/lumibot/traders/debug_log_trader.py
+++ b/lumibot/traders/debug_log_trader.py
@@ -1,0 +1,9 @@
+from lumibot.traders.trader import Trader
+
+
+class DebugLogTrader(Trader):
+    """I'm just a trader instance with debug turned on by default"""
+
+    def __init__(self, logfile="", backtest=False, debug=True, strategies=None, quiet_logs=False):
+        super().__init__(logfile=logfile, backtest=backtest, debug=debug, strategies=strategies, quiet_logs=quiet_logs)
+

--- a/lumibot/traders/trader.py
+++ b/lumibot/traders/trader.py
@@ -7,7 +7,6 @@ from pathlib import Path
 # Overloading time.sleep to warn users against using it
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class Trader:
@@ -142,6 +141,7 @@ class Trader:
         result = self._collect_analysis()
 
         if self.is_backtest_broker:
+            logger.setLevel(logging.INFO)
             logger.info("Backtesting finished")
             strat.backtest_analysis(
                 logdir=self.logdir,
@@ -189,8 +189,8 @@ class Trader:
 
         if self.debug:
             logger.setLevel(logging.DEBUG)
-        elif self.is_backtest_broker:
-            logger.setLevel(logging.INFO)
+        elif self.quiet_logs:
+            logger.setLevel(logging.ERROR)
             for handler in logger.handlers:
                 if handler.__class__.__name__ == "StreamHandler":
                     handler.setLevel(logging.ERROR)

--- a/tests/backtest/fixtures.py
+++ b/tests/backtest/fixtures.py
@@ -10,7 +10,6 @@ from lumibot.entities import Data, Asset
 from lumibot.backtesting import PolygonDataBacktesting
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 @pytest.fixture

--- a/tests/backtest/test_example_strategies.py
+++ b/tests/backtest/test_example_strategies.py
@@ -41,7 +41,7 @@ class TestExampleStrategies:
             show_plot=False,
             show_tearsheet=False,
             save_tearsheet=False,
-            polygon_api_key=POLYGON_API_KEY,
+            show_indicators=False,
         )
         assert results
         assert isinstance(strat_obj, StockBracket)

--- a/tests/backtest/test_example_strategies.py
+++ b/tests/backtest/test_example_strategies.py
@@ -208,6 +208,7 @@ class TestExampleStrategies:
         assert round(results["total_return"] * 100, 1) >= 0.7
         assert round(results["max_drawdown"]["drawdown"] * 100, 1) <= 0.2
 
+    @pytest.mark.skipif(POLYGON_API_KEY == '<your key here>', reason="This test requires a Polygon.io API key")
     def test_options_hold_to_expiry(self):
         """
         Test the example strategy OptionsHoldToExpiry by running a backtest and checking that the strategy object is

--- a/tests/backtest/test_pandas_backtest.py
+++ b/tests/backtest/test_pandas_backtest.py
@@ -8,7 +8,6 @@ from tests.backtest.fixtures import pandas_data_fixture
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class TestPandasBacktest:

--- a/tests/backtest/test_passing_trader_into_backtest.py
+++ b/tests/backtest/test_passing_trader_into_backtest.py
@@ -9,7 +9,6 @@ from lumibot.example_strategies.lifecycle_logger import LifecycleLogger
 from tests.backtest.fixtures import pandas_data_fixture
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class TestPassingTraderIntoBacktest:

--- a/tests/backtest/test_passing_trader_into_backtest.py
+++ b/tests/backtest/test_passing_trader_into_backtest.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 
 from lumibot.traders.trader import Trader
+from lumibot.traders.debug_log_trader import DebugLogTrader
 from lumibot.backtesting import PandasDataBacktesting
 from lumibot.example_strategies.lifecycle_logger import LifecycleLogger
 
@@ -11,18 +12,11 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-class DebugLogTrader(Trader):
-    """I'm just a trader instance with debug turned on by default"""
-
-    def __init__(self, logfile="", backtest=False, debug=True, strategies=None, quiet_logs=False):
-        super().__init__(logfile=logfile, backtest=backtest, debug=debug, strategies=strategies, quiet_logs=quiet_logs)
-
-
 class TestPassingTraderIntoBacktest:
 
     def test_not_passing_trader_class_into_backtest_creates_generic_trader(self, pandas_data_fixture):
         # When we create a backtest and don't pass in a trader_class, the trader it creates should be a Trader object
-        strategy_name = "LifecycleLogger"
+        strategy_name = "LifecycleLogger_with_default_trader"
         strategy_class = LifecycleLogger
         backtesting_start = datetime.datetime(2019, 1, 14)
         backtesting_end = datetime.datetime(2019, 1, 20)
@@ -58,7 +52,7 @@ class TestPassingTraderIntoBacktest:
 
     def test_passing_trader_class_into_backtest_creates_trader_class(self, pandas_data_fixture):
         # When we create a backtest and pass in a trader_class, the trader it creates should be an instance of that class
-        strategy_name = "LifecycleLogger"
+        strategy_name = "LifecycleLogger_with_DebugLogTrader"
         strategy_class = LifecycleLogger
         backtesting_start = datetime.datetime(2019, 1, 14)
         backtesting_end = datetime.datetime(2019, 1, 20)

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -6,6 +6,7 @@ import pytest
 
 import pandas_market_calendars as mcal
 
+
 from tests.backtest.fixtures import polygon_data_backtesting
 import pytz
 from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting
@@ -18,7 +19,7 @@ from datetime import timedelta
 
 # Global parameters
 # API Key for testing Polygon.io
-POLYGON_API_KEY = os.environ.get("POLYGON_API_KEY")
+from lumibot.credentials import POLYGON_API_KEY
 
 
 class PolygonBacktestStrat(Strategy):

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -2,6 +2,7 @@ import datetime
 import os
 from collections import defaultdict
 import pandas as pd
+import pytest
 
 import pandas_market_calendars as mcal
 
@@ -199,6 +200,7 @@ class TestPolygonBacktestFull:
         )
         assert "fill" not in poly_strat_obj.order_time_tracker[stoploss_order_id]
 
+    @pytest.mark.skipif(POLYGON_API_KEY == '<your key here>', reason="This test requires a Polygon.io API key")
     def test_polygon_restclient(self):
         """
         Test Polygon REST Client with Lumibot Backtesting and real API calls to Polygon. Using the Amazon stock
@@ -226,6 +228,7 @@ class TestPolygonBacktestFull:
         assert results
         self.verify_backtest_results(poly_strat_obj)
 
+    @pytest.mark.skipif(POLYGON_API_KEY == '<your key here>', reason="This test requires a Polygon.io API key")
     def test_intraday_daterange(self):
         tzinfo = pytz.timezone("America/New_York")
         backtesting_start = datetime.datetime(2024, 2, 7).astimezone(tzinfo)
@@ -249,6 +252,7 @@ class TestPolygonBacktestFull:
         # Assert the end datetime is before the market open of the next trading day.
         assert broker.datetime == datetime.datetime.fromisoformat("2024-02-12 08:30:00-05:00")
 
+    @pytest.mark.skipif(POLYGON_API_KEY == '<your key here>', reason="This test requires a Polygon.io API key")
     def test_polygon_legacy_backtest(self):
         """
         Do the same backtest as test_polygon_restclient() but using the legacy backtest() function call instead of
@@ -275,6 +279,7 @@ class TestPolygonBacktestFull:
         assert results
         self.verify_backtest_results(poly_strat_obj)
 
+    @pytest.mark.skipif(POLYGON_API_KEY == '<your key here>', reason="This test requires a Polygon.io API key")
     def test_polygon_legacy_backtest2(self):
         """Test that the legacy backtest() function call works without returning the startegy object"""
         # Parameters: True = Live Trading | False = Backtest
@@ -340,6 +345,7 @@ class TestPolygonBacktestFull:
 
 class TestPolygonDataSource:
 
+    @pytest.mark.skipif(POLYGON_API_KEY == '<your key here>', reason="This test requires a Polygon.io API key")
     def test_get_historical_prices(self):
         tzinfo = pytz.timezone("America/New_York")
         start = datetime.datetime(2024, 2, 5).astimezone(tzinfo)

--- a/tests/backtest/test_thetadata.py
+++ b/tests/backtest/test_thetadata.py
@@ -78,15 +78,15 @@ THETADATA_USERNAME = os.environ.get("THETADATA_USERNAME")
 THETADATA_PASSWORD = os.environ.get("THETADATA_PASSWORD")
 ############################################################################################################
 secrets_not_found = False
-if not THETADATA_USERNAME:
+if not THETADATA_USERNAME or THETADATA_USERNAME == "uname":
     print("CHECK: Unable to get THETADATA_USERNAME in the environemnt variables.")
     secrets_not_found = True
-if not THETADATA_PASSWORD:
+if not THETADATA_PASSWORD or THETADATA_PASSWORD == "pwd":
     print("CHECK: Unable to get THETADATA_PASSWORD in the environemnt variables.")
     secrets_not_found = True
 
 if secrets_not_found:
-    raise "ERROR: Unable to get ThetaData API credentials from the environment variables."
+    print("ERROR: Unable to get ThetaData API credentials from the environment variables.")
 
 
 class ThetadataBacktestStrat(Strategy):
@@ -316,6 +316,10 @@ class TestThetaDataBacktestFull:
         )
         assert "fill" not in theta_strat_obj.order_time_tracker[stoploss_order_id]
 
+    @pytest.mark.skipif(
+        secrets_not_found,
+        reason="Skipping test because ThetaData API credentials not found in environment variables",
+    )
     def test_thetadata_restclient(self):
         """
         Test ThetaDataBacktesting with Lumibot Backtesting and real API calls to ThetaData. Using the Amazon stock

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,114 @@
+import datetime
+import logging
+
+from lumibot.example_strategies.lifecycle_logger import LifecycleLogger
+from lumibot.backtesting import YahooDataBacktesting
+
+
+class TestLogging:
+
+    def test_logging(self, caplog):
+        caplog.set_level(logging.INFO)
+        logger = logging.getLogger()
+        logger.info("This is an info message")
+        assert "This is an info message" in caplog.text
+
+    def test_backtest_produces_no_logs_by_default(self, caplog):
+        caplog.set_level(logging.INFO)
+        backtesting_start = datetime.datetime(2023, 1, 2)
+        backtesting_end = datetime.datetime(2023, 1, 4)
+
+        LifecycleLogger.backtest(
+            YahooDataBacktesting,
+            backtesting_start,
+            backtesting_end,
+            parameters={"sleeptime": "1D", "market": "NYSE"},
+            show_plot=False,
+            save_tearsheet=False,
+            show_tearsheet=False,
+            show_indicators=False,
+            save_logfile=False,
+        )
+        # count that this contains 3 new lines. Its an easy proxy for the number of log messages and avoids
+        # the issue where the datetime is always gonna be different.
+        assert caplog.text.count("\n") == 3
+        assert "Starting backtest...\n" in caplog.text
+        assert "Backtesting starting...\n" in caplog.text
+        assert "Backtesting finished\n" in caplog.text
+
+    def test_run_backtest_produces_no_logs_by_default(self, caplog):
+        caplog.set_level(logging.INFO)
+        backtesting_start = datetime.datetime(2023, 1, 2)
+        backtesting_end = datetime.datetime(2023, 1, 4)
+
+        LifecycleLogger.run_backtest(
+            YahooDataBacktesting,
+            backtesting_start,
+            backtesting_end,
+            parameters={"sleeptime": "1D", "market": "NYSE"},
+            show_plot=False,
+            save_tearsheet=False,
+            show_tearsheet=False,
+            show_indicators=False,
+            save_logfile=False,
+        )
+        # count that this contains 3 new lines. Its an easy proxy for the number of log messages and avoids
+        # the issue where the datetime is always gonna be different.
+        assert caplog.text.count("\n") == 3
+        assert "Starting backtest...\n" in caplog.text
+        assert "Backtesting starting...\n" in caplog.text
+        assert "Backtesting finished\n" in caplog.text
+
+    def test_backtest_produces_no_logs_when_quiet_logs_is_true(self, caplog):
+        caplog.set_level(logging.INFO)
+        backtesting_start = datetime.datetime(2023, 1, 2)
+        backtesting_end = datetime.datetime(2023, 1, 4)
+
+        LifecycleLogger.backtest(
+            YahooDataBacktesting,
+            backtesting_start,
+            backtesting_end,
+            parameters={"sleeptime": "1D", "market": "NYSE"},
+            show_plot=False,
+            save_tearsheet=False,
+            show_tearsheet=False,
+            show_indicators=False,
+            save_logfile=False,
+            show_progress_bar=True,
+            quiet_logs=True,
+        )
+        # count that this contains 3 new lines. Its an easy proxy for the number of log messages and avoids
+        # the issue where the datetime is always gonna be different.
+        assert caplog.text.count("\n") == 3
+        assert "Starting backtest...\n" in caplog.text
+        assert "Backtesting starting...\n" in caplog.text
+        assert "Backtesting finished\n" in caplog.text
+
+    def test_backtest_produces_logs_when_quiet_logs_is_false(self, caplog):
+        caplog.set_level(logging.INFO)
+        backtesting_start = datetime.datetime(2023, 1, 2)
+        backtesting_end = datetime.datetime(2023, 1, 4)
+
+        LifecycleLogger.backtest(
+            YahooDataBacktesting,
+            backtesting_start,
+            backtesting_end,
+            parameters={"sleeptime": "1D", "market": "NYSE"},
+            show_plot=False,
+            save_tearsheet=False,
+            show_tearsheet=False,
+            show_indicators=False,
+            save_logfile=False,
+            show_progress_bar=False,
+            quiet_logs=False,
+        )
+
+        assert caplog.text.count("\n") == 9
+        assert "Starting backtest...\n" in caplog.text
+        assert "Backtesting starting...\n" in caplog.text
+        assert "before_market_opens called\n" in caplog.text
+        assert "before_starting_trading called\n" in caplog.text
+        assert "on_trading_iteration called\n" in caplog.text
+        assert "before_market_closes called\n" in caplog.text
+        assert "after_market_closes called\n" in caplog.text
+        assert "Backtesting finished\n" in caplog.text

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -24,6 +24,7 @@ def tradier():
 
 
 @pytest.mark.apitest
+@pytest.mark.skipif(not TRADIER_ACCOUNT_ID_PAPER or not TRADIER_TOKEN_PAPER, reason="No Tradier credentials provided.")
 class TestTradierDataAPI:
     """
     API Tests skipped by default. To run all API tests, use the following command:
@@ -92,6 +93,7 @@ class TestTradierDataAPI:
 
 
 @pytest.mark.apitest
+@pytest.mark.skipif(not TRADIER_ACCOUNT_ID_PAPER or not TRADIER_TOKEN_PAPER, reason="No Tradier credentials provided.")
 class TestTradierBrokerAPI:
     """
     API Tests skipped by default. To run all API tests, use the following command:
@@ -114,6 +116,8 @@ class TestTradierBrokerAPI:
         # How do we check this? Who changes the Lumibot order status to "canceled"?
         tradier.cancel_order(submitted_order)
 
+
+@pytest.mark.skipif(not TRADIER_ACCOUNT_ID_PAPER or not TRADIER_TOKEN_PAPER, reason="No Tradier credentials provided.")
 class TestTradierBroker:
     """
     Unit tests for the Tradier broker. These tests do not require any API calls.


### PR DESCRIPTION
Found a bunch of places where I was setting the logger level to info unintentionally and removed those. Changed the traader to respect the quiet_logs property regardless of backtest or live trading. Updated the tests to skip ones that require an API key when no API key is present.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement enhancement for `quiet_logs` configuration to ensure it sets log levels correctly to reduce noise, add capability to skip tests that require API keys when those keys are unavailable, and update the README with backtesting instructions.

### Why are these changes being made?

The previous log noise reduction feature wasn't functioning as intended due to non-conditional log level settings, which this change corrects by ensuring log levels are adjusted based on the `quiet_logs` parameter. Tests were failing unnecessarily when API keys weren't provided, hence skipping is introduced to accommodate such scenarios. Moreover, README updates improve user documentation by explaining backtesting process.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->