### PR TITLE
Adding indicator subplots

### DIFF
--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -1413,7 +1413,7 @@ class Strategy(_Strategy):
         >>> order2 = self.create_order((asset_ETH, asset_quote), 10, "buy")
         >>> self.submit_order([order1, order2])
         """
-        
+
         if isinstance(order, list):
             # Submit multiple orders
             # Validate orders
@@ -1422,10 +1422,10 @@ class Strategy(_Strategy):
             for o in order:
                 if not self._validate_order(o):
                     return
-                
+
                 if o.asset.asset_type != "option":
                     default_multileg = False
-            
+
             if 'is_multileg' not in kwargs:
                 kwargs['is_multileg'] = default_multileg
 
@@ -2027,10 +2027,10 @@ class Strategy(_Strategy):
         return self.broker.get_chain(chains)
 
     def get_chain_full_info(
-            self, 
+            self,
             asset: Asset,
-            expiry: Union[str, datetime.datetime, datetime.date], 
-            chains: dict = None, 
+            expiry: Union[str, datetime.datetime, datetime.date],
+            chains: dict = None,
             underlying_price: float = None,
             risk_free_rate: float = None,
             strike_min: float = None,
@@ -2193,7 +2193,7 @@ class Strategy(_Strategy):
         timestamp : datetime.datetime | pd.Timestamp
             The timestamp for which the first Friday of the month is
             needed.
-        
+
         Returns
         -------
         datetime.datetime
@@ -2659,14 +2659,15 @@ class Strategy(_Strategy):
         )
 
     def add_marker(
-            self, 
-            name: str, 
+            self,
+            name: str,
             value: float = None,
-            color: str = "blue", 
+            color: str = "blue",
             symbol: str = "circle",
             size: int = None,
             detail_text: str = None,
-            dt: Union[datetime.datetime, pd.Timestamp] = None
+            dt: Union[datetime.datetime, pd.Timestamp] = None,
+            plot_name: str = "default_plot"
             ):
         """Adds a marker to the indicators plot that loads after a backtest. This can be used to mark important events on the graph, such as price crossing a certain value, marking a support level, marking a resistance level, etc.
 
@@ -2686,6 +2687,8 @@ class Strategy(_Strategy):
             The text to display when the marker is hovered over.
         dt : datetime.datetime or pandas.Timestamp
             The datetime of the marker. Default is the current datetime.
+        plot_name : str
+            The name of the subplot to add the marker to. If "default_plot" (the default value) or None, the marker will be added to the main plot.
 
         Example
         -------
@@ -2748,7 +2751,12 @@ class Strategy(_Strategy):
         if len(self._chart_markers_list) > 0:
             timestamp = dt.timestamp()
             for marker in self._chart_markers_list:
-                if marker["timestamp"] == timestamp and marker["name"] == name and marker["symbol"] == symbol:
+                if (
+                        marker["timestamp"] == timestamp
+                        and marker["name"] == name
+                        and marker["symbol"] == symbol
+                        and marker['plot_name'] == plot_name
+                ):
                     return None
 
         new_marker = {
@@ -2760,6 +2768,7 @@ class Strategy(_Strategy):
             "size": size,
             "value": value,
             "detail_text": detail_text,
+            "plot_name": plot_name,
         }
 
         self._chart_markers_list.append(new_marker)
