### PR TITLE
Fix alpaca order issues (and more importantly fix the broken alpaca stuff)

### DIFF
--- a/lumibot/components/drift_rebalancer_logic.py
+++ b/lumibot/components/drift_rebalancer_logic.py
@@ -491,11 +491,6 @@ class DriftOrderLogic:
                     )
                     buy_orders.append(order)
                     cash_position -= quantity * limit_price
-                else:
-                    self.strategy.logger.info(
-                        f"Ran out of cash to buy {quantity} of {base_asset.symbol}. "
-                        f"Cash: {cash_position} and limit_price: {limit_price:.2f}"
-                    )
 
     def calculate_limit_price(self, *, last_price: Decimal, side: str) -> Decimal:
         if side == "sell":

--- a/lumibot/components/drift_rebalancer_logic.py
+++ b/lumibot/components/drift_rebalancer_logic.py
@@ -1,5 +1,5 @@
 from typing import Dict, Any, List
-from decimal import Decimal, ROUND_DOWN
+from decimal import Decimal, ROUND_DOWN, ROUND_UP
 import time
 
 import pandas as pd
@@ -385,7 +385,7 @@ class DriftOrderLogic:
                 base_asset = row["base_asset"]
                 quantity = row["current_quantity"]
                 last_price = get_last_price_or_raise(self.strategy, base_asset, self.strategy.quote_asset)
-                limit_price = self.calculate_limit_price(last_price=last_price, side="sell")
+                limit_price = self.calculate_limit_price(last_price=last_price, side="sell", asset=base_asset)
                 if quantity == 0 and self.shorting:
                     # Create a 100% short position.
                     total_value = df["current_value"].sum()
@@ -410,7 +410,7 @@ class DriftOrderLogic:
 
                 base_asset = row["base_asset"]
                 last_price = get_last_price_or_raise(self.strategy, base_asset, self.strategy.quote_asset)
-                limit_price = self.calculate_limit_price(last_price=last_price, side="sell")
+                limit_price = self.calculate_limit_price(last_price=last_price, side="sell", asset=base_asset)
                 quantity = (row["current_value"] - row["target_value"]) / limit_price
                 if self.fractional_shares:
                     quantity = quantity.quantize(Decimal('1.000000000'), rounding=ROUND_DOWN)
@@ -441,7 +441,7 @@ class DriftOrderLogic:
                 base_asset = row["base_asset"]
                 quantity = abs(row["current_quantity"])
                 last_price = get_last_price_or_raise(self.strategy, base_asset, self.strategy.quote_asset)
