### PR TITLE
Drift Rebalancer shorting tests

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -49,8 +49,6 @@ def pandas_data_fixture() -> Dict[Asset, Data]:
             parse_dates=True,
             index_col=0,
             header=0,
-            usecols=[0, 1, 2, 3, 4, 6, 7],
-            names=["Date", "Open", "High", "Low", "Close", "Volume", "Dividends"],
         )
         df = df.rename(
             columns={


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove specific column selection from `pandas_data_fixture` and enhance `MockStrategyWithDriftCalculationLogic` by explicitly requiring a broker; add a new test to validate behavior when shorting more as prices increase.

### Why are these changes being made?

These changes clean up unnecessary fixture details, ensuring the strategy instantiation explicitly acknowledges its dependency on a broker. The added test ensures robustness in handling scenarios where market conditions lead to increased shorting, thereby enhancing the Drift Rebalancer's accuracy in such situations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->