### PR TITLE
All Bars now all have return column; get_momentum now uses lookback instead of start/end

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,13 @@ git commit -m "my changes"
 git push -u origin my-feature
 ```
 
-If work on main progressed while you were in another branch, fetch it, then merge it into your branch:
+If work on main progressed while you were in another branch, this is how you rebase it into your branch:
 ```shell
 git checkout dev
 git fetch origin
-git merge origin/d
-git checkout my-feature
 git merge origin/dev
+git checkout my-feature
+git rebase dev
 ```
 
 When ready to merge the branch into main, go into github, create a pull request, and await review. When your PR is approved it will automatically be merged into the dev branch remotely. Now, you can delete your local branch and the remote branch.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,22 @@ Here's an example of an actual launch.json file:
 }
 ```
 
+## Notes on data sources
+
+This table points out some of the differences between the data sources we use in Lumibot. These refer to the data 
+returned in a Bars entity that is returned from calls to get_historical_prices. 
+
+| data_source | type  | OHLCV | split adjusted | dividends | returns | dividend adjusted returns |
+|-------------|-------|-------|----------------|-----------|---------|---------------------------|
+| yahoo       | stock | Yes   | Yes            | Yes       | Yes     | Yes                       |
+| alpaca      | stock | Yes   | Yes            | No        | Yes     | No                        |
+| polygon     | stock | Yes   | Yes            | No        | No      | N/A                       |
+| Tradier     | stock | Yes   | Yes            | No        | No      | N/A                       |
+| Pandas*     | stock | Yes   | Yes            | Yes       | Yes     | Yes                       |
+
+*Pandas is not a data source per se, but it can load csv files in the same format as Yahoo dataframes,
+which can contain dividends.
+
 ## An assortment of git commands our contributors may find useful
 
 Making a new branch and pulling from main:

