### PR TITLE
Drift rebalancer shorting tests

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -49,8 +49,6 @@ def pandas_data_fixture() -> Dict[Asset, Data]:
             parse_dates=True,
             index_col=0,
             header=0,
-            usecols=[0, 1, 2, 3, 4, 6, 7],
-            names=["Date", "Open", "High", "Low", "Close", "Volume", "Dividends"],
         )
         df = df.rename(
             columns={


### PR DESCRIPTION
Added a test to confirm that when the value of the shorted asset increase, the drift rebalancer correctly reduces the short position. 

Fixed a "bug" in the csv text fixture, so that it doesn't assume the column order of a csv file.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove unused columns from the `pandas_data_fixture` in `fixtures.py` and introduce a new test case `test_shorting_more_when_price_goes_up_short_something` to evaluate the drift rebalancer's handling of short positions when the asset price increases in `test_drift_rebalancer.py`.

### Why are these changes being made?

The removal of unused columns enhances code clarity and performance by eliminating unnecessary data processing. The additional test case ensures that the drift rebalancer logic correctly rebalance short positions in scenarios where the price of the asset increases, which is crucial for validating the strategy's robustness and accuracy under various market conditions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->