### PR TITLE
conform orders during submit_order

### DIFF
--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -386,6 +386,8 @@ class BacktestingBroker(Broker):
 
     def submit_order(self, order):
         """Submit an order for an asset"""
+        self._conform_order(order)
+
         # NOTE: This code is to address Tradier API requirements, they want is as "to_open" or "to_close" instead of just "buy" or "sell"
         # If the order has a "buy_to_open" or "buy_to_close" side, then we should change it to "buy"
         if order.is_buy_order():

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -475,10 +475,18 @@ class Alpaca(Broker):
             """
             The minimum price variance exists for limit orders.
             Orders received in excess of the minimum price variance will be rejected.
-            Limit price >=$1.00: Max Decimals= 2
+            Limit price >=$1.00: Max Decimals = 2
             Limit price <$1.00: Max Decimals = 4
             """
-            order.limit_price = round(order.limit_price, 2) if order.limit_price >= 1.0 else round(order.limit_price, 4)
+            orig_price = order.limit_price
+            if order.limit_price >= 1.0:
+                order.limit_price = round(order.limit_price, 2)
+            else:
+                order.limit_price = round(order.limit_price, 4)
+            logging.warning(
+                f"Order {order} was changed to conform to Alpaca's requirements. "
+                f"The limit price was changed from {orig_price} to {order.limit_price}."
+            )
 
     def cancel_order(self, order):
         """Cancel an order

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -467,6 +467,19 @@ class Alpaca(Broker):
 
         return order
 
+    def _conform_order(self, order):
+        """Conform an order to Alpaca's requirements
+        See: https://docs.alpaca.markets/docs/orders-at-alpaca
+        """
+        if order.asset.asset_type == "stock" and order.type == "limit":
+            """
+            The minimum price variance exists for limit orders.
+            Orders received in excess of the minimum price variance will be rejected.
+            Limit price >=$1.00: Max Decimals= 2
+            Limit price <$1.00: Max Decimals = 4
+            """
+            order.limit_price = round(order.limit_price, 2) if order.limit_price >= 1.0 else round(order.limit_price, 4)
+
     def cancel_order(self, order):
         """Cancel an order
 

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -958,8 +958,13 @@ class Broker(ABC):
         return result
 
     def submit_order(self, order):
-        """Submit an order for an asset"""
+        """Conform an order for an asset to broker constraints and submit it."""
+        self._conform_order(order)
         self._submit_order(order)
+
+    def _conform_order(self, order):
+        """Conform an order to broker constraints. Derived brokers should implement this method."""
+        pass
 
     def submit_orders(self, orders, **kwargs):
         """Submit orders"""

--- a/lumibot/tools/helpers.py
+++ b/lumibot/tools/helpers.py
@@ -239,3 +239,18 @@ def parse_timestep_qty_and_unit(timestep):
         unit = m.group(2).rstrip("s")  # remove trailing 's' if any
 
     return quantity, unit
+
+
+def has_more_than_n_decimal_places(number: float, n: int) -> bool:
+    """Return True if the number has more than n decimal places, False otherwise."""
+
+    # Convert the number to a string
+    number_str = str(number)
+
+    # Split the string at the decimal point
+    if '.' in number_str:
+        decimal_part = number_str.split('.')[1]
+        # Check if the length of the decimal part is greater than n
+        return len(decimal_part) > n
+    else:
+        return False

--- a/tests/backtest/test_brokers.py
+++ b/tests/backtest/test_brokers.py
@@ -1,5 +1,0 @@
-
-class TestBroker:
-
-    def test_submit_order_calls_conform_order(self):
-        pass

--- a/tests/backtest/test_brokers.py
+++ b/tests/backtest/test_brokers.py
@@ -1,0 +1,5 @@
+
+class TestBroker:
+
+    def test_submit_order_calls_conform_order(self):
+        pass

--- a/tests/test_backtesting_broker.py
+++ b/tests/test_backtesting_broker.py
@@ -1,7 +1,9 @@
 import datetime
+from unittest.mock import MagicMock
 
 from lumibot.backtesting import BacktestingBroker
 from lumibot.data_sources import PandasData
+from lumibot.entities import Asset, Order
 
 
 class TestBacktestingBroker:
@@ -56,3 +58,15 @@ class TestBacktestingBroker:
         # Stop not triggered
         stop_price = 80
         assert not broker.stop_order(stop_price, 'sell', open_=100, high=110, low=90)
+
+    def test_submit_order_calls_conform_order(self):
+        start = datetime.datetime(2023, 8, 1)
+        end = datetime.datetime(2023, 8, 2)
+        data_source = PandasData(datetime_start=start, datetime_end=end, pandas_data={})
+        broker = BacktestingBroker(data_source=data_source)
+
+        # mock _conform_order method
+        broker._conform_order = MagicMock()
+        Order(asset=Asset("SPY"), quantity=10, side="buy", strategy='abc')
+        broker.submit_order(Order(asset=Asset("SPY"), quantity=10, side="buy", strategy='abc'))
+        broker._conform_order.assert_called_once()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,17 @@
+from lumibot.tools.helpers import has_more_than_n_decimal_places
+
+
+def test_has_more_than_n_decimal_places():
+    assert has_more_than_n_decimal_places(1.2, 0) == True
+    assert has_more_than_n_decimal_places(1.2, 1) == False
+    assert has_more_than_n_decimal_places(1.22, 0) == True
+    assert has_more_than_n_decimal_places(1.22, 1) == True
+    assert has_more_than_n_decimal_places(1.22, 5) == False
+
+    assert has_more_than_n_decimal_places(1.2345, 0) == True
+    assert has_more_than_n_decimal_places(1.2345, 1) == True
+    assert has_more_than_n_decimal_places(1.2345, 3) == True
+    assert has_more_than_n_decimal_places(1.2345, 4) == False
+    assert has_more_than_n_decimal_places(1.2345, 5) == False
+
+


### PR DESCRIPTION
This adds a new virtual method to the base broker. the _conform_order method is called during the broker.submit_order call and can be derived by brokers to adjust orders to broker requirements.

The Alpaca broker _conform_order method was implemented to adjust limit order prices.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add an order conformance step to the `submit_order` process across brokers to ensure compliance with specific broker constraints before submission.

### Why are these changes being made?

This change standardizes the order submission process by introducing an `_conform_order` method that ensures orders adhere to specific requirements, such as the price variance limit for limit orders in Alpaca. This improvement increases the reliability of the order processing pipeline across different brokers, preventing submission errors due to non-compliant orders. Additionally, tests have been added or modified to ensure this functionality works as intended across the updated classes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->