### PR TITLE
MultiLeg Parent Not Returned on Submission

### DIFF
--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -65,10 +65,6 @@ class BacktestingBroker(Broker):
     def datetime(self):
         return self.data_source.get_datetime()
 
-    def _submit_order(self, order):
-        """TODO: Why is this not used for Backtesting, but it is used for real brokers?"""
-        pass
-
     def _get_balances_at_broker(self, quote_asset, strategy):
         """
         Get the balances of the broker
@@ -390,9 +386,8 @@ class BacktestingBroker(Broker):
                 logger.info("Position %r liquidated" % existing_position)
                 self._filled_positions.remove(existing_position)
 
-    def submit_order(self, order):
+    def _submit_order(self, order):
         """Submit an order for an asset"""
-        self._conform_order(order)
 
         # NOTE: This code is to address Tradier API requirements, they want is as "to_open" or "to_close" instead of just "buy" or "sell"
         # If the order has a "buy_to_open" or "buy_to_close" side, then we should change it to "buy"
@@ -410,7 +405,7 @@ class BacktestingBroker(Broker):
         )
         return order
 
-    def submit_orders(self, orders, is_multileg=False, **kwargs):
+    def _submit_orders(self, orders, is_multileg=False, **kwargs):
         """Submit multiple orders for an asset"""
 
         # Check that orders is a list and not zero

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from queue import Queue
 from threading import RLock, Thread
+from typing import Union
 
 import pandas as pd
 import pandas_market_calendars as mcal
@@ -942,19 +943,19 @@ class Broker(ABC):
         result = self._parse_broker_orders(response, strategy_name, strategy_object=strategy_object)
         return result
 
-    def submit_order(self, order):
+    def submit_order(self, order) -> Order:
         """Conform an order for an asset to broker constraints and submit it."""
         self._conform_order(order)
-        self._submit_order(order)
+        return self._submit_order(order)
 
     def _conform_order(self, order):
         """Conform an order to broker constraints. Derived brokers should implement this method."""
         pass
 
-    def submit_orders(self, orders, **kwargs):
+    def submit_orders(self, orders, **kwargs) -> Union[Order, list[Order]]:
         """Submit orders"""
         if hasattr(self, '_submit_orders'):
-            self._submit_orders(orders, **kwargs)
+            return self._submit_orders(orders, **kwargs)
         else:
             with ThreadPoolExecutor(
                 max_workers=self.max_workers,
@@ -967,6 +968,7 @@ class Broker(ABC):
                 result = []
                 for task in as_completed(tasks):
                     result.append(task.result())
+                return result
 
     def wait_for_order_registration(self, order):
         """Wait for the order to be registered by the broker"""

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -649,7 +649,14 @@ def get_chains_cached(
                 f"within {RECENT_FILE_TOLERANCE_DAYS} days of {current_date}."
             )
             df_cached = pd.read_feather(fpath)
-            return df_cached["data"][0]
+
+            # Convert the data back to a dictionary of lists instead of NP arrays to match original return types
+            data = df_cached["data"][0]
+            for right in data["Chains"]:
+                for exp_date in data["Chains"][right]:
+                    data["Chains"][right][exp_date] = list(data["Chains"][right][exp_date])
+
+            return data
 
     # 5) No suitable file => must fetch from Polygon
     logging.debug(


### PR DESCRIPTION
The main issue addressed in this branch is that multileg submissions were no longer returning the parent order that was created.  This was not caught by tests because BacktestingBroker uses an independent submission system from all of the rest of the brokers.  BacktestingBroker has now been updated to use the same methods as the live brokers so that future issues like this will be caught in regression testing.

- backtest_broker: Fixing backtesting_broker to use the same _submit_order() and _submit_orders() strategy as all the other brokers so that it can serve as a valid test for live. It missed a bug that prevented submitted orders from being returned correctly.
- broker: was no longer returning submitted orders, esp multileg parent orders.
- polygon_helper: get_chains caching was changing the data types of the returned data structures.
- backtesting: fixed tests not handling timezones correctly in new tests.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor order submission methods to return orders, update timezone handling for tests, and rectify data return format for chain data in `polygon_helper`.

### Why are these changes being made?

These changes implement a more consistent and expected behavior by ensuring that order submission methods return the submitted orders, improving code readability and maintainability. The timezone handling updates address potential issues with datetime localization in tests, preventing discrepancies across different environments. Adjusting the data return format in `polygon_helper` harmonizes the structure to existing protocols, enhancing compatibility with dependent systems.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->