### PR TITLE
Migrate to correct logger interface

### DIFF
--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -249,7 +249,7 @@ def validate_cache(force_cache_update: bool, asset: Asset, cache_file: Path, api
                 cache_file.parent.mkdir(parents=True, exist_ok=True)
                 splits_df.to_feather(splits_file_path)
         else:
-            logging.warn(f"Unexpected response getting splits for {asset.symbol} from Polygon.  Response: {splits}")
+            logging.warning(f"Unexpected response getting splits for {asset.symbol} from Polygon.  Response: {splits}")
     return force_cache_update
 
 


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the logging interface method by replacing the deprecated `logging.warn` with `logging.warning` in the `polygon_helper.py` file.

### Why are these changes being made?

The `logging.warn` method is deprecated and has been replaced by `logging.warning` to ensure compatibility with newer versions of Python and to adhere to best practices for logging methods. This change prevents potential warnings and errors in future Python releases.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->