### PR TITLE
Order Management Overhaul

### DIFF
--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -426,7 +426,7 @@ class Alpaca(Broker):
         alpaca_type = order.order_type
         if order.order_class == Order.OrderClass.OCO:
             alpaca_type = Order.OrderType.LIMIT
-        elif order.order_class in [Order.OrderType.BRACKET, Order.OrderType.OTO]:
+        elif order.order_class in [Order.OrderClass.BRACKET, Order.OrderClass.OTO]:
             alpaca_type = Order.OrderType.MARKET
 
         limit_price = order.limit_price if order.order_type != Order.OrderType.STOP_LIMIT else order.stop_limit_price

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -265,12 +265,12 @@ class Alpaca(Broker):
         if position.asset_class == "crypto":
             asset = Asset(
                 symbol=position.symbol.replace("USD", ""),
-                asset_type="crypto",
+                asset_type=Asset.AssetType.CRYPTO,
             )
         elif position.asset_class == "option":
             asset = Asset(
                 symbol=position.symbol,
-                asset_type="option",
+                asset_type=Asset.AssetType.OPTION,
             )
         else:
             asset = Asset(
@@ -330,11 +330,11 @@ class Alpaca(Broker):
         return result
 
     # =======Orders and assets functions=========
-    def map_asset_type(self, type):
+    def map_asset_type(self, alpaca_type):
         for k, v in self.ASSET_TYPE_MAP.items():
-            if type in v:
+            if alpaca_type in v:
                 return k
-        raise ValueError(f"The type {type} is not in the ASSET_TYPE_MAP in the Alpaca Module.")
+        raise ValueError(f"The type {alpaca_type} is not in the ASSET_TYPE_MAP in the Alpaca Module.")
 
     def _parse_broker_order(self, response, strategy_name, strategy_object=None):
         """parse a broker order representation
@@ -347,6 +347,11 @@ class Alpaca(Broker):
         else:
             symbol = response.symbol
 
+        # Alpaca Order type/class mostly matches LumiBot's Order type/class with exceptons of 'mleg' and 'trailing_stop'
+        limit_price = response.limit_price if response.order_type != Order.OrderType.STOP_LIMIT else None
+        stop_limit_price = response.limit_price if response.order_type == Order.OrderType.STOP_LIMIT else None
+        order_class = response.order_class if response.order_class != "mleg" else Order.OrderClass.MULTILEG
+        order_type = response.order_type if response.order_type != "trailing_stop" else Order.OrderType.TRAIL
         order = Order(
             strategy_name,
             Asset(
@@ -355,9 +360,15 @@ class Alpaca(Broker):
             ),
             Decimal(response.qty),
             response.side,
-            limit_price=response.limit_price,
+            limit_price=limit_price,  # order.py always converts to 'float'. Crypto issue?
             stop_price=response.stop_price,
+            stop_limit_price=stop_limit_price,
+            trail_price=response.trail_price if response.trail_price else None,
+            trail_percent=response.trail_percent if response.trail_percent else None,
             time_in_force=response.time_in_force,
+            order_class=order_class,
+            order_type=order_type,
+
             # TODO: remove hardcoding in case Alpaca allows crypto to crypto trading
             quote=Asset(symbol="USD", asset_type="forex"),
         )
@@ -411,47 +422,57 @@ class Alpaca(Broker):
         else:
             trade_symbol = order.asset.symbol
 
-        # If order type is OCO, set to limit (Alpaca wants this for OCO)
-        if order.type == Order.OrderType.OCO:
-            order.type = Order.OrderType.LIMIT
+        # If order class is OCO, set to type limit (Alpaca wants this for OCO), Bracket becomes 'market'
+        alpaca_type = order.order_type
+        if order.order_class == Order.OrderClass.OCO:
+            alpaca_type = Order.OrderType.LIMIT
+        elif order.order_class in [Order.OrderType.BRACKET, Order.OrderType.OTO]:
+            alpaca_type = Order.OrderType.MARKET
 
+        limit_price = order.limit_price if order.order_type != Order.OrderType.STOP_LIMIT else order.stop_limit_price
         kwargs = {
             "symbol": trade_symbol,
             "qty": qty,
             "side": order.side,
-            "type": order.type,
+            "type": alpaca_type,
             "order_class": order.order_class,
             "time_in_force": order.time_in_force,
-            "limit_price": str(order.limit_price) if order.limit_price else None,
+            # Crypto can use 9 decimal places on Alpaca
+            "limit_price": str(limit_price) if limit_price else None,
             "stop_price": str(order.stop_price) if order.stop_price else None,
             "trail_price": str(order.trail_price) if order.trail_price else None,
-            "trail_percent": order.trail_percent,
+            "trail_percent": str(order.trail_percent) if order.trail_percent else None,
         }
         # Remove items with None values
         kwargs = {k: v for k, v in kwargs.items() if v}
 
-        if order.take_profit_price:
-            kwargs["take_profit"] = {
-                "limit_price": float(round(order.take_profit_price, 2))
-                if isinstance(order.take_profit_price, Decimal)
-                else order.take_profit_price,
-            }
+        if order.order_class in [Order.OrderClass.OCO, Order.OrderClass.OTO, Order.OrderClass.BRACKET]:
+            child_limit_orders = [child for child in order.child_orders if child.order_type == Order.OrderType.LIMIT]
+            child_stop_orders = [child for child in order.child_orders if child.is_stop_order()]
+            child_limit = child_limit_orders[0] if child_limit_orders else None
+            child_stop = child_stop_orders[0] if child_stop_orders else None
+            if child_limit:
+                kwargs["take_profit"] = {
+                    "limit_price": float(round(child_limit.limit_price, 2))
+                    if isinstance(order.limit_price, Decimal)
+                    else order.limit_price,
+                }
 
-        if order.stop_loss_price:
-            kwargs["stop_loss"] = {
-                "stop_price": float(round(order.stop_loss_price, 2))
-                if isinstance(order.stop_loss_price, Decimal)
-                else order.stop_loss_price,
-            }
-            if order.stop_loss_limit_price:
-                kwargs["stop_loss"]["limit_price"] = float(
-                    round(order.stop_loss_limit_price, 2)
-                    if isinstance(
-                        order.stop_loss_limit_price,
-                        Decimal,
+            if order.stop_price:
+                kwargs["stop_loss"] = {
+                    "stop_price": float(round(order.stop_price, 2))
+                    if isinstance(order.stop_loss_price, Decimal)
+                    else order.stop_loss_price,
+                }
+                if order.stop_limit_price:
+                    kwargs["stop_loss"]["limit_price"] = float(
+                        round(order.stop_limit_price, 2)
+                        if isinstance(
+                            order.stop_limit_price,
+                            Decimal,
+                        )
+                        else order.stop_limit_price
                     )
-                    else order.stop_loss_limit_price
-                )
 
         try:
             order_data = OrderData(**kwargs)
@@ -486,7 +507,7 @@ class Alpaca(Broker):
         """Conform an order to Alpaca's requirements
         See: https://docs.alpaca.markets/docs/orders-at-alpaca
         """
-        if order.asset.asset_type == "stock" and order.type == "limit":
+        if order.asset.asset_type == Asset.AssetType.STOCK and order.order_type == Order.OrderType.LIMIT:
             """
             The minimum price variance exists for limit orders.
             Orders received in excess of the minimum price variance will be rejected.
@@ -555,7 +576,6 @@ class Alpaca(Broker):
         Get the broker stream connection
         """
         stream = TradingStream(self.api_key, self.api_secret, paper=self.is_paper)
-
         return stream
 
     def _register_stream_events(self):

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -454,24 +454,18 @@ class Alpaca(Broker):
             if child_limit:
                 kwargs["take_profit"] = {
                     "limit_price": float(round(child_limit.limit_price, 2))
-                    if isinstance(order.limit_price, Decimal)
-                    else order.limit_price,
+                    if isinstance(child_limit.limit_price, Decimal) else child_limit.limit_price,
                 }
 
-            if order.stop_price:
+            if child_stop:
                 kwargs["stop_loss"] = {
-                    "stop_price": float(round(order.stop_price, 2))
-                    if isinstance(order.stop_loss_price, Decimal)
-                    else order.stop_loss_price,
+                    "stop_price": float(round(child_stop.stop_price, 2))
+                    if isinstance(child_stop.stop_price, Decimal) else child_stop.stop_price,
                 }
-                if order.stop_limit_price:
+                if child_stop.stop_limit_price:
                     kwargs["stop_loss"]["limit_price"] = float(
-                        round(order.stop_limit_price, 2)
-                        if isinstance(
-                            order.stop_limit_price,
-                            Decimal,
-                        )
-                        else order.stop_limit_price
+                        round(child_stop.stop_limit_price, 2)
+                        if isinstance(child_stop.stop_limit_price, Decimal) else child_stop.stop_limit_price
                     )
 
         try:

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -1230,9 +1230,9 @@ class Broker(ABC):
                 self._on_canceled_order(stored_order)
         elif Order.is_equivalent_status(type_event, self.MODIFIED_ORDER):
             # Modify is only allowed to adjust the stop and limit price, not quantity or other attributes.
-            if stored_order.type == Order.OrderType.STOP:
+            if stored_order.order_type == Order.OrderType.STOP:
                 stored_order.stop_price = price
-            elif stored_order.type == Order.OrderType.LIMIT:
+            elif stored_order.order_type == Order.OrderType.LIMIT:
                 stored_order.limit_price = price
         elif Order.is_equivalent_status(type_event, self.PARTIALLY_FILLED_ORDER):
             stored_order, position = self._process_partially_filled_order(stored_order, price, filled_quantity)
@@ -1242,7 +1242,7 @@ class Broker(ABC):
             self._on_filled_order(position, stored_order, price, filled_quantity, multiplier)
         elif Order.is_equivalent_status(type_event, self.CASH_SETTLED):
             self._process_cash_settlement(stored_order, price, filled_quantity)
-            stored_order.type = self.CASH_SETTLED
+            stored_order.order_type = self.CASH_SETTLED
         else:
             self.logger.info(f"Unhandled type event {type_event} for {stored_order}")
 
@@ -1254,7 +1254,7 @@ class Broker(ABC):
             "identifier": stored_order.identifier,
             "symbol": stored_order.symbol,
             "side": stored_order.side,
-            "type": stored_order.type,
+            "type": stored_order.order_type,
             "status": stored_order.status,
             "price": price,
             "filled_quantity": filled_quantity,

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -46,6 +46,7 @@ class Broker(ABC):
     PARTIALLY_FILLED_ORDER = "partial_fill"
     CASH_SETTLED = "cash_settled"
     ERROR_ORDER = "error"
+    PLACEHOLDER_ORDER = "placeholder"
 
     def __init__(self, name="", connect_stream=True, data_source: DataSource = None, option_source: DataSource = None,
                  config=None, max_workers=20, extended_trading_minutes=0):
@@ -54,6 +55,7 @@ class Broker(ABC):
         self.name = name
         self._lock = RLock()
         self._unprocessed_orders = SafeList(self._lock)
+        self._placeholder_orders = SafeList(self._lock)
         self._new_orders = SafeList(self._lock)
         self._canceled_orders = SafeList(self._lock)
         self._partially_filled_orders = SafeList(self._lock)
@@ -598,6 +600,14 @@ class Broker(ABC):
         self._new_orders.append(order)
         return order
 
+    def _process_placeholder_order(self, order):
+        """Used to track a placeholder order that never gets filled. I.e. OCO parent order"""
+        self._unprocessed_orders.remove(order.identifier, key="identifier")
+        order.status = self.NEW_ORDER
+        order.set_new()
+        self._placeholder_orders.append(order)
+        return order
+
     def _process_canceled_order(self, order):
         self._new_orders.remove(order.identifier, key="identifier")
         self._unprocessed_orders.remove(order.identifier, key="identifier")
@@ -848,9 +858,10 @@ class Broker(ABC):
 
     # =========Orders and assets functions=================
 
-    def get_tracked_order(self, identifier):
+    def get_tracked_order(self, identifier, use_placeholders=False):
         """get a tracked order given an identifier"""
-        for order in self._tracked_orders:
+        tracked_orders = list(self._tracked_orders) + (self._placeholder_orders.get_list() if use_placeholders else [])
+        for order in tracked_orders:
             if order.identifier == identifier:
                 return order
         return None
@@ -1222,6 +1233,9 @@ class Broker(ABC):
 
         if Order.is_equivalent_status(type_event, self.NEW_ORDER):
             stored_order = self._process_new_order(stored_order)
+            self._on_new_order(stored_order)
+        if Order.is_equivalent_status(type_event, self.PLACEHOLDER_ORDER):
+            stored_order = self._process_placeholder_order(stored_order)
             self._on_new_order(stored_order)
         elif Order.is_equivalent_status(type_event, self.CANCELED_ORDER):
             # Do not cancel or re-cancel already completed orders

--- a/lumibot/brokers/ccxt.py
+++ b/lumibot/brokers/ccxt.py
@@ -305,7 +305,7 @@ class Ccxt(Broker):
                 symbol=pair[1],
                 asset_type="crypto",
             ),
-            type=response["type"] if "type" in response else None,
+            order_type=response["type"] if "type" in response else None,
         )
         order.set_identifier(response["id"])
         order.status = response["status"]
@@ -404,8 +404,8 @@ class Ccxt(Broker):
             logging.error(f"A compound order of {order.order_class} was entered. " f"{markets_error_message}")
             return
 
-        if order.type not in order_types:
-            logging.error(f"An order type of {order.type} was entered which is not " f"valid. {markets_error_message}")
+        if order.order_type not in order_types:
+            logging.error(f"An order type of {order.order_type} was entered which is not " f"valid. {markets_error_message}")
             return
 
         # Check order within limits.
@@ -553,7 +553,7 @@ class Ccxt(Broker):
         if self.is_margin_enabled() and self.api.exchangeId != "binance":
             params["tradeType"] = "MARGIN_TRADE"
 
-        # if self.api.exchangeId == "coinbase" and order.type == "market":
+        # if self.api.exchangeId == "coinbase" and order.order_type == "market":
         #     params["createMarketBuyOrderRequiresPrice"] = False
 
         try:
@@ -686,7 +686,7 @@ class Ccxt(Broker):
         broker = self.api.exchangeId
         if broker == "binance":
             params = {}
-            if order.type in ["stop_limit"]:
+            if order.order_type in ["stop_limit"]:
                 params = {
                     "stopPrice": str(order.stop_price),
                 }
@@ -697,11 +697,11 @@ class Ccxt(Broker):
 
             args = [
                 order.pair,
-                order_type_map[order.type],
+                order_type_map[order.order_type],
                 order.side,
                 str(order.quantity),
             ]
-            if order.type in ["limit", "stop_limit"]:
+            if order.order_type in ["limit", "stop_limit"]:
                 args.append(str(order.limit_price))
 
             if len(params) > 0:
@@ -711,7 +711,7 @@ class Ccxt(Broker):
 
         elif broker in ["kraken", "kucoin", "coinbasepro", "coinbase"]:
             params = {}
-            if order.type in ["stop_limit"]:
+            if order.order_type in ["stop_limit"]:
                 params = {
                     "stop": "entry" if order.side == "buy" else "loss",
                     "stop_price": str(order.stop_price),
@@ -729,15 +729,15 @@ class Ccxt(Broker):
 
             args = [
                 order.pair,
-                order_type_map[order.type],
+                order_type_map[order.order_type],
                 order.side,
                 str(order.quantity),  # check this with coinbase.
             ]
-            if order_type_map[order.type] == "limit":
+            if order_type_map[order.order_type] == "limit":
                 args.append(str(order.limit_price))
 
             # If coinbase, you need to pass the price even with a market order
-            if broker == "coinbase" and order_type_map[order.type] == "market":
+            if broker == "coinbase" and order_type_map[order.order_type] == "market":
                 price = self.data_source.get_last_price(order.asset, quote=order.quote)
                 args.append(str(price))
 

--- a/lumibot/brokers/interactive_brokers.py
+++ b/lumibot/brokers/interactive_brokers.py
@@ -326,9 +326,9 @@ class InteractiveBrokers(Broker):
             #If price is not None, then set the limit price for for the parent order and set the type to limit.
             if price is not None:
                 multileg_order.limit_price = price
-                multileg_order.type = OrderLum.OrderType.LIMIT
+                multileg_order.order_type = OrderLum.OrderType.LIMIT
             else:
-                multileg_order.type = OrderLum.OrderType.MARKET
+                multileg_order.order_type = OrderLum.OrderType.MARKET
 
             # Submit the multileg order.
             self._orders_queue.put(multileg_order)
@@ -342,7 +342,7 @@ class InteractiveBrokers(Broker):
         # Initial order
         order.identifier = self.ib.nextOrderId()
         kwargs = {
-            "type": order.type,
+            "type": order.order_type,
             "order_class": order.order_class,
             "time_in_force": order.time_in_force,
             "good_till_date": order.good_till_date,
@@ -354,17 +354,18 @@ class InteractiveBrokers(Broker):
         # Remove items with None values
         kwargs = {k: v for k, v in kwargs.items() if v}
 
-        if order.take_profit_price:
-            kwargs["take_profit"] = {"limit_price": order.take_profit_price}
-
-        if order.stop_loss_price:
-            kwargs["stop_loss"] = {"stop_price": order.stop_loss_price}
-            if order.stop_loss_limit_price:
-                kwargs["stop_loss"]["limit_price"] = order.stop_loss_limit_price
+        if order.child_orders:
+            for child_order in order.child_orders:
+                if child_order.order_type == OrderLum.OrderType.LIMIT:
+                    kwargs["take_profit"] = {"limit_price": child_order.limit_price}
+                elif child_order.order_type in [OrderLum.OrderType.STOP, OrderLum.OrderType.STOP_LIMIT]:
+                    kwargs["stop_loss"] = {"stop_price": child_order.stop_price}
+                    if child_order.order_type == OrderLum.OrderType.STOP_LIMIT:
+                        kwargs["stop_loss"]["limit_price"] = child_order.stop_limit_price
 
         if self.subaccount is not None:
             order.account = self.subaccount # to be tested
-        
+
         self._unprocessed_orders.append(order)
         self.ib.execute_order(order)
         order.status = "submitted"
@@ -1483,8 +1484,9 @@ class IBApp(IBWrapper, IBClient):
         elif asset.asset_type == "index":
             pass
         else:
+            valid_types = [a.value for a in Asset.AssetType]
             raise ValueError(
-                f"The asset {asset.symbol} has a type of {asset.asset_type}. " f"It must be one of {asset._asset_types}"
+                f"The asset {asset.symbol} has a type of {asset.asset_type}. " f"It must be one of {valid_types}"
             )
 
         return contract
@@ -1511,7 +1513,7 @@ class IBApp(IBWrapper, IBClient):
             takeProfit.action = "SELL" if self.get_safe_action(parent.action) == "BUY" else "BUY"
             takeProfit.orderType = "LMT"
             takeProfit.totalQuantity = order.quantity
-            takeProfit.lmtPrice = order.take_profit_price
+            takeProfit.lmtPrice = order.limit_price
             takeProfit.parentId = parent.orderId
             takeProfit.transmit = False
 
@@ -1519,7 +1521,7 @@ class IBApp(IBWrapper, IBClient):
             stopLoss.orderId = self.nextOrderId()
             stopLoss.action = "SELL" if self.get_safe_action(parent.action) == "BUY" else "BUY"
             stopLoss.orderType = "STP"
-            stopLoss.auxPrice = order.stop_loss_price
+            stopLoss.auxPrice = order.stop_price
             stopLoss.totalQuantity = order.quantity
             stopLoss.parentId = parent.orderId
             stopLoss.transmit = True
@@ -1544,23 +1546,23 @@ class IBApp(IBWrapper, IBClient):
             parent.lmtPrice = order.limit_price
             parent.transmit = False
 
-            if order.take_profit_price:
+            if order.limit_price:
                 takeProfit = Order()
                 takeProfit.orderId = self.nextOrderId()
                 takeProfit.action = "SELL" if self.get_safe_action(parent.action) == "BUY" else "BUY"
                 takeProfit.orderType = "LMT"
                 takeProfit.totalQuantity = order.quantity
-                takeProfit.lmtPrice = order.take_profit_price
+                takeProfit.lmtPrice = order.limit_price
                 takeProfit.parentId = parent.orderId
                 takeProfit.transmit = True
                 return [parent, takeProfit]
 
-            elif order.stop_loss_price:
+            elif order.stop_price:
                 stopLoss = Order()
                 stopLoss.orderId = self.nextOrderId()
                 stopLoss.action = "SELL" if self.get_safe_action(parent.action) == "BUY" else "BUY"
                 stopLoss.orderType = "STP"
-                stopLoss.auxPrice = order.stop_loss_price
+                stopLoss.auxPrice = order.stop_price
                 stopLoss.totalQuantity = order.quantity
                 stopLoss.parentId = parent.orderId
                 stopLoss.transmit = True
@@ -1572,7 +1574,7 @@ class IBApp(IBWrapper, IBClient):
             takeProfit.action = self.get_safe_action(order.side)
             takeProfit.orderType = "LMT"
             takeProfit.totalQuantity = order.quantity
-            takeProfit.lmtPrice = order.take_profit_price
+            takeProfit.lmtPrice = order.limit_price
             takeProfit.transmit = False
 
             oco_Group = f"oco_{takeProfit.orderId}"
@@ -1584,7 +1586,7 @@ class IBApp(IBWrapper, IBClient):
             stopLoss.action = self.get_safe_action(order.side)
             stopLoss.orderType = "STP"
             stopLoss.totalQuantity = order.quantity
-            stopLoss.auxPrice = order.stop_loss_price
+            stopLoss.auxPrice = order.stop_price
             stopLoss.transmit = True
 
             stopLoss.ocaGroup = oco_Group
@@ -1593,7 +1595,7 @@ class IBApp(IBWrapper, IBClient):
             return [takeProfit, stopLoss]
         else:
             ib_order.action = self.get_safe_action(order.side)
-            ib_order.orderType = ORDERTYPE_MAPPING[order.type]
+            ib_order.orderType = ORDERTYPE_MAPPING[order.order_type]
             ib_order.totalQuantity = order.quantity
             ib_order.lmtPrice = order.limit_price if order.limit_price else 0
             ib_order.auxPrice = order.stop_price if order.stop_price else ""
@@ -1651,13 +1653,13 @@ class IBApp(IBWrapper, IBClient):
         combo_order = Order()
         combo_order.action = "BUY" # TODO: This is a placeholder. This should be set based on the order side
         combo_order.orderId = combo_order_id
-        combo_order.orderType = ORDERTYPE_MAPPING[order.type]
+        combo_order.orderType = ORDERTYPE_MAPPING[order.order_type]
         combo_order.tif = order.time_in_force.upper()
         combo_order.goodTillDate = order.good_till_date if order.good_till_date else ""
         combo_order.totalQuantity = min([child_order.quantity for child_order in order.child_orders])
 
         # Set the limit price if this is a limit order and a price is provided
-        if order.type == OrderLum.OrderType.LIMIT and order.limit_price:
+        if order.order_type == OrderLum.OrderType.LIMIT and order.limit_price:
             combo_order.lmtPrice = order.limit_price
 
         # Return the combo contract and order        

--- a/lumibot/brokers/interactive_brokers_rest.py
+++ b/lumibot/brokers/interactive_brokers_rest.py
@@ -808,7 +808,7 @@ class InteractiveBrokersREST(Broker):
                 logging.error(colored("Order Side Not Found", "red"))
                 return None
 
-            orderType = ORDERTYPE_MAPPING[order.type]
+            orderType = ORDERTYPE_MAPPING[order.order_type]
 
             conid = self.data_source.get_conid_from_asset(order.asset)
 
@@ -968,7 +968,7 @@ class InteractiveBrokersREST(Broker):
         order = orders[0]
 
         # Determine the order type, defaulting to "MKT" if not specified
-        order_type_value = order_type if order_type is not None else order.type
+        order_type_value = order_type if order_type is not None else order.order_type
         if order_type_value is None:
             order_type_value = "MKT"
             logging.info("Order type not specified. Defaulting to 'MKT'.")

--- a/lumibot/components/drift_rebalancer_logic.py
+++ b/lumibot/components/drift_rebalancer_logic.py
@@ -258,8 +258,9 @@ class DriftCalculationLogic:
         A positive drift means we need to buy more of the asset,
         a negative drift means we need to sell some of the asset.
         """
+        # Don't let total_value be zero - to avoid division by zero
         total_value = self.df["current_value"].sum()
-        self.df["current_weight"] = self.df["current_value"] / total_value
+        self.df["current_weight"] = self.df["current_value"] / total_value if total_value > 0 else Decimal(0)
         self.df["target_value"] = self.df["target_weight"] * total_value
         self.df["drift"] = self.df.apply(self._calculate_drift_row, axis=1)
         return self.df.copy()

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from collections import namedtuple
 from decimal import Decimal
+from enum import StrEnum
 from threading import Event
 import datetime
 from typing import Union
@@ -47,26 +48,26 @@ STATUS_ALIAS_MAP = {
     "expired": "canceled",  # Tradier status
 }
 
+NONE_TYPE = type(None)  # Order is shadowing 'type' parameter, this is a workaround to still access type(None)
+
 class Order:
     Transaction = namedtuple("Transaction", ["quantity", "price"])
 
-    class OrderClass:
+    class OrderClass(StrEnum):
+        SIMPLE = "simple"
         BRACKET = "bracket"
         OCO = "oco"
         OTO = "oto"
         MULTILEG = "multileg"
 
-    class OrderType:
+    class OrderType(StrEnum):
         MARKET = "market"
         LIMIT = "limit"
         STOP = "stop"
         STOP_LIMIT = "stop_limit"
         TRAIL = "trailing_stop"
-        BRACKET = "bracket"
-        OCO = "oco"
-        OTO = "oto"
 
-    class OrderSide:
+    class OrderSide(StrEnum):
         BUY = "buy"
         SELL = "sell"
         BUY_TO_COVER = "buy_to_cover"
@@ -76,7 +77,7 @@ class Order:
         SELL_TO_OPEN = "sell_to_open"
         SELL_TO_CLOSE = "sell_to_close"
 
-    class OrderStatus:
+    class OrderStatus(StrEnum):
         UNPROCESSED = "unprocessed"
         SUBMITTED = "submitted"
         OPEN = "open"
@@ -97,11 +98,17 @@ class Order:
         side: OrderSide = None,
         limit_price: float = None,
         stop_price: float = None,
-        take_profit_price: float = None,
-        stop_loss_price: float = None,
-        stop_loss_limit_price: float = None,
+        stop_limit_price: float = None,
         trail_price: float = None,
         trail_percent: float = None,
+        secondary_limit_price: float = None,
+        secondary_stop_price: float = None,
+        secondary_stop_limit_price: float = None,
+        secondary_trail_price: float = None,
+        secondary_trail_percent: float = None,
+        take_profit_price: float = None,  # Deprecated
+        stop_loss_price: float = None,  # Deprecated
+        stop_loss_limit_price: float = None,  # Deprecated
         time_in_force: str = "day",
         good_till_date: datetime.datetime = None,
         exchange: str = None,
@@ -109,14 +116,15 @@ class Order:
         quote: "Asset" = None,
         pair: str = None,
         date_created: datetime.datetime = None,
-        type: OrderType = None,
-        order_class: OrderClass = None,
+        type: Union[OrderType, None] = None,  # Deprecated, use 'order_type' instead
+        order_type: Union[OrderType, None] = None,
+        order_class: Union[OrderClass, None] = OrderClass.SIMPLE,
         trade_cost: float = None,
         custom_params: dict = {},
         identifier: str = None,
         avg_fill_price: float = None,
         error_message: str = None,
-        child_orders: list = None,
+        child_orders: Union[list, None] = None,
         tag: str = "",
         status: OrderStatus = "unprocessed",
     ):