-                limit_price = self.calculate_limit_price(last_price=last_price, side="buy")
+                limit_price = self.calculate_limit_price(last_price=last_price, side="buy", asset=base_asset)
                 order = self.place_order(
                     base_asset=base_asset,
                     quantity=quantity,
@@ -458,7 +458,7 @@ class DriftOrderLogic:
 
                 base_asset = row["base_asset"]
                 last_price = get_last_price_or_raise(self.strategy, base_asset, self.strategy.quote_asset)
-                limit_price = self.calculate_limit_price(last_price=last_price, side="buy")
+                limit_price = self.calculate_limit_price(last_price=last_price, side="buy", asset=base_asset)
                 order_value = row["target_value"] - row["current_value"]
                 desired_quantity = min(order_value, cash_position) / limit_price
 
@@ -492,11 +492,21 @@ class DriftOrderLogic:
                     buy_orders.append(order)
                     cash_position -= quantity * limit_price
 
-    def calculate_limit_price(self, *, last_price: Decimal, side: str) -> Decimal:
+    def calculate_limit_price(self, *, last_price: Decimal, side: str, asset: Asset) -> Decimal:
         if side == "sell":
-            return last_price * (1 - self.acceptable_slippage)
+            limit_price = last_price * (1 - self.acceptable_slippage)
         else:
-            return last_price * (1 + self.acceptable_slippage)
+            limit_price = last_price * (1 + self.acceptable_slippage)
+
+        if asset.asset_type != Asset.AssetType.CRYPTO:
+            # reduce to 2 decimals
+            if side == "buy":
+                limit_price = limit_price.quantize(Decimal('1.00'), rounding=ROUND_DOWN)
+            else:
+                limit_price = limit_price.quantize(Decimal('1.00'), rounding=ROUND_UP)
+
+        return limit_price
+
 
     def get_current_cash_position(self) -> Decimal:
         self.strategy.update_broker_balances(force_update=True)

--- a/lumibot/data_sources/alpaca_data.py
+++ b/lumibot/data_sources/alpaca_data.py
@@ -49,39 +49,59 @@ class AlpacaData(DataSource):
     TIMESTEP_MAPPING = [
         {
             "timestep": "minute",
-            "representations": [TimeFrame.Minute, "minute", "1m"],
+            "representations": [TimeFrame.Minute, "minute"],
         },
         {
             "timestep": "5 minutes",
-            "representations": [TimeFrame(5, TimeFrame.Minute), "5minute", "5m"],
+            "representations": [
+                [f"5{TimeFrame.Minute}", "minute"],
+            ],
         },
         {
             "timestep": "10 minutes",
-            "representations": [TimeFrame(10, TimeFrame.Minute), "10minute", "10m"],
+            "representations": [
+                [f"10{TimeFrame.Minute}", "minute"],
+            ],
         },
         {
             "timestep": "15 minutes",
-            "representations": [TimeFrame(15, TimeFrame.Minute), "15minute", "15m"],
+            "representations": [
+                [f"15{TimeFrame.Minute}", "minute"],
+            ],
         },
         {
             "timestep": "30 minutes",
-            "representations": [TimeFrame(30, TimeFrame.Minute), "30minute", "30m"],
+            "representations": [
+                [f"30{TimeFrame.Minute}", "minute"],
+            ],
         },
         {
             "timestep": "hour",
-            "representations": [TimeFrame.Hour, "1hour", "1h"],
+            "representations": [
+                [f"{TimeFrame.Hour}", "hour"],
+            ],
+        },
+        {
+            "timestep": "1 hour",
+            "representations": [
+                [f"{TimeFrame.Hour}", "hour"],
+            ],
         },
         {
             "timestep": "2 hours",
-            "representations": [TimeFrame(2, TimeFrame.Hour), "2hour", "2h"],
+            "representations": [
+                [f"2{TimeFrame.Hour}", "hour"],
+            ],
         },
         {
             "timestep": "4 hours",
-            "representations": [TimeFrame(4, TimeFrame.Hour), "4hour", "4h"],
+            "representations": [
+                [f"4{TimeFrame.Hour}", "hour"],
+            ],
         },
         {
             "timestep": "day",
-            "representations": [TimeFrame.Day, "day", "1d"],
+            "representations": [TimeFrame.Day, "day"],
         },
     ]
     LUMIBOT_DEFAULT_QUOTE_ASSET = Asset(LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL, LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE)
@@ -355,7 +375,7 @@ class AlpacaData(DataSource):
             include_after_hours: bool = True
     ) -> Optional[pd.DataFrame]:
 
-        timeframe = self._parse_source_timestep(timestep, reverse=False)
+        timeframe = self._parse_source_timestep(timestep, reverse=True)
 
         now = dt.datetime.now(self._tzinfo)
 

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -1053,9 +1053,13 @@ class Order:
 
         if not status1 or not status2:
             return False
-        elif status1.lower() in [status2.lower(), STATUS_ALIAS_MAP.get(status2.lower(), "")]:
+        elif status1.lower() == status2.lower():  # Direct match check
             return True
-        # open/new status is equivalent
+        elif status1.lower() in STATUS_ALIAS_MAP.get(status2.lower(), []):
+            return True
+        elif status2.lower() in STATUS_ALIAS_MAP.get(status1.lower(), []):
+            # Bidirectional alias check
+            return True
         elif {status1.lower(), status2.lower()}.issubset({"open", "new"}):
             return True
         else:

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -175,7 +175,18 @@ class StrategyExecutor(Thread):
                     for order_attr in order_attrs:
                         olumi = getattr(order_lumi, order_attr)
                         obroker = getattr(order, order_attr)
