### PR TITLE
Remove DriftRebalancer.get_last_price and just use Strategy.get_last_price

### DIFF
--- a/lumibot/components/drift_rebalancer_logic.py
+++ b/lumibot/components/drift_rebalancer_logic.py
@@ -206,7 +206,7 @@ class DriftCalculationLogic:
                 current_value = Decimal(position.quantity)
             else:
                 is_quote_asset = False
-                last_price = self.strategy.get_last_price(position.asset)
+                last_price = Decimal(self.strategy.get_last_price(position.asset))
                 current_value = current_quantity * last_price
             self._add_position(
                 symbol=symbol,
@@ -359,7 +359,7 @@ class DriftOrderLogic:
                 # Sell everything (or create 100% short position)
                 base_asset = row["base_asset"]
                 quantity = row["current_quantity"]
-                last_price = self.strategy.get_last_price(base_asset)
+                last_price = Decimal(self.strategy.get_last_price(base_asset))
                 limit_price = self.calculate_limit_price(last_price=last_price, side="sell")
                 if quantity == 0 and self.shorting:
                     # Create a 100% short position.
@@ -380,7 +380,7 @@ class DriftOrderLogic:
 
             elif row["drift"] < 0:
                 base_asset = row["base_asset"]
-                last_price = self.strategy.get_last_price(base_asset)
+                last_price = Decimal(self.strategy.get_last_price(base_asset))
                 limit_price = self.calculate_limit_price(last_price=last_price, side="sell")
                 quantity = (row["current_value"] - row["target_value"]) / limit_price
                 if self.fractional_shares:
@@ -414,7 +414,7 @@ class DriftOrderLogic:
                 # Cover our short position
                 base_asset = row["base_asset"]
                 quantity = abs(row["current_quantity"])
-                last_price = self.strategy.get_last_price(base_asset)
+                last_price = Decimal(self.strategy.get_last_price(base_asset))
                 limit_price = self.calculate_limit_price(last_price=last_price, side="buy")
                 order = self.place_order(
                     base_asset=base_asset,
@@ -427,7 +427,7 @@ class DriftOrderLogic:
 
             elif row["drift"] > 0:
                 base_asset = row["base_asset"]
-                last_price = self.strategy.get_last_price(base_asset)
+                last_price = Decimal(self.strategy.get_last_price(base_asset))
                 limit_price = self.calculate_limit_price(last_price=last_price, side="buy")
                 order_value = row["target_value"] - row["current_value"]
                 quantity = min(order_value, cash_position) / limit_price

--- a/lumibot/example_strategies/crypto_50_50.py
+++ b/lumibot/example_strategies/crypto_50_50.py
@@ -35,11 +35,11 @@ if __name__ == "__main__":
         parameters["portfolio_weights"] = [
             {
                 "base_asset": Asset(symbol='BTC-USD', asset_type='stock'),
-                "weight": Decimal("0.6")
+                "weight": Decimal("0.5")
             },
             {
                 "base_asset": Asset(symbol='ETH-USD', asset_type='stock'),
-                "weight": Decimal("0.4")
+                "weight": Decimal("0.5")
             }
         ]
         results = DriftRebalancer.backtest(
@@ -64,11 +64,11 @@ if __name__ == "__main__":
         parameters["portfolio_weights"] = [
             {
                 "base_asset": Asset(symbol='BTC', asset_type='crypto'),
-                "weight": Decimal("0.6")
+                "weight": Decimal("0.5")
             },
             {
                 "base_asset": Asset(symbol='ETH', asset_type='crypto'),
-                "weight": Decimal("0.4")
+                "weight": Decimal("0.5")
             }
         ]
         strategy = DriftRebalancer(broker, parameters=parameters)

--- a/lumibot/example_strategies/drift_rebalancer.py
+++ b/lumibot/example_strategies/drift_rebalancer.py
@@ -120,9 +120,3 @@ class DriftRebalancer(Strategy):
 
         self.drift_df = self.drift_rebalancer_logic.calculate(portfolio_weights=self.portfolio_weights)
         self.drift_rebalancer_logic.rebalance(drift_df=self.drift_df)
-
-    def get_last_price(self, asset: Union[Asset, str], quote=None, exchange=None):
-        """Override get_last_price to use the strategy's quote asset and return a decimal."""
-        quote_asset = self.quote_asset or Asset(symbol="USD", asset_type="forex")
-        return Decimal(super().get_last_price(asset=asset, quote=quote_asset))
-        


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the method `DriftRebalancer.get_last_price` and consistently use `Strategy.get_last_price`, and update certain portfolio weights to reflect equal distribution in example strategies.

### Why are these changes being made?

The `get_last_price` method in `DriftRebalancer` was redundant as its functionality can be achieved using `Strategy.get_last_price` with minor adjustments, leading to cleaner and more maintainable code. Additionally, adjusting the portfolio weights in example strategies reflects a balanced 50/50 asset distribution, which is easier to understand for users testing the strategies.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->