### PR TITLE
Fix for Alpaca order tracking

### DIFF
--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -447,6 +447,7 @@ class Alpaca(Broker):
             order.set_identifier(response.id)
             order.status = response.status
             order.update_raw(response)
+            self._unprocessed_orders.append(order)
 
         except Exception as e:
             order.set_error(e)

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -548,14 +548,13 @@ class Alpaca(Broker):
         """
 
         async def _trade_update(trade_update):
-            self._orders_queue.join()
             try:
                 logged_order = trade_update.order
                 type_event = trade_update.event
                 identifier = logged_order.id
                 stored_order = self.get_tracked_order(identifier)
                 if stored_order is None:
-                    logging.info(f"Untracked order {identifier} was logged by broker {self.name}")
+                    logging.debug(f"Untracked order {identifier} was logged by broker {self.name}")
                     return False
 
                 price = trade_update.price

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -1204,21 +1204,21 @@ class Broker(ABC):
             except ValueError:
                 raise error
 
-        if type_event == self.NEW_ORDER:
+        if Order.is_equivalent_status(type_event, self.NEW_ORDER):
             stored_order = self._process_new_order(stored_order)
             self._on_new_order(stored_order)
-        elif type_event == self.CANCELED_ORDER:
+        elif Order.is_equivalent_status(type_event, self.CANCELED_ORDER):
             # Do not cancel or re-cancel already completed orders
             if stored_order.is_active():
                 stored_order = self._process_canceled_order(stored_order)
                 self._on_canceled_order(stored_order)
-        elif type_event == self.PARTIALLY_FILLED_ORDER:
+        elif Order.is_equivalent_status(type_event, self.PARTIALLY_FILLED_ORDER):
             stored_order, position = self._process_partially_filled_order(stored_order, price, filled_quantity)
             self._on_partially_filled_order(position, stored_order, price, filled_quantity, multiplier)
-        elif type_event == self.FILLED_ORDER:
+        elif Order.is_equivalent_status(type_event, self.FILLED_ORDER):
             position = self._process_filled_order(stored_order, price, filled_quantity)
             self._on_filled_order(position, stored_order, price, filled_quantity, multiplier)
-        elif type_event == self.CASH_SETTLED:
+        elif Order.is_equivalent_status(type_event, self.CASH_SETTLED):
             self._process_cash_settlement(stored_order, price, filled_quantity)
             stored_order.type = self.CASH_SETTLED
         else:

--- a/lumibot/data_sources/interactive_brokers_rest_data.py
+++ b/lumibot/data_sources/interactive_brokers_rest_data.py
@@ -307,6 +307,10 @@ class InteractiveBrokersRESTData(DataSource):
             self.ping_iserver()
             retrying = True
             re_msg = "Lumibot got Deauthenticated"
+        
+        elif 'There was an error processing the request. Please try again.' in error_message:
+            retrying = True
+            re_msg = "Something went wrong."
 
         elif "no bridge" in error_message.lower() or "not authenticated" in error_message.lower():
             retrying = True

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -817,7 +817,21 @@ class Order:
             return True
         else:
             return False
+    
+    @classmethod
+    def is_equivalent_status(cls, status1, status2) -> bool:
+        """Returns if the 2 statuses passed are equivalent."""
 
+        if not status1 or not status2:
+            return False
+        elif status1.lower() in [status2.lower(), STATUS_ALIAS_MAP.get(status2.lower(), "")]:
+            return True
+        # open/new status is equivalent
+        elif {status1.lower(), status2.lower()}.issubset({"open", "new"}):
+            return True
+        else:
+            return False
+    
     def set_error(self, error):
         self.status = "error"
         self._error = error


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add unprocessed orders to a tracking list upon order submission in the Alpaca broker integration.

### Why are these changes being made?

Previously, orders that were submitted to Alpaca but not processed were not being tracked, potentially leading to discrepancies or missed updates. By appending such orders to the `_unprocessed_orders` list, we ensure more accurate tracking and handling of orders.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->