@@ -164,6 +172,28 @@ class Order:
             In cryptocurrencies, if the order has both a `stop_price`
             and a `limit_price`, then once the stop price is met, a
             limit order will become active with the `limit_price'.
+        stop_limit_price : float
+            Stop loss with limit price used to ensure a specific fill price
+            when the stop price is reached. For more information, visit:
+            https://www.investopedia.com/terms/s/stop-limitorder.asp
+        secondary_limit_price : float
+            Limit price used for child orders of Advanced Orders like
+            Bracket Orders and One Triggers Other (OTO) orders. One Cancels
+            Other (OCO) orders do not use this field as the primary prices
+            can specify all info needed to execute the OCO (because there is
+            no corresponding Entry Order).
+        secondary_stop_price : float
+            Stop price used for child orders of Advanced Orders like
+            Bracket Orders and One Triggers Other (OTO) orders. One Cancels
+            Other (OCO) orders do not use this field as the primary prices
+            can specify all info needed to execute the OCO (because there is
+            no corresponding Entry Order).
+        secondary_stop_limit_price : float
+            Stop limit price used for child orders of Advanced Orders like
+            Bracket Orders and One Triggers Other (OTO) orders. One Cancels
+            Other (OCO) orders do not use this field as the primary prices
+            can specify all info needed to execute the OCO (because there is
+            no corresponding Entry Order).
         time_in_force : str
             Amount of time the order is in force. Order types include:
                 - `day` Orders valid for the remainder of the day.
@@ -175,13 +205,13 @@ class Order:
             This is the time order is valid for Good Though Date orders.
         take_profit_price : float
             Limit price used for bracket orders and one cancels other
-            orders.
+            orders. (Deprecated, use 'secondary_limit_price' instead)
         stop_loss_price : float
             Stop price used for bracket orders and one cancels other
-            orders.
+            orders. (Deprecated, use 'secondary_stop_price' instead)
         stop_loss_limit_price : float
-            Stop loss with limit price used for bracket orders and one
-            cancels other orders.
+            Stop loss with limit price used to ensure a specific fill price.
+            (Deprecated, use 'secondary_stop_limit_price' instead)
         trail_price : float
             Trailing stop orders allow you to continuously and
             automatically keep updating the stop price threshold based
@@ -190,8 +220,12 @@ class Order:
         trail_percent : float
             Trailing stop orders allow you to continuously and
             automatically keep updating the stop price threshold based
-            on the stock price movement. `trail_price` sets the
+            on the stock price movement. `trail_percent` sets the
             trailing price in percent.
+        secondary_trail_price : float
+            Trailing stop price for child orders of Advanced Orders like Bracket or OTO orders.
+        secondary_trail_percent : float
+            Trailing stop percent for child orders of Advanced Orders like Bracket or OTO orders.
         position_filled : bool
             The order has been filled.
         exchange : str
@@ -204,10 +238,13 @@ class Order:
             A string representation of the trading pair. eg: `BTC/USD`.
         date_created : datetime.datetime
             The date the order was created.
-        type : str
-            The type of order. Possible values are: `market`, `limit`, `stop`, `stop_limit`, `trail`, `trail_limit`, `bracket`, `bracket_limit`, `bracket_stop`, `bracket_stop_limit`.
+        type : str or Order.OrderType
+            The type of order. Possible values are: `market`, `limit`, `stop`, `stop_limit`, `trail`, `trail_limit`.
+            (Deprecated, use 'order_type' instead)
+        order_type : str or Order.OrderType
+            The type of order. Possible values are: `market`, `limit`, `stop`, `stop_limit`, `trail`, `trail_limit`.
         order_class : str
-            The order class. Possible values are: `bracket`, `oco`, `oto`, `multileg`.
+            The order class. Possible values are: `simple`, `bracket`, `oco`, `oto`, `multileg`.
         trade_cost : float
             The cost of this order in the quote currency.
         custom_params : dict
@@ -236,9 +273,8 @@ class Order:
         ...     quantity=100,
         ...     side="buy",
         ...     limit_price=100,
-        ...     take_profit_price=110,
-        ...     stop_loss_price=90,
-        ...     stop_loss_limit_price=80,
+        ...     stop_price=90,
+        ...     stop_limit_price=80,
         ... )
         >>> order.asset
         Asset(symbol='MSFT', asset_type='stock')
@@ -248,11 +284,9 @@ class Order:
         'buy'
         >>> order.limit_price
         100
-        >>> order.take_profit_price
-        110
-        >>> order.stop_loss_price
+        >>> order.stop_price
         90
-        >>> order.stop_loss_limit_price
+        >>> order.stop_limit_price
         80
         >>> order.time_in_force
         'day'
@@ -262,10 +296,10 @@ class Order:
         False
         >>> order.status
         'open'
-        >>> order.type
+        >>> order.order_type
         'limit'
         >>> order.order_class
-        'bracket'
+        'simple'
         >>> order.strategy
         'test'
 
@@ -313,6 +347,7 @@ class Order:
         self.position_filled = position_filled
         self.limit_price = None
         self.stop_price = None
+        self.stop_limit_price = None
         self.trail_price = None
         self.trail_percent = None
         self.price_triggered = False
@@ -323,10 +358,10 @@ class Order:
         self.order_class = order_class
         self.dependent_order = None
         self.dependent_order_filled = False
-        self.type = type
+        self.order_type = order_type
         self.trade_cost = trade_cost
         self.custom_params = custom_params
-        self._trail_stop_price = None
+        self._trail_stop_price = None  # Used by backtesting broker to track desired trailing stop price so far
         self.tag = tag
         self._avg_fill_price = avg_fill_price # The weighted average filled price for this order. Calculated if not given by broker
         self.broker_create_date = None  # The datetime the order was created by the broker
@@ -357,34 +392,127 @@ class Order:
 
         self._quantity = quantity
 
-        self.side = side
+        try:
+            self.side = side if isinstance(side, (self.OrderSide, NONE_TYPE)) else self.OrderSide(side)
+        except ValueError:
+            raise ValueError(f"Order: Invalid side {side}. Must be one of:"
+                             f" {', '.join([str(s.value) for s in self.OrderSide])}") from None
 
-        self._set_type(
+        try:
+            self.order_class = order_class \
+                if isinstance(order_class, (self.OrderClass, NONE_TYPE)) else self.OrderClass(order_class)
+        except ValueError:
+            raise ValueError(f"Order: Invalid order_class '{order_class}'. Must be one of:"
+                             f" {', '.join([str(oc.value) for oc in self.OrderClass])}") from None
+
+        # Check - deprecated parameters and inform the user
+        deprecated_params = {
+            "take_profit_price": "limit_price",
+            "stop_loss_price": "stop_price",
+            "stop_loss_limit_price": "stop_limit_price",
+            "type": "order_type",
+        }
+        for param, new_param in deprecated_params.items():
+            if locals()[param] is not None:
+                logging.warning(f"Order: {param} is deprecated. Use {new_param} instead.")
+                if locals()[new_param]:
+                    raise ValueError(f"You cannot set both {param} and {new_param}. "
+                                     f"This may cause unexpected behavior.")
+                locals()[new_param] = locals()[param]
+
+        # TODO: Remove when type//take_profit_price/stop_loss_price/stop_loss_limit_price are finally
+        #  deprecated permanently
+        secondary_limit_price = secondary_limit_price if secondary_limit_price is not None \
+            else take_profit_price if take_profit_price is not None else secondary_limit_price
+        secondary_stop_price = secondary_stop_price if secondary_stop_price is not None \
+            else stop_loss_price if stop_loss_price is not None else secondary_stop_price
+        secondary_stop_limit_price = secondary_stop_limit_price if secondary_stop_limit_price is not None \
+            else stop_loss_limit_price if stop_loss_limit_price is not None else secondary_stop_limit_price
+        order_type = order_type if order_type is not None else type if type is not None else order_type
+
+        # Check - only provide a single stoploss modifier like trail_price, trail_percent, stop_limit_price, etc.
+        unique_sl_modifiers = ["stop_limit_price", "trail_price", "trail_percent"]
+        unique_secondary_modifiers = ["secondary_stop_limit_price", "secondary_trail_price", "secondary_trail_percent"]
+        local_vars = locals()
+        for unique_mods in [unique_sl_modifiers, unique_secondary_modifiers]:
+            unique_count = sum([1 for unique_mod in unique_mods
+                                if unique_mod in local_vars and local_vars[unique_mod] is not None])
+            if unique_count > 1:
+                raise ValueError(f"Order: You can only specify one of {', '.join(unique_mods)}. "
+                                 f"{unique_count} were given.")
+
+        # Check - Order Class values passed in the 'type' parameter is depricated. OTO/Bracket/etc should
+        # be passed in the 'order_class' parameter. The 'type' parameter should only be used for order types like
+        # market, limit, stop, etc.
+        valid_order_classes = [order_class for order_class in Order.OrderClass]
+        valid_order_types = [order_type for order_type in Order.OrderType]
+        if order_type in valid_order_classes:
+            logging.warning(f"Order: Passing Advanced order class ({self.order_type}) in 'order_type' field is "
+                            f"deprecated. Please use 'order_class' instead. "
+                            f"Valid Classes: {', '.join(valid_order_classes)} | "
+                            f"Valid Types: {', '.join(valid_order_types)}")
+            self.order_class = order_type
+            self.order_type = None
+            order_type = None
+
+        # Check - Order Class values passed in the 'type' parameter is depricated. OTO/Bracket/etc should
+        # This is done here so that the older depricated parameters are still accepted for backwards compatibility
+        try:
+            self.order_type = order_type \
+                if isinstance(order_type, (self.OrderType, NONE_TYPE)) else self.OrderType(order_type)
+        except ValueError:
+            raise ValueError(f"Order: Invalid order_type {order_type}. Must be one of:"
+                             f" {', '.join([str(t.value) for t in self.OrderType])}") from None
+
+        self._set_prices(
             limit_price,
             stop_price,
-            take_profit_price,
-            stop_loss_price,
-            stop_loss_limit_price,
+            stop_limit_price,
+            trail_price,
+            trail_percent,
+            secondary_limit_price,
+            secondary_stop_price,
+            secondary_stop_limit_price,
+            secondary_trail_price,
+            secondary_trail_percent,
+        )
+
+        self._set_type_and_prices(
+            limit_price,
+            stop_price,
+            stop_limit_price,
             trail_price,
             trail_percent,
             position_filled,
         )
+        self._set_order_class_children(
+            secondary_limit_price,
+            secondary_stop_price,
+            secondary_stop_limit_price,
+            secondary_trail_price,
+            secondary_trail_percent,
+        )
+    def is_advanced_order(self):
+        return self.order_class in [self.OrderClass.OCO, self.OrderClass.BRACKET, self.OrderClass.OTO]
 
     def is_buy_order(self):
         return self.side is not None and (
-            self.side.lower() == self.OrderSide.BUY or
-            self.side.lower() == self.OrderSide.BUY_TO_OPEN or
-            self.side.lower() == self.OrderSide.BUY_TO_COVER or
-            self.side.lower() == self.OrderSide.BUY_TO_CLOSE
+            self.side == self.OrderSide.BUY or
+            self.side == self.OrderSide.BUY_TO_OPEN or
+            self.side == self.OrderSide.BUY_TO_COVER or
+            self.side == self.OrderSide.BUY_TO_CLOSE
         )
-    
+
     def is_sell_order(self):
         return self.side is not None and (
-            self.side.lower() == self.OrderSide.SELL or
-            self.side.lower() == self.OrderSide.SELL_SHORT or
-            self.side.lower() == self.OrderSide.SELL_TO_OPEN or
-            self.side.lower() == self.OrderSide.SELL_TO_CLOSE
+            self.side == self.OrderSide.SELL or
+            self.side == self.OrderSide.SELL_SHORT or
+            self.side == self.OrderSide.SELL_TO_OPEN or
+            self.side == self.OrderSide.SELL_TO_CLOSE
         )
+
+    def is_stop_order(self):
+        return self.order_type in [self.OrderType.STOP, self.OrderType.STOP_LIMIT, self.OrderType.TRAIL]
 
     def is_parent(self) -> bool:
         """
@@ -420,15 +548,14 @@ class Order:
         price : float
             The last price of the asset. For trailing stop orders, this is the price that will be used to update the trail stop price.
         """
-
         # If the order is not a trailing stop order, then do nothing.
-        if self.type != "trailing_stop":
+        if self.order_type != self.OrderType.TRAIL:
             return
 
         # Update the trail stop price if we have a trail_percent
         if self.trail_percent is not None:
             # Get potential trail stop price
-            if self.side == "buy":
+            if self.is_buy_order():
                 potential_trail_stop_price = price * (1 + self.trail_percent)
             # Buy/Sell are the only valid sides, so we can use else here.
             else:
@@ -440,21 +567,21 @@ class Order:
                 return
 
             # Ratchet down the trail stop price for a buy order if the price has decreased.
-            if self.side == "buy" and potential_trail_stop_price < self._trail_stop_price:
+            if self.is_sell_order() and potential_trail_stop_price < self._trail_stop_price:
                 # Update the trail stop price
                 self._trail_stop_price = potential_trail_stop_price
 
             # Ratchet up the trail stop price for a sell order if the price has increased.
-            if self.side == "sell" and potential_trail_stop_price > self._trail_stop_price:
+            if self.is_sell_order() and potential_trail_stop_price > self._trail_stop_price:
                 # Update the trail stop price
                 self._trail_stop_price = potential_trail_stop_price
 
         # Update the trail stop price if we have a trail_price
         if self.trail_price is not None:
             # Get potential trail stop price
-            if self.side == "buy":
+            if self.is_buy_order():
                 potential_trail_stop_price = price + self.trail_price
-            elif self.side == "sell":
+            elif self.is_sell_order():
                 potential_trail_stop_price = price - self.trail_price
             else:
                 raise ValueError(f"side must be either 'buy' or 'sell'. Got {self.side} instead.")
@@ -465,171 +592,228 @@ class Order:
                 return
 
             # Ratchet down the trail stop price for a buy order if the price has decreased.
-            if self.side == "buy" and potential_trail_stop_price < self._trail_stop_price:
+            if self.is_buy_order() and potential_trail_stop_price < self._trail_stop_price:
                 # Update the trail stop price
                 self._trail_stop_price = potential_trail_stop_price
 
             # Ratchet up the trail stop price for a sell order if the price has increased.
-            if self.side == "sell" and potential_trail_stop_price > self._trail_stop_price:
+            if self.is_sell_order() and potential_trail_stop_price > self._trail_stop_price:
                 # Update the trail stop price
                 self._trail_stop_price = potential_trail_stop_price
 
-    def _set_type(
+    def get_current_trail_stop_price(self):
+        """
+        Get the current trailing stop price. This is the price that the trailing stop order will be triggered at.
+
+        Returns
+        -------
+        float
+            The current trailing stop price.
+        """
+        return self._trail_stop_price
+
+    def _set_prices(
+            self,
+            limit_price,
+            stop_price,
+            stop_limit_price,
+            trail_price,
+            trail_percent,
+            secondary_limit_price,
+            secondary_stop_price,
+            secondary_stop_limit_price,
+            secondary_trail_price,
+            secondary_trail_percent,
+    ):
+        self.limit_price = check_price(limit_price, "limit_price must be float.", nullable=True)
+        self.stop_price = check_price(stop_price, "stop_price must be float.", nullable=True)
+        self.stop_limit_price = check_price(stop_limit_price, "stop_limit_price must be float.",
+                                            nullable=True)
+        self.trail_price = check_price(trail_price, "trail_price must be positive float.", nullable=True)
+        self.trail_percent = check_positive(trail_percent, float, "trail_percent must be positive float.")
+        self.secondary_limit_price = check_price(secondary_limit_price, "secondary_limit_price must be float.",
+                                                 nullable=True)
+        self.secondary_stop_price = check_price(secondary_stop_price, "secondary_stop_price must be float.",
+                                                nullable=True)
+        self.secondary_stop_limit_price = check_price(secondary_stop_limit_price,
+                                                      "secondary_stop_limit_price must be float.", nullable=True)
+        self.secondary_trail_price = check_price(secondary_trail_price, "secondary_trail_price must be positive float.",
+                                                 nullable=True)
+        self.secondary_trail_percent = check_positive(secondary_trail_percent, float, "secondary_trail_percent must be positive float.")
+
+    def _set_type_and_prices(
         self,
         limit_price,
         stop_price,
-        take_profit_price,
-        stop_loss_price,
-        stop_loss_limit_price,
+        stop_limit_price,
         trail_price,
         trail_percent,
         position_filled,
     ):
-        if self.type is None:
+        if self.order_type is None:
             # Check if this is a trailing stop order
             if trail_price is not None or trail_percent is not None:
-                self.type = self.OrderType.TRAIL
+                self.order_type = self.OrderType.TRAIL
 
             # Check if this is a market order
             elif limit_price is None and stop_price is None:
-                self.type = self.OrderType.MARKET
+                self.order_type = self.OrderType.MARKET
 
             # Check if this is a stop order
             elif limit_price is None and stop_price is not None:
-                self.type = self.OrderType.STOP
+                self.order_type = self.OrderType.STOP if not stop_limit_price else self.OrderType.STOP_LIMIT
 
             # Check if this is a limit order
             elif limit_price is not None and stop_price is None:
-                self.type = self.OrderType.LIMIT
+                self.order_type = self.OrderType.LIMIT
 
-            # Check if this is a stop limit order
-            elif limit_price is not None and stop_price is not None:
-                self.type = self.OrderType.STOP_LIMIT
+            elif self.order_class == self.OrderClass.OCO:
+                # This is a "One-Cancel-Other" advanced order. All info needed to calculate the child orders exists
+                # so they will be created automatically here unless specified directly by the user. It is expected that
+                # the broker will only submit the child orders as active orders, the parent order is just to tie them
+                # together.
+                self.order_type = self.OrderType.LIMIT
 
             else:
                 raise ValueError(
                     "Order type could not be determined. If you are trying to create an advanced order such \
-                                 as a Bracket Order, OCO or OTO, please specify the type parameter when creating the order."
+                                 as a Bracket Order, OCO or OTO, please specify the order_class parameter when \
+                                 creating the order."
                 )
 
-        if self.type == self.OrderType.OCO:
-            # This is a "One-Cancel-Other" advanced order
-            self.order_class = self.OrderType.OCO
-            self.type = self.OrderType.OCO
-            if stop_loss_price is not None and take_profit_price is not None:
-                self.take_profit_price = check_price(take_profit_price, "take_profit_price must be float.")
-                self.stop_loss_price = check_price(stop_loss_price, "stop_loss_price must be float.")
-                self.stop_loss_limit_price = check_price(
-                    stop_loss_limit_price,
-                    "stop_loss_limit_price must be float.",
-                    nullable=True,
-                )
+    def _set_order_class_children(self, secondary_limit_price, secondary_stop_price, secondary_stop_limit_price,
+                                  secondary_trail_price, secondary_trail_percent):
 
+        if self.order_class == self.OrderClass.OCO:
+            # This is a "One-Cancel-Other" advanced order. All info needed to calculate the child orders exists
+            # so they will be created automatically here unless specified directly by the user. It is expected that
+            # the broker will only submit the child orders as active orders, the parent order is just to tie them
+            # together.
+            if not self.child_orders and self.stop_price is not None and self.limit_price is not None:
                 # Create the child orders
-                self.child_orders = [
-                    Order(
-                        strategy=self.strategy,
-                        asset=self.asset,
-                        quantity=self.quantity,
-                        side=self.side,
-                        limit_price=self.take_profit_price,
-                        type="limit",
-                        position_filled=True,
-                    ),
-                    Order(
-                        strategy=self.strategy,
-                        asset=self.asset,
-                        quantity=self.quantity,
-                        side=self.side,
-                        limit_price=self.stop_loss_limit_price,
-                        stop_price=self.stop_loss_price,
-                        type="stop_limit",
-                        position_filled=True,
-                    ),
-                ]
+                limit_order = Order(
+                    strategy=self.strategy,
+                    asset=self.asset,
+                    quantity=self.quantity,
+                    side=self.side,
+                    limit_price=self.limit_price,
+                    order_type=Order.OrderType.LIMIT,
+                )
+                stop_order = Order(
+                    # Stop Type will be filled in automatically for child based on the Stop Modifiers
+                    strategy=self.strategy,
+                    asset=self.asset,
+                    quantity=self.quantity,
+                    side=self.side,
+                    stop_price=self.stop_price,
+                    stop_limit_price=self.stop_limit_price,
+                    trail_price=self.trail_price,
+                    trail_percent=self.trail_percent,
+                )
+                # Set dependencies so that the two orders will cancel the other in BackTesting
+                limit_order.dependent_order = stop_order
+                stop_order.dependent_order = limit_order
+                self.child_orders = [limit_order, stop_order]
 
             elif len(self.child_orders) == 2:
                 # Verify that the child orders are valid order objects
                 for child_order in self.child_orders:
                     if not isinstance(child_order, Order):
                         raise ValueError("Child orders must be of type Order")
-
-        elif self.type == "bracket":
-            # This is a "One-Cancel-Other" advanced order
-            self.order_class = "bracket"
-
-            # If limit_price is set then the initial order is a limit order
-            if limit_price is not None:
-                self.type = "limit"
-                self.limit_price = check_price(limit_price, "limit_price must be float.")
-            # If stop_price is set then the initial order is a stop order
-            elif stop_price is not None:
-                self.type = "stop"
-                self.stop_price = check_price(stop_price, "stop_price must be float.")
-            # If neither limit_price nor stop_price is set then the initial order is a market order
             else:
-                self.type = "market"
+                raise ValueError("Order class is OCO but child orders are not set and no limit/stop prices have "
+                                 "been provided.")
 
-            self.take_profit_price = check_price(take_profit_price, "take_profit_price must be float.")
-            self.stop_loss_price = check_price(stop_loss_price, "stop_loss_price must be float.")
-            self.stop_loss_limit_price = check_price(
-                stop_loss_limit_price,
-                "stop_loss_limit_price must be float.",
-                nullable=True,
-            )
+        elif self.order_class == self.OrderClass.BRACKET:
+            # This is a "Bracket" advanced order which typically consists of a primary (entry) order and
+            # two child orders. The user can provide their own list of child orders to the parent order object to
+            # override the defaults. It is expected that the broker object will submit the parent (entry) order as
+            # well as the child orders.
 
-        elif self.type == "oto":
-            # This is a "One-Triggers-One" advanced order
-            self.order_class = "oto"
+            # Create the child orders. There can be one or two child orders depending on what secondary values
+            # have been provided.
+            if not self.child_orders:
+                child_side = self.OrderSide.SELL_TO_CLOSE if self.is_buy_order() else self.OrderSide.BUY_TO_CLOSE
+                if secondary_limit_price is not None:
+                    self.child_orders.append(
+                        Order(
+                            strategy=self.strategy,
+                            asset=self.asset,
+                            quantity=self.quantity,
+                            side=child_side,
+                            limit_price=secondary_limit_price,
+                            order_type=Order.OrderType.LIMIT,
+                        )
+                    )
+                if secondary_stop_price is not None:
+                    self.child_orders.append(
+                        Order(
+                            # Stop Type will be filled in automatically for child based on the Stop Modifiers
+                            strategy=self.strategy,
+                            asset=self.asset,
+                            quantity=self.quantity,
+                            side=child_side,
+                            stop_price=secondary_stop_price,
+                            stop_limit_price=secondary_stop_limit_price,
+                            trail_price=secondary_trail_price,
+                            trail_percent=secondary_trail_percent,
+                        )
+                    )
 
-            # If limit_price is set then the initial order is a limit order
-            if limit_price is not None:
-                self.type = "limit"
-                self.limit_price = check_price(limit_price, "limit_price must be float.")
-            # If stop_price is set then the initial order is a stop order
-            elif stop_price is not None:
-                self.type = "stop"
-                self.stop_price = check_price(stop_price, "stop_price must be float.")
-            # If neither limit_price nor stop_price is set then the initial order is a market order
-            else:
-                self.type = "market"
+            # Error check that at least 1 child order exists
+            if not self.child_orders:
+                raise ValueError("Order class is BRACKET but no child orders or secondary limit/stop prices "
+                                 "have been provided.")
+            elif len(self.child_orders) > 1:
+                # Set dependencies so that the two orders will cancel the other in BackTesting
+                self.child_orders[0].dependent_order = self.child_orders[1]
+                self.child_orders[1].dependent_order = self.child_orders[0]
 
-            if take_profit_price is not None:
-                self.take_profit_price = check_price(
-                    take_profit_price,
-                    "take_profit_price must be float.",
-                )
-            else:
-                self.stop_loss_price = check_price(stop_loss_price, "stop_loss_price must be float.")
-                self.stop_loss_limit_price = check_price(
-                    stop_loss_limit_price,
-                    "stop_loss_limit_price must be float.",
-                    nullable=True,
-                )
+        elif self.order_class == self.OrderClass.OTO:
+            # This is a "One-Triggers-One" advanced order. This order is typically used as a "half-bracket" where the
+            # parent order is an entry order and the child order is either the stop or limit order that will be
+            # placed if the parent order is filled. It is expected that the broker object will submit the
+            # parent (entry) order as well as the child order.
+            if secondary_limit_price is not None and secondary_stop_price is not None:
+                raise ValueError("Order class is OTO but both secondary limit and stop prices have been provided. "
+                                 "OTO only allows for one of these values.")
+            if secondary_limit_price is None and secondary_stop_price is None:
+                raise ValueError("Order class is OTO but no secondary limit or stop prices have been provided. Must "
+                                 "provide exactly one of 'secondary_limit_price' or 'secondary_stop_price'.")
 
-        # If it's a trailing stop order, then make sure the trailing price is set
-        elif self.type == "trailing_stop":
-            if trail_price is not None:
-                self.trail_price = check_price(trail_price, "trail_price must be positive float.", allow_negative=False)
-            else:
-                self.trail_percent = check_positive(
-                    trail_percent,
-                    float,
-                    "trail_percent must be positive float.",
-                )
+            # Implement child orders: Open Position Order, one Triggered Order (Limit or Stop)
+            if not self.child_orders:
+                child_side = self.OrderSide.SELL_TO_CLOSE if self.is_buy_order() else self.OrderSide.BUY_TO_CLOSE
+                if secondary_limit_price is not None:
+                    self.child_orders.append(
+                        Order(
+                            strategy=self.strategy,
+                            asset=self.asset,
+                            quantity=self.quantity,
+                            side=child_side,
+                            limit_price=secondary_limit_price,
+                            order_type=Order.OrderType.LIMIT,
+                        )
+                    )
+                elif secondary_stop_price is not None:
+                    self.child_orders.append(
+                        Order(
+                            # Stop Type will be filled in automatically for child based on the Stop Modifiers
+                            strategy=self.strategy,
+                            asset=self.asset,
+                            quantity=self.quantity,
+                            side=child_side,
+                            stop_price=secondary_stop_price,
+                            stop_limit_price=secondary_stop_limit_price,
+                            trail_price=secondary_trail_price,
+                            trail_percent=secondary_trail_percent,
+                        )
+                    )
 
-        # If it's a stop order, then make sure the stop price is set
-        elif self.type == "stop":
-            self.stop_price = check_price(stop_price, "stop_price must be float.")
-
-        # If it's a limit order, then make sure the limit price is set
-        elif self.type == "limit":
-            self.limit_price = check_price(limit_price, "limit_price must be float.")
-
-        # If it's a stop limit order, then make sure the stop and limit prices are set
-        elif self.type == "stop_limit":
-            self.limit_price = check_price(limit_price, "limit_price must be float.")
-            self.stop_price = check_price(stop_price, "stop_price must be float.")
+            # Error check that only 1 child order exists
+            if len(self.child_orders) != 1:
+                raise ValueError(f"Order class is OTO found {len(self.child_orders)} child orders. OTO requires exactly"
+                                 f" one child order.")
 
     @property
     def avg_fill_price(self):
@@ -638,6 +822,17 @@ class Order:
     @avg_fill_price.setter
     def avg_fill_price(self, value):
         self._avg_fill_price = round(float(value), 2) if value is not None else None
+
+    @property
+    def identifier(self):
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, value):
+        self._identifier = value
+        if self.is_parent():
+            for child_order in self.child_orders:
+                child_order.parent_identifier = value
 
     @property
     def status(self):
@@ -713,13 +908,14 @@ class Order:
             if self.order_class:
                 repr_str = f"{self.order_class} order |"
             else:
-                repr_str = f"{self.type} order |"
+                repr_str = f"{self.order_type} order |"
 
             # Add the child orders to the repr
             for child_order in self.child_orders:
-                repr_str = f"{repr_str} {child_order.type} {child_order.side} {child_order.quantity} {child_order.asset} |"
+                repr_str = (f"{repr_str} {child_order.order_type} {child_order.side} {child_order.quantity} "
+                            f"{child_order.asset} |")
         else:
-            repr_str = f"{self.type} order of | {self.quantity} {self.rep_asset} {self.side} |"
+            repr_str = f"{self.order_type} order of | {self.quantity} {self.rep_asset} {self.side} |"
         if price:
             repr_str = f"{repr_str} @ ${price}"
 
@@ -782,7 +978,8 @@ class Order:
         bool
             True if the order is active, False otherwise.
         """
-        return not self.is_filled() and not self.is_canceled()
+        active_children = any([child for child in self.child_orders if child.is_active()])
+        return not self.is_filled() and not self.is_canceled() or active_children
 
     def is_canceled(self):
         """

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -864,6 +864,10 @@ class Order:
         quantity = Decimal(value)
         self._quantity = quantity
 
+        # Update the quantity for all child orders
+        for child_order in self.child_orders:
+            child_order.quantity = quantity
+
     def __hash__(self):
         return hash(self.identifier)
 
@@ -906,14 +910,14 @@ class Order:
         if self.child_orders:
             # If there is an order class, use that in the repr instead of the type
             if self.order_class:
-                repr_str = f"{self.order_class} order |"
+                repr_str = f"{self.order_class} {self.quantity} order |"
             else:
-                repr_str = f"{self.order_type} order |"
+                repr_str = f"{self.order_type} {self.quantity} order |"
 
             # Add the child orders to the repr
             for child_order in self.child_orders:
-                repr_str = (f"{repr_str} {child_order.order_type} {child_order.side} {child_order.quantity} "
-                            f"{child_order.asset} |")
+                child_str = str(child_order).replace('|', '')
+                repr_str = f"{repr_str} child {child_str} |"
         else:
             repr_str = f"{self.order_type} order of | {self.quantity} {self.rep_asset} {self.side} |"
         if price:

--- a/lumibot/example_strategies/stock_bracket.py
+++ b/lumibot/example_strategies/stock_bracket.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from lumibot.entities import Order
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -27,6 +28,7 @@ class StockBracket(Strategy):
 
         # Our Own Variables
         self.counter = 0
+        self.submitted_bracket_order = None  # Useful for updating/canceling orders
 
     def on_trading_iteration(self):
         """Buys the self.buy_symbol once, then never again"""
@@ -45,12 +47,12 @@ class StockBracket(Strategy):
             order = self.create_order(
                 buy_symbol,
                 quantity,
-                "buy",
-                take_profit_price=take_profit_price,
-                stop_loss_price=stop_loss_price,
-                type="bracket",
+                Order.OrderSide.BUY,
+                secondary_limit_price=take_profit_price,
+                secondary_stop_price=stop_loss_price,
+                order_class=Order.OrderClass.BRACKET,
             )
-            self.submit_order(order)
+            self.submitted_bracket_order = self.submit_order(order)
 
 
 if __name__ == "__main__":

--- a/lumibot/example_strategies/stock_oco.py
+++ b/lumibot/example_strategies/stock_oco.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from lumibot.entities import Order
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -27,6 +28,8 @@ class StockOco(Strategy):
 
         # Our Own Variables
         self.counter = 0
+        self.submitted_oco_order = None  # Useful for updating/cancelling orders
+
 
     def on_trading_iteration(self):
         """Buys the self.buy_symbol once, then never again"""
@@ -43,7 +46,7 @@ class StockOco(Strategy):
         if self.first_iteration:
             # Market order
                 main_order = self.create_order(
-                    buy_symbol, quantity, "buy",
+                    buy_symbol, quantity, Order.OrderSide.BUY,
                 )
                 self.submit_order(main_order)
 
@@ -51,12 +54,12 @@ class StockOco(Strategy):
                 order = self.create_order(
                     buy_symbol,
                     quantity,
-                    "sell",
-                    take_profit_price=take_profit_price,
-                    stop_loss_price=stop_loss_price,
-                    type="oco",
+                    Order.OrderSide.SELL,
+                    limit_price=take_profit_price,
+                    stop_price=stop_loss_price,
+                    order_class=Order.OrderClass.OCO,
                 )
-                self.submit_order(order)
+                self.submitted_oco_order = self.submit_order(order)
 
 
 if __name__ == "__main__":

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -150,6 +150,7 @@ class _Strategy:
         should_send_summary_to_discord=True,
         save_logfile=False,
         lumiwealth_api_key=None,
+        include_cash_positions=False,
         **kwargs,
     ):
         """Initializes a Strategy object.
@@ -233,6 +234,9 @@ class _Strategy:
         save_logfile : bool
             Whether to save the logfile. Defaults to False. If True, the logfile will be saved to the logs directory.
             Turning on this option will slow down the backtest.
+        include_cash_positions : bool
+            If True, the strategy will include cash positions in the positions list returned by the get_positions
+            method. Defaults to False.
         lumiwealth_api_key : str
             The API key to use for the LumiWealth data source. Defaults to None (saving to the cloud is off).
         kwargs : dict
@@ -272,6 +276,7 @@ class _Strategy:
 
         self.hide_positions = HIDE_POSITIONS
         self.hide_trades = HIDE_TRADES
+        self.include_cash_positions = include_cash_positions
 
         # If the MARKET env variable is set, use it as the market
         if MARKET:
@@ -973,6 +978,7 @@ class _Strategy:
         show_progress_bar = True,
         quiet_logs = False,
         trader_class = Trader,
+        include_cash_positions=False,
         **kwargs,
     ):
         """Backtest a strategy.
@@ -1285,6 +1291,7 @@ class _Strategy:
             buy_trading_fees=buy_trading_fees,
             sell_trading_fees=sell_trading_fees,
             save_logfile=save_logfile,
+            include_cash_positions=include_cash_positions,
             **kwargs,
         )
         self._trader.add_strategy(strategy)

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -499,7 +499,7 @@ class _Strategy:
                 f"Order must be an Order object. You entered {order}."
             )
             return False
-
+        
         # Check if the order does not have a quantity of zero
         if order.quantity == 0:
             self.logger.error(

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -1114,12 +1114,13 @@ class Strategy(_Strategy):
         """
         return self.cash
 
-    def get_positions(self):
+    def get_positions(self, include_cash_positions: bool = False):
         """Get all positions for the account.
 
         Parameters
         ----------
-        None
+        include_cash_positions : bool
+            If True, include cash positions in the returned list. If False, exclude cash positions.
 
         Returns
         -------
@@ -1139,13 +1140,13 @@ class Strategy(_Strategy):
         >>>     self.log_message(position.asset)
 
         """
-
+        include_cash = include_cash_positions or self.include_cash_positions
         tracked_positions = self.broker.get_tracked_positions(self.name)
 
         # Remove the quote asset from the positions list if it is there
         clean_positions = []
         for position in tracked_positions:
-            if position.asset != self.quote_asset:
+            if position.asset != self.quote_asset or include_cash:
                 clean_positions.append(position)
 
         return clean_positions
@@ -3868,6 +3869,7 @@ class Strategy(_Strategy):
         show_progress_bar: bool = True,
         quiet_logs: bool = True,
         trader_class: Type[Trader] = Trader,
+        include_cash_positions=False,
         **kwargs,
     ):
         """Backtest a strategy.
@@ -4029,6 +4031,7 @@ class Strategy(_Strategy):
             show_progress_bar=show_progress_bar,
             quiet_logs=quiet_logs,
             trader_class=trader_class,
+            include_cash_positions=include_cash_positions,
             **kwargs,
         )
         return results

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -391,18 +391,26 @@ class Strategy(_Strategy):
         side: str,
         limit_price: float = None,
         stop_price: float = None,
-        time_in_force: str = "gtc",
-        good_till_date: datetime.datetime = None,
-        take_profit_price: float = None,
-        stop_loss_price: float = None,
-        stop_loss_limit_price: float = None,
+        stop_limit_price: float = None,
         trail_price: float = None,
         trail_percent: float = None,
+        secondary_limit_price: float = None,
+        secondary_stop_price: float = None,
+        secondary_stop_limit_price: float = None,
+        secondary_trail_price: float = None,
+        secondary_trail_percent: float = None,
+        time_in_force: str = "gtc",
+        good_till_date: datetime.datetime = None,
+        take_profit_price: float = None,  # Deprecated, use 'secondary_limit_price' instead
+        stop_loss_price: float = None,  # Deprecated, use 'secondary_stop_price' instead
+        stop_loss_limit_price: float = None,  # Deprecated, use 'secondary_stop_limit_price' instead
         position_filled: float = None,
         exchange: str = None,
         quote: Asset = None,
         pair: str = None,
-        type: str = None,
+        order_type: Union[Order.OrderType, None] = None,
+        order_class: Union[Order.OrderClass, None] = None,
+        type: Union[Order.OrderType, None] = None,  # Deprecated, use 'order_type' instead
         custom_params: dict = None,
     ):
         # noinspection PyShadowingNames,PyUnresolvedReferences
@@ -438,11 +446,13 @@ class Strategy(_Strategy):
             eg: Decimal("3.213"). Internally all will convert to Decimal.
         side : str
             Whether the order is ``buy`` or ``sell``.
-        type : str
+        order_type : Order.OrderType
             The type of order. Order types include: ``'market'``, ``'limit'``, ``'stop'``, ``'stop_limit'``,
-            ``trailing_stop``, ``'oco'``, ``'bracket'``, ``'oto'``.
-            We will try to determine the order type if you do not specify it. It is mandatory to set the type
-            for advanced order types such as ``'oco'``, ``'bracket'``, ``'oto'``.
+            ``trailing_stop``
+            We will try to determine the order type if you do not specify it.
+        order_class: Order.OrderClass
+            The class of the order. Order classes include: ``'simple'``, ``'bracket'``, ``'oco'``, ``'oto'``,
+            ``'multileg'``
         limit_price : float
             A Limit order is an order to buy or sell at a specified
             price or better. The Limit order ensures that if the
@@ -452,6 +462,31 @@ class Strategy(_Strategy):
             A Stop order is an instruction to submit a buy or sell
             market order if and when the user-specified stop trigger
             price is attained or penetrated.
+        stop_limit_price : float
+            Stop loss with limit price used to ensure a specific fill price
+            when the stop price is reached. For more information, visit:
+            https://www.investopedia.com/terms/s/stop-limitorder.asp
+        secondary_limit_price : float
+            Limit price used for child orders of Advanced Orders like
+            Bracket Orders and One Triggers Other (OTO) orders. One Cancels
+            Other (OCO) orders do not use this field as the primary prices
+            can specify all info needed to execute the OCO (because there is
+            no corresponding Entry Order).
+        secondary_stop_price : float
+            Stop price used for child orders of Advanced Orders like
+            Bracket Orders and One Triggers Other (OTO) orders. One Cancels
+            Other (OCO) orders do not use this field as the primary prices
+            can specify all info needed to execute the OCO (because there is
+            no corresponding Entry Order).
+        secondary_stop_limit_price : float
+            Stop limit price used for child orders of Advanced Orders like
+            Bracket Orders and One Triggers Other (OTO) orders. One Cancels
+            Other (OCO) orders do not use this field as the primary prices
+            can specify all info needed to execute the OCO (because there is
+            no corresponding Entry Order).
+        stop_loss_limit_price : float
+            Stop loss with limit price used for bracket orders and one
+            cancels other orders. (Depricated, use 'stop_limit_price` instead)
         time_in_force : str
             Amount of time the order is in force. Order types include:
                 - ``'day'`` Orders valid for the remainder of the day.
