### PR TITLE
Be alpaca backtesting

### DIFF
--- a/lumibot/example_strategies/classic_60_40.py
+++ b/lumibot/example_strategies/classic_60_40.py
@@ -38,8 +38,7 @@ if __name__ == "__main__":
         save_tearsheet=False,
         show_indicators=False,
         save_logfile=True,
-        show_progress_bar=True,
-        include_cash_positions=True,
+        show_progress_bar=True
     )
 
     print(results)

--- a/lumibot/example_strategies/crypto_50_50.py
+++ b/lumibot/example_strategies/crypto_50_50.py
@@ -63,8 +63,7 @@ if __name__ == "__main__":
         save_tearsheet=False,
         show_indicators=False,
         save_logfile=False,
-        show_progress_bar=True,
-        include_cash_positions=True,
+        show_progress_bar=True
     )
 
     trades_df = strategy.broker._trade_event_log_df # noqa

--- a/lumibot/example_strategies/crypto_50_50.py
+++ b/lumibot/example_strategies/crypto_50_50.py
@@ -64,6 +64,7 @@ if __name__ == "__main__":
         show_indicators=False,
         save_logfile=False,
         show_progress_bar=True,
+        include_cash_positions=True,
     )
 
     trades_df = strategy.broker._trade_event_log_df # noqa

--- a/lumibot/example_strategies/drift_rebalancer.py
+++ b/lumibot/example_strategies/drift_rebalancer.py
@@ -111,6 +111,9 @@ class DriftRebalancer(Strategy):
             only_rebalance_drifted_assets=self.only_rebalance_drifted_assets,
         )
 
+        # Always include cash_positions or else there will be no cash buy stuff with.
+        self.include_cash_positions = True
+
     # noinspection PyAttributeOutsideInit
     def on_trading_iteration(self) -> None:
         dt = self.get_datetime()

--- a/lumibot/tools/helpers.py
+++ b/lumibot/tools/helpers.py
@@ -1,13 +1,15 @@
 import os
 import re
 import sys
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta, date, time
+from pytz import timezone
 
+import pandas as pd
 import pandas_market_calendars as mcal
+from pandas_market_calendars.market_calendar import MarketCalendar
 from termcolor import colored
 
 from lumibot import LUMIBOT_DEFAULT_PYTZ
-import pandas as pd
 
 
 def get_chunks(l, chunk_size):
@@ -34,11 +36,6 @@ def deduplicate_sequence(seq, key=""):
             pos += 1
     del seq[pos:]
     return seq
-
-import pandas_market_calendars as mcal
-from pandas_market_calendars.market_calendar import MarketCalendar
-from datetime import time
-from pytz import timezone
 
 
 class TwentyFourSevenCalendar(MarketCalendar):

--- a/tests/test_drift_rebalancer.py
+++ b/tests/test_drift_rebalancer.py
@@ -1448,7 +1448,6 @@ class TestDriftRebalancer:
             show_indicators=False,
             save_logfile=False,
             show_progress_bar=False,
-            include_cash_positions=True,
             # quiet_logs=False,
         )
 
@@ -1504,7 +1503,6 @@ class TestDriftRebalancer:
             show_indicators=False,
             save_logfile=False,
             show_progress_bar=False,
-            include_cash_positions=True,
             # quiet_logs=False,
         )
 
@@ -1562,7 +1560,6 @@ class TestDriftRebalancer:
             show_indicators=False,
             save_logfile=False,
             show_progress_bar=False,
-            include_cash_positions=True,
         )
 
         trades_df = strat_obj.broker._trade_event_log_df
@@ -1626,7 +1623,6 @@ class TestDriftRebalancer:
             show_indicators=False,
             save_logfile=False,
             show_progress_bar=False,
-            include_cash_positions=True,
         )
 
         trades_df = strat_obj.broker._trade_event_log_df


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Remove the `include_cash_positions` parameter from strategy setup to use a default configuration for cash handling except in `drift_rebalancer`, where it is explicitly set to `True`.

### Why are these changes being made?
This change standardizes strategy configuration by removing the redundant `include_cash_positions` parameter, allowing the system's default handling of cash positions unless explicitly needed, like in the `drift_rebalancer` strategy. The updated approach minimizes code duplication and potential configuration errors across different strategy files.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->