### PR TITLE
Fix: Check timeInForce exists on Kraken API response.

### DIFF
--- a/lumibot/brokers/ccxt.py
+++ b/lumibot/brokers/ccxt.py
@@ -299,7 +299,7 @@ class Ccxt(Broker):
             response["side"],
             limit_price=response["price"],
             stop_price=response["stopPrice"],
-            time_in_force=response["timeInForce"].lower(),
+            time_in_force=response["timeInForce"].lower() if response["timeInForce"] else None,
             quote=Asset(
                 symbol=pair[1],
                 asset_type="crypto",
@@ -324,7 +324,10 @@ class Ccxt(Broker):
     def _pull_broker_closed_orders(self):
         params = {}
 
-        if self.is_margin_enabled():
+        if self.api.id == "kraken":  # Check if the exchange is Kraken
+            logging.info("Detected Kraken exchange. Not sending params for closed orders.")
+            params = None  # Ensure no parameters are sent
+        elif self.is_margin_enabled():
             params["tradeType"] = "MARGIN_TRADE"
 
         closed_orders = self.api.fetch_closed_orders(params)


### PR DESCRIPTION
I was trying to submit buy/sell on DOGE and to then check the order completed. I ran into two issues.

1. timeInForce was None on existing open orders. These were created with Bitsgap and the parse code in ccxt.py assumes the key will exist, but it does not from Kraken for me on some orders.
2. when querying for closed orders the fetch to kraken API fails, I'm not fetching with margin, so I removed the dict as an arg to the api fetch and it works... I'm not sure where the API code for kraken is, possibly this part of the change could be done differently.

This change allows me to submit orders to kraken and check the status of orders.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Modify the CCXT broker in the Lumibot project to handle potential absence of the `timeInForce` key in the Kraken API response and ensure no parameters are sent for closed orders when the exchange is Kraken.

### Why are these changes being made?
These changes address two issues: preventing errors when `timeInForce` is missing in the Kraken API responses by safely checking its existence, and adhering to Kraken's requirements by refraining from sending additional parameters for closed orders which can cause the requests to fail. These adjustments improve compatibility with Kraken's API.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->