### PR TITLE
Added only_rebalance_drifted_assets parameter

### DIFF
--- a/lumibot/example_strategies/classic_60_40_config.py
+++ b/lumibot/example_strategies/classic_60_40_config.py
@@ -22,5 +22,7 @@ parameters = {
             "weight": Decimal("0.4")
         }
     ],
-    "shorting": False
+    "shorting": False,
+    "fractional_shares": False,
+    "only_rebalance_drifted_assets": False,
 }

--- a/lumibot/example_strategies/crypto_50_50.py
+++ b/lumibot/example_strategies/crypto_50_50.py
@@ -23,7 +23,8 @@ if __name__ == "__main__":
         "acceptable_slippage": "0.005",  # 50 BPS
         "fill_sleeptime": 15,
         "shorting": False,
-        "fractional_shares": True
+        "fractional_shares": True,
+        "only_rebalance_drifted_assets": False,
     }
 
     if not is_live:

--- a/lumibot/example_strategies/drift_rebalancer.py
+++ b/lumibot/example_strategies/drift_rebalancer.py
@@ -41,7 +41,9 @@ class DriftRebalancer(Strategy):
                 "weight": Decimal("0.4")
             }
         ],
-        "shorting": False
+        "shorting": False,
+        "fractional_shares": False,
+        "only_rebalance_drifted_assets": False,
     }
 
     Description of parameters:
@@ -79,6 +81,7 @@ class DriftRebalancer(Strategy):
     - portfolio_weights: A list of dictionaries containing the base_asset and weight of each asset in the portfolio.
     - shorting: If you want to allow shorting, set this to True. Default is False.
     - fractional_shares: If you want to allow fractional shares, set this to True. Default is False.