--- a/README.md
+++ b/README.md
@@ -139,6 +139,40 @@ Here's an example of an actual launch.json file:
 }
 ```
 
+## An assortment of git commands our contributors may find useful
+
+Making a new branch and pulling from main:
+```shell
+git checkout -b my-feature
+git fetch origin
+git merge origin/dev
+```
+Committing work to you feature branch:
+```shell
+git add .
+git commit -m "my changes"
+git push -u origin my-feature
+```
+
+If work on main progressed while you were in another branch, fetch it, then merge it into your branch:
+```shell
+git checkout dev
+git fetch origin
+git merge origin/d
+git checkout my-feature
+git merge origin/dev
+```
+
+When ready to merge the branch into main, go into github, create a pull request, and await review. When your PR is approved it will automatically be merged into the dev branch remotely. Now, you can delete your local branch and the remote branch.
+```shell
+git checkout dev
+git fetch origin
+git merge origin/dev
+git branch -D my-feature
+git push origin --delete my-feature
+```
+
+
 ## Community
 
 If you want to learn more about Lumibot or Algorithmic Trading then you will love out communities! You can join us on Discord.

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ returned in a Bars entity that is returned from calls to get_historical_prices.
 |-------------|-------|-------|----------------|-----------|---------|---------------------------|
 | yahoo       | stock | Yes   | Yes            | Yes       | Yes     | Yes                       |
 | alpaca      | stock | Yes   | Yes            | No        | Yes     | No                        |
-| polygon     | stock | Yes   | Yes            | No        | No      | N/A                       |
-| Tradier     | stock | Yes   | Yes            | No        | No      | N/A                       |
+| polygon     | stock | Yes   | Yes            | No        | Yes     | No                        |
+| Tradier     | stock | Yes   | Yes            | No        | Yes     | No                        |
 | Pandas*     | stock | Yes   | Yes            | Yes       | Yes     | Yes                       |
 
 *Pandas is not a data source per se, but it can load csv files in the same format as Yahoo dataframes,

--- a/lumibot/data_sources/alpaca_data.py
+++ b/lumibot/data_sources/alpaca_data.py
@@ -335,7 +335,6 @@ class AlpacaData(DataSource):
         return response[asset]
 
     def _parse_source_symbol_bars(self, response, asset, quote=None, length=None):
-        # TODO: Alpaca return should also include dividend yield
-        response["return"] = response["close"].pct_change()
+        # TODO: Alpaca return should also include dividends
         bars = Bars(response, self.SOURCE, asset, raw=response, quote=quote)
         return bars

--- a/lumibot/data_sources/ccxt_backtesting_data.py
+++ b/lumibot/data_sources/ccxt_backtesting_data.py
@@ -228,8 +228,6 @@ class CcxtBacktestingData(DataSourceBacktesting):
     def _parse_source_symbol_bars(self, response:DataFrame, asset:tuple[Asset,Asset],
                                   quote:Asset=None, length:int=None)->Bars:
         # Parse the dataframe returned from CCXT.
-        if "return" not in response.columns:
-            response["return"] = response["close"].pct_change()
         bars = Bars(response, self.SOURCE, asset, quote=quote, raw=response)
         return bars
 

--- a/lumibot/data_sources/ccxt_data.py
+++ b/lumibot/data_sources/ccxt_data.py
@@ -206,7 +206,6 @@ class CcxtData(DataSource):
 
     def _parse_source_symbol_bars(self, response, asset, quote=None, length=None):
         # Parse the dataframe returned from CCXT.
-        response["return"] = response["close"].pct_change()
         bars = Bars(response, self.SOURCE, asset, quote=quote, raw=response)
         return bars
 

--- a/lumibot/entities/bars.py
+++ b/lumibot/entities/bars.py
@@ -213,27 +213,11 @@ class Bars:
 
         return df_copy
 
-    def get_momentum(self, start=None, end=None):
-        """Return the momentum (return based on closing prices) of the bars between start and end
-
-        Parameters
-        ----------
-        start : datetime.datetime
-            The start of the range to filter on (inclusive) (default: None)
-
-        end : datetime.datetime
-            The end of the range to filter on (inclusive) (default: None)
-
-        Returns
-        -------
-        float
+    def get_momentum(self, num_periods: int = 1):
         """
-        df_copy = self.filter(start=start, end=end)
-        n_rows = df_copy.shape[0]
-        if n_rows == 0:
-            return 0
-
-        momentum = df_copy["close"].pct_change(n_rows - 1).iloc[-1]
+        Calculate the momentum of the asset over the last num_periods rows.
+        """
+        momentum = self.df["close"].pct_change(num_periods).iloc[-1]
         return momentum
 
     def get_total_volume(self, start=None, end=None):

--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -579,6 +579,8 @@ class Data:
             return None
 
         df = pd.DataFrame(data).assign(datetime=lambda df: pd.to_datetime(df['datetime'])).set_index('datetime')
+        if "dividend" in df.columns:
+            agg_column_map["dividend"] = "sum"
         df_result = df.resample(f"{quantity}{unit}").agg(agg_column_map)
 
         # Drop any rows that have NaN values (this can happen if the data is not complete, eg. weekends)

--- a/lumibot/example_strategies/stock_momentum.py
+++ b/lumibot/example_strategies/stock_momentum.py
@@ -125,16 +125,12 @@ class Momentum(Strategy):
         Gets the momentums (the percentage return) for all the assets we are tracking,
         over the time period set in self.period
         """
-
         momentums = []
-        start_date = self.get_round_day(timeshift=self.period + 1)
-        end_date = self.get_round_day(timeshift=1)
         data = self.get_bars(self.symbols, self.period + 2, timestep="day")
         for asset, bars_set in data.items():
             # Get the return for symbol over self.period days
-            # (from start_date to end_date)
             symbol = asset.symbol
-            symbol_momentum = bars_set.get_momentum(start=start_date, end=end_date)
+            symbol_momentum = bars_set.get_momentum(num_periods=self.period)
             self.log_message(
                 "%s has a return value of %.2f%% over the last %d day(s)."
                 % (symbol, 100 * symbol_momentum, self.period)

--- a/lumibot/tools/pandas.py
+++ b/lumibot/tools/pandas.py
@@ -42,3 +42,18 @@ def fill_void(df_, interval, end):
     df_ = pd.concat([df_, missing_lines])
     df_ = df_.sort_index()
     return df_
+
+
+def print_full_pandas_dataframes():
+    """
+    Show the whole dataframe when printing pandas dataframes
+    """
+    pd.set_option('display.max_columns', None)
+    pd.set_option('display.max_colwidth', None)
+    pd.set_option('display.max_rows', None)
+    pd.set_option('display.width', 1000)
+
+
+def set_pandas_float_precision(precision: int = 5):
+    format_str = '{:.' + str(precision) + 'f}'
+    pd.set_option('display.float_format', format_str.format)

--- a/tests/backtest/test_pandas_backtest.py
+++ b/tests/backtest/test_pandas_backtest.py
@@ -4,7 +4,7 @@ from datetime import datetime as DateTime
 from lumibot.backtesting import PandasDataBacktesting
 from lumibot.example_strategies.lifecycle_logger import LifecycleLogger
 
-from tests.backtest.fixtures import pandas_data_fixture
+from tests.fixtures import pandas_data_fixture
 
 
 logger = logging.getLogger(__name__)

--- a/tests/backtest/test_passing_trader_into_backtest.py
+++ b/tests/backtest/test_passing_trader_into_backtest.py
@@ -6,7 +6,7 @@ from lumibot.traders.debug_log_trader import DebugLogTrader
 from lumibot.backtesting import PandasDataBacktesting
 from lumibot.example_strategies.lifecycle_logger import LifecycleLogger
 
-from tests.backtest.fixtures import pandas_data_fixture
+from tests.fixtures import pandas_data_fixture
 
 logger = logging.getLogger(__name__)
 

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -1,10 +1,12 @@
 import datetime
 import os
 from collections import defaultdict
+
+import numpy as np
 import pandas as pd
 import pytest
-
 import pandas_market_calendars as mcal
+from pandas.testing import assert_frame_equal
 
 
 from tests.fixtures import polygon_data_backtesting
@@ -148,7 +150,9 @@ class PolygonBacktestStrat(Strategy):
         else:
             self.cancel_open_orders()
 
+
 class TestPolygonBacktestFull:
+
     def verify_backtest_results(self, poly_strat_obj):
         assert isinstance(poly_strat_obj, PolygonBacktestStrat)
 
@@ -369,7 +373,8 @@ class TestPolygonDataSource:
                 "high": 494.3778,
                 "low": 490.23,
                 "close": 492.57,
-                "volume": 74655145.0
+                "volume": 74655145.0,
+                "return": np.nan
             },
             {
                 "datetime": "2024-02-06 00:00:00-05:00",
@@ -377,10 +382,11 @@ class TestPolygonDataSource:
                 "high": 494.3200,
                 "low": 492.03,
                 "close": 493.82,
-                "volume": 54775803.0
+                "volume": 54775803.0,
+                "return": 0.0025377103761901054
             },
         ], index="datetime")
         expected_df.index = pd.to_datetime(expected_df.index).tz_convert(tzinfo)
 
         assert prices is not None
-        assert prices.df.equals(expected_df)
+        assert_frame_equal(prices.df, expected_df, check_dtype=False, check_index_type=False)

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -7,7 +7,7 @@ import pytest
 import pandas_market_calendars as mcal
 
 
-from tests.backtest.fixtures import polygon_data_backtesting
+from tests.fixtures import polygon_data_backtesting
 import pytz
 from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting
 from lumibot.entities import Asset
@@ -147,7 +147,6 @@ class PolygonBacktestStrat(Strategy):
         # Not the 1st iteration, cancel orders.
         else:
             self.cancel_open_orders()
-
 
 class TestPolygonBacktestFull:
     def verify_backtest_results(self, poly_strat_obj):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -49,8 +49,8 @@ def pandas_data_fixture() -> Dict[Asset, Data]:
             parse_dates=True,
             index_col=0,
             header=0,
-            usecols=[0, 1, 2, 3, 4, 6],
-            names=["Date", "Open", "High", "Low", "Close", "Volume"],
+            usecols=[0, 1, 2, 3, 4, 6, 7],
+            names=["Date", "Open", "High", "Low", "Close", "Volume", "Dividends"],
         )
         df = df.rename(
             columns={
@@ -60,9 +60,10 @@ def pandas_data_fixture() -> Dict[Asset, Data]:
                 "Low": "low",
                 "Close": "close",
                 "Volume": "volume",
+                "Dividends": "dividend",
             }
         )
-        df = df[["open", "high", "low", "close", "volume"]]
+        df = df[["open", "high", "low", "close", "volume", "dividend"]]
         df.index.name = "datetime"
 
         data = Data(

--- a/tests/test_bars.py
+++ b/tests/test_bars.py
@@ -1,0 +1,244 @@
+import os
+import datetime
+import logging
+from typing import Any
+
+import pytest
+
+import pandas as pd
+import pytz
+from pandas.testing import assert_series_equal
+
+from lumibot.strategies import Strategy
+from lumibot.backtesting import PandasDataBacktesting, YahooDataBacktesting, PolygonDataBacktesting
+from lumibot.data_sources import AlpacaData, TradierData, YahooData, PandasData
+from tests.fixtures import pandas_data_fixture
+from lumibot.tools.pandas import print_full_pandas_dataframes, set_pandas_float_precision
+from lumibot.traders import Trader
+from lumibot.brokers import Alpaca
+from lumibot.entities import Asset
+
+# Global parameters
+# API Key for testing Polygon.io
+from lumibot.credentials import POLYGON_API_KEY
+from lumibot.credentials import TRADIER_CONFIG, ALPACA_CONFIG
+
+
+logger = logging.getLogger(__name__)
+print_full_pandas_dataframes()
+set_pandas_float_precision(precision=15)
+
+
+# class BarsTester(Strategy):
+#     """This strategy saves the return values each trading iteration, so we can compare them later."""
+#     symbol: str = ""
+#     actual_df: pd.DataFrame = None
+#     timestep: str = ""
+#
+#     parameters = {
+#         "market": "NYSE",
+#         "sleeptime": "1D",
+#         "symbol": "SPY",
+#         "timestep": "day",
+#     }
+#
+#     def initialize(self, parameters: Any = None) -> None:
+#         self.set_market(self.parameters["market"])
+#         self.sleeptime = self.parameters["sleeptime"]
+#         self.symbol = self.parameters["symbol"]
+#         self.timestep = self.parameters["timestep"]
+#
+#         # build a dataframe where the index is a Date and the columns are the actual returns
+#         self.actual_df = pd.DataFrame(columns=["actual_return"])
+#
+#     def on_trading_iteration(self):
+#         bars = self.get_historical_prices(self.symbol, 1, timestep=self.timestep)
+#         dt = bars.df.index[-1]
+#         actual_return = bars.df["return"].iloc[-1]
+#         self.actual_df.loc[dt.date()] = {
+#             "actual_return": actual_return,
+#         }
+
+
+class TestBarsContainReturns:
+    """These tests check that the bars from get_historical_prices contain returns for the different data sources."""
+
+    expected_df = None
+    backtesting_start = datetime.datetime(2019, 3, 1)
+    backtesting_end = datetime.datetime(2019, 3, 31)
+
+    @classmethod
+    def setup_class(cls):
+        # We load the SPY data directly and calculate the adjusted returns.
+        file_path = os.getcwd() + "/data/SPY.csv"
+        df = pd.read_csv(file_path)
+        df.rename(columns={"Date": "date"}, inplace=True)
+        df['date'] = pd.to_datetime(df['date'])
+        df.set_index('date', inplace=True)
+        df['expected_return'] = df['Adj Close'].pct_change()
+        cls.expected_df = df
+    #
+    # def build_comparison_df(self, strat_obj) -> pd.DataFrame:
+    #     # This helper function just gets the actual_returns from the strategy and the expected_returns from the test
+    #     # and puts them side by side for comparison.
+    #     actual_df = strat_obj.actual_df
+    #
+    #     # make a new dataframe with the actual and expected values side by side using the actual_df index
+    #     comparison_df = pd.concat(
+    #         [actual_df["actual_return"],
+    #          self.expected_df["expected_return"]],
+    #         axis=1).reindex(actual_df.index)
+    #     return comparison_df
+
+    @pytest.mark.skipif(not ALPACA_CONFIG['API_KEY'], reason="This test requires an alpaca API key")
+    @pytest.mark.skipif(ALPACA_CONFIG['API_KEY'] == '<your key here>', reason="This test requires an alpaca API key")
+    def test_alpaca_data_source_generates_simple_returns(self):
+        """
+        This tests that the alpaca data_source calculates SIMPLE returns for bars. Since we don't get dividends with
+        alpaca, we are not going to check if the returns are adjusted correctly.
+        """
+        data_source = AlpacaData(ALPACA_CONFIG)
+        prices = data_source.get_historical_prices("SPY", 2, "day")
+
+        # assert that the last row has a return value
+        assert prices.df["return"].iloc[-1] is not None
+
+        # check that there is no dividend column... This test will fail when dividends are added. We hope that's soon.
+        assert "dividend" not in prices.df.columns
+
+    def test_yahoo_data_source_generates_adjusted_returns(self):
+        """
+        This tests that the yahoo data_source calculates adjusted returns for bars and that they
+        are calculated correctly.
+        """
+        start = self.backtesting_start + datetime.timedelta(days=25)
+        end = self.backtesting_end + datetime.timedelta(days=25)
+        data_source = YahooData(datetime_start=start, datetime_end=end)
+        prices = data_source.get_historical_prices("SPY", 25, "day")
+
+        # assert that the last row has a return value
+        assert prices.df["return"].iloc[-1] is not None
+
+        # check that there is a dividend column.
+        assert "dividend" in prices.df.columns
+
+        # assert that there was a dividend paid on 3/15
+        assert prices.df["dividend"].loc["2019-03-15"] != 0.0
+
+        # make a new dataframe where the index is Date and the columns are the actual returns
+        actual_df = pd.DataFrame(columns=["actual_return"])
+        for dt, row in prices.df.iterrows():
+            actual_return = row["return"]
+            actual_df.loc[dt.date()] = {
+                "actual_return": actual_return,
+            }
+
+        comparison_df = pd.concat(
+            [actual_df["actual_return"],
+             self.expected_df["expected_return"]],
+            axis=1).reindex(actual_df.index)
+
+        # print(f"\n{comparison_df}")
+
+        # check that the returns are adjusted correctly
+        assert_series_equal(
+            comparison_df["actual_return"],
+            comparison_df["expected_return"],
+            check_names=False,
+            check_index=True,
+            atol=1e-4,
+            rtol=0
+        )
+
+    @pytest.mark.skip(reason="Pandas bars don't have returns.... yet")
+    def test_pandas_data_source_generates_adjusted_returns(self, pandas_data_fixture):
+        """
+        This tests that the pandas data_source calculates adjusted returns for bars and that they
+        are calculated correctly. It assumes that it is provided split adjusted OHLCV and dividend data.
+        """
+        start = self.backtesting_start + datetime.timedelta(days=25)
+        end = self.backtesting_end + datetime.timedelta(days=25)
+        data_source = PandasData(
+            datetime_start=start,
+            datetime_end=end,
+            pandas_data=pandas_data_fixture
+        )
+        prices = data_source.get_historical_prices("SPY", 25, "day")
+        # print(f"\n{prices.df}")
+        return
+
+        # assert that the last row has a return value
+        assert prices.df["return"].iloc[-1] is not None
+
+        # check that there is a dividend column.
+        assert "dividend" in prices.df.columns
+
+        # assert that there was a dividend paid on 3/15
+        assert prices.df["dividend"].loc["2019-03-15"] != 0.0
+
+        # make a new dataframe where the index is Date and the columns are the actual returns
+        actual_df = pd.DataFrame(columns=["actual_return"])
+        for dt, row in prices.df.iterrows():
+            actual_return = row["return"]
+            actual_df.loc[dt.date()] = {
+                "actual_return": actual_return,
+            }
+
+        comparison_df = pd.concat(
+            [actual_df["actual_return"],
+             self.expected_df["expected_return"]],
+            axis=1).reindex(actual_df.index)
+
+        # print(f"\n{comparison_df}")
+
+        # check that the returns are adjusted correctly
+        assert_series_equal(
+            comparison_df["actual_return"],
+            comparison_df["expected_return"],
+            check_names=False,
+            check_index=True,
+            atol=1e-4,
+            rtol=0
+        )
+
+    @pytest.mark.skip(reason="Polygon bars don't have returns.... yet")
+    @pytest.mark.skipif(POLYGON_API_KEY == '<your key here>', reason="This test requires a Polygon.io API key")
+    def test_polygon_data_source_generates_simple_returns(self):
+        """
+        This tests that the po broker calculates SIMPLE returns for bars. Since we don't get dividends with
+        alpaca, we are not going to check if the returns are adjusted correctly.
+        """
+        # get data from  3 months ago, so we can use the free Polygon.io data
+        start = datetime.datetime.now() - datetime.timedelta(days=90)
+        end = datetime.datetime.now() - datetime.timedelta(days=60)
+        tzinfo = pytz.timezone("America/New_York")
+        start = start.astimezone(tzinfo)
+        end = end.astimezone(tzinfo)
+
+        data_source = PolygonDataBacktesting(
+            start, end, api_key=POLYGON_API_KEY
+        )
+        prices = data_source.get_historical_prices("SPY", 2, "day")
+        # print(f"\n{prices.df}")
+        # print(f"\n{prices.df[['close', 'return']]}")
+        # assert that the last row has a return value
+        assert prices.df["return"].iloc[-1] is not None
+
+    @pytest.mark.skip(reason="Tradier bars don't have returns.... yet")
+    @pytest.mark.skipif(not TRADIER_CONFIG['ACCESS_TOKEN'], reason="No Tradier credentials provided.")
+    def test_tradier_data_source_generates_simple_returns(self):
+        """
+        This tests that the po broker calculates SIMPLE returns for bars. Since we don't get dividends with
+        tradier, we are not going to check if the returns are adjusted correctly.
+        """
+        data_source = TradierData(
+                account_number=TRADIER_CONFIG["ACCOUNT_NUMBER"],
+                access_token=TRADIER_CONFIG["ACCESS_TOKEN"],
+                paper=TRADIER_CONFIG["PAPER"],
+        )
+        spy_asset = Asset("SPY")
+        prices = data_source.get_historical_prices(spy_asset, 2, "day")
+        # print(f"\n{prices.df}")
+        # print(f"\n{prices.df[['close', 'return']]}")
+        # assert that the last row has a return value
+        # assert prices.df["return"].iloc[-1] is not None

--- a/tests/test_momentum.py
+++ b/tests/test_momentum.py
@@ -1,0 +1,130 @@
+import os
+import datetime
+import logging
+import pytest
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+import numpy as np
+
+from lumibot.strategies import Strategy
+from lumibot.backtesting import PandasDataBacktesting
+from tests.backtest.fixtures import pandas_data_fixture
+
+logger = logging.getLogger(__name__)
+
+
+class MomoTester(Strategy):
+
+    parameters = {
+        "lookback_period": 2,
+    }
+
+    def initialize(self):
+        self.set_market("NYSE")
+        self.sleeptime = "1D"
+        self.symbol = "SPY"
+        self.lookback_period = self.parameters["lookback_period"]
+
+        # build a dataframe to store the datetime, closing price, and momentum
+        self.momo_df = pd.DataFrame(columns=["dt", "start_close", "end_close", "lumi_momo", "my_momo"])
+
+    def on_trading_iteration(self):
+        dt, start_close, end_close, lumi_momo, my_momo = self.get_momentum(self.symbol, self.lookback_period)
+        self.momo_df.loc[len(self.momo_df)] = {"dt": dt, "start_close": start_close, "end_close": end_close,
+                                               "lumi_momo": lumi_momo, "my_momo": my_momo}
+
+    def get_momentum(self, symbol, lookback_period):
+        start_date = self.get_round_day(timeshift=lookback_period + 1)
+        end_date = self.get_round_day(timeshift=1)
+        bars = self.get_historical_prices(symbol, lookback_period + 2, timestep="day")
+        dt = self.get_datetime()
+        start_close = bars.df["close"].iloc[-lookback_period - 1]
+        end_close = bars.df["close"].iloc[-1]
+        lumi_momo = bars.get_momentum(start=start_date, end=end_date)
+        my_momo = (end_close - start_close) / start_close
+        return dt, start_close, end_close, lumi_momo, my_momo
+
+
+class TestMomentum:
+    backtesting_start = datetime.datetime(2019, 3, 1)
+    backtesting_end = datetime.datetime(2019, 3, 31)
+
+    def test_momo_tester_strategy_lookback_2(self, pandas_data_fixture):
+        parameters = {
+            "lookback_period": 2,
+        }
+
+        results, strat_obj = MomoTester.run_backtest(
+            datasource_class=PandasDataBacktesting,
+            backtesting_start=self.backtesting_start,
+            backtesting_end=self.backtesting_end,
+            pandas_data=list(pandas_data_fixture.values()),
+            parameters=parameters,
+            show_plot=False,
+            show_tearsheet=False,
+            save_tearsheet=False,
+            show_indicators=False,
+            save_logfile=False,
+            show_progress_bar=False,
+        )
+
+        # convert the momo_tracker dictionary to a DataFrame
+        momo_df = strat_obj.momo_df
+        # use date as the index
+        momo_df.set_index("dt", inplace=True)
+
+        logger.info(f"\n{momo_df}")
+
+    def test_momo_tester_strategy_lookback_3(self, pandas_data_fixture):
+        parameters = {
+            "lookback_period": 3,
+        }
+
+        results, strat_obj = MomoTester.run_backtest(
+            datasource_class=PandasDataBacktesting,
+            backtesting_start=self.backtesting_start,
+            backtesting_end=self.backtesting_end,
+            pandas_data=list(pandas_data_fixture.values()),
+            parameters=parameters,
+            show_plot=False,
+            show_tearsheet=False,
+            save_tearsheet=False,
+            show_indicators=False,
+            save_logfile=False,
+            show_progress_bar=False,
+        )
+
+        # convert the momo_tracker dictionary to a DataFrame
+        momo_df = strat_obj.momo_df
+        # use date as the index
+        momo_df.set_index("dt", inplace=True)
+
+        logger.info(f"\n{momo_df}")
+
+    @pytest.mark.skip()
+    def test_momentum_using_adjusted_close_diff_from_unadjusted_momentum(self):
+        file_path = os.getcwd() + "/data/SPY.csv"
+        df = pd.read_csv(file_path, parse_dates=True, index_col=0)
+        lookback_period = 2
+
+        df["adj_momentum"] = df["Adj Close"].pct_change(lookback_period).shift(1)
+        df["momentum"] = df["Close"].pct_change(lookback_period).shift(1)
+
+        # Use March 2019 because there is a dividend on March 15th
+        # momo_df = df.loc["2019-03-02":"2019-03-31", ["adj_momentum",  "unadj_momentum"]]
+        momo_df = df.loc[self.backtesting_start:self.backtesting_end, ["Close", "momentum", "Adj Close", "adj_momentum", ]]
+        # momo_df['diff'] = momo_df['adj_momentum'] - momo_df['unadj_momentum']
+
+        # show diff as zeros not in scientific notation
+        pd.options.display.float_format = '{:.9f}'.format
+        logger.error(f"\n{momo_df}")
+
+        # # get a series for the values of the diff column before the dividend date
+        # assert momo_df.loc["2019-03-02":"2019-03-14"]["diff"].abs().max() < 1e-5
+        #
+        # # assert that the diff increases on the dividend date
+        # assert momo_df.loc["2019-03-15"]["diff"] > 0
+        #
+        # # assert that the diff remains increased after the dividend date
+        # assert momo_df.loc["2019-03-16":]["diff"].abs().min() > 1e-5

--- a/tests/test_momentum.py
+++ b/tests/test_momentum.py
@@ -1,62 +1,99 @@
 import os
 import datetime
 import logging
+from typing import Any
+
 import pytest
 
 import pandas as pd
 from pandas.testing import assert_series_equal
 
 from lumibot.strategies import Strategy
-from lumibot.backtesting import PandasDataBacktesting
-from tests.backtest.fixtures import pandas_data_fixture
+from lumibot.backtesting import PandasDataBacktesting, YahooDataBacktesting, PolygonDataBacktesting
+from tests.fixtures import pandas_data_fixture
 from lumibot.tools.pandas import print_full_pandas_dataframes, set_pandas_float_precision
+
+# Global parameters
+# API Key for testing Polygon.io
+from lumibot.credentials import POLYGON_CONFIG
+
 
 logger = logging.getLogger(__name__)
 print_full_pandas_dataframes()
-set_pandas_float_precision(precision=5)
+set_pandas_float_precision(precision=15)
 
 
 class MomoTester(Strategy):
+    """This strategy saves the momentum values calculated each trading iteration, so we can compare them later."""
+    symbol: str = ""
+    lookback_period: int = 0
+    actual_df: pd.DataFrame = None
 
     parameters = {
         "lookback_period": 2,
     }
 
-    def initialize(self):
+    def initialize(self, parameters: Any = None) -> None:
         self.set_market("NYSE")
         self.sleeptime = "1D"
         self.symbol = "SPY"
         self.lookback_period = self.parameters["lookback_period"]
 
-        # build a dataframe to store the datetime, closing price, and momentum
-        self.momo_df = pd.DataFrame(columns=["dt", "start_close", "end_close", "actual_momo", "expected_momo"])
+        # build a dataframe to store the date, closing price, and momentum
+        self.actual_df = pd.DataFrame(columns=["date", "actual_momo"])
 
     def on_trading_iteration(self):
-        dt, start_close, end_close, actual_momo, expected_momo = self.get_momentum(self.symbol, self.lookback_period)
-        self.momo_df.loc[len(self.momo_df)] = {
-            "dt": dt, 
-            "start_close": start_close, 
-            "end_close": end_close,
-            "actual_momo": actual_momo, 
-            "expected_momo": expected_momo
+        dt, actual_momo = self.get_momentum(self.symbol, self.lookback_period)
+        self.actual_df.loc[len(self.actual_df)] = {
+            "date": dt.date(),
+            "actual_momo": actual_momo,
         }
 
     def get_momentum(self, symbol, lookback_period):
         bars = self.get_historical_prices(symbol, lookback_period + 2, timestep="day")
-        dt = self.get_datetime()
-        start_close = bars.df["close"].iloc[-lookback_period - 1]
-        end_close = bars.df["close"].iloc[-1]
+        dt = bars.df.index[-1]
         actual_momo = bars.get_momentum(lookback_period)
-        expected_momo = (end_close - start_close) / start_close
-        return dt, start_close, end_close, actual_momo, expected_momo
+        return dt, actual_momo
 
 
 class TestMomentum:
+    df = None
     backtesting_start = datetime.datetime(2019, 3, 1)
     backtesting_end = datetime.datetime(2019, 3, 31)
 
-    # @pytest.mark.skip()
-    def test_momo_tester_strategy_lookback_2(self, pandas_data_fixture):
+    @classmethod
+    def setup_class(cls):
+        # We load the SPY data directly and calculate the adjusted returns.
+        file_path = os.getcwd() + "/data/SPY.csv"
+        df = pd.read_csv(file_path)
+        df.rename(columns={"Date": "date"}, inplace=True)
+        df['date'] = pd.to_datetime(df['date'])
+        df.set_index('date', inplace=True)
+        df['adj_returns'] = df['Adj Close'].pct_change()
+        cls.df = df
+
+    # noinspection PyMethodMayBeStatic
+    def calculate_expected_momo(self, df_orig, lookback_period) -> pd.DataFrame:
+        # Given a dataframe with adjusted close prices, calculate the expected momentum values just like we do
+        # in bars.get_momentum. But here were using the Adjusted Close from yahoo. And in bars.get_momentum,
+        # we calculated the adjusted returns by using unadjusted close prices and dividends.
+        df = df_orig.copy()
+        df['expected_momo'] = df['Adj Close'].pct_change(lookback_period)
+        return df
+
+    def build_comparison_df(self, strat_obj) -> pd.DataFrame:
+        # This helper function just gets the dataframe of actual momentum values from the strategy object
+        # and the dataframe of expected momentum values calculated from the adjusted close prices,
+        # and puts them side by side for comparison.
+        actual_df = strat_obj.actual_df
+        actual_df.set_index("date", inplace=True)
+        expected_df = self.calculate_expected_momo(self.df, strat_obj.lookback_period)
+
+        # make a new dataframe with the actual and expected momentum values side by side but for the dates in the actual_df
+        comparison_df = pd.concat([actual_df["actual_momo"], expected_df["expected_momo"]], axis=1).reindex(actual_df.index)
+        return comparison_df
+
+    def test_momo_pandas_lookback_2(self, pandas_data_fixture):
         parameters = {
             "lookback_period": 2,
         }
@@ -74,21 +111,20 @@ class TestMomentum:
             save_logfile=False,
             show_progress_bar=False,
         )
+        comparison_df = self.build_comparison_df(strat_obj)
+        # print(f"\n{comparison_df}")
 
-        momo_df = strat_obj.momo_df
-        # print(f"\n{momo_df}")
         assert_series_equal(
-            momo_df["actual_momo"],
-            momo_df["expected_momo"],
+            comparison_df["actual_momo"],
+            comparison_df["expected_momo"],
             check_names=False,
-            atol=1e-10,
+            atol=1e-3,
             rtol=0
         )
 
-    # @pytest.mark.skip()
-    def test_momo_tester_strategy_lookback_3(self, pandas_data_fixture):
+    def test_momo_pandas_lookback_30(self, pandas_data_fixture):
         parameters = {
-            "lookback_period": 3,
+            "lookback_period": 30,
         }
 
         results, strat_obj = MomoTester.run_backtest(
@@ -104,28 +140,26 @@ class TestMomentum:
             save_logfile=False,
             show_progress_bar=False,
         )
+        comparison_df = self.build_comparison_df(strat_obj)
+        # print(f"\n{comparison_df}")
 
-        momo_df = strat_obj.momo_df
-        # print(f"\n{momo_df}")
         assert_series_equal(
-            momo_df["actual_momo"],
-            momo_df["expected_momo"],
+            comparison_df["actual_momo"],
+            comparison_df["expected_momo"],
             check_names=False,
-            atol=1e-10,
+            atol=1e-3,
             rtol=0
         )
 
-    # @pytest.mark.skip()
-    def test_momo_tester_strategy_lookback_20(self, pandas_data_fixture):
+    def test_momo_yahoo_lookback_2(self, pandas_data_fixture):
         parameters = {
-            "lookback_period": 20,
+            "lookback_period": 2,
         }
 
         results, strat_obj = MomoTester.run_backtest(
-            datasource_class=PandasDataBacktesting,
+            datasource_class=YahooDataBacktesting,
             backtesting_start=self.backtesting_start,
             backtesting_end=self.backtesting_end,
-            pandas_data=list(pandas_data_fixture.values()),
             parameters=parameters,
             show_plot=False,
             show_tearsheet=False,
@@ -134,35 +168,41 @@ class TestMomentum:
             save_logfile=False,
             show_progress_bar=False,
         )
+        comparison_df = self.build_comparison_df(strat_obj)
+        # print(f"\n{comparison_df}")
 
-        momo_df = strat_obj.momo_df
-        # print(f"\n{momo_df}")
         assert_series_equal(
-            momo_df["actual_momo"],
-            momo_df["expected_momo"],
+            comparison_df["actual_momo"],
+            comparison_df["expected_momo"],
             check_names=False,
-            atol=1e-10,
+            atol=1e-3,
             rtol=0
         )
 
-    def test_calculate_adjusted_returns_from_close_and_dividends(self):
-        file_path = os.getcwd() + "/data/SPY.csv"
-        df = pd.read_csv(file_path, parse_dates=True, index_col=0)
-        df = df.sort_index(ascending=True)
+    def test_momo_yahoo_lookback_30(self, pandas_data_fixture):
+        parameters = {
+            "lookback_period": 30,
+        }
 
-        # Adjusted returns  = (current close - previous close + dividends) / previous close
-        df['my_adj_returns'] = (df['Close'] - df['Close'].shift(1) + df['Dividends']) / df['Close'].shift(1)
-
-        # For comparison, calculate the adjusted returns using the Adj Close column
-        df['adj_returns'] = df['Adj Close'].pct_change()
-
-        # cols_to_print = ['Close', 'Adj Close', 'Dividends', 'adj_returns', 'my_adj_returns']
-        cols_to_print = ['Dividends', 'adj_returns', 'my_adj_returns']
-        # print(f"\n{df[-15:][cols_to_print]}")
+        results, strat_obj = MomoTester.run_backtest(
+            datasource_class=YahooDataBacktesting,
+            backtesting_start=self.backtesting_start,
+            backtesting_end=self.backtesting_end,
+            parameters=parameters,
+            show_plot=False,
+            show_tearsheet=False,
+            save_tearsheet=False,
+            show_indicators=False,
+            save_logfile=False,
+            show_progress_bar=False,
+        )
+        comparison_df = self.build_comparison_df(strat_obj)
+        # print(f"\n{comparison_df}")
 
         assert_series_equal(
-            df["adj_returns"],
-            df["my_adj_returns"],
+            comparison_df["actual_momo"],
+            comparison_df["expected_momo"],
             check_names=False,
-            atol=1e-4,
+            atol=1e-2,
+            rtol=0
         )

--- a/tests/test_momentum.py
+++ b/tests/test_momentum.py
@@ -118,7 +118,7 @@ class TestMomentum:
             comparison_df["actual_momo"],
             comparison_df["expected_momo"],
             check_names=False,
-            atol=1e-3,
+            atol=1e-4,
             rtol=0
         )
 
@@ -147,7 +147,7 @@ class TestMomentum:
             comparison_df["actual_momo"],
             comparison_df["expected_momo"],
             check_names=False,
-            atol=1e-3,
+            atol=1e-4,
             rtol=0
         )
 
@@ -175,7 +175,7 @@ class TestMomentum:
             comparison_df["actual_momo"],
             comparison_df["expected_momo"],
             check_names=False,
-            atol=1e-3,
+            atol=1e-4,
             rtol=0
         )
 
@@ -203,6 +203,6 @@ class TestMomentum:
             comparison_df["actual_momo"],
             comparison_df["expected_momo"],
             check_names=False,
-            atol=1e-2,
+            atol=1e-4,
             rtol=0
         )

--- a/tests/test_pandas_data.py
+++ b/tests/test_pandas_data.py
@@ -1,0 +1,20 @@
+from tests.fixtures import pandas_data_fixture
+
+
+class TestPandasData:
+
+    def test_pandas_data_fixture(self, pandas_data_fixture):
+        assert pandas_data_fixture is not None
+
+    def test_spy_has_dividends(self, pandas_data_fixture):
+        spy = list(pandas_data_fixture.values())[0]
+        expected_columns = [
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "dividend",
+        ]
+        assert spy.df.columns.tolist() == expected_columns
+


### PR DESCRIPTION
Not all Bars had return columns. And only the yahoo Bars had returns that were dividend adjusted. Now all Bars have return a column. And when dividends are available, the returns will be dividend adjusted. 

Also, the get_momentum function now uses a lookback period instead of a start and end calendar date.This is more what people should expect (a 50 period lookback is 50 bars... not 50 calendar days).

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Standardize the return calculation across all data sources in the Bars entity by adding a 'return' column, and modify the `get_momentum` method in Bars to utilize a lookback period instead of specific start and end dates.

### Why are these changes being made?

The unified 'return' calculation simplifies handling various data sources, especially those with dividend adjustments, ensuring consistent return calculations across different data inputs. The switch to using a lookback period for momentum calculation enhances flexibility and aligns with the prevalent strategy backtesting models, which typically require specifying the number of periods rather than exact date ranges. This change improves code readability and reduces potential errors in date management.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->