@@ -462,13 +497,10 @@ class Strategy(_Strategy):
             This is the time order is valid for Good Though Date orders.
         take_profit_price : float
             Limit price used for bracket orders and one cancels other
-            orders.
+            orders. (Depricated, use 'secondary_limit_price` instead)
         stop_loss_price : float
             Stop price used for bracket orders and one cancels other
-            orders.
-        stop_loss_limit_price : float
-            Stop loss with limit price used for bracket orders and one
-            cancels other orders.
+            orders. (Depricated, use 'secondary_stop_price` instead)
         trail_price : float
             Trailing stop orders allow you to continuously and
             automatically keep updating the stop price threshold based
@@ -479,6 +511,10 @@ class Strategy(_Strategy):
             automatically keep updating the stop price threshold based
             on the stock price movement. E.g. 0.05 would be a 5% trailing stop.
             `trail_percent` sets the trailing price in percent.
+        secondary_trail_price : float
+            Trailing stop price for child orders of Advanced Orders like Bracket or OTO orders.
+        secondary_trail_percent : float
+            Trailing stop percent for child orders of Advanced Orders like Bracket or OTO orders.
         exchange : str
             The exchange where the order will be placed.
             ``Default = 'SMART'``
@@ -489,6 +525,14 @@ class Strategy(_Strategy):
         custom_params : dict
             A dictionary of custom parameters that can be used to pass additional information to the broker. This is useful for passing custom parameters to the broker that are not supported by Lumibot.
             E.g. `custom_params={"leverage": 3}` for Kraken margin trading.
+        type : Order.OrderType
+            Deprecated, use 'order_type' instead
+
+        Further Reading
+        -------
+        - Although the term "stop_limit" can be confusing, it is important to remember that this is a StopLoss modifier
+            not a true limit price nor bracket-style order. For more information, visit:
+            https://www.investopedia.com/terms/s/stop-limitorder.asp
 
         Returns
         -------
@@ -514,7 +558,7 @@ class Strategy(_Strategy):
         >>> self.submit_order(order)
 
         >>> # For a stop limit order
-        >>> order = self.create_order("SPY", 100, "buy", limit_price=100.00, stop_price=100.00)
+        >>> order = self.create_order("SPY", 100, "buy", stop_price=100.00, stop_limit_price=99.95)
         >>> self.submit_order(order)
 
         >>> # For a market sell order
@@ -529,47 +573,49 @@ class Strategy(_Strategy):
         >>> order = self.create_order("SPY", 100, "buy", trail_price=100.00)
         >>> self.submit_order(order)
 
-        >>> # For an OCO order
+        >>> # For an OCO order - No entry order specified, only exit order info.
         >>> order = self.create_order(
         >>>                "SPY",
         >>>                100,
         >>>                "sell",
-        >>>                take_profit_price=limit,
-        >>>                stop_loss_price=stop_loss,
-        >>>                type="oco",
+        >>>                limit_price=limit,  # Exit Profit point
+        >>>                stop_price=stop_loss,  # Exit Loss point
+        >>>                stop_limit_price=stop_loss_limit,  # Stop loss modifier (optional)
+        >>>                order_class=Order.OrderClass.OCO,
         >>>            )
 
-        >>> # For a bracket order
+        >>> # For a bracket order - One Entry order with a Profit and Loss exit orders (2 child orders).
         >>> order = self.create_order(
         >>>                "SPY",
         >>>                100,
-        >>>                "sell",
-        >>>                take_profit_price=limit,
-        >>>                stop_loss_price=stop_loss,
-        >>>                stop_loss_limit_price=stop_loss_limit,
-        >>>                type="bracket",
+        >>>                "buy",
+        >>>                limit_price=limit,  # When the Entry order will execute
+        >>>                secondary_limit_price=sec_limit,  # When the child Profit Exit order will execute
+        >>>                secondary_stop_price=stop_loss,  # When the child Loss Exit order will execute
+        >>>                secondary_stop_limit_price=stop_loss_limit,  # Child loss modifier (optional)
+        >>>                order_class=Order.OrderClass.BRACKET,
         >>>            )
 
         >>> # For a bracket order with a trailing stop
         >>> order = self.create_order(
         >>>                "SPY",
         >>>                100,
-        >>>                "sell",
-        >>>                trail_percent=trail_percent,
-        >>>                take_profit_price=limit,
-        >>>                stop_loss_price=stop_loss,
-        >>>                stop_loss_limit_price=stop_loss_limit,
-        >>>                type="bracket",
+        >>>                "buy",
+        >>>                limit_price=limit,  # When to Enter
+        >>>                secondary_limit_price=sec_limit,  # When to Exit Profit
+        >>>                secondary_stop_price=stop_loss,  # When to Exit Loss
+        >>>                secondary_trail_percent=trail_percent,  # Exit stop modifier (optional)
+        >>>                order_class=Order.OrderClass.BRACKET,
         >>>            )
 
-        >>> # For an OTO order
+        >>> # For an OTO order - One Entry, only a single Exit criteria is allowed (1/2 of a bracket order)
         >>> order = self.create_order(
         >>>                "SPY",
         >>>                100,
-        >>>                "sell",
-        >>>                take_profit_price=limit,
-        >>>                stop_loss_price=stop_loss,
-        >>>                type="oto",
+        >>>                "buy",
+        >>>                limit_price=limit,  # When to Enter
+        >>>                secondary_stop_price=stop_loss,  # When to Exit
+        >>>                order_class=Order.OrderClass.OTO,
         >>>            )
 
         >>> # For a futures order
@@ -587,9 +633,10 @@ class Strategy(_Strategy):
         >>>                asset,
         >>>                100,
         >>>                "buy",
-        >>>                trail_percent=trail_percent,
-        >>>                limit_price=limit,
-        >>>                stop_price=stop_loss,
+        >>>                limit_price=limit,  # When to Enter
+        >>>                secondary_stop_price=stop_loss,  # When to Exit
+        >>>                secondary_trail_percent=trail_percent,  # Exit modifier (optional)
+        >>>                order_class=Order.OrderClass.OTO,
         >>>            )
         >>> self.submit_order(order)
 
@@ -608,9 +655,10 @@ class Strategy(_Strategy):
         >>>                asset,
         >>>                100,
         >>>                "buy",
-        >>>                trail_percent=trail_percent,
         >>>                limit_price=limit,
-        >>>                stop_price=stop_loss,
+        >>>                secondary_stop_price=stop_loss,
+        >>>                secondary_trail_percent=trail_percent,
+        >>>                order_class=Order.OrderClass.BRACKET,
         >>>            )
         >>> self.submit_order(order)
 