+    - only_rebalance_drifted_assets: If you want to only rebalance assets that have drifted, set this to True. Default is False.
 
     """
 
@@ -94,6 +97,7 @@ class DriftRebalancer(Strategy):
         self.portfolio_weights = self.parameters.get("portfolio_weights", {})
         self.shorting = self.parameters.get("shorting", False)
         self.fractional_shares = self.parameters.get("fractional_shares", False)
+        self.only_rebalance_drifted_assets = self.parameters.get("only_rebalance_drifted_assets", False)
         self.drift_df = pd.DataFrame()
         self.drift_rebalancer_logic = DriftRebalancerLogic(
             strategy=self,
@@ -104,6 +108,7 @@ class DriftRebalancer(Strategy):
             fill_sleeptime=self.fill_sleeptime,
             shorting=self.shorting,
             fractional_shares=self.fractional_shares,
+            only_rebalance_drifted_assets=self.only_rebalance_drifted_assets,
         )
 
     # noinspection PyAttributeOutsideInit

--- a/tests/test_drift_rebalancer.py
+++ b/tests/test_drift_rebalancer.py
@@ -954,6 +954,49 @@ class TestDriftOrderLogic:
         assert strategy.orders[0].quantity == Decimal("5")
         assert strategy.orders[0].type == Order.OrderType.LIMIT
 
+    def test_selling_with_only_rebalance_drifted_assets_when_over_drift_threshold(self):
+        strategy = MockStrategyWithOrderLogic(
+            broker=self.backtesting_broker,
+            order_type=Order.OrderType.LIMIT
+        )
+        df = pd.DataFrame({
+            "symbol": ["AAPL"],
+            "base_asset": [Asset("AAPL", "stock")],
+            "is_quote_asset": False,
+            "current_quantity": [Decimal("10")],
+            "current_value": [Decimal("1000")],
+            "current_weight": [Decimal("1.0")],
+            "target_weight": Decimal("0.5"),
+            "target_value": Decimal("500"),
+            "drift": Decimal("-0.5")
+        })
+        strategy.order_logic.only_rebalance_drifted_assets = True
+        strategy.order_logic.rebalance(drift_df=df)
+        assert len(strategy.orders) == 1
+        assert strategy.orders[0].side == "sell"
+        assert strategy.orders[0].quantity == Decimal("5")
+        assert strategy.orders[0].type == Order.OrderType.LIMIT
+
+    def test_selling_with_only_rebalance_drifted_assets_when_not_over_drift_threshold(self):
+        strategy = MockStrategyWithOrderLogic(
+            broker=self.backtesting_broker,
+            order_type=Order.OrderType.LIMIT
+        )
+        df = pd.DataFrame({
+            "symbol": ["AAPL"],
+            "base_asset": [Asset("AAPL", "stock")],
+            "is_quote_asset": False,
+            "current_quantity": [Decimal("10")],
+            "current_value": [Decimal("1000")],
+            "current_weight": [Decimal("1.0")],
+            "target_weight": Decimal("0.5"),
+            "target_value": Decimal("500"),
+            "drift": Decimal("-0.001")  # make drift small
+        })
+        strategy.order_logic.only_rebalance_drifted_assets = True
+        strategy.order_logic.rebalance(drift_df=df)
+        assert len(strategy.orders) == 0
+
     def test_selling_part_of_a_holding_with_market_order(self):
         strategy = MockStrategyWithOrderLogic(
             broker=self.backtesting_broker,
@@ -1318,6 +1361,49 @@ class TestDriftOrderLogic:
         assert strategy.orders[0].side == "sell"
         assert strategy.orders[0].quantity == Decimal("1.507537688")
         assert strategy.orders[0].type == Order.OrderType.LIMIT
+
+    def test_buying_with_only_rebalance_drifted_assets_when_over_drift_threshold(self):
+        strategy = MockStrategyWithOrderLogic(
+            broker=self.backtesting_broker,
+            order_type=Order.OrderType.LIMIT
+        )
+        df = pd.DataFrame({
+            "symbol": ["AAPL"],
+            "base_asset": [Asset("AAPL", "stock")],
+            "is_quote_asset": False,
+            "current_quantity": [Decimal("0")],
+            "current_value": [Decimal("0")],
+            "current_weight": [Decimal("0.0")],
+            "target_weight": Decimal("0.5"),
+            "target_value": Decimal("500"),
+            "drift": Decimal("0.5")
+        })
+        strategy.order_logic.only_rebalance_drifted_assets = True
+        strategy.order_logic.rebalance(drift_df=df)
+        assert len(strategy.orders) == 1
+        assert strategy.orders[0].side == "buy"
+        assert strategy.orders[0].quantity == Decimal("4.0")  #
+        assert strategy.orders[0].type == Order.OrderType.LIMIT
+
+    def test_buying_with_only_rebalance_drifted_assets_when_not_over_drift_threshold(self):
+        strategy = MockStrategyWithOrderLogic(
+            broker=self.backtesting_broker,
+            order_type=Order.OrderType.LIMIT
+        )
+        df = pd.DataFrame({
+            "symbol": ["AAPL"],
+            "base_asset": [Asset("AAPL", "stock")],
+            "is_quote_asset": False,
+            "current_quantity": [Decimal("0")],
+            "current_value": [Decimal("0")],
+            "current_weight": [Decimal("0.0")],
+            "target_weight": Decimal("0.5"),
+            "target_value": Decimal("500"),
+            "drift": Decimal("0.001")  # make drift small
+        })
+        strategy.order_logic.only_rebalance_drifted_assets = True
+        strategy.order_logic.rebalance(drift_df=df)
+        assert len(strategy.orders) == 0
 
 
 # @pytest.mark.skip()


### PR DESCRIPTION
Before the change, when a rebalance was triggered, all positions would reblance. That's still the default behavior, but now, you can set only_rebalance_drifted_assets, and only the assets that have drifted beyond the drift_threshold will rebalance. 

This is useful when rebalancing portfolios with lots of positions, some of which are volatile and some of which arent.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a `only_rebalance_drifted_assets` parameter to `DriftRebalancerLogic` and its associated classes and configurations, enabling selective rebalancing of assets that exceed a defined drift threshold.

### Why are these changes being made?

This change provides users with a more efficient portfolio management option by rebalancing only those assets that have drifted beyond a specified threshold, thus optimizing trade executions and potentially reducing trading costs. The approach streamlines portfolio adjustments by ignoring minor drifts that don't meet user-defined criteria.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->