### PR TITLE
fix(entities): pass avg_fill_price in to_position

### DIFF
--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -863,6 +863,7 @@ class Order:
             self.asset,
             position_qty,
             orders=[self],
+            avg_fill_price=self.avg_fill_price
         )
         return position
 

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -236,3 +236,15 @@ class TestOrderBasics:
         order1.status = "open"
         order2.status = ""
         assert not order1.equivalent_status("")
+
+    def test_to_position(self):
+        asset = Asset("SPY")
+        order = Order(strategy='abc', asset=asset, side="buy", quantity=100, avg_fill_price=100)
+        position = order.to_position(order.quantity)
+        assert position.strategy == order.strategy
+        assert position.asset == order.asset
+        assert position.quantity == order.quantity
+        assert position.orders == [order]
+        assert position.hold == 0
+        assert position.available == 0
+        assert position.avg_fill_price == order.avg_fill_price


### PR DESCRIPTION
This fixes `Position.avg_fill_price` being `None` when it's created from an `Order`.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add `avg_fill_price` as a parameter when creating a position in the `to_position` method within the `order.py` file.

### Why are these changes being made?

This change ensures that the average fill price is included in the position object, which is crucial for accurate backtesting and performance analysis. Without this addition, position objects may lack complete pricing information, impacting financial calculations and strategies.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->