@@ -2780,14 +2789,15 @@ class Strategy(_Strategy):
         return df
 
     def add_line(
-            self, 
-            name: str, 
-            value: float, 
+            self,
+            name: str,
+            value: float,
             color: str = None,
             style: str = "solid",
             width: int = None,
             detail_text: str = None,
-            dt: Union[datetime.datetime, pd.Timestamp] = None
+            dt: Union[datetime.datetime, pd.Timestamp] = None,
+            plot_name: str = "default_plot"
             ):
         """Adds a line data point to the indicator chart. This can be used to add lines such as bollinger bands, prices for specific assets, or any other line you want to add to the chart.
 
@@ -2807,6 +2817,8 @@ class Strategy(_Strategy):
             The text to display when the line is hovered over.
         dt : datetime.datetime or pandas.Timestamp
             The datetime of the line. Default is the current datetime.
+        plot_name : str
+            The name of the subplot to add the line to. If "default_plot" (the default value) or None, the line will be added to the main plot.
 
         Example
         -------
@@ -2871,6 +2883,7 @@ class Strategy(_Strategy):
                 "style": style,
                 "width": width,
                 "detail_text": detail_text,
+                "plot_name": plot_name,
             }
         )
 
@@ -2889,12 +2902,12 @@ class Strategy(_Strategy):
 
     def write_backtest_settings(self, settings_file: str):
         """Writes the backtest settings to a file.
-        
+
         Parameters
         ----------
         settings_file : str
             The file path to write the settings to.
-            
+
         Returns
         -------
         None
@@ -3706,10 +3719,10 @@ class Strategy(_Strategy):
         pass
 
     def on_partially_filled_order(
-            self, 
-            position: Position, 
-            order: Order, 
-            price: float, 
+            self,
+            position: Position,
+            order: Order,
+            price: float,
             quantity: Union[float, int],
             multiplier: float
             ):
@@ -3823,7 +3836,7 @@ class Strategy(_Strategy):
 
         trader.add_strategy(self)
         trader.run_all()
