### PR TITLE
Hourly data support in alpaca backtesting.

### DIFF
--- a/lumibot/backtesting/alpaca_backtesting.py
+++ b/lumibot/backtesting/alpaca_backtesting.py
@@ -44,7 +44,7 @@ class AlpacaBacktesting(PandasData):
             adjustment: str = 'all',
             config: dict | None = None,
             tz_name: str = timezone.utc,
-            warm_up_bars: int = 0,
+            warm_up_trading_days: int = 0,
             auto_adjust: bool = True,
     ):
         """
@@ -71,7 +71,7 @@ class AlpacaBacktesting(PandasData):
                 `API_SECRET` for authenticating with Alpaca APIs.
             tz_name (str): The name of the timezone to localize datetime values.
                 Default is `timezone.utc`.
-            warm_up_bars (int): The number of additional data points to fetch before
+            warm_up_trading_days (int): The number of additional trading days to fetch before
                 `start_date`, useful for warming up trading algorithms. Default is 0.
         """
         self.CACHE_SUBFOLDER = 'alpaca'
@@ -91,9 +91,9 @@ class AlpacaBacktesting(PandasData):
         start_dt = pd.to_datetime(start_date).tz_localize(self.tz_name)
         end_dt = pd.to_datetime(end_date).tz_localize(self.tz_name)
 
-        if warm_up_bars > 0:
+        if warm_up_trading_days > 0:
             warm_up_start_dt = date_n_days_from_date(
-                n_bars=warm_up_bars,
+                n_bars=warm_up_trading_days,
                 start_datetime=start_dt,
             )
             # Combine with a default time (midnight)

--- a/lumibot/example_strategies/crypto_50_50.py
+++ b/lumibot/example_strategies/crypto_50_50.py
@@ -1,76 +1,72 @@
 from datetime import datetime
-import logging
-from decimal import Decimal
 
-from lumibot.credentials import broker
-from lumibot.backtesting import YahooDataBacktesting
-from lumibot.brokers import Alpaca
+from lumibot.components.configs_helper import ConfigsHelper
+from lumibot.credentials import IS_BACKTESTING
 from lumibot.example_strategies.drift_rebalancer import DriftRebalancer
-from lumibot.components.drift_rebalancer_logic import DriftType
-from lumibot.entities import Order, Asset
+from lumibot.backtesting import AlpacaBacktesting, PandasDataBacktesting
+from lumibot.credentials import ALPACA_CONFIG
 
-logger = logging.getLogger(__name__)
+"""
+Strategy Description
+
+This strategy demonstration shows the DriftRebalancer hourly data using AlpacaBacktesting. 
+It rebalances a portfolio of assets to a target weight every time the asset drifts
+by a certain threshold. The strategy will sell the assets that has drifted the most and buy the
+assets that has drifted the least to bring the portfolio back to the target weights.
+"""
+
 
 if __name__ == "__main__":
-    is_live = False
 
-    parameters = {
-        "market": "24/7",
-        "sleeptime": "1D",
-        "drift_type": DriftType.ABSOLUTE,
-        "drift_threshold": "0.05",  # 5%
-        "order_type": Order.OrderType.LIMIT,
-        "acceptable_slippage": "0.005",  # 50 BPS
-        "fill_sleeptime": 15,
-        "shorting": False,
-        "fractional_shares": True,
-        "only_rebalance_drifted_assets": False,
-    }
+    configs_helper = ConfigsHelper(configs_folder="example_strategies")
+    parameters = configs_helper.load_config("crypto_50_50_config")
 
-    if not is_live:
-        # Backtest this strategy
-        backtesting_start = datetime(2023, 1, 1)
-        backtesting_end = datetime(2023, 8, 1)
+    if not IS_BACKTESTING:
+        print("This strategy is not meant to be run live. Please set IS_BACKTESTING to True.")
+        exit()
 
