### PR TITLE
Implement strategy.run_live() in example strategies

### DIFF
--- a/lumibot/example_strategies/crypto_important_functions.py
+++ b/lumibot/example_strategies/crypto_important_functions.py
@@ -3,8 +3,6 @@ import datetime
 from lumibot.brokers import Ccxt
 from lumibot.entities import Asset
 from lumibot.strategies.strategy import Strategy
-from lumibot.traders import Trader
-
 
 class ImportantFunctions(Strategy):
     def initialize(self):
@@ -123,8 +121,6 @@ class ImportantFunctions(Strategy):
 
 
 if __name__ == "__main__":
-    trader = Trader()
-
     KRAKEN_CONFIG = {
         "exchange_id": "kraken",
         "apiKey": "YOUR_API_KEY",
@@ -145,5 +141,4 @@ if __name__ == "__main__":
         broker=broker,
     )
 
-    trader.add_strategy(strategy)
-    strategy_executors = trader.run_all()
+    strategy.run_live()

--- a/lumibot/example_strategies/forex_hold_to_expiry.py
+++ b/lumibot/example_strategies/forex_hold_to_expiry.py
@@ -59,14 +59,8 @@ if __name__ == "__main__":
     is_live = True
 
     if is_live:
-        from lumibot.traders import Trader
-
-        trader = Trader()
-
         strategy = FuturesHoldToExpiry()
-
-        trader.add_strategy(strategy)
-        strategy_executors = trader.run_all()
+        strategy.run_live()
 
     else:
         from lumibot.backtesting import PolygonDataBacktesting

--- a/lumibot/example_strategies/futures_hold_to_expiry.py
+++ b/lumibot/example_strategies/futures_hold_to_expiry.py
@@ -83,11 +83,5 @@ if __name__ == "__main__":
         )
 
     else:
-        from lumibot.traders import Trader
-
-        trader = Trader()
-
         strategy = FuturesHoldToExpiry()
-
-        trader.add_strategy(strategy)
-        strategy_executors = trader.run_all()
+        strategy.run_live()

--- a/lumibot/example_strategies/lifecycle_logger.py
+++ b/lumibot/example_strategies/lifecycle_logger.py
@@ -62,10 +62,7 @@ if __name__ == "__main__":
     else:
         from lumibot.credentials import ALPACA_CONFIG
         from lumibot.brokers import Alpaca
-        from lumibot.traders import Trader
 
-        trader = Trader()
         broker = Alpaca(ALPACA_CONFIG)
         strategy = LifecycleLogger(broker=broker)
-        trader.add_strategy(strategy)
-        strategy_executors = trader.run_all()
+        strategy.run_live()

--- a/lumibot/example_strategies/options_hold_to_expiry.py
+++ b/lumibot/example_strategies/options_hold_to_expiry.py
@@ -68,15 +68,11 @@ if __name__ == "__main__":
         from credentials import INTERACTIVE_BROKERS_CONFIG
 
         from lumibot.brokers import InteractiveBrokers
-        from lumibot.traders import Trader
-
-        trader = Trader()
 
         broker = InteractiveBrokers(INTERACTIVE_BROKERS_CONFIG)
         strategy = OptionsHoldToExpiry(broker=broker)
 
-        trader.add_strategy(strategy)
-        strategy_executors = trader.run_all()
+        strategy.run_live()
 
     else:
         from lumibot.backtesting import PolygonDataBacktesting

--- a/lumibot/example_strategies/simple_start_single_file.py
+++ b/lumibot/example_strategies/simple_start_single_file.py
@@ -5,8 +5,6 @@ from credentials import AlpacaConfig
 from lumibot.backtesting import YahooDataBacktesting
 from lumibot.brokers import Alpaca
 from lumibot.strategies.strategy import Strategy
-from lumibot.traders import Trader
-
 
 class MyStrategy(Strategy):
     def initialize(self, symbol=""):
@@ -26,7 +24,6 @@ class MyStrategy(Strategy):
 if __name__ == "__main__":
     live = True
 
-    trader = Trader()
     broker = Alpaca(AlpacaConfig)
     strategy = MyStrategy(broker, symbol="SPY")
 
@@ -42,5 +39,4 @@ if __name__ == "__main__":
         )
     else:
         # Run the strategy live
-        trader.add_strategy(strategy)
-        trader.run_all()
+        strategy.run_live()

--- a/lumibot/example_strategies/stock_bracket.py
+++ b/lumibot/example_strategies/stock_bracket.py
@@ -60,16 +60,11 @@ if __name__ == "__main__":
         from credentials import ALPACA_CONFIG
 
         from lumibot.brokers import Alpaca
-        from lumibot.traders import Trader
-
-        trader = Trader()
 
         broker = Alpaca(ALPACA_CONFIG)
 
         strategy = StockBracket(broker=broker)
-
-        trader.add_strategy(strategy)
-        strategy_executors = trader.run_all()
+        strategy.run_live()
 
     else:
         from lumibot.backtesting import YahooDataBacktesting

