### PR TITLE
Add placeholder orders to tracked orders in broker.py to better match…

### DIFF
--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -371,8 +371,8 @@ class Broker(ABC):
     @property
     def _tracked_orders(self):
         return (self._unprocessed_orders.get_list() + self._new_orders.get_list() +
-                self._partially_filled_orders.get_list() + self._filled_orders.get_list() + 
-                self._error_orders.get_list() + self._canceled_orders.get_list())
+                self._partially_filled_orders.get_list() + self._filled_orders.get_list() +
+                self._error_orders.get_list() + self._canceled_orders.get_list() + self._placeholder_orders.get_list())
 
     def is_backtesting_broker(self):
         return self.IS_BACKTESTING_BROKER

--- a/tests/backtest/test_example_strategies.py
+++ b/tests/backtest/test_example_strategies.py
@@ -107,10 +107,11 @@ class TestExampleStrategies:
         assert filled_orders.iloc[1]["price"] >= 405
 
         all_orders = strat_obj.broker.get_all_orders()
-        assert len(all_orders) == 3
+        assert len(all_orders) == 4
         entry_order = [o for o in all_orders if o.order_type == Order.OrderType.MARKET][0]
         limit_order = [o for o in all_orders if o.order_type == Order.OrderType.LIMIT][0]
         stop_order = [o for o in all_orders if o.order_type == Order.OrderType.STOP][0]
+        oco_order = [oco for oco in all_orders if oco.order_class == Order.OrderClass.OCO][0]
 
         assert entry_order.quantity == 10
         assert limit_order.quantity == 10
@@ -119,6 +120,7 @@ class TestExampleStrategies:
         assert entry_order.is_filled()
         assert limit_order.is_filled()
         assert stop_order.is_canceled()
+        assert oco_order.is_filled()
 
         assert entry_order.get_fill_price() > 1
         assert limit_order.get_fill_price() >= 405


### PR DESCRIPTION
… how orders are returned in Live runs.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add `_placeholder_orders` to the list of tracked orders in `broker.py`.

### Why are these changes being made?
This change is being made to ensure that placeholder orders are accounted for in the list of tracked orders, improving consistency and accuracy in order tracking within the system. This approach provides a more comprehensive overview of all order types being monitored.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->