@@ -640,9 +688,10 @@ class Strategy(_Strategy):
         >>>                asset,
         >>>                100,
         >>>                "buy",
-        >>>                trail_percent=trail_percent,
-        >>>                limit_price=limit,
-        >>>                stop_price=stop_loss,
+        >>>                limit_price=limit,  # When to Enter
+        >>>                secondary_stop_price=stop_loss,  # When to Exit
+        >>>                secondary_trail_percent=trail_percent,  # Exit modifier (optional)
+        >>>                order_class=Order.OrderClass.OTO,
         >>>            )
         >>> self.submit_order(order)
 
@@ -674,19 +723,27 @@ class Strategy(_Strategy):
             side,
             limit_price=limit_price,
             stop_price=stop_price,
+            stop_limit_price=stop_limit_price,
+            secondary_limit_price=secondary_limit_price,
+            secondary_stop_price=secondary_stop_price,
+            secondary_stop_limit_price=secondary_stop_limit_price,
             time_in_force=time_in_force,
             good_till_date=good_till_date,
-            take_profit_price=take_profit_price,
-            stop_loss_price=stop_loss_price,
-            stop_loss_limit_price=stop_loss_limit_price,
+            take_profit_price=take_profit_price,  # Depricated, use 'secondary_limit_price' instead
+            stop_loss_price=stop_loss_price,  # Depricated, use 'secondary_stop_price' instead
+            stop_loss_limit_price=stop_loss_limit_price,  # Depricated, use 'secondary_stop_limit_price' instead
             trail_price=trail_price,
             trail_percent=trail_percent,