--- a/lumibot/example_strategies/stock_buy_and_hold.py
+++ b/lumibot/example_strategies/stock_buy_and_hold.py
@@ -82,13 +82,8 @@ if __name__ == "__main__":
         }
 
         from lumibot.brokers import Alpaca
-        from lumibot.traders import Trader
-
-        trader = Trader()
 
         broker = Alpaca(ALPACA_CONFIG)
 
         strategy = BuyAndHold(broker=broker)
-
-        trader.add_strategy(strategy)
-        strategy_executors = trader.run_all()
+        strategy.run_live()

--- a/lumibot/example_strategies/stock_diversified_leverage.py
+++ b/lumibot/example_strategies/stock_diversified_leverage.py
@@ -4,7 +4,6 @@ from lumibot.backtesting import YahooDataBacktesting
 from lumibot.brokers import Alpaca
 from lumibot.entities import TradingFee
 from lumibot.strategies.strategy import Strategy
-from lumibot.traders import Trader
 
 """
 Strategy Description
@@ -127,11 +126,9 @@ if __name__ == "__main__":
         ####
         from credentials import ALPACA_CONFIG
 
-        trader = Trader()
         broker = Alpaca(ALPACA_CONFIG)
         strategy = DiversifiedLeverage(broker=broker)
-        trader.add_strategy(strategy)
-        trader.run_all()
+        strategy.run_live()
 
     else:
         ####

--- a/lumibot/example_strategies/stock_limit_and_trailing_stops.py
+++ b/lumibot/example_strategies/stock_limit_and_trailing_stops.py
@@ -68,16 +68,12 @@ if __name__ == "__main__":
         from credentials import ALPACA_CONFIG
 
         from lumibot.brokers import Alpaca
-        from lumibot.traders import Trader
-
-        trader = Trader()
 
         broker = Alpaca(ALPACA_CONFIG)
 
         strategy = LimitAndTrailingStop(broker=broker)
 
-        trader.add_strategy(strategy)
-        strategy_executors = trader.run_all()
+        strategy.run_live()
 
     else:
         from lumibot.backtesting import YahooDataBacktesting

--- a/lumibot/example_strategies/stock_momentum.py
+++ b/lumibot/example_strategies/stock_momentum.py
@@ -153,16 +153,11 @@ if __name__ == "__main__":
     if is_live:
         from lumibot.credentials import ALPACA_CONFIG
         from lumibot.brokers import Alpaca
-        from lumibot.traders import Trader
-
-        trader = Trader()
 
         broker = Alpaca(ALPACA_CONFIG)
 
         strategy = Momentum(broker=broker)
-
-        trader.add_strategy(strategy)
-        strategy_executors = trader.run_all()
+        strategy.run_live()
 
     else:
         from lumibot.backtesting import YahooDataBacktesting

--- a/lumibot/example_strategies/stock_oco.py
+++ b/lumibot/example_strategies/stock_oco.py
@@ -66,16 +66,11 @@ if __name__ == "__main__":
         from credentials import ALPACA_CONFIG
 
         from lumibot.brokers import Alpaca
-        from lumibot.traders import Trader
-
-        trader = Trader()
 
         broker = Alpaca(ALPACA_CONFIG)
 
         strategy = StockOco(broker=broker)
-
-        trader.add_strategy(strategy)
-        strategy_executors = trader.run_all()
+        strategy.run_live()
 
     else:
         from lumibot.backtesting import YahooDataBacktesting

--- a/lumibot/example_strategies/strangle.py
+++ b/lumibot/example_strategies/strangle.py
@@ -3,8 +3,7 @@ import logging
 import time
 from itertools import cycle
 
-import pandas as pd
-from yfinance import Ticker, download
+from yfinance import Ticker
 
 from lumibot.strategies.strategy import Strategy
 

--- a/lumibot/example_strategies/test_broker_functions.py
+++ b/lumibot/example_strategies/test_broker_functions.py
@@ -1,12 +1,6 @@
-from datetime import date, datetime
-from decimal import Decimal
-
 import logging
-from lumibot.brokers import InteractiveBrokers, Tradier, InteractiveBrokersREST, ExampleBroker
 from lumibot.entities import Asset, Order
 from lumibot.strategies.strategy import Strategy
-from lumibot.traders import Trader
-import yfinance as yf
 from datetime import timedelta
 
 # from lumiwealth_tradier import Tradier as _Tradier
@@ -132,8 +126,5 @@ if __name__ == "__main__":
     # broker = ExampleBroker()
 
     strategy = BrokerTest()
+    strategy.run_live()
 
-    trader = Trader()
-
-    trader.add_strategy(strategy)
-    strategy_executors = trader.run_all()


### PR DESCRIPTION
Replace the use of Trader to run strategies with a direct call to strategy.run_live(), simplifying the execution process for live trading.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?
Refactor example strategy scripts to use `strategy.run_live()` instead of `Trader` instance management.

### Why are these changes being made?
This change simplifies the execution process by replacing the use of a `Trader` object to manage and execute strategies with the direct invocation of `strategy.run_live()`. This refactor reduces redundancy and improves the clarity of strategy execution in live trading scenarios, making the example code easier to understand and maintain.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->