### PR TITLE
Fx alpaca order issues

### DIFF
--- a/lumibot/components/drift_rebalancer_logic.py
+++ b/lumibot/components/drift_rebalancer_logic.py
@@ -491,11 +491,6 @@ class DriftOrderLogic:
                     )
                     buy_orders.append(order)
                     cash_position -= quantity * limit_price
-                else:
-                    self.strategy.logger.info(
-                        f"Ran out of cash to buy {quantity} of {base_asset.symbol}. "
-                        f"Cash: {cash_position} and limit_price: {limit_price:.2f}"
-                    )
 
     def calculate_limit_price(self, *, last_price: Decimal, side: str) -> Decimal:
         if side == "sell":

--- a/lumibot/components/drift_rebalancer_logic.py
+++ b/lumibot/components/drift_rebalancer_logic.py
@@ -1,5 +1,5 @@
 from typing import Dict, Any, List
-from decimal import Decimal, ROUND_DOWN
+from decimal import Decimal, ROUND_DOWN, ROUND_UP
 import time
 
 import pandas as pd
@@ -385,7 +385,7 @@ class DriftOrderLogic:
                 base_asset = row["base_asset"]
                 quantity = row["current_quantity"]
                 last_price = get_last_price_or_raise(self.strategy, base_asset, self.strategy.quote_asset)
-                limit_price = self.calculate_limit_price(last_price=last_price, side="sell")
+                limit_price = self.calculate_limit_price(last_price=last_price, side="sell", asset=base_asset)
                 if quantity == 0 and self.shorting:
                     # Create a 100% short position.
                     total_value = df["current_value"].sum()
@@ -410,7 +410,7 @@ class DriftOrderLogic:
 
                 base_asset = row["base_asset"]
                 last_price = get_last_price_or_raise(self.strategy, base_asset, self.strategy.quote_asset)
-                limit_price = self.calculate_limit_price(last_price=last_price, side="sell")
+                limit_price = self.calculate_limit_price(last_price=last_price, side="sell", asset=base_asset)
                 quantity = (row["current_value"] - row["target_value"]) / limit_price
                 if self.fractional_shares:
                     quantity = quantity.quantize(Decimal('1.000000000'), rounding=ROUND_DOWN)
@@ -441,7 +441,7 @@ class DriftOrderLogic:
                 base_asset = row["base_asset"]
                 quantity = abs(row["current_quantity"])
                 last_price = get_last_price_or_raise(self.strategy, base_asset, self.strategy.quote_asset)
