### PR TITLE
fix alpaca get_quote and get_last_price

### DIFF
--- a/tests/test_alpaca_data.py
+++ b/tests/test_alpaca_data.py
@@ -3,6 +3,7 @@ import pytest
 import math
 from datetime import datetime, timedelta, time
 import pytz
+from unittest.mock import MagicMock
 
 from lumibot.data_sources import AlpacaData, DataSource
 from lumibot.tools import print_full_pandas_dataframes, set_pandas_float_display_precision
@@ -296,3 +297,244 @@ class TestAlpacaData(BaseDataSourceTester):
 
         bars = data_source.get_historical_prices(asset=o_asset, length=length, timestep=timestep)
         assert len(bars.df) > 0
+
+    def check_quote_data(self, quote_data):
+        """Helper method to check quote data structure"""
+        assert quote_data is not None
+        assert isinstance(quote_data, dict)
+        assert 'bid' in quote_data and quote_data['bid'] is not None
+        assert 'ask' in quote_data and quote_data['ask'] is not None
+        assert 'last' in quote_data and quote_data['last'] is not None
+        assert 'symbol' in quote_data
+
+    def test_get_quote_stock(self):
+        """Test get_quote for stock assets"""
+        data_source = self._create_data_source()
+        asset = Asset('SPY', asset_type='stock')
+        quote_asset = Asset('USD', asset_type='forex')
+
+        quote_data = data_source.get_quote(asset, quote_asset)
+        self.check_quote_data(quote_data)
+
+    def test_get_quote_crypto(self):
+        """Test get_quote for crypto assets"""
+        data_source = self._create_data_source()
+        asset = Asset('BTC', asset_type='crypto')
+        quote_asset = Asset('USD', asset_type='forex')
+
+        quote_data = data_source.get_quote(asset, quote_asset)
+        self.check_quote_data(quote_data)
+
+    def test_get_quote_when_stock_bid_is_zero(self):
+        """Test get_quote when stock bid is 0.0"""
+        data_source = self._create_data_source()
+        asset = Asset('SPY', asset_type='stock')
+
+        # Create a mock for the quote object
+        mock_quote = MagicMock()
+        mock_quote.bid_price = 0.0
+        mock_quote.ask_price = 100.0  # Some non-zero value for ask
+
+        # Store the original method
+        original_get_stock_client = data_source._get_stock_client
+
+        # Create a mock client
+        mock_client = MagicMock()
+        mock_client.get_stock_latest_quote.return_value = {asset.symbol: mock_quote}
+
+        # Replace the _get_stock_client method temporarily
+        data_source._get_stock_client = lambda: mock_client
+
+        try:
+            # Call get_quote
+            quote_data = data_source.get_quote(asset)
+
+            # Verify the results
+            assert quote_data is not None
+            assert isinstance(quote_data, dict)
+            assert 'bid' in quote_data
+            assert quote_data['bid'] == 0.0
+            assert 'ask' in quote_data
+            assert quote_data['ask'] == 100.0
+            assert 'last' in quote_data
+            # last should be None if bid or ask is zero
+            assert quote_data['last'] == None
+            assert 'symbol' in quote_data
+            assert quote_data['symbol'] == asset.symbol
+
+        finally:
+            # Restore the original method
+            data_source._get_stock_client = original_get_stock_client
+
+    def test_get_quote_when_stock_ask_is_zero(self):
+        """Test get_quote when stock ask is 0.0"""
+        data_source = self._create_data_source()
+        asset = Asset('SPY', asset_type='stock')
+
+        # Create a mock for the quote object
+        mock_quote = MagicMock()
+        mock_quote.bid_price = 100.0
+        mock_quote.ask_price = 0.0
+
+        # Store the original method
+        original_get_stock_client = data_source._get_stock_client
+
+        # Create a mock client
+        mock_client = MagicMock()
+        mock_client.get_stock_latest_quote.return_value = {asset.symbol: mock_quote}
+
+        # Replace the _get_stock_client method temporarily
+        data_source._get_stock_client = lambda: mock_client
+
+        try:
+            # Call get_quote
+            quote_data = data_source.get_quote(asset)
+
+            # Verify the results
+            assert quote_data is not None
+            assert isinstance(quote_data, dict)
+            assert 'bid' in quote_data
+            assert quote_data['bid'] == 100.0
+            assert 'ask' in quote_data
+            assert quote_data['ask'] == 0.0
+            assert 'last' in quote_data
+            # last should be None if bid or ask is zero
+            assert quote_data['last'] == None
+            assert 'symbol' in quote_data
+            assert quote_data['symbol'] == asset.symbol
+
+        finally:
+            # Restore the original method
+            data_source._get_stock_client = original_get_stock_client
+
+    def test_get_last_price_stock_when_bid_is_zero(self):
+        """Test get_last_price when stock bid is 0.0"""
+        data_source = self._create_data_source()
+        asset = Asset('SPY', asset_type='stock')
+
+        # Store the original method
+        original_get_quote = data_source.get_quote
+
+        # Create a mock for the get_quote method
+        mock_quote_data = {
+            'bid': 0.0,
+            'ask': 100.0,
+            'last': None,
+            'symbol': asset.symbol
+        }
+
+        # Replace the get_quote method temporarily
+        data_source.get_quote = lambda a, q=None, e=None: mock_quote_data if a.symbol == asset.symbol else None
+
+        try:
+            # Call get_last_price
+            price = data_source.get_last_price(asset)
+
+            # Verify the results
+            # Since 'last' is None and bid is 0.0, it should return the ask value
+            assert price == 100.0
+
+        finally:
+            # Restore the original method
+            data_source.get_quote = original_get_quote
+
+    def test_get_last_price_stock_when_ask_is_zero(self):
+        """Test get_last_price when stock ask is 0.0"""
+        data_source = self._create_data_source()
+        asset = Asset('SPY', asset_type='stock')
+
+        # Store the original method
+        original_get_quote = data_source.get_quote
+
+        # Create a mock for the get_quote method
+        mock_quote_data = {
+            'bid': 100.0,  # Some non-zero value for bid
+            'ask': 0.0,
+            'last': None,
+            'symbol': asset.symbol
+        }
+
+        # Replace the get_quote method temporarily
+        data_source.get_quote = lambda a, q=None, e=None: mock_quote_data if a.symbol == asset.symbol else None
+
+        try:
+            # Call get_last_price
+            price = data_source.get_last_price(asset)
+
+            # Verify the results
+            # Since 'last' is None and ask is 0.0 it should return the bid value (100.0)
+            assert price == 100.0
+
+        finally:
+            # Restore the original method
+            data_source.get_quote = original_get_quote
+
+    def test_get_last_price_stock_when_last(self):
+        """Test get_last_price when stock ask is 0.0"""
+        data_source = self._create_data_source()
+        asset = Asset('SPY', asset_type='stock')
+
+        # Store the original method
+        original_get_quote = data_source.get_quote
+
+        # Create a mock for the get_quote method
+        mock_quote_data = {
+            'bid': 100.0,  # Some non-zero value for bid
+            'ask': 101.0,
+            'last': 100.5,
+            'symbol': asset.symbol
+        }
+
+        # Replace the get_quote method temporarily
+        data_source.get_quote = lambda a, q=None, e=None: mock_quote_data if a.symbol == asset.symbol else None
+
+        try:
+            # Call get_last_price
+            price = data_source.get_last_price(asset)
+
+            # Verify the results
+            assert price == 100.5
+
+        finally:
+            # Restore the original method
+            data_source.get_quote = original_get_quote
+
+    def test_get_quote_when_stock_bid_and_ask(self):
+        """Test get_quote when stock ask and ask"""
+        data_source = self._create_data_source()
+        asset = Asset('SPY', asset_type='stock')
+
+        # Create a mock for the quote object
+        mock_quote = MagicMock()
+        mock_quote.bid_price = 100.0
+        mock_quote.ask_price = 101.0
+
+        # Store the original method
+        original_get_stock_client = data_source._get_stock_client
+
+        # Create a mock client
+        mock_client = MagicMock()
+        mock_client.get_stock_latest_quote.return_value = {asset.symbol: mock_quote}
+
+        # Replace the _get_stock_client method temporarily
+        data_source._get_stock_client = lambda: mock_client
+
+        try:
+            # Call get_quote
+            quote_data = data_source.get_quote(asset)
+
+            # Verify the results
+            assert quote_data is not None
+            assert isinstance(quote_data, dict)
+            assert 'bid' in quote_data
+            assert quote_data['bid'] == 100.0
+            assert 'ask' in quote_data
+            assert quote_data['ask'] == 101.0
+            assert 'last' in quote_data
+            assert quote_data['last'] == 100.5
+            assert 'symbol' in quote_data
+            assert quote_data['symbol'] == asset.symbol
+
+        finally:
+            # Restore the original method
+            data_source._get_stock_client = original_get_stock_client


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor `get_last_price` to utilize `get_quote` for fetching the last price and improve the accuracy of `last` field by correctly checking bid and ask values' presence in `get_quote`.

### Why are these changes being made?

These changes address potential inaccuracies when calculating the last price from bid and ask values, and streamline the process by delegating price fetching tasks to `get_quote`. They also systematically handle cases where bid or ask prices might be zero, thus ensuring correct functionality. Additional tests have been added to verify changes and scenarios, improving robustness.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->