### PR TITLE
feat: Add option pricing to get last price and historical data on Alpaca

### DIFF
--- a/tests/test_alpaca.py
+++ b/tests/test_alpaca.py
@@ -5,12 +5,16 @@ from lumibot.brokers.alpaca import Alpaca
 from lumibot.data_sources.alpaca_data import AlpacaData
 from lumibot.example_strategies.stock_buy_and_hold import BuyAndHold
 
+from datetime import datetime, timedelta
+
+import math
+
 # Fake credentials, they do not need to be real
 ALPACA_CONFIG = {  # Paper trading!
     # Put your own Alpaca key here:
-    "API_KEY": "PKP00CIO3VSDTZIT1HSV",
+    "API_KEY": "",
     # Put your own Alpaca secret here:
-    "API_SECRET": "sKdQGSgtOxdARoNwkELaZqgvhGaxlPtBq82t5MhR",
+    "API_SECRET": "",
     # If you want to use real money you must change this to False
     "PAPER": True,
 }
@@ -51,3 +55,33 @@ class TestAlpacaBroker:
         order = Order(asset=Asset("SPY"), quantity=10, side="buy", limit_price=0.12345, strategy='abc')
         broker._conform_order(order)
         assert order.limit_price == 0.1235
+
+    def test_option_get_last_price(self):
+        broker = Alpaca(ALPACA_CONFIG)
+        dte = datetime.now()
+        spy_price = broker.get_last_price(asset='SPY')
+        price = broker.get_last_price(asset=Asset('SPY', Asset.AssetType.OPTION, expiration=dte, strike=math.floor(spy_price), right='CALL'))
+        assert price != 0
+
+    def test_stock_get_last_price(self):
+        broker = Alpaca(ALPACA_CONFIG)
+        price = broker.get_last_price(asset='SPY')
+        assert price != 0
+        price = broker.get_last_price(asset=Asset(symbol='SPY'))
+        assert price != 0
+
+    def test_crypto_get_last_price(self):
+        broker = Alpaca(ALPACA_CONFIG)
+        base = Asset(symbol="BTC", asset_type=Asset.AssetType.CRYPTO)
+        quote = Asset(symbol="USD", asset_type=Asset.AssetType.FOREX)
+        price = broker.get_last_price(asset=base, quote=quote)
+        assert price != 0
+
+    def test_option_get_historical_prices(self):
+        broker = Alpaca(ALPACA_CONFIG)
+        dte = datetime.now() - timedelta(days=2)
+        spy_price = broker.get_last_price(asset='SPY')
+        asset = Asset('SPY', Asset.AssetType.OPTION, expiration=dte, strike=math.floor(spy_price), right='CALL')
+        print(asset)
+        bars = broker.data_source.get_historical_prices(asset, 10, "day")
+        assert len(bars.df) > 0

--- a/tests/test_get_historical_prices.py
+++ b/tests/test_get_historical_prices.py
@@ -1,11 +1,5 @@
-import os
 from datetime import datetime, timedelta
-import logging
 
-import pytest
-
-import pandas as pd
-import pytz
 from pandas.testing import assert_series_equal
 
 from lumibot.backtesting import PolygonDataBacktesting, YahooDataBacktesting
@@ -18,6 +12,12 @@ from lumibot.tools import get_trading_days
 # Global parameters
 from lumibot.credentials import TRADIER_CONFIG, ALPACA_CONFIG, POLYGON_CONFIG
 
+import os
+import logging
+import pytest
+import math
+import pandas as pd
+import pytz
 
 logger = logging.getLogger(__name__)
 print_full_pandas_dataframes()
@@ -454,6 +454,37 @@ class TestDatasourceGetHistoricalPricesDailyData:
     def test_alpaca_data_source_get_historical_prices_daily_bars(self):
         data_source = AlpacaData(ALPACA_CONFIG)
         bars = data_source.get_historical_prices(asset=self.asset, length=self.length, timestep=self.timestep)
+
+        # Alpaca's time zone is UTC. We should probably convert it to America/New_York
+        # Alpaca data source does not provide dividends
+        check_bars(bars=bars, length=self.length, check_timezone=False)
+        self.check_date_of_last_bar_is_correct_for_live_data_sources(bars)
+
+        # TODO: convert the timezones returned by alpaca to America/New_York
+        assert bars.df.index[0].tzinfo == pytz.timezone("UTC")
+
+        # This simulates what the call to get_yesterday_dividends does (lookback of 1)
+        bars = data_source.get_historical_prices(asset=self.asset, length=1, timestep=self.timestep)
+        check_bars(bars=bars, length=1, check_timezone=False)
+        self.check_date_of_last_bar_is_correct_for_live_data_sources(bars)
+
+    @pytest.mark.skipif(
+        not ALPACA_CONFIG['API_KEY'],
+        reason="This test requires an alpaca API key"
+    )
+    @pytest.mark.skipif(
+        ALPACA_CONFIG['API_KEY'] == '<your key here>',
+        reason="This test requires an alpaca API key"
+    )
+    def test_alpaca_data_source_get_historical_option_prices(self):
+        data_source = AlpacaData(ALPACA_CONFIG)
+
+        # Get a 0dte option
+        dte = datetime.now()
+        spy_price = data_source.get_last_price(asset=self.ticker)
+        o_asset = Asset(self.ticker, Asset.AssetType.OPTION, expiration=dte, strike=math.floor(spy_price), right='CALL')
+
+        bars = data_source.get_historical_prices(asset=o_asset, length=self.length, timestep=self.timestep)
 
         # Alpaca's time zone is UTC. We should probably convert it to America/New_York
         # Alpaca data source does not provide dividends


### PR DESCRIPTION
This PR serves to add option in the Alpaca broker. This includes:

- Get last price taking an option contract
- Get historical prices taking an option contract
- Updating positions to know what a option contract is

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add support for retrieving last price and historical data for options via the Alpaca API.

### Why are these changes being made?
The update enhances the Alpaca API integration by enabling access to option pricing data, meeting user demand for comprehensive option trading capabilities. This change addresses the gap in current functionality by supporting the retrieval of both real-time and historical data for options, ensuring better data handling and decision-making for users.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->