### PR TITLE
logging: Fixed broken backtest and quite_logs options so that backtes…

### DIFF
--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -98,7 +98,7 @@ class BacktestingBroker(Broker):
         self.data_source._update_datetime(new_datetime, cash=cash, portfolio_value=portfolio_value)
         if self.option_source:
             self.option_source._update_datetime(new_datetime, cash=cash, portfolio_value=portfolio_value)
-        logger.debug(f"Current backtesting datetime {self.datetime}")
+        logger.info(f"Current backtesting datetime {self.datetime}")
 
     # =========Clock functions=====================
 

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -884,7 +884,7 @@ class _Strategy:
         save_logfile=False,
         use_quote_data=False,
         show_progress_bar=True,
-        quiet_logs=True,
+        quiet_logs=False,
         trader_class=Trader,
         **kwargs,
     ):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -13,52 +13,6 @@ class TestLogging:
         logger.info("This is an info message")
         assert "This is an info message" in caplog.text
 
-    def test_backtest_produces_no_logs_by_default(self, caplog):
-        caplog.set_level(logging.INFO)
-        backtesting_start = datetime.datetime(2023, 1, 2)
-        backtesting_end = datetime.datetime(2023, 1, 4)
-
-        LifecycleLogger.backtest(
-            YahooDataBacktesting,
-            backtesting_start,
-            backtesting_end,
-            parameters={"sleeptime": "1D", "market": "NYSE"},
-            show_plot=False,
-            save_tearsheet=False,
-            show_tearsheet=False,
-            show_indicators=False,
-            save_logfile=False,
-        )
-        # count that this contains 3 new lines. Its an easy proxy for the number of log messages and avoids
-        # the issue where the datetime is always gonna be different.
-        assert caplog.text.count("\n") == 3
-        assert "Starting backtest...\n" in caplog.text
-        assert "Backtesting starting...\n" in caplog.text
-        assert "Backtesting finished\n" in caplog.text
-
-    def test_run_backtest_produces_no_logs_by_default(self, caplog):
-        caplog.set_level(logging.INFO)
-        backtesting_start = datetime.datetime(2023, 1, 2)
-        backtesting_end = datetime.datetime(2023, 1, 4)
-
-        LifecycleLogger.run_backtest(
-            YahooDataBacktesting,
-            backtesting_start,
-            backtesting_end,
-            parameters={"sleeptime": "1D", "market": "NYSE"},
-            show_plot=False,
-            save_tearsheet=False,
-            show_tearsheet=False,
-            show_indicators=False,
-            save_logfile=False,
-        )
-        # count that this contains 3 new lines. Its an easy proxy for the number of log messages and avoids
-        # the issue where the datetime is always gonna be different.
-        assert caplog.text.count("\n") == 3
-        assert "Starting backtest...\n" in caplog.text
-        assert "Backtesting starting...\n" in caplog.text
-        assert "Backtesting finished\n" in caplog.text
-
     def test_backtest_produces_no_logs_when_quiet_logs_is_true(self, caplog):
         caplog.set_level(logging.INFO)
         backtesting_start = datetime.datetime(2023, 1, 2)
@@ -79,10 +33,11 @@ class TestLogging:
         )
         # count that this contains 3 new lines. Its an easy proxy for the number of log messages and avoids
         # the issue where the datetime is always gonna be different.
-        assert caplog.text.count("\n") == 3
+        assert caplog.text.count("\n") == 4
         assert "Starting backtest...\n" in caplog.text
         assert "Backtesting starting...\n" in caplog.text
         assert "Backtesting finished\n" in caplog.text
+        assert "Backtest took " in caplog.text
 
     def test_backtest_produces_logs_when_quiet_logs_is_false(self, caplog):
         caplog.set_level(logging.INFO)
@@ -103,7 +58,7 @@ class TestLogging:
             quiet_logs=False,
         )
 
-        assert caplog.text.count("\n") == 9
+        assert caplog.text.count("\n") >= 9
         assert "Starting backtest...\n" in caplog.text
         assert "Backtesting starting...\n" in caplog.text
         assert "before_market_opens called\n" in caplog.text


### PR DESCRIPTION
…ting runs will both produce sane results again and stop swamping the console. Additionally reduced log signature length in normal runs. Full signature can be restored by setting the debug flag in Trader().

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the functionality of the `backtest` and `quiet_logs` options by adjusting the logging levels and corresponding behavior in various parts of the codebase, including updating test assertions.

### Why are these changes being made?

The current implementation was not correctly setting logging levels during backtesting sessions, leading to issues with the intended suppression of logs. By correcting the default for `quiet_logs` and ensuring clear separation between debugging, standard, and error logging, it improves both development and operational clarity when running backtests. The test updates ensure that these corrective logging behaviors are accurately verified.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->