-                limit_price = self.calculate_limit_price(last_price=last_price, side="buy")
+                limit_price = self.calculate_limit_price(last_price=last_price, side="buy", asset=base_asset)
                 order = self.place_order(
                     base_asset=base_asset,
                     quantity=quantity,
@@ -458,7 +458,7 @@ class DriftOrderLogic:
 
                 base_asset = row["base_asset"]
                 last_price = get_last_price_or_raise(self.strategy, base_asset, self.strategy.quote_asset)
-                limit_price = self.calculate_limit_price(last_price=last_price, side="buy")
+                limit_price = self.calculate_limit_price(last_price=last_price, side="buy", asset=base_asset)
                 order_value = row["target_value"] - row["current_value"]
                 desired_quantity = min(order_value, cash_position) / limit_price
 
@@ -492,11 +492,21 @@ class DriftOrderLogic:
                     buy_orders.append(order)
                     cash_position -= quantity * limit_price
 
-    def calculate_limit_price(self, *, last_price: Decimal, side: str) -> Decimal:
+    def calculate_limit_price(self, *, last_price: Decimal, side: str, asset: Asset) -> Decimal:
         if side == "sell":
-            return last_price * (1 - self.acceptable_slippage)
+            limit_price = last_price * (1 - self.acceptable_slippage)
         else:
-            return last_price * (1 + self.acceptable_slippage)
+            limit_price = last_price * (1 + self.acceptable_slippage)
+
+        if asset.asset_type != Asset.AssetType.CRYPTO:
+            # reduce to 2 decimals
+            if side == "buy":
+                limit_price = limit_price.quantize(Decimal('1.00'), rounding=ROUND_DOWN)
+            else:
+                limit_price = limit_price.quantize(Decimal('1.00'), rounding=ROUND_UP)
+
+        return limit_price
+
 
     def get_current_cash_position(self) -> Decimal:
         self.strategy.update_broker_balances(force_update=True)

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -1053,9 +1053,13 @@ class Order:
 
         if not status1 or not status2:
             return False
-        elif status1.lower() in [status2.lower(), STATUS_ALIAS_MAP.get(status2.lower(), "")]:
+        elif status1.lower() == status2.lower():  # Direct match check
             return True
-        # open/new status is equivalent
+        elif status1.lower() in STATUS_ALIAS_MAP.get(status2.lower(), []):
+            return True
+        elif status2.lower() in STATUS_ALIAS_MAP.get(status1.lower(), []):
+            # Bidirectional alias check
+            return True
         elif {status1.lower(), status2.lower()}.issubset({"open", "new"}):
             return True
         else:

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -175,7 +175,18 @@ class StrategyExecutor(Thread):
                     for order_attr in order_attrs:
                         olumi = getattr(order_lumi, order_attr)
                         obroker = getattr(order, order_attr)
-                        if olumi != obroker:
+
+                        if isinstance(olumi, (int, float)) and isinstance(obroker, (int, float)):
+                            # Compare with tolerance for numeric types
+                            epsilon = 1e-9
+                            if abs(olumi - obroker) > epsilon:
+                                setattr(order_lumi, order_attr, obroker)
+                                self.strategy.logger.warning(
+                                    f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "
+                                    f"to be {obroker} because what we have in memory does not match the broker."
+                                )
+                                self.strategy.logger.warning(f"Difference in {order_attr}: {abs(olumi - obroker)}")
+                        elif olumi != obroker:  # Direct comparison for other types
                             setattr(order_lumi, order_attr, obroker)
                             self.strategy.logger.warning(
                                 f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -175,18 +175,7 @@ class StrategyExecutor(Thread):
                     for order_attr in order_attrs:
                         olumi = getattr(order_lumi, order_attr)
                         obroker = getattr(order, order_attr)
-
-                        if isinstance(olumi, (int, float)) and isinstance(obroker, (int, float)):
-                            # Compare with tolerance for numeric types
-                            epsilon = 1e-9
-                            if abs(olumi - obroker) > epsilon:
-                                setattr(order_lumi, order_attr, obroker)
-                                self.strategy.logger.warning(
-                                    f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "
-                                    f"to be {obroker} because what we have in memory does not match the broker."
-                                )
-                                self.strategy.logger.warning(f"Difference in {order_attr}: {abs(olumi - obroker)}")
-                        elif olumi != obroker:  # Direct comparison for other types
+                        if olumi != obroker:
                             setattr(order_lumi, order_attr, obroker)
                             self.strategy.logger.warning(
                                 f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "

--- a/tests/test_drift_rebalancer.py
+++ b/tests/test_drift_rebalancer.py
@@ -1234,9 +1234,10 @@ class TestDriftOrderLogic:
             broker=self.backtesting_broker,
             order_type=Order.OrderType.LIMIT,
         )
+        asset = Asset("AAPL", "stock")
         df = pd.DataFrame({
             "symbol": ["AAPL"],
-            "base_asset": [Asset("AAPL", "stock")],
+            "base_asset": [asset],
             "is_quote_asset": False,
             "current_quantity": [Decimal("10")],
             "current_value": [Decimal("1000")],
@@ -1250,7 +1251,7 @@ class TestDriftOrderLogic:
             acceptable_slippage=Decimal("0.005")
         )
         strategy.order_logic.rebalance(drift_df=df)
-        limit_price = strategy.order_logic.calculate_limit_price(last_price=Decimal("120.00"), side="sell")
+        limit_price = strategy.order_logic.calculate_limit_price(last_price=Decimal("120.00"), side="sell", asset=asset)
         assert limit_price == Decimal("119.4")
 
     def test_calculate_limit_price_when_buying(self):
@@ -1258,9 +1259,10 @@ class TestDriftOrderLogic:
             broker=self.backtesting_broker,
             order_type=Order.OrderType.LIMIT,
         )
+        asset = Asset("AAPL", "stock")
         df = pd.DataFrame({
             "symbol": ["AAPL"],
-            "base_asset": [Asset("AAPL", "stock")],
+            "base_asset": [asset],
             "is_quote_asset": False,
             "current_quantity": [Decimal("0")],
             "current_value": [Decimal("0")],
@@ -1274,7 +1276,7 @@ class TestDriftOrderLogic:
             acceptable_slippage=Decimal("0.005")
         )
         strategy.order_logic.rebalance(drift_df=df)
-        limit_price = strategy.order_logic.calculate_limit_price(last_price=Decimal("120.00"), side="buy")
+        limit_price = strategy.order_logic.calculate_limit_price(last_price=Decimal("120.00"), side="buy", asset=asset)
         assert limit_price == Decimal("120.6")
 
     def test_buying_whole_shares(self):
@@ -1649,12 +1651,12 @@ class TestDriftRebalancer:
         assert filled_orders.iloc[0]["type"] == "limit"
         assert filled_orders.iloc[0]["side"] == "buy"
         assert filled_orders.iloc[0]["symbol"] == "SPY"
-        assert filled_orders.iloc[0]["filled_quantity"] == 238.634160544
+        assert filled_orders.iloc[0]["filled_quantity"] == 238.635007755
 
         assert filled_orders.iloc[2]["type"] == "limit"
         assert filled_orders.iloc[2]["side"] == "sell"
         assert filled_orders.iloc[2]["symbol"] == "SPY"
-        assert filled_orders.iloc[2]["filled_quantity"] == 8.346738266
+        assert filled_orders.iloc[2]["filled_quantity"] == 8.347327921
 
     # @pytest.mark.skip()
     def test_crypto_50_50_with_yahoo(self):

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -322,3 +322,7 @@ class TestOrderAdvanced:
         assert order.child_orders[1].is_stop_order()
         assert order.child_orders[1].stop_price == 99.0
         assert order.child_orders[1].stop_limit_price == 99.10
+
+    def test_is_equivalent_status(self):
+        assert Order.is_equivalent_status("pending_new", Order.OrderStatus.NEW)
+


### PR DESCRIPTION
This PR addresses two things:
* the order class was missing an equivalancy check for "pending_new" and "new" orders.
* The drift rebalancer now quantizes limit order prices to 2 decimals preventing orders from being conformed by brokers and causing warnings.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Enhance alpaca order processing by improving the calculation of limit prices to consider asset type and status equivalence checks.

### Why are these changes being made?
These changes address issues in precision and consistency when calculating limit prices for orders. The update ensures that stocks, unlike crypto assets, conform to the appropriate decimal places rules, and enhances order status matching by correctly handling status alias comparisons. This refinement helps prevent order placement errors and improves compatibility with asset pricing requirements.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->