-        # Backtesting crypto using yahoo means we need to use stock assets.
-        parameters["portfolio_weights"] = [
-            {
-                "base_asset": Asset(symbol='BTC-USD', asset_type='stock'),
-                "weight": Decimal("0.5")
-            },
-            {
-                "base_asset": Asset(symbol='ETH-USD', asset_type='stock'),
-                "weight": Decimal("0.5")
-            }
-        ]
-        results = DriftRebalancer.backtest(
-            YahooDataBacktesting,
-            backtesting_start,
-            backtesting_end,
-            benchmark_asset="SPY",
-            parameters=parameters,
-            show_plot=True,
-            show_tearsheet=True,
-            save_tearsheet=False,
-            show_indicators=False,
-            save_logfile=False,
-            show_progress_bar=True
+    if not ALPACA_CONFIG:
+        print("This strategy requires an ALPACA_CONFIG config file to be set.")
+        exit()
+
+    if not ALPACA_CONFIG['PAPER']:
+        print(
+            "Even though this is a backtest, and only uses the alpaca keys for the data source"
+            "you should use paper keys."
         )
+        exit()
 
-    elif isinstance(broker, Alpaca):
-        # Run the strategy live
-        logger.info("Running the strategy live with alpaca.")
+    backtesting_start = datetime(2025, 1, 1)
+    backtesting_end = datetime(2025, 2, 1)
+    tickers = ["BTC/USD", "ETH/USD"]  # must be the Alpaca tickers for the Assets in the config file
+    timestep = 'hour'
 
-        # Trading crypto live means we need to use crypto assets.
-        parameters["portfolio_weights"] = [
-            {
-                "base_asset": Asset(symbol='BTC', asset_type='crypto'),
-                "weight": Decimal("0.5")
-            },
-            {
-                "base_asset": Asset(symbol='ETH', asset_type='crypto'),
-                "weight": Decimal("0.5")
-            }
-        ]
-        strategy = DriftRebalancer(broker, parameters=parameters)
-        strategy.run_live()
+    data_source = AlpacaBacktesting(
+        tickers=tickers,
+        start_date=backtesting_start.date().isoformat(),
+        end_date=backtesting_end.date().isoformat(),
+        timestep=timestep,
+        config=ALPACA_CONFIG,
+    )
+
+    strategy: DriftRebalancer
+    results, strategy = DriftRebalancer.run_backtest(
+        datasource_class=PandasDataBacktesting,
+        pandas_data=data_source.pandas_data,
+        backtesting_start=backtesting_start,
+        backtesting_end=backtesting_end,
+        parameters=parameters,
+        show_plot=False,
+        show_tearsheet=False,
+        save_tearsheet=False,
+        show_indicators=False,
+        save_logfile=False,
+        show_progress_bar=True,
+    )
+
+    trades_df = strategy.broker._trade_event_log_df # noqa
+    filled_orders = trades_df[(trades_df["status"] == "fill")]
+    print(
+        f"\nfilled_orders:\n"
+        f"{filled_orders[['time','symbol','type','side','status', 'price', 'filled_quantity', 'trade_cost']]}"
+    )

--- a/lumibot/example_strategies/crypto_50_50_config.py
+++ b/lumibot/example_strategies/crypto_50_50_config.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+import logging
+from decimal import Decimal
+
+from lumibot.credentials import broker
+from lumibot.backtesting import YahooDataBacktesting
+from lumibot.brokers import Alpaca
+from lumibot.example_strategies.drift_rebalancer import DriftRebalancer
+from lumibot.components.drift_rebalancer_logic import DriftType
+from lumibot.entities import Order, Asset
+
+parameters = {
+    "market": "24/7",
+    "sleeptime": "60M",
+    "drift_type": DriftType.ABSOLUTE,
+    "drift_threshold": "0.05",  # 5%
+    "order_type": Order.OrderType.LIMIT,
+    "acceptable_slippage": "0.005",  # 50 BPS
+    "fill_sleeptime": 15,
+    "portfolio_weights": [
+        {
+            "base_asset": Asset(symbol='BTC', asset_type='crypto'),
+            "weight": Decimal("0.5")
+        },
+        {
+            "base_asset": Asset(symbol='ETH', asset_type='crypto'),
+            "weight": Decimal("0.5")
+        }
+    ],
+    "shorting": False,
+    "fractional_shares": True,
+    "only_rebalance_drifted_assets": False,
+}

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1,5 +1,7 @@
 import datetime
 import logging
+from typing import Union, List, Dict
+
 from termcolor import colored
 from asyncio.log import logger
 from decimal import Decimal
@@ -23,7 +25,7 @@ from sqlalchemy import create_engine, inspect, text
 import pandas as pd
 from lumibot import LUMIBOT_DEFAULT_PYTZ
 from ..backtesting import BacktestingBroker, PolygonDataBacktesting, ThetaDataBacktesting
-from ..entities import Asset, Position, Order
+from ..entities import Asset, Position, Order, Data
 from ..tools import (
     create_tearsheet,
     day_deduplicate,
@@ -952,7 +954,7 @@ class _Strategy:
         plot_file_html = None,
         trades_file = None,
         settings_file = None,
-        pandas_data = None,
+        pandas_data: Union[List, Dict[Asset, Data]] = None,
         quote_asset = Asset(symbol="USD", asset_type="forex"),
         starting_positions = None,
         show_plot = None,

--- a/tests/test_drift_rebalancer.py
+++ b/tests/test_drift_rebalancer.py
@@ -1413,7 +1413,7 @@ class TestDriftRebalancer:
     backtesting_end = datetime(2019, 2, 28)
 
     # @pytest.mark.skip()
-    def test_classic_60_60(self, pandas_data_fixture):
+    def test_classic_60_40(self, pandas_data_fixture):
         parameters = {
             "market": "NYSE",
             "sleeptime": "1D",
@@ -1467,7 +1467,7 @@ class TestDriftRebalancer:
         assert filled_orders.iloc[2]["filled_quantity"] == 7.0
 
     # @pytest.mark.skip()
-    def test_classic_60_60_with_fractional(self, pandas_data_fixture):
+    def test_classic_60_40_with_fractional(self, pandas_data_fixture):
         parameters = {
             "market": "NYSE",
             "sleeptime": "1D",

--- a/tests/test_momentum.py
+++ b/tests/test_momentum.py
@@ -230,7 +230,7 @@ class TestMomentum:
             config=ALPACA_CONFIG,
             refresh_cache=refresh_cache,
             tz_name=tz_name,
-            warm_up_bars=lookback_period
+            warm_up_trading_days=lookback_period
         )
 
         results, strategy = MomoTester.run_backtest(


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?
Add support for hourly data in Alpaca backtesting in the Lumibot library.

### Why are these changes being made?
These changes enable more granular backtesting resolutions using Alpaca data, addressing the need for strategies that require hourly timeframes. Adjustments also streamline data-fetching parameters and make the system flexible with auto-adjustment types, enhancing utility and alignment with more precise trading strategy requirements.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->