-                        if olumi != obroker:
+
+                        if isinstance(olumi, (int, float)) and isinstance(obroker, (int, float)):
+                            # Compare with tolerance for numeric types
+                            epsilon = 1e-9
+                            if abs(olumi - obroker) > epsilon:
+                                setattr(order_lumi, order_attr, obroker)
+                                self.strategy.logger.warning(
+                                    f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "
+                                    f"to be {obroker} because what we have in memory does not match the broker."
+                                )
+                                self.strategy.logger.warning(f"Difference in {order_attr}: {abs(olumi - obroker)}")
+                        elif olumi != obroker:  # Direct comparison for other types
                             setattr(order_lumi, order_attr, obroker)
                             self.strategy.logger.warning(
                                 f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -175,18 +175,7 @@ class StrategyExecutor(Thread):
                     for order_attr in order_attrs:
                         olumi = getattr(order_lumi, order_attr)
                         obroker = getattr(order, order_attr)
-
-                        if isinstance(olumi, (int, float)) and isinstance(obroker, (int, float)):
-                            # Compare with tolerance for numeric types
-                            epsilon = 1e-9
-                            if abs(olumi - obroker) > epsilon:
-                                setattr(order_lumi, order_attr, obroker)
-                                self.strategy.logger.warning(
-                                    f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "
-                                    f"to be {obroker} because what we have in memory does not match the broker."
-                                )
-                                self.strategy.logger.warning(f"Difference in {order_attr}: {abs(olumi - obroker)}")
-                        elif olumi != obroker:  # Direct comparison for other types
+                        if olumi != obroker:
                             setattr(order_lumi, order_attr, obroker)
                             self.strategy.logger.warning(
                                 f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -218,7 +218,7 @@ class StrategyExecutor(Thread):
                                 self.strategy.logger.warning(
                                     f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "
                                     f"to be {obroker} because what we have in memory does not match the broker "
-                                    f"and the types are different."
+                                    f"and the types are different. olumi:{type(olumi)} obroker: {type(obroker)}."
                                 )
                         elif olumi != obroker:  # Handle cases where one or both are None
                             setattr(order_lumi, order_attr, obroker)

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -1,4 +1,5 @@
 import inspect
+import math
 import time
 import traceback
 import json
@@ -175,12 +176,58 @@ class StrategyExecutor(Thread):
                     for order_attr in order_attrs:
                         olumi = getattr(order_lumi, order_attr)
                         obroker = getattr(order, order_attr)
-                        if olumi != obroker:
+                        if olumi is not None and obroker is not None:  # Ensure both values are not None
+                            if isinstance(olumi, float) and isinstance(obroker, float):
+                                # check if both are floats
+                                if not math.isclose(olumi, obroker, abs_tol=1e-9):
+                                    setattr(order_lumi, order_attr, obroker)
+                                    self.strategy.logger.warning(
+                                        f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "
+                                        f"to be {obroker} because what we have in memory does not match the broker "
+                                        f"and both are floats"
+                                    )
+                            elif isinstance(olumi, (int, float)) and isinstance(obroker, (int, float)):
+                                # check if both are ints
+                                if isinstance(olumi, int) and isinstance(obroker, int):
+                                    if olumi != obroker:
+                                        setattr(order_lumi, order_attr, obroker)
+                                        self.strategy.logger.warning(
+                                            f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "
+                                            f"to be {obroker} because what we have in memory does not match the broker "
+                                            f"and both are ints."
+                                        )
+                                elif not math.isclose(float(olumi), float(obroker), abs_tol=1e-9):
+                                    # Convert to float for comparison
+                                    setattr(order_lumi, order_attr, obroker)
+                                    self.strategy.logger.warning(
+                                        f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "
+                                        f"to be {obroker} because what we have in memory does not match the broker "
+                                        f"and one is float and one is int."
+                                    )
+
+                            elif type(olumi) == type(obroker):  # Compare if types are the same
+                                if olumi != obroker:
+                                    setattr(order_lumi, order_attr, obroker)
+                                    self.strategy.logger.warning(
+                                        f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "
+                                        f"to be {obroker} because what we have in memory does not match the broker "
+                                        f"and they are both the same type: {type(olumi)}."
+                                    )
+                            else:
+                                setattr(order_lumi, order_attr, obroker)  # Update if types are different
+                                self.strategy.logger.warning(
+                                    f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "
+                                    f"to be {obroker} because what we have in memory does not match the broker "
+                                    f"and the types are different."
+                                )
+                        elif olumi != obroker:  # Handle cases where one or both are None
                             setattr(order_lumi, order_attr, obroker)
                             self.strategy.logger.warning(
                                 f"We are adjusting the {order_attr} of the order {order_lumi}, from {olumi} "
-                                f"to be {obroker} because what we have in memory does not match the broker."
+                                f"to be {obroker} because what we have in memory does not match the broker "
+                                f" and one or both are none."
                             )
+
                 else:
                     # If it is the brokers first iteration then fully process the order because it is likely
                     # that the order was filled/canceled/etc before the strategy started. This is also a recovery

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -4,6 +4,7 @@ import time
 import traceback
 import json
 from datetime import datetime, timedelta
+from decimal import Decimal
 from functools import wraps
 from queue import Empty, Queue
 from threading import Event, Lock, Thread
@@ -186,7 +187,7 @@ class StrategyExecutor(Thread):
                                         f"to be {obroker} because what we have in memory does not match the broker "
                                         f"and both are floats"
                                     )
-                            elif isinstance(olumi, (int, float)) and isinstance(obroker, (int, float)):
+                            elif isinstance(olumi, (int, float, Decimal)) and isinstance(obroker, (int, float, Decimal)):
                                 # check if both are ints
                                 if isinstance(olumi, int) and isinstance(obroker, int):
                                     if olumi != obroker:

--- a/tests/test_drift_rebalancer.py
+++ b/tests/test_drift_rebalancer.py
@@ -1234,9 +1234,10 @@ class TestDriftOrderLogic:
             broker=self.backtesting_broker,
             order_type=Order.OrderType.LIMIT,
         )