-    
+
     @classmethod
     def backtest(
         self,

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -409,8 +409,8 @@ def plot_indicators(
                     bgcolor="white",
                 ),
                 rangeslider=dict(
-                    visible=False,
-                    thickness=0.15  # Make the range slider height shorter than the plot height
+                    visible=True,
+                    thickness=0.05  # Make the range slider height shorter to avoid layout issues
                 ),
                 row=i,
                 col=1

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -368,7 +368,7 @@ def plot_indicators(
         # Set title and layout
         # Calculate height based on number of subplots
         # 400px per subplot
-        height = num_subplots * 400
+        height = max(800, num_subplots * 400)
 
         fig.update_layout(
             title_text=f"Indicators for {strategy_name}",

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -415,10 +415,15 @@ def plot_indicators(
 
     if has_chart_data:
         # Set title and layout
+        # Calculate height based on number of subplots to prevent squishing
+        # Base height of 600px plus 400px for each additional subplot
+        height = 600 + (num_subplots - 1) * 400
+
         fig.update_layout(
             title_text=f"Indicators for {strategy_name}",
             title_font_size=30,
             template="plotly_dark",
+            height=height,  # Dynamic height based on number of subplots
         )
 
         # Range selector buttons

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -264,7 +264,7 @@ def plot_indicators(
         cols=1,
         subplot_titles=subplot_titles,
         shared_xaxes=False,  # Do not use shared x-axes
-        vertical_spacing=0.1  # Increase spacing between subplots for better separation
+        vertical_spacing=0.15,  # Increase spacing between subplots to prevent range slider overlap,
     )
 
     has_chart_data = False
@@ -366,9 +366,9 @@ def plot_indicators(
 
     if has_chart_data:
         # Set title and layout
-        # Calculate height based on number of subplots to prevent squishing
-        # Base height of 600px plus 400px for each additional subplot
-        height = 600 + (num_subplots - 1) * 400
+        # Calculate height based on number of subplots
+        # 400px per subplot
+        height = num_subplots * 400
 
         fig.update_layout(
             title_text=f"Indicators for {strategy_name}",
@@ -410,7 +410,7 @@ def plot_indicators(
                 ),
                 rangeslider=dict(
                     visible=True,
-                    thickness=0.05  # Make the range slider height shorter to avoid layout issues
+                    thickness=0.02  # Make the range slider height shorter to make line graph appear taller
                 ),
                 row=i,
                 col=1

--- a/tests/test_indicator_subplots.py
+++ b/tests/test_indicator_subplots.py
@@ -1,0 +1,203 @@
+import logging
+from datetime import datetime as DateTime
+
+from lumibot.backtesting import PandasDataBacktesting
+from lumibot.strategies.strategy import Strategy
+from lumibot.entities import Asset
+
+from tests.fixtures import pandas_data_fixture
+
+
+logger = logging.getLogger(__name__)
+
+
+class TestDefaultIndicatorStrategy(Strategy):
+    """
+    A strategy that adds the closing prices of each asset to a line.
+    """
+
+    def initialize(self):
+        self.sleeptime = "1D"
+        self.set_market("24/7")
+
+        # Define the assets we want to track (SPY, TLT, GLD)
+        self.assets = [
+            Asset(symbol="SPY", asset_type="stock"),
+            Asset(symbol="TLT", asset_type="stock"),
+            Asset(symbol="GLD", asset_type="stock")
+        ]
+
+
+    def on_trading_iteration(self):
+        # Get the current datetime
+        dt = self.get_datetime()
+
+        # For each asset, get the closing price and add it to a line
+        for asset in self.assets:
+            # Get the latest price data for the asset
+            price_data = self.get_last_price(asset)
+
+            # Add the closing price to a line
+            if price_data is not None:
+                close_price = price_data
+                self.add_line(
+                    name=f"{asset.symbol} Close",
+                    value=close_price,
+                    dt=dt
+                )
+
+                self.add_line(
+                    name=f"{asset.symbol} Close price 2",
+                    value=close_price,
+                    dt=dt
+                )
+
+                # Add a green up triangle on Mondays
+                if dt.weekday() == 0:  # Monday is 0
+                    self.add_marker(
+                        name="buy",
+                        value=close_price,
+                        color="green",
+                        symbol="triangle-up",
+                        dt=dt,
+                    )
+
+                # Add a red upside-down triangle on Fridays
+                if dt.weekday() == 4:  # Friday is 4
+                    self.add_marker(
+                        name="sell",
+                        value=close_price,
+                        color="red",
+                        symbol="triangle-down",
+                        dt=dt,
+                    )
+
+
+class TestIndicatorStrategy(Strategy):
+    """
+    A strategy that adds the closing prices of each asset to a line.
+    """
+
+    def initialize(self):
+        self.sleeptime = "1D"
+        self.set_market("24/7")
+
+        # Define the assets we want to track (SPY, TLT, GLD)
+        self.assets = [
+            Asset(symbol="SPY", asset_type="stock"),
+            Asset(symbol="TLT", asset_type="stock"),
+            Asset(symbol="GLD", asset_type="stock")
+        ]
+
+        self.colors = {
+            "SPY": "lightblue",
+            "TLT": "pink",
+            "GLD": "yellow"
+        }
+
+    def on_trading_iteration(self):
+        # Get the current datetime
+        dt = self.get_datetime()
+
+        # For each asset, get the closing price and add it to a line
+        for asset in self.assets:
+            # Get the latest price data for the asset
+            price_data = self.get_last_price(asset)
+
+            # Add the closing price to a line
+            if price_data is not None:
+                close_price = price_data
+                self.add_line(
+                    name=f"{asset.symbol} Close",
+                    value=close_price,
+                    color=self.colors[asset.symbol],
+                    dt=dt,
+                    plot_name=asset.symbol
+                )
+
+                self.add_line(
+                    name=f"{asset.symbol} Close price 2",
+                    value=close_price,
+                    color=self.colors[asset.symbol],
+                    dt=dt,
+                    plot_name=f"{asset.symbol} line 2"
+                )
+
+                # Add a green up triangle on Mondays
+                if dt.weekday() == 0:  # Monday is 0
+                    self.add_marker(
+                        name="buy",
+                        value=close_price,
+                        color="green",
+                        symbol="triangle-up",
+                        dt=dt,
+                        plot_name=asset.symbol
+                    )
+
+                # Add a red upside-down triangle on Fridays
+                if dt.weekday() == 4:  # Friday is 4
+                    self.add_marker(
+                        name="sell",
+                        value=close_price,
+                        color="red",
+                        symbol="triangle-down",
+                        dt=dt,
+                        plot_name=asset.symbol
+                    )
+
+
+class TestIndicators:
+
+    def test_default_lines(self, pandas_data_fixture):
+        """Test the default behavior (unnamed lines)"""
+        strategy_name = "TestDefaultIndicatorStrategy"
+        strategy_class = TestDefaultIndicatorStrategy
+        backtesting_start = DateTime(2019, 1, 1)
+        backtesting_end = DateTime(2019, 3, 1)
+
+        result = strategy_class.backtest(
+            datasource_class=PandasDataBacktesting,
+            backtesting_start=backtesting_start,
+            backtesting_end=backtesting_end,
+            pandas_data=pandas_data_fixture,
+            risk_free_rate=0,
+            show_plot=False,
+            save_tearsheet=False,
+            show_tearsheet=False,
+            show_indicators=True,  # This is set to True as per the requirement
+            save_logfile=False,
+            name=strategy_name,
+            budget=40000,
+            show_progress_bar=False,
+            quiet_logs=False,
+        )
+        logger.info(f"Result: {result}")
+        assert result is not None
+
+    def test_named_lines(self, pandas_data_fixture):
+        """Test the named lines"""
+        strategy_name = "TestIndicatorStrategy"
+        strategy_class = TestIndicatorStrategy
+        backtesting_start = DateTime(2019, 1, 1)
+        backtesting_end = DateTime(2019, 3, 1)
+
+        result = strategy_class.backtest(
+            datasource_class=PandasDataBacktesting,
+            backtesting_start=backtesting_start,
+            backtesting_end=backtesting_end,
+            pandas_data=pandas_data_fixture,
+            risk_free_rate=0,
+            show_plot=False,
+            save_tearsheet=False,
+            show_tearsheet=False,
+            show_indicators=True,  # This is set to True as per the requirement
+            save_logfile=False,
+            name=strategy_name,
+            budget=40000,
+            show_progress_bar=False,
+            quiet_logs=False,
+        )
+        logger.info(f"Result: {result}")
+        assert result is not None
+
+

--- a/tests/test_indicator_subplots.py
+++ b/tests/test_indicator_subplots.py
@@ -152,7 +152,7 @@ class TestIndicators:
         """Test the default behavior (unnamed lines)"""
         strategy_name = "TestDefaultIndicatorStrategy"
         strategy_class = TestDefaultIndicatorStrategy
-        backtesting_start = DateTime(2019, 1, 1)
+        backtesting_start = DateTime(2019, 1, 2)
         backtesting_end = DateTime(2019, 3, 1)
 
         result = strategy_class.backtest(
@@ -178,7 +178,7 @@ class TestIndicators:
         """Test the named lines"""
         strategy_name = "TestIndicatorStrategy"
         strategy_class = TestIndicatorStrategy
-        backtesting_start = DateTime(2019, 1, 1)
+        backtesting_start = DateTime(2019, 1, 2)
         backtesting_end = DateTime(2019, 3, 1)
 
         result = strategy_class.backtest(


### PR DESCRIPTION
You can now add a plot_name when adding markers or lines. These will show up on their own subplot.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add support for indicator subplots within the `lumibot` strategies, enabling markers and lines to be plotted on separate subplots; include test cases for default and named indicator strategies.

### Why are these changes being made?
These changes enhance the visualization capabilities of the trading strategies by allowing for more organized and insightful displays of trading indicators. This improvement aids in better visual separation and categorization of markers and lines, potentially improving analysis and decision-making processes. The addition of test cases ensures the new functionality works as intended and maintains the existing system's integrity.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->