### PR TITLE
Introduce environment variables for backtesting logging control

### DIFF
--- a/lumibot/credentials.py
+++ b/lumibot/credentials.py
@@ -137,6 +137,29 @@ STRATEGY_NAME = os.environ.get("STRATEGY_NAME")
 # Flag to determine if backtest progress should be logged to a file (True/False)
 LOG_BACKTEST_PROGRESS_TO_FILE = os.environ.get("LOG_BACKTEST_PROGRESS_TO_FILE")
 
+# Determine if backtesting logs should be quiet via env variable (default True)
+_btl = os.environ.get("BACKTESTING_QUIET_LOGS", None)
+if _btl is not None:
+    if _btl.lower() == "true":
+        BACKTESTING_QUIET_LOGS = True
+    elif _btl.lower() == "false":
+        BACKTESTING_QUIET_LOGS = False
+    else:
+        colored_message = termcolor.colored(f"BACKTESTING_QUIET_LOGS must be set to 'true' or 'false'. Got '{_btl}'. Defaulting to True.", "yellow")
+        logger.warning(colored_message)
+        BACKTESTING_QUIET_LOGS = True
+
+_btl = os.environ.get("BACKTESTING_SHOW_PROGRESS_BAR", None)
+if _btl is not None:
+    if _btl.lower() == "true":
+        BACKTESTING_SHOW_PROGRESS_BAR = True
+    elif _btl.lower() == "false":
+        BACKTESTING_SHOW_PROGRESS_BAR = False
+    else:
+        colored_message = termcolor.colored(f"BACKTESTING_SHOW_PROGRESS_BAR must be set to 'true' or 'false'. Got '{_btl}'. Defaulting to True.", "yellow")
+        logger.warning(colored_message)
+        BACKTESTING_SHOW_PROGRESS_BAR = True
+
 # Set a hard limit on the memory polygon uses
 POLYGON_MAX_MEMORY_BYTES = os.environ.get("POLYGON_MAX_MEMORY_BYTES")
 

--- a/lumibot/credentials.py
+++ b/lumibot/credentials.py
@@ -148,6 +148,8 @@ if _btl is not None:
         colored_message = termcolor.colored(f"BACKTESTING_QUIET_LOGS must be set to 'true' or 'false'. Got '{_btl}'. Defaulting to True.", "yellow")
         logger.warning(colored_message)
         BACKTESTING_QUIET_LOGS = True
+else:
+    BACKTESTING_QUIET_LOGS = None
 
 _btl = os.environ.get("BACKTESTING_SHOW_PROGRESS_BAR", None)
 if _btl is not None:
@@ -159,6 +161,8 @@ if _btl is not None:
         colored_message = termcolor.colored(f"BACKTESTING_SHOW_PROGRESS_BAR must be set to 'true' or 'false'. Got '{_btl}'. Defaulting to True.", "yellow")
         logger.warning(colored_message)
         BACKTESTING_SHOW_PROGRESS_BAR = True
+else:
+    BACKTESTING_SHOW_PROGRESS_BAR = None
 
 # Set a hard limit on the memory polygon uses
 POLYGON_MAX_MEMORY_BYTES = os.environ.get("POLYGON_MAX_MEMORY_BYTES")

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -58,6 +58,8 @@ from ..credentials import (
     BACKTESTING_END,
     LOG_BACKTEST_PROGRESS_TO_FILE,
     INTERACTIVE_BROKERS_REST_CONFIG,
+    BACKTESTING_QUIET_LOGS,
+    BACKTESTING_SHOW_PROGRESS_BAR
 )
 # Set the stats table name for when storing stats in a database, defined by db_connection_str
 STATS_TABLE_NAME = "strategy_tracker"
@@ -1260,7 +1262,13 @@ class _Strategy:
                 "the original positional arguments for backtesting. \n\n"
             )
             return None
+        
+        if BACKTESTING_QUIET_LOGS is not None:
+            quiet_logs = BACKTESTING_QUIET_LOGS
 
+        if BACKTESTING_SHOW_PROGRESS_BAR is not None:
+            show_progress_bar = BACKTESTING_SHOW_PROGRESS_BAR
+        
         self._trader = trader_class(logfile=logfile, backtest=True, quiet_logs=quiet_logs)
 
         if datasource_class == PolygonDataBacktesting:

--- a/lumibot/traders/trader.py
+++ b/lumibot/traders/trader.py
@@ -196,8 +196,8 @@ class Trader:
             if self.quiet_logs:
                 logger.setLevel(logging.ERROR)
 
-            # Ensure console has minimal logging to keep things clean during backtesting
-            stream_handler.setLevel(logging.ERROR)
+                # Ensure console has minimal logging to keep things clean during backtesting
+                stream_handler.setLevel(logging.ERROR)
 
         else:
             # Live trades should always have full logging.


### PR DESCRIPTION
Add BACKTESTING_QUIET_LOGS and BACKTESTING_SHOW_PROGRESS_BAR environment variables to manage logging behavior during backtesting. These variables allow users to customize log visibility and progress bar display. Default values are set to ensure consistent behavior.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Introduce environment variables `BACKTESTING_QUIET_LOGS` and `BACKTESTING_SHOW_PROGRESS_BAR` to control the verbosity of backtesting logs and the display of progress bars in the Lumibot framework.

### Why are these changes being made?
These changes provide users with greater customization over their backtesting environment by allowing them to suppress logs and control the display of progress bars through environment variables. This enhances the usability in varying development scenarios where users might require less console output or clean interfaces, and was determined to be the best approach due to its minimal code intrusion and compatibility with existing logging mechanisms.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->