### PR TITLE
Added tests for ccxt data. Standardized signature of get_last_price

### DIFF
--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -2,6 +2,8 @@ import logging
 import traceback
 from collections import OrderedDict, defaultdict
 from datetime import date, timedelta
+from decimal import Decimal
+from typing import Union
 
 from polygon.exceptions import BadResponse
 from termcolor import colored
@@ -216,7 +218,7 @@ class PolygonDataBacktesting(PandasData):
         bars = self._parse_source_symbol_bars(response, asset, quote=quote)
         return bars
 
-    def get_last_price(self, asset, timestep="minute", quote=None, exchange=None, **kwargs):
+    def get_last_price(self, asset, timestep="minute", quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:
         try:
             dt = self.get_datetime()
             self._update_pandas_data(asset, quote, 1, timestep, dt)

--- a/lumibot/backtesting/thetadata_backtesting.py
+++ b/lumibot/backtesting/thetadata_backtesting.py
@@ -1,6 +1,9 @@
 import logging
 import re
 import traceback
+from decimal import Decimal
+from typing import Union
+
 import pandas as pd
 import subprocess
 from datetime import date, datetime, timedelta
@@ -247,7 +250,7 @@ class ThetaDataBacktesting(PandasData):
         bars = self._parse_source_symbol_bars(response, asset, quote=quote)
         return bars
 
-    def get_last_price(self, asset, timestep="minute", quote=None, exchange=None, **kwargs):
+    def get_last_price(self, asset, timestep="minute", quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:
         try:
             dt = self.get_datetime()
             self._update_pandas_data(asset, quote, 1, timestep, dt)

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -304,7 +304,7 @@ class Broker(ABC):
 
     # =========Market functions=======================
 
-    def get_last_price(self, asset: Asset, quote=None, exchange=None) -> float:
+    def get_last_price(self, asset: Asset, quote=None, exchange=None) -> Union[float, Decimal, None]:
         """
         Takes an asset and returns the last known price
 
@@ -319,7 +319,7 @@ class Broker(ABC):
 
         Returns
         -------
-        float
+        float or Decimal or None
             The last known price of the asset.
         """
         if self.option_source and asset.asset_type == "option":

--- a/lumibot/data_sources/alpaca_data.py
+++ b/lumibot/data_sources/alpaca_data.py
@@ -1,5 +1,7 @@
 import logging
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Union
 
 import pandas as pd
 from alpaca.data.historical import CryptoHistoricalDataClient, StockHistoricalDataClient
@@ -141,7 +143,7 @@ class AlpacaData(DataSource):
             "feature, please use a different data source."
         )
 
-    def get_last_price(self, asset, quote=None, exchange=None, **kwargs):
+    def get_last_price(self, asset, quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:
         if quote is not None:
             # If the quote is not None, we use it even if the asset is a tuple
             if type(asset) == Asset and asset.asset_type == "stock":

--- a/lumibot/data_sources/ccxt_backtesting_data.py
+++ b/lumibot/data_sources/ccxt_backtesting_data.py
@@ -238,8 +238,7 @@ class CcxtBacktestingData(DataSourceBacktesting):
         bars = Bars(response, self.SOURCE, asset, quote=quote, raw=response)
         return bars
 
-
-    def get_last_price(self, asset, timestep=None, quote=None, exchange=None, **kwargs):
+    def get_last_price(self, asset, timestep=None, quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:
         """Takes an asset and returns the last known price of close"""
         if timestep is None:
             timestep = self.get_timestep()

--- a/lumibot/data_sources/ccxt_data.py
+++ b/lumibot/data_sources/ccxt_data.py
@@ -1,6 +1,8 @@
 import datetime
 import logging
 import time
+from decimal import Decimal
+from typing import Union
 
 import ccxt
 import pandas as pd
@@ -209,7 +211,7 @@ class CcxtData(DataSource):
         bars = Bars(response, self.SOURCE, asset, quote=quote, raw=response)
         return bars
 
-    def get_last_price(self, asset, quote=None, exchange=None, **kwargs):
+    def get_last_price(self, asset, quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:
         if quote is not None:
             symbol = f"{asset.symbol}/{quote.symbol}"
         else:

--- a/lumibot/data_sources/data_source.py
+++ b/lumibot/data_sources/data_source.py
@@ -4,6 +4,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 import traceback
 import time
+from decimal import Decimal
+from typing import Union
 
 import pandas as pd
 
@@ -101,7 +103,7 @@ class DataSource(ABC):
         pass
 
     @abstractmethod
-    def get_last_price(self, asset, quote=None, exchange=None) -> float:
+    def get_last_price(self, asset, quote=None, exchange=None) -> Union[float, Decimal, None]:
         """
         Takes an asset and returns the last known price
 
@@ -116,7 +118,7 @@ class DataSource(ABC):
 
         Returns
         -------
-        float
+        float or Decimal or None
             The last known price of the asset.
         """
         pass

--- a/lumibot/data_sources/example_broker_data.py
+++ b/lumibot/data_sources/example_broker_data.py
@@ -1,4 +1,7 @@
 import logging
+from decimal import Decimal
+from typing import Union
+
 from termcolor import colored
 from lumibot.entities import Asset, Bars
 from lumibot.data_sources import DataSource
@@ -25,6 +28,6 @@ class ExampleBrokerData(DataSource):
         logging.error(colored("Method 'get_historical_prices' is not yet implemented.", "red"))
         return None  # Return None as a placeholder
 
-    def get_last_price(self, asset, quote=None, exchange=None) -> float:
+    def get_last_price(self, asset, quote=None, exchange=None) -> Union[float, Decimal, None]:
         logging.error(colored("Method 'get_last_price' is not yet implemented.", "red"))
         return 0.0  # Return 0.0 as a placeholder

--- a/lumibot/data_sources/interactive_brokers_data.py
+++ b/lumibot/data_sources/interactive_brokers_data.py
@@ -1,5 +1,7 @@
 import datetime
 import math
+from decimal import Decimal
+from typing import Union
 
 import pandas as pd
 
@@ -340,7 +342,7 @@ class InteractiveBrokersData(DataSource):
         bars = self._parse_source_symbol_bars(response, asset, quote=quote, length=length)
         return bars
 
-    def get_last_price(self, asset, timestep=None, quote=None, exchange=None, **kwargs):
+    def get_last_price(self, asset, timestep=None, quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:
         if exchange is None:
             exchange = "SMART"
 

--- a/lumibot/data_sources/interactive_brokers_rest_data.py
+++ b/lumibot/data_sources/interactive_brokers_rest_data.py
@@ -1,4 +1,7 @@
 import logging
+from decimal import Decimal
+from typing import Union
+
 from termcolor import colored
 
 from lumibot import LUMIBOT_DEFAULT_PYTZ
@@ -842,7 +845,7 @@ class InteractiveBrokersRESTData(DataSource):
 
         return bars
 
-    def get_last_price(self, asset, quote=None, exchange=None) -> float | None:
+    def get_last_price(self, asset, quote=None, exchange=None) -> Union[float, Decimal, None]:
         field = "last_price"
         response = self.get_market_snapshot(asset, [field])  # TODO add exchange
 

--- a/lumibot/data_sources/pandas_data.py
+++ b/lumibot/data_sources/pandas_data.py
@@ -1,6 +1,8 @@
 import logging
 from collections import defaultdict, OrderedDict
 from datetime import timedelta
+from decimal import Decimal
+from typing import Union
 
 import pandas as pd
 from lumibot.data_sources import DataSourceBacktesting
@@ -178,7 +180,7 @@ class PandasData(DataSourceBacktesting):
 
         return dt_index
 
-    def get_last_price(self, asset, quote=None, exchange=None):
+    def get_last_price(self, asset, quote=None, exchange=None) -> Union[float, Decimal, None]:
         # Takes an asset and returns the last known price
         tuple_to_find = self.find_asset_in_data_store(asset, quote)
 

--- a/lumibot/data_sources/tradier_data.py
+++ b/lumibot/data_sources/tradier_data.py
@@ -1,6 +1,8 @@
 import logging
 from collections import defaultdict
 from datetime import datetime, date, timedelta
+from decimal import Decimal
+from typing import Union
 
 import pandas as pd
 
@@ -255,7 +257,7 @@ class TradierData(DataSource):
 
         return bars
 
-    def get_last_price(self, asset, quote=None, exchange=None):
+    def get_last_price(self, asset, quote=None, exchange=None) -> Union[float, Decimal, None]:
         """
         This function returns the last price of an asset.
         Parameters
@@ -269,7 +271,7 @@ class TradierData(DataSource):
 
         Returns
         -------
-        float
+        float or Decimal or none
            Price of the asset
         """
 

--- a/lumibot/data_sources/yahoo_data.py
+++ b/lumibot/data_sources/yahoo_data.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import timedelta
 from decimal import Decimal
+from typing import Union
 
 import numpy
 
@@ -131,7 +132,7 @@ class YahooData(DataSourceBacktesting):
         bars = Bars(response, self.SOURCE, asset, raw=response)
         return bars
 
-    def get_last_price(self, asset, timestep=None, quote=None, exchange=None, **kwargs):
+    def get_last_price(self, asset, timestep=None, quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:
         """Takes an asset and returns the last known price"""
         if timestep is None:
             timestep = self.get_timestep()

--- a/lumibot/entities/bars.py
+++ b/lumibot/entities/bars.py
@@ -1,5 +1,7 @@
 import logging
 from datetime import datetime
+from decimal import Decimal
+from typing import Union
 
 import pandas as pd
 
@@ -168,7 +170,7 @@ class Bars:
 
         return result
 
-    def get_last_price(self):
+    def get_last_price(self) -> Union[float, Decimal, None]:
         """Return the last price of the last bar
 
         Parameters
@@ -177,7 +179,7 @@ class Bars:
 
         Returns
         -------
-        float
+        float, Decimal or None
 
         """
         return self.df["close"].iloc[-1]

--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -1,6 +1,8 @@
 import datetime
 import logging
 import re
+from decimal import Decimal
+from typing import Union
 
 import pandas as pd
 from lumibot import LUMIBOT_DEFAULT_PYTZ as DEFAULT_PYTZ
@@ -383,7 +385,7 @@ class Data:
         return checker
 
     @check_data
-    def get_last_price(self, dt, length=1, timeshift=0):
+    def get_last_price(self, dt, length=1, timeshift=0) -> Union[float, Decimal, None]:
         """Returns the last known price of the data.
 
         Parameters
@@ -399,7 +401,7 @@ class Data:
 
         Returns
         -------
-        float
+        float or Decimal or None
         """
         iter_count = self.get_iter_count(dt)
         open_price = self.datalines["open"].dataline[iter_count]

--- a/lumibot/example_strategies/ccxt_backtesting_example.py
+++ b/lumibot/example_strategies/ccxt_backtesting_example.py
@@ -28,7 +28,7 @@ class CcxtBacktestingExampleStrategy(Strategy):
         return cash, last_price, quantity
 
     def _get_historical_prices(self):
-        return self.get_historical_prices(asset=self.asset,length=None,
+        return self.get_historical_prices(asset=self.asset,length=self.window,
                                     timestep="day",quote=self.quote).df
 
     def _get_bbands(self,history_df:DataFrame):

--- a/lumibot/example_strategies/ccxt_backtesting_example.py
+++ b/lumibot/example_strategies/ccxt_backtesting_example.py
@@ -24,6 +24,8 @@ class CcxtBacktestingExampleStrategy(Strategy):
     def _position_sizing(self):
         cash = self.get_cash()
         last_price = self.get_last_price(asset=self.asset,quote=self.quote)
+        if last_price is None:
+            return cash, last_price, 0.0
         quantity = round(cash * self.cash_at_risk / last_price,0)
         return cash, last_price, quantity
 

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -1651,7 +1651,7 @@ class Strategy(_Strategy):
         """
         self.broker.sell_all(self.name, cancel_open_orders=cancel_open_orders, strategy=self, is_multileg=is_multileg)
 
-    def get_last_price(self, asset: Union[Asset, str], quote=None, exchange=None):
+    def get_last_price(self, asset: Union[Asset, str], quote=None, exchange=None) -> Union[float, Decimal, None]:
         """Takes an asset and returns the last known price
 
         Makes an active call to the market to retrieve the last price.

--- a/tests/backtest/test_example_strategies.py
+++ b/tests/backtest/test_example_strategies.py
@@ -245,8 +245,6 @@ class TestExampleStrategies:
         assert round(cash_settled_orders.iloc[0]["price"], 0) == 0
         assert cash_settled_orders.iloc[0]["filled_quantity"] == 10
 
-    @pytest.mark.skip(reason="This test is skipped because the CCXTBackTesting data source is not currently "
-                             "returning data for this date range.")
     def test_ccxt_backtesting(self):
         """
         Test the example strategy StockBracket by running a backtest and checking that the strategy object is returned

--- a/tests/backtest/test_example_strategies.py
+++ b/tests/backtest/test_example_strategies.py
@@ -245,6 +245,7 @@ class TestExampleStrategies:
         assert round(cash_settled_orders.iloc[0]["price"], 0) == 0
         assert cash_settled_orders.iloc[0]["filled_quantity"] == 10
 
+    @pytest.mark.skip()  # Skip this test; it works locally but i can't get it to work on github actions
     def test_ccxt_backtesting(self):
         """
         Test the example strategy StockBracket by running a backtest and checking that the strategy object is returned

--- a/tests/test_brokers_handle_crypto.py
+++ b/tests/test_brokers_handle_crypto.py
@@ -2,6 +2,7 @@ import pytest
 from datetime import datetime, timedelta
 from typing import assert_type
 
+import pytz
 from lumibot.entities import Asset, Order, Bars
 from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting, YahooDataBacktesting, CcxtBacktesting
 from lumibot.brokers.alpaca import Alpaca
@@ -205,9 +206,8 @@ class TestBrokerHandlesCrypto:
         broker.cancel_order(order)
 
     def test_ccxt_backtesting_with_base_and_quote(self):
-        # Expensive polygon subscriptions required if we go back to 2019. Just use recent dates.
-        start = datetime.now() - timedelta(days=4)
-        end = datetime.now() - timedelta(days=2)
+        start = (datetime.now() - timedelta(days=4)).replace(hour=0, minute=0, second=0, microsecond=0)
+        end = (datetime.now() - timedelta(days=2)).replace(hour=0, minute=0, second=0, microsecond=0)
         kwargs = {
             # "max_data_download_limit":10000, # optional
             "exchange_id": "kraken"  #"kucoin" #"bybit" #"okx" #"bitmex" # "binance"

--- a/tests/test_brokers_handle_crypto.py
+++ b/tests/test_brokers_handle_crypto.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import assert_type
 
 from lumibot.entities import Asset, Order, Bars
-from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting, YahooDataBacktesting
+from lumibot.backtesting import BacktestingBroker, PolygonDataBacktesting, YahooDataBacktesting, CcxtBacktesting
 from lumibot.brokers.alpaca import Alpaca
 from lumibot.credentials import ALPACA_CONFIG, POLYGON_CONFIG
 
@@ -48,7 +48,7 @@ class TestBrokerHandlesCrypto:
             strategy="test",
             asset=asset,
             quantity=1,
-            side="buy",
+            side=Order.OrderSide.BUY,
             limit_price=limit_price,
         )
         assert order.status == "unprocessed"
@@ -88,7 +88,7 @@ class TestBrokerHandlesCrypto:
             strategy="test",
             asset=self.base,
             quantity=1,
-            side="buy",
+            side=Order.OrderSide.BUY,
             limit_price=limit_price,
             quote=self.quote
         )
@@ -148,7 +148,7 @@ class TestBrokerHandlesCrypto:
             strategy="test",
             asset=self.base,
             quantity=1,
-            side="buy",
+            side=Order.OrderSide.BUY,
             limit_price=limit_price,
             quote=self.quote
         )
@@ -195,7 +195,59 @@ class TestBrokerHandlesCrypto:
             strategy="test",
             asset=self.base,
             quantity=1,
-            side="buy",
+            side=Order.OrderSide.BUY,
+            limit_price=limit_price,
+            quote=self.quote
+        )
+        assert order.status == "unprocessed"
+        broker.submit_order(order)
+        assert order.status == "new"
+        broker.cancel_order(order)
+
+    def test_ccxt_backtesting_with_base_and_quote(self):
+        # Expensive polygon subscriptions required if we go back to 2019. Just use recent dates.
+        start = datetime.now() - timedelta(days=4)
+        end = datetime.now() - timedelta(days=2)
+        kwargs = {
+            # "max_data_download_limit":10000, # optional
+            "exchange_id": "kraken"  #"kucoin" #"bybit" #"okx" #"bitmex" # "binance"
+        }
+
+        data_source = CcxtBacktesting(
+            datetime_start=start,
+            datetime_end=end,
+            **kwargs
+        )
+        broker = BacktestingBroker(data_source=data_source)
+
+        # test_get_last_price
+        last_price = broker.data_source.get_last_price(asset=self.base, quote=self.quote)
+        assert_type(last_price, float)
+        assert last_price > 0.0
+
+        # test_get_historical_prices
+        bars = broker.data_source.get_historical_prices(
+            asset=self.base,
+            length=self.length,
+            timestep=self.timestep,
+            quote=self.quote
+        )
+
+        assert_type(bars, Bars)
+        assert len(bars.df) == self.length
+        # get the date of the last bar, which should be the day before the start date
+        last_date = bars.df.index[-1]
+        assert last_date.date() == (start - timedelta(days=1)).date()
+        last_price = bars.df['close'].iloc[-1]
+        assert last_price > 0.0
+
+        # test_submit_limit_order
+        limit_price = 1.0  # Make sure we never hit this price
+        order = Order(
+            strategy="test",
+            asset=self.base,
+            quantity=1,
+            side=Order.OrderSide.BUY,
             limit_price=limit_price,
             quote=self.quote
         )

--- a/tests/test_brokers_handle_crypto.py
+++ b/tests/test_brokers_handle_crypto.py
@@ -212,7 +212,6 @@ class TestBrokerHandlesCrypto:
             # "max_data_download_limit":10000, # optional
             "exchange_id": "kraken"  #"kucoin" #"bybit" #"okx" #"bitmex" # "binance"
         }
-
         data_source = CcxtBacktesting(
             datetime_start=start,
             datetime_end=end,

--- a/tests/test_data_source.py
+++ b/tests/test_data_source.py
@@ -1,3 +1,6 @@
+from decimal import Decimal
+from typing import Union
+
 from lumibot.data_sources.data_source import DataSource
 from lumibot.entities import Asset
 
@@ -9,7 +12,7 @@ class DataSourceTestable(DataSource):
     def get_chains(self, asset: Asset, quote: Asset = None) -> dict:
         return {}
 
-    def get_last_price(self, asset, quote=None, exchange=None):
+    def get_last_price(self, asset, quote=None, exchange=None) -> Union[float, Decimal, None]:
         return 0.0
 
     def get_historical_prices(

--- a/tests/test_drift_rebalancer.py
+++ b/tests/test_drift_rebalancer.py
@@ -44,7 +44,7 @@ class MockStrategyWithDriftCalculationLogic(Strategy):
             fractional_shares=fractional_shares
         )
 
-    def get_last_price(self, asset: Union[Asset, str], quote=None, exchange=None):
+    def get_last_price(self, asset: Union[Asset, str], quote=None, exchange=None) -> Union[float, Decimal, None]:
         return Decimal(100.0)  # Mock price
 
     def update_broker_balances(self, force_update: bool = False) -> None:
@@ -866,7 +866,7 @@ class MockStrategyWithOrderLogic(Strategy):
             fractional_shares=fractional_shares
         )
 
-    def get_last_price(self, asset: Union[Asset, str], quote=None, exchange=None):
+    def get_last_price(self, asset: Union[Asset, str], quote=None, exchange=None) -> Union[float, Decimal, None]:
         return Decimal(100.0)  # Mock price
 
     def update_broker_balances(self, force_update: bool = False) -> None:


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?

Standardize the return type of `get_last_price` method across various data sources to `Union[float, Decimal, None]` and add unit tests for CCXT-based data handling.

### Why are these changes being made?

Previously, the `get_last_price` method across the codebase was inconsistent in its return type, which could lead to errors or misinterpretations when handling asset prices. By standardizing to `Union[float, Decimal, None]`, the code enhances type consistency, allowing more precise handling of different numeric types and potential use of high-precision `Decimal` for financial computations. The addition of tests for the CCXT data source improves test coverage, ensuring that functionality related to this data source is correctly implemented and verified.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->