+            secondary_trail_price=secondary_trail_price,
+            secondary_trail_percent=secondary_trail_percent,
             exchange=exchange,
             position_filled=position_filled,
             date_created=self.get_datetime(),
             quote=quote,
             pair=pair,
             type=type,
+            order_type=order_type,
+            order_class=order_class,
             custom_params=custom_params,
         )
         return order
@@ -2394,7 +2451,7 @@ class Strategy(_Strategy):
         """
         return self.broker.data_source.get_timestamp()
 
-    def get_round_minute(self, timeshif: int = 0):
+    def get_round_minute(self, timeshift: int = 0):
         """Returns the current minute rounded to the nearest minute. In a backtest this will be the current bar's timestamp. In live trading this will be the current timestamp on the exchange.
 
         Parameters

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -1083,7 +1083,15 @@ class Strategy(_Strategy):
 
         """
 
-        return self.broker.get_tracked_positions(self.name)
+        tracked_positions = self.broker.get_tracked_positions(self.name)
+
+        # Remove the quote asset from the positions list if it is there
+        clean_positions = []
+        for position in tracked_positions:
+            if position.asset != self.quote_asset:
+                clean_positions.append(position)
+
+        return clean_positions
 
     def get_historical_bot_stats(self):
         """Get the historical account value.

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -130,7 +130,7 @@ def get_price_data_from_polygon(
       to avoid multiple simultaneous sleeps.
     """
     # 1) Decide where to cache the data (based on asset & timespan).
-    cache_file = build_cache_filename(asset, timespan)
+    cache_file = build_cache_filename(asset, quote_asset, timespan)
 
     # 2) Possibly invalidate the cache if we detect changed splits, etc.
     force_cache_update = validate_cache(force_cache_update, asset, cache_file, api_key)
@@ -179,7 +179,7 @@ def get_price_data_from_polygon(
     # Helper function for each chunk
     def fetch_chunk(start_date, end_date):
         # This call may trigger the built-in rate-limit logic in polygon_client._get()
-        return polygon_client.get_aggs(
+        result = polygon_client.get_aggs(
             ticker=symbol,
             from_=start_date,
             to=end_date,
@@ -187,6 +187,8 @@ def get_price_data_from_polygon(
             timespan=timespan,
             limit=50000,
         )
+
+        return result
 
     # 8) Download chunks in parallel
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -372,8 +374,24 @@ def get_polygon_symbol(asset, polygon_client, quote_asset=None):
     return symbol
 
 
-def build_cache_filename(asset: Asset, timespan: str):
-    """Helper function to create the cache filename for a given asset and timespan"""
+def build_cache_filename(asset: Asset, quote_asset: Asset, timespan: str):
+    """
+    Helper function to create the cache filename for a given asset and timespan
+
+    Parameters
+    ----------
+    asset : Asset
+        Asset we are getting data for
+    quote_asset : Asset
+        Quote asset for the asset we are getting data for
+    timespan : str
+        Timespan for the data requested
+
+    Returns
+    -------
+    Path
+        The path to the cache file
+    """
 
     lumibot_polygon_cache_folder = Path(LUMIBOT_CACHE_FOLDER) / "polygon"
 
@@ -385,6 +403,8 @@ def build_cache_filename(asset: Asset, timespan: str):
         # Make asset.expiration datetime into a string like "YYMMDD"
         expiry_string = asset.expiration.strftime("%y%m%d")
         uniq_str = f"{asset.symbol}_{expiry_string}_{asset.strike}_{asset.right}"
+    elif quote_asset:
+        uniq_str = f"{asset.symbol}_{quote_asset.symbol}"
     else:
         uniq_str = asset.symbol
 

--- a/lumibot/tools/yahoo_helper.py
+++ b/lumibot/tools/yahoo_helper.py
@@ -175,6 +175,7 @@ class YahooHelper:
 
         return df["Close"].iloc[-1]
 
+    @staticmethod
     def download_symbol_data(symbol, interval="1d"):
         """
         Attempts to download historical data from yfinance for the specified symbol and interval.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="3.9.13",
+    version="3.9.14",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="3.9.12",
+    version="3.9.13",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/tests/backtest/test_polygon.py
+++ b/tests/backtest/test_polygon.py
@@ -113,7 +113,10 @@ class PolygonBacktestStrat(Strategy):
             expiration = self.select_option_expiration(chain, days_to_expiration=1)
             # expiration = datetime.date(2023, 8, 4)
 
-            strike_price = round(current_asset_price)
+            # Get the stike price closest to the current asset price
+            expiration_str = expiration.strftime("%Y-%m-%d")
+            strike_price = min(chain['Chains']['CALL'][expiration_str], key=lambda x: abs(x - current_asset_price))
+
             option_asset = Asset(
                 symbol=underlying_asset.symbol,
                 asset_type="option",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,9 +3,11 @@ import os
 import pytest
 import logging
 import datetime
+from pathlib import Path
 
 import pandas as pd
 
+from lumibot import LUMIBOT_SOURCE_PATH
 from lumibot.entities import Data, Asset
 from lumibot.backtesting import PolygonDataBacktesting
 
@@ -36,10 +38,11 @@ def pandas_data_fixture() -> Dict[Asset, Data]:
     """
     symbols = ["SPY", "TLT", "GLD"]
     pandas_data = dict()
-    data_dir = os.getcwd() + "/data"
+    lumibot_git_dir = Path(LUMIBOT_SOURCE_PATH).parent
+    data_dir = lumibot_git_dir / "data"
     print(data_dir)
     for symbol in symbols:
-        csv_path = data_dir + f"/{symbol}.csv"
+        csv_path = data_dir / f"{symbol}.csv"
         asset = Asset(
             symbol=symbol,
             asset_type="stock",

--- a/tests/test_drift_rebalancer.py
+++ b/tests/test_drift_rebalancer.py
@@ -1448,6 +1448,7 @@ class TestDriftRebalancer:
             show_indicators=False,
             save_logfile=False,
             show_progress_bar=False,
+            include_cash_positions=True,
             # quiet_logs=False,
         )
 
@@ -1503,6 +1504,7 @@ class TestDriftRebalancer:
             show_indicators=False,
             save_logfile=False,
             show_progress_bar=False,
+            include_cash_positions=True,
             # quiet_logs=False,
         )
 
@@ -1521,7 +1523,7 @@ class TestDriftRebalancer:
         assert filled_orders.iloc[2]["symbol"] == "SPY"
         assert filled_orders.iloc[2]["filled_quantity"] == 8.346738268
 
-    # @pytest.mark.skip()
+    @pytest.mark.skip("Currently broken with Yahoo interaction. Uncomment when fixed.")
     def test_crypto_50_50_with_yahoo(self):
         parameters = {
             "market": "24/7",
@@ -1560,6 +1562,7 @@ class TestDriftRebalancer:
             show_indicators=False,
             save_logfile=False,
             show_progress_bar=False,
+            include_cash_positions=True,
         )
 
         trades_df = strat_obj.broker._trade_event_log_df
@@ -1623,6 +1626,7 @@ class TestDriftRebalancer:
             show_indicators=False,
             save_logfile=False,
             show_progress_bar=False,
+            include_cash_positions=True,
         )
 
         trades_df = strat_obj.broker._trade_event_log_df

--- a/tests/test_drift_rebalancer.py
+++ b/tests/test_drift_rebalancer.py
@@ -907,7 +907,7 @@ class TestDriftOrderLogic:
         assert len(strategy.orders) == 1
         assert strategy.orders[0].side == "sell"
         assert strategy.orders[0].quantity == Decimal("10")
-        assert strategy.orders[0].type == Order.OrderType.LIMIT
+        assert strategy.orders[0].order_type == Order.OrderType.LIMIT
 
     def test_selling_everything_with_market_orders(self):
         strategy = MockStrategyWithOrderLogic(
@@ -930,7 +930,7 @@ class TestDriftOrderLogic:
         assert len(strategy.orders) == 1
         assert strategy.orders[0].side == "sell"
         assert strategy.orders[0].quantity == Decimal("10")
-        assert strategy.orders[0].type == Order.OrderType.MARKET
+        assert strategy.orders[0].order_type == Order.OrderType.MARKET
 
     def test_selling_part_of_a_holding_with_limit_order(self):
         strategy = MockStrategyWithOrderLogic(
@@ -952,7 +952,7 @@ class TestDriftOrderLogic:
         assert len(strategy.orders) == 1
         assert strategy.orders[0].side == "sell"
         assert strategy.orders[0].quantity == Decimal("5")
-        assert strategy.orders[0].type == Order.OrderType.LIMIT
+        assert strategy.orders[0].order_type == Order.OrderType.LIMIT
 
     def test_selling_with_only_rebalance_drifted_assets_when_over_drift_threshold(self):
         strategy = MockStrategyWithOrderLogic(
@@ -975,7 +975,7 @@ class TestDriftOrderLogic:
         assert len(strategy.orders) == 1
         assert strategy.orders[0].side == "sell"
         assert strategy.orders[0].quantity == Decimal("5")
-        assert strategy.orders[0].type == Order.OrderType.LIMIT
+        assert strategy.orders[0].order_type == Order.OrderType.LIMIT
 
     def test_selling_with_only_rebalance_drifted_assets_when_not_over_drift_threshold(self):
         strategy = MockStrategyWithOrderLogic(
@@ -1017,7 +1017,7 @@ class TestDriftOrderLogic:
         assert len(strategy.orders) == 1
         assert strategy.orders[0].side == "sell"
         assert strategy.orders[0].quantity == Decimal("5")
-        assert strategy.orders[0].type == Order.OrderType.MARKET
+        assert strategy.orders[0].order_type == Order.OrderType.MARKET
 
     def test_selling_short_doesnt_create_and_order_when_shorting_is_disabled(self):
         strategy = MockStrategyWithOrderLogic(
@@ -1113,7 +1113,7 @@ class TestDriftOrderLogic:
         assert len(strategy.orders) == 1
         assert strategy.orders[0].quantity == Decimal("10")
         assert strategy.orders[0].side == "sell"
-        assert strategy.orders[0].type == Order.OrderType.LIMIT
+        assert strategy.orders[0].order_type == Order.OrderType.LIMIT
 
     def test_buying_something_when_we_have_enough_money_and_there_is_slippage(self):
         strategy = MockStrategyWithOrderLogic(
@@ -1157,7 +1157,7 @@ class TestDriftOrderLogic:
         assert len(strategy.orders) == 1
         assert strategy.orders[0].side == "buy"
         assert strategy.orders[0].quantity == Decimal("4")
-        assert strategy.orders[0].type == Order.OrderType.LIMIT
+        assert strategy.orders[0].order_type == Order.OrderType.LIMIT
 
     def test_market_buy_when_we_dont_have_enough_money_for_everything(self):
         strategy = MockStrategyWithOrderLogic(
@@ -1180,7 +1180,7 @@ class TestDriftOrderLogic:
         assert len(strategy.orders) == 1
         assert strategy.orders[0].side == "buy"
         assert strategy.orders[0].quantity == Decimal("4")
-        assert strategy.orders[0].type == Order.OrderType.MARKET
+        assert strategy.orders[0].order_type == Order.OrderType.MARKET
 
     def test_attempting_to_buy_when_we_dont_have_enough_money_for_even_one_share(self):
         strategy = MockStrategyWithOrderLogic(
@@ -1336,7 +1336,7 @@ class TestDriftOrderLogic:
         assert len(strategy.orders) == 1
         assert strategy.orders[0].side == "sell"
         assert strategy.orders[0].quantity == Decimal("9.5")
-        assert strategy.orders[0].type == Order.OrderType.LIMIT
+        assert strategy.orders[0].order_type == Order.OrderType.LIMIT
 
     def test_selling_some_with_fractional_limit_orders(self):
         strategy = MockStrategyWithOrderLogic(
@@ -1360,7 +1360,7 @@ class TestDriftOrderLogic:
         assert len(strategy.orders) == 1
         assert strategy.orders[0].side == "sell"
         assert strategy.orders[0].quantity == Decimal("1.507537688")
-        assert strategy.orders[0].type == Order.OrderType.LIMIT
+        assert strategy.orders[0].order_type == Order.OrderType.LIMIT
 
     def test_buying_with_only_rebalance_drifted_assets_when_over_drift_threshold(self):
         strategy = MockStrategyWithOrderLogic(
@@ -1383,7 +1383,7 @@ class TestDriftOrderLogic:
         assert len(strategy.orders) == 1
         assert strategy.orders[0].side == "buy"
         assert strategy.orders[0].quantity == Decimal("4.0")  #
-        assert strategy.orders[0].type == Order.OrderType.LIMIT
+        assert strategy.orders[0].order_type == Order.OrderType.LIMIT
 
     def test_buying_with_only_rebalance_drifted_assets_when_not_over_drift_threshold(self):
         strategy = MockStrategyWithOrderLogic(

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -9,15 +9,12 @@ class TestOrderBasics:
         assert Order(asset=Asset("SPY"), quantity=10, side="sell", strategy='abc').side == 'sell'
 
     def test_blank_oco(self):
-        # Create an OCO order without any child 
-        order = Order(
-            strategy="",
-            type=Order.OrderType.OCO,
-        )
-
-        assert order.avg_fill_price == None
-        assert order.quantity == None
-        assert order.status == "unprocessed"
+        # Create an OCO order without any child or limit/stop settings -- Error!
+        with pytest.raises(ValueError):
+            Order(
+                strategy="",
+                type=Order.OrderClass.OCO,
+            )
 
         # Add a child order
         child_order = Order(
@@ -33,19 +30,8 @@ class TestOrderBasics:
         # Assert that the child order does not have any child orders of its own
         assert child_order.child_orders == []
 
-        # Add a child order to the OCO order
-        order.child_orders.append(child_order)
-
         # Assert that the child order still does not have any child orders of its own
         assert child_order.child_orders == []
-
-        # Check that the original order did not change as a result of adding a child order
-        assert order.avg_fill_price == None
-        assert order.quantity == None
-        assert order.status == "unprocessed"
-        assert order.side == None
-        assert order.asset == None
-        assert order.child_orders == [child_order]
 
         # Add another child order to the OCO order
         child_order_2 = Order(
@@ -57,6 +43,14 @@ class TestOrderBasics:
             limit_price=200,
         )
 
+        order = Order(
+            strategy="",
+            type=Order.OrderClass.OCO,
+            asset=Asset("SPY"),
+            side=Order.OrderSide.SELL,
+            quantity=10,
+            child_orders=[child_order, child_order_2]
+        )
         order.add_child_order(child_order_2)
 
         # Print the order and child order 
@@ -65,7 +59,7 @@ class TestOrderBasics:
         first_child_order_text = str(first_child_order).lower()
 
         # Assert the order text contains the order type
-        assert Order.OrderType.OCO in order_text
+        assert order.order_class == Order.OrderClass.OCO
 
         # Check that both child orders are present in the parent order text
         assert "buy" in order_text
@@ -83,7 +77,8 @@ class TestOrderBasics:
         assert "55" not in first_child_order_text
 
     def test_price_doesnt_exist(self):
-        # Test that the price does not exist for any orders, we should be more specific such as limit_price, stop_price, fill_price, etc.
+        # Test that the price does not exist for any orders, we should be more specific such as limit_price,
+        # stop_price, fill_price, etc.
         with pytest.raises(TypeError):
             Order(
                 strategy="",
@@ -198,6 +193,24 @@ class TestOrderBasics:
         order.status = 'submitted'
         assert order.is_active()
 
+    def test_active_oco(self):
+        asset = Asset("SPY")
+        order = Order(strategy='abc', asset=asset, side=Order.OrderSide.SELL, quantity=100,
+                      order_class=Order.OrderClass.OCO, limit_price=100, stop_price=90)
+        assert order.is_active()
+        assert order.is_parent()
+
+        assert len(order.child_orders) == 2
+        assert order.child_orders[0].is_active()
+        assert order.child_orders[1].is_active()
+
+        order.status = 'filled'
+        assert order.is_active(), "OCO is still active while child orders are active"
+        order.child_orders[0].status = 'filled'
+        assert order.is_active(), "OCO is still active while child orders are active"
+        order.child_orders[1].status = 'filled'
+        assert not order.is_active()
+
     def test_status(self):
         asset = Asset("SPY")
         order = Order(strategy='abc', asset=asset, side="buy", quantity=100)
@@ -248,3 +261,64 @@ class TestOrderBasics:
         assert position.hold == 0
         assert position.available == 0
         assert position.avg_fill_price == order.avg_fill_price
+
+
+class TestOrderAdvanced:
+    def test_oco_type_reassigned(self):
+        order = Order(
+            strategy="",
+            type=Order.OrderClass.OCO,  # This is depricated, should use order_class=Order.OrderClass.OCO
+            asset=Asset("SPY"),
+            side=Order.OrderSide.SELL,
+            limit_price=101.0,
+            stop_price=100.0,
+            quantity=10,
+        )
+        assert order.order_class == Order.OrderClass.OCO
+        assert order.order_type == Order.OrderType.LIMIT
+        assert len(order.child_orders) == 2
+
+        # Desired case
+        order = Order(
+            strategy="",
+            asset=Asset("SPY"),
+            side=Order.OrderSide.SELL,
+            limit_price=101.0,
+            stop_price=100.0,
+            quantity=10,
+            order_class=Order.OrderClass.OCO,
+        )
+        assert order.order_class == Order.OrderClass.OCO
+        assert order.order_type == Order.OrderType.LIMIT
+        assert len(order.child_orders) == 2
+        assert order.child_orders[0].order_type == Order.OrderType.LIMIT
+        assert order.child_orders[0].limit_price == 101.0
+        assert order.child_orders[1].order_type == Order.OrderType.STOP
+        assert order.child_orders[1].stop_price == 100.0
+
+    def test_bracket_standard(self):
+        # Expecting the parent entry order plus two child orders
+        order = Order(
+            strategy="",
+            asset=Asset("SPY"),
+            side=Order.OrderSide.BUY,
+            limit_price=101.0,
+            quantity=10,
+            order_class=Order.OrderClass.BRACKET,
+            secondary_limit_price=102.0,
+            secondary_stop_price=99.0,
+            secondary_stop_limit_price=99.10,
+        )
+        assert order.order_class == Order.OrderClass.BRACKET
+        assert order.side == Order.OrderSide.BUY
+        assert order.order_type == Order.OrderType.LIMIT
+        assert order.limit_price == 101.0
+        assert len(order.child_orders) == 2
+        assert order.child_orders[0].order_type == Order.OrderType.LIMIT
+        assert order.child_orders[0].limit_price == 102.0
+        assert order.child_orders[0].is_sell_order()
+        assert order.child_orders[1].order_type == Order.OrderType.STOP_LIMIT
+        assert order.child_orders[1].is_sell_order()
+        assert order.child_orders[1].is_stop_order()
+        assert order.child_orders[1].stop_price == 99.0
+        assert order.child_orders[1].stop_limit_price == 99.10

--- a/tests/test_polygon_helper.py
+++ b/tests/test_polygon_helper.py
@@ -21,17 +21,17 @@ class TestPolygonHelpers:
         timespan = "1D"
         mocker.patch.object(ph, "LUMIBOT_CACHE_FOLDER", tmpdir)
         expected = tmpdir / "polygon" / "stock_SPY_1D.feather"
-        assert ph.build_cache_filename(asset, timespan) == expected
+        assert ph.build_cache_filename(asset, None, timespan) == expected
 
         expire_date = datetime.date(2023, 8, 1)
         option_asset = Asset("SPY", asset_type="option", expiration=expire_date, strike=100, right="CALL")
         expected = tmpdir / "polygon" / "option_SPY_230801_100_CALL_1D.feather"
-        assert ph.build_cache_filename(option_asset, timespan) == expected
+        assert ph.build_cache_filename(option_asset, None, timespan) == expected
 
         # Bad option asset with no expiration
         option_asset = Asset("SPY", asset_type="option", strike=100, right="CALL")
         with pytest.raises(ValueError):
-            ph.build_cache_filename(option_asset, timespan)
+            ph.build_cache_filename(option_asset, None, timespan)
 
     def test_missing_dates(self):
         # Setup some basics
@@ -309,7 +309,7 @@ class TestPolygonPriceData:
         start_date = tz_e.localize(datetime.datetime(2023, 8, 2, 6, 30))  # Include PreMarket
         end_date = tz_e.localize(datetime.datetime(2023, 8, 2, 13, 0))
         timespan = "minute"
-        expected_cachefile = ph.build_cache_filename(asset, timespan)
+        expected_cachefile = ph.build_cache_filename(asset, None, timespan)
 
         assert not expected_cachefile.exists()
         assert not expected_cachefile.parent.exists()
@@ -403,7 +403,7 @@ class TestPolygonPriceData:
         tz_e = pytz.timezone("US/Eastern")
         start_date = tz_e.localize(datetime.datetime(2023, 8, 2, 6, 30))  # Include PreMarket
         end_date = tz_e.localize(datetime.datetime(2023, 8, 2, 13, 0))
-        expected_cachefile = ph.build_cache_filename(asset, timespan)
+        expected_cachefile = ph.build_cache_filename(asset, None, timespan)
         assert not expected_cachefile.exists()
 
         # Fake some data from Polygon between start and end date

--- a/tests/test_polygon_helper.py
+++ b/tests/test_polygon_helper.py
@@ -21,17 +21,17 @@ class TestPolygonHelpers:
         timespan = "1D"
         mocker.patch.object(ph, "LUMIBOT_CACHE_FOLDER", tmpdir)
         expected = tmpdir / "polygon" / "stock_SPY_1D.feather"
-        assert ph.build_cache_filename(asset, None, timespan) == expected
+        assert ph.build_cache_filename(asset, timespan) == expected
 
         expire_date = datetime.date(2023, 8, 1)
         option_asset = Asset("SPY", asset_type="option", expiration=expire_date, strike=100, right="CALL")
         expected = tmpdir / "polygon" / "option_SPY_230801_100_CALL_1D.feather"
-        assert ph.build_cache_filename(option_asset, None, timespan) == expected
+        assert ph.build_cache_filename(option_asset, timespan) == expected
 
         # Bad option asset with no expiration
         option_asset = Asset("SPY", asset_type="option", strike=100, right="CALL")
         with pytest.raises(ValueError):
-            ph.build_cache_filename(option_asset, None, timespan)
+            ph.build_cache_filename(option_asset, timespan)
 
     def test_missing_dates(self):
         # Setup some basics
@@ -309,7 +309,7 @@ class TestPolygonPriceData:
         start_date = tz_e.localize(datetime.datetime(2023, 8, 2, 6, 30))  # Include PreMarket
         end_date = tz_e.localize(datetime.datetime(2023, 8, 2, 13, 0))
         timespan = "minute"
-        expected_cachefile = ph.build_cache_filename(asset, None, timespan)
+        expected_cachefile = ph.build_cache_filename(asset, timespan)
 
         assert not expected_cachefile.exists()
         assert not expected_cachefile.parent.exists()
@@ -403,7 +403,7 @@ class TestPolygonPriceData:
         tz_e = pytz.timezone("US/Eastern")
         start_date = tz_e.localize(datetime.datetime(2023, 8, 2, 6, 30))  # Include PreMarket
         end_date = tz_e.localize(datetime.datetime(2023, 8, 2, 13, 0))
-        expected_cachefile = ph.build_cache_filename(asset, None, timespan)
+        expected_cachefile = ph.build_cache_filename(asset, timespan)
         assert not expected_cachefile.exists()
 
         # Fake some data from Polygon between start and end date

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -107,7 +107,7 @@ class TestTradierBrokerAPI:
 
     def test_submit_order(self, tradier):
         asset = Asset("AAPL")
-        order = Order('strat_unittest', asset, 1, 'buy', type='market')
+        order = Order('strat_unittest', asset, 1, 'buy', order_type='market')
         submitted_order = tradier._submit_order(order)
         assert submitted_order.status == "submitted"
         assert submitted_order.identifier > 0
@@ -132,7 +132,7 @@ class TestTradierBroker:
         mock_modify = mocker.patch.object(broker.tradier.orders, "modify")
 
         stock_asset = Asset("SPY")
-        order = Order("my_strat", stock_asset, 10, "sell", type="limit")
+        order = Order("my_strat", stock_asset, 10, Order.OrderSide.SELL, order_type="limit")
 
         # Errors if no ID exists for this order
         order.identifier = None
@@ -153,10 +153,16 @@ class TestTradierBroker:
 
     def test_tradier_side2lumi(self):
         broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True)
-        assert broker._tradier_side2lumi("buy") == "buy"
-        assert broker._tradier_side2lumi("sell") == "sell"
-        assert broker._tradier_side2lumi("buy_to_cover") == "buy"
-        assert broker._tradier_side2lumi("sell_short") == "sell"
+        assert broker._tradier_side2lumi("buy") == Order.OrderSide.BUY
+        assert broker._tradier_side2lumi("sell") == Order.OrderSide.SELL
+        assert broker._tradier_side2lumi("buy_to_open") == Order.OrderSide.BUY_TO_OPEN
+        assert broker._tradier_side2lumi("sell_to_open") == Order.OrderSide.SELL_TO_OPEN
+        assert broker._tradier_side2lumi("buy_to_close") == Order.OrderSide.BUY_TO_CLOSE
+        assert broker._tradier_side2lumi("sell_to_close") == Order.OrderSide.SELL_TO_CLOSE
+        assert broker._tradier_side2lumi("buy_to_cover") == Order.OrderSide.BUY_TO_COVER
+        assert broker._tradier_side2lumi("sell_short") == Order.OrderSide.SELL_SHORT
+        assert broker._tradier_side2lumi("buy_something_something") == Order.OrderSide.BUY
+        assert broker._tradier_side2lumi("sell_something_something") == Order.OrderSide.SELL
 
         with pytest.raises(ValueError):
             broker._tradier_side2lumi("blah")
@@ -167,8 +173,8 @@ class TestTradierBroker:
         strategy = "strat_unittest"
         stock_asset = Asset("SPY")
         option_asset = Asset("SPY", asset_type='option')
-        stock_order = Order(strategy, stock_asset, 1, 'buy', type='market')
-        option_order = Order(strategy, option_asset, 1, 'buy', type='market')
+        stock_order = Order(strategy, stock_asset, 1, 'buy', order_type='market')
+        option_order = Order(strategy, option_asset, 1, 'buy', order_type='market')
 
         # No Positions exist
         assert broker._lumi_side2tradier(stock_order) == "buy"
@@ -182,13 +188,13 @@ class TestTradierBroker:
         assert not broker._lumi_side2tradier(option_order)
 
         # Stoploss always submits as a "to_close" order
-        stop_stock_order = Order(strategy, stock_asset, 1, 'sell', type='stop', stop_price=100.0)
+        stop_stock_order = Order(strategy, stock_asset, 1, 'sell', order_type='stop', stop_price=100.0)
         assert broker._lumi_side2tradier(stop_stock_order) == "sell"
-        stop_option_order = Order(strategy, option_asset, 1, 'sell', type='stop', stop_price=100.0)
+        stop_option_order = Order(strategy, option_asset, 1, 'sell', order_type='stop', stop_price=100.0)
         assert broker._lumi_side2tradier(stop_option_order) == "sell_to_close"
 
         # TODO: Fix this test, it's commented out temporarily until we can figure out how to handle this case.
-        # limit_option_order = Order(strategy, option_asset, 1, 'sell', type='limit', limit_price=100.0)
+        # limit_option_order = Order(strategy, option_asset, 1, 'sell', order_type='limit', limit_price=100.0)
         # assert broker._lumi_side2tradier(limit_option_order) == "sell_to_close"
 
         # Positions exist
@@ -236,7 +242,7 @@ class TestTradierBroker:
         assert stock_order.quantity == 1
         assert stock_order.side == "buy"
         assert stock_order.status == "submitted"
-        assert stock_order.type == "market"
+        assert stock_order.order_type == "market"
         assert stock_order.tag == tag
 
         # Test with an option and stop order
@@ -263,7 +269,7 @@ class TestTradierBroker:
         assert option_order.quantity == 1
         assert option_order.side == "sell"
         assert option_order.status == "submitted"
-        assert option_order.type == "stop"
+        assert option_order.order_type == "stop"
         assert option_order.stop_price == 1.0
         assert option_order.tag == tag
 
@@ -290,7 +296,7 @@ class TestTradierBroker:
         # Submit an order to test polling with
         stock_asset = Asset("SPY")
         stock_qty = 10
-        order = Order(strategy, stock_asset, stock_qty, 'buy', type='market')
+        order = Order(strategy, stock_asset, stock_qty, 'buy', order_type='market')
         sub_order = broker._submit_order(order)
         assert sub_order.status == "submitted"
         assert sub_order.identifier == 123
@@ -337,7 +343,7 @@ class TestTradierBroker:
 
         # Add a 2nd order: stop loss
         mock_submit_order.return_value = {'id': 124, 'status': 'ok'}
-        stop_order = Order(strategy, stock_asset, 1, 'sell', type='stop', stop_price=100.0)
+        stop_order = Order(strategy, stock_asset, 1, 'sell', order_type='stop', stop_price=100.0)
         sub_order = broker._submit_order(stop_order)
         assert sub_order.status == "submitted"
         assert sub_order.identifier == 124
@@ -387,7 +393,7 @@ class TestTradierBroker:
         assert len(filled_orders) == 1
         order1 = filled_orders[0]
         assert order1.identifier == 123
-        assert order1.type == "market"
+        assert order1.order_type == "market"
         assert order1.is_filled()
         assert order1.get_fill_price() == 101.0
         assert len(broker._new_orders) == 1
@@ -408,7 +414,7 @@ class TestTradierBroker:
         assert len(broker._canceled_orders) == 1
         order2 = broker._canceled_orders[0]
         assert order2.identifier == 124
-        assert order2.type == "stop"
+        assert order2.order_type == "stop"
         assert order2.is_canceled()
         assert not order2.get_fill_price()
 
@@ -424,7 +430,7 @@ class TestTradierBroker:
 
         # 3rd Order: Submit an order that causes a broker error
         mock_submit_order.return_value = {'id': 125, 'status': 'ok'}
-        stop_order = Order(strategy, stock_asset, stock_qty, 'sell', type='limit', limit_price=1000.0)
+        stop_order = Order(strategy, stock_asset, stock_qty, 'sell', order_type='limit', limit_price=1000.0)
         sub_order = broker._submit_order(stop_order)
         assert sub_order.status == "submitted"
         assert sub_order.identifier == 125
@@ -459,14 +465,14 @@ class TestTradierBroker:
         assert len(broker.get_all_orders()) == 3, "Includes Filled/Cancelled orders"
         error_order = broker._canceled_orders[1]
         assert error_order.identifier == 125
-        assert error_order.type == "limit"
+        assert error_order.order_type == "limit"
         assert error_order.status == "error"
         assert not error_order.get_fill_price()
         assert error_order.error_message == "API Error Msg"
 
         # There is a Lumibot order that is not tracked by the broker, so it should be canceled.
         mock_submit_order.return_value = {'id': 126, 'status': 'ok'}
-        drop_order = Order(strategy, stock_asset, stock_qty, 'sell', type='market')
+        drop_order = Order(strategy, stock_asset, stock_qty, 'sell', order_type='market')
         broker._submit_order(drop_order)
         assert len(broker._unprocessed_orders) == 1
         assert len(broker._new_orders) == 0


### PR DESCRIPTION
Advanced order handling of OCO/OTO/Bracket orders did not work in all contexts and brokers. There are also several confusing and deprecated features being utilized and all of these have been modified across all brokers so that the behavior is consistent going forward.

### Change highlights:
- `order.type` has been replaced with `order.order_type` to match (most) broker's terminology and to prevent shadowing with Python's built-in `type`.
- `order.order_type` no longer accepts "oco", "oto", or "bracket". These have been consolidated into the `order.order_class` parameter for clarity.
- `order.child_orders` is now populated automatically for all advanced order types at order creation time. Previously, each broker object was handling this themselves differently and it led to divergent and inconsistent behavior across brokers (including BackTestingBroker).
- `stop_limit` and `trailing_stop` are now allowed within OCO/OTO/Bracket children.  Previously these settings were ignored for any non-Simple order class.
- Documentation changes to clarify how these options should be used going forward.
- Backwards compatibility maintained with numerous checks and warnings are now issued to inform the user if their current methodology needs changing for the future.
- Removed BackTestingBroker `__get_attribute()` silliness. Seriously silly ... seriously.

### Why was this change made?
Tradier and BackTesting were not handling OCO orders in the same way.  Each was making different assumptions that led to being unable for a single strategy to run using both.  As part of trying to tease all of this out I kept coming upon more stumbling blocks and eventually had to just rip all of the order handling apart so I could put it back together in a way that will make sense for most brokers.  The previous implementation was very much tied to IBKR specific ways of doing things that don't apply 1-to-1 with the more modern brokers.

### How do make sense of all of this
 1. Start with the changes made to `strategy.create_order()`.  The documenation has been updated here to explain what the expected behavior is supposed to be.
 2. Next look at `Order.__init__()`.  It will show how backwards compatibility is maintained.
 3. Look at `Order._set_order_class_children`.  This should make intuitive sense based upon how OCO/OTO/Bracket orders work.  Any assumptions that should be challenged will most likely come from looking at this code.  This code will also lead you nicely down the rabbit hole of looking at the mess in all of the other Brokers.

### Testing
 - All unit tests are currently passing (with the exception of the drift rebalancer, but I think that is unrelated)
 - I still need to do some long running backtesting and live Tradier testing, but that is going to have to wait until next week and I felt like this PR is already so big that it is ready from some other eyeballs.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?
Refactor the order management logic by unifying the order class and type handling, improving advanced order handling (such as bracket and OCO orders), and aligning the order attributes with those needed for different brokers' requirements.

### Why are these changes being made?
Existing logic had redundant and inconsistent handling of order classes and types, leading to potential errors and difficulties in broker integration. This refactor introduces a more unified and clear model for managing and issuing orders, making it easier to implement complex order types, such as bracket orders, and ensuring compatibility across different brokers. Some components were deprecated to encourage a move to the new system, enhancing future maintainability and code clarity.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->