+        asset = Asset("AAPL", "stock")
         df = pd.DataFrame({
             "symbol": ["AAPL"],
-            "base_asset": [Asset("AAPL", "stock")],
+            "base_asset": [asset],
             "is_quote_asset": False,
             "current_quantity": [Decimal("10")],
             "current_value": [Decimal("1000")],
@@ -1250,7 +1251,7 @@ class TestDriftOrderLogic:
             acceptable_slippage=Decimal("0.005")
         )
         strategy.order_logic.rebalance(drift_df=df)
-        limit_price = strategy.order_logic.calculate_limit_price(last_price=Decimal("120.00"), side="sell")
+        limit_price = strategy.order_logic.calculate_limit_price(last_price=Decimal("120.00"), side="sell", asset=asset)
         assert limit_price == Decimal("119.4")
 
     def test_calculate_limit_price_when_buying(self):
@@ -1258,9 +1259,10 @@ class TestDriftOrderLogic:
             broker=self.backtesting_broker,
             order_type=Order.OrderType.LIMIT,
         )
+        asset = Asset("AAPL", "stock")
         df = pd.DataFrame({
             "symbol": ["AAPL"],
-            "base_asset": [Asset("AAPL", "stock")],
+            "base_asset": [asset],
             "is_quote_asset": False,
             "current_quantity": [Decimal("0")],
             "current_value": [Decimal("0")],
@@ -1274,7 +1276,7 @@ class TestDriftOrderLogic:
             acceptable_slippage=Decimal("0.005")
         )
         strategy.order_logic.rebalance(drift_df=df)
-        limit_price = strategy.order_logic.calculate_limit_price(last_price=Decimal("120.00"), side="buy")
+        limit_price = strategy.order_logic.calculate_limit_price(last_price=Decimal("120.00"), side="buy", asset=asset)
         assert limit_price == Decimal("120.6")
 
     def test_buying_whole_shares(self):
@@ -1649,12 +1651,12 @@ class TestDriftRebalancer:
         assert filled_orders.iloc[0]["type"] == "limit"
         assert filled_orders.iloc[0]["side"] == "buy"
         assert filled_orders.iloc[0]["symbol"] == "SPY"
-        assert filled_orders.iloc[0]["filled_quantity"] == 238.634160544
+        assert filled_orders.iloc[0]["filled_quantity"] == 238.635007755
 
         assert filled_orders.iloc[2]["type"] == "limit"
         assert filled_orders.iloc[2]["side"] == "sell"
         assert filled_orders.iloc[2]["symbol"] == "SPY"
-        assert filled_orders.iloc[2]["filled_quantity"] == 8.346738266
+        assert filled_orders.iloc[2]["filled_quantity"] == 8.347327921
 
     # @pytest.mark.skip()
     def test_crypto_50_50_with_yahoo(self):

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -322,3 +322,7 @@ class TestOrderAdvanced:
         assert order.child_orders[1].is_stop_order()
         assert order.child_orders[1].stop_price == 99.0
         assert order.child_orders[1].stop_limit_price == 99.10
+
+    def test_is_equivalent_status(self):
+        assert Order.is_equivalent_status("pending_new", Order.OrderStatus.NEW)
+


### PR DESCRIPTION
This branch was created to fix a warning that occurs when alpaca limit orders created with decimal prices somtimes dont "match" the float prices that get stored in the broker. It now converts decimals to floats and checks those making the warning go away.

However the more important changes are to the timestep mapping and _parse_source_timestep. I've reverted the changes made which broke everything.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the alpaca order handling logic to fix issues with limit price calculation, expand time-frame representations, improve order synchronization logic, and include additional tests for these functionalities.

### Why are these changes being made?

These changes address specific issues with order limit prices by ensuring they correctly account for slippage and asset type, thereby improving precision in order execution. The time-frame representations have been revised for clarity and consistency. Enhancements to order synchronization involve closer type checks between memory and broker data. Additionally, new test cases have been added to ensure accuracy and functionality, particularly for the new limit price and status equivalence logic, thereby ensuring better reliability and maintainability of the order process.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->