### PR TITLE
fixed alpaca broker to pass the custom params set by user to the broker.

### DIFF
--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -401,6 +401,16 @@ class Alpaca(Broker):
 
         return orders
 
+    def _validate_custom_params(self, params):
+        """
+        Validate custom params for submitting to orders
+        """
+        # Define allowlist of acceptable custom parameters, add more as needed
+        ALLOWED_PARAMS = {'extended_hours'}
+        if params:
+            return {k: v for k, v in params.items() if k in ALLOWED_PARAMS}
+        return {}
+
     def _submit_order(self, order):
         """Submit an order for an asset"""
 
@@ -450,6 +460,7 @@ class Alpaca(Broker):
 
         # INJECT STRATEGY‑LEVEL CUSTOM_PARAMS
         if getattr(order, "custom_params", None):
+            validated_params = self._validate_custom_params(order.custom_params)
             kwargs.update(order.custom_params)
 
         if order.order_class in [Order.OrderClass.OCO, Order.OrderClass.OTO, Order.OrderClass.BRACKET]:

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -448,6 +448,10 @@ class Alpaca(Broker):
         # Remove items with None values
         kwargs = {k: v for k, v in kwargs.items() if v}
 
+        # INJECT STRATEGY‑LEVEL CUSTOM_PARAMS
+        if getattr(order, "custom_params", None):
+            kwargs.update(order.custom_params)
+
         if order.order_class in [Order.OrderClass.OCO, Order.OrderClass.OTO, Order.OrderClass.BRACKET]:
             child_limit_orders = [child for child in order.child_orders if child.order_type == Order.OrderType.LIMIT]
             child_stop_orders = [child for child in order.child_orders if child.is_stop_order()]


### PR DESCRIPTION
Hi team,

I just fixed a issue where alpaca cannot parse user provided custom parameters to the user.

Thanks
Scott

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Enhance the Alpaca broker by allowing user-defined `custom_params` to be passed and integrated into order submissions.

### Why are these changes being made?
This change facilitates greater flexibility and user customization within order processing by allowing strategy-level parameters to be directly incorporated into the order submission process. It addresses user needs for customized behavior beyond the default order parameters provided by the broker.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->