### PR TITLE
fix resilience test

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -113,7 +113,7 @@ def test_get_trading_days():
     start = dt.datetime(2025, 1, 1)
     end = dt.datetime(2025, 2, 1)
     trading_days = get_trading_days('NYSE', start_date=start, end_date=end, tzinfo=ny_tz)
-    assert len(trading_days) == 20  # Changed from 21 to 20 - Jan 1st 2025 is New Year's Day holiday
+    assert len(trading_days) == 20  # https://www.nyse.com/publicdocs/ICE_NYSE_2025_Yearly_Trading_Calendar.pdf
 
     # Check all market opens and closes
     for open_time, close_time in zip(trading_days.market_open, trading_days.market_close):

--- a/tests/test_live_trading_resilience.py
+++ b/tests/test_live_trading_resilience.py
@@ -8,6 +8,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 from threading import RLock
 
+from lumibot import LUMIBOT_DEFAULT_PYTZ
 from lumibot.backtesting import YahooDataBacktesting, BacktestingBroker
 from lumibot.brokers import Broker
 from lumibot.data_sources import DataSource
@@ -19,6 +20,8 @@ from lumibot.trading_builtins import SafeList
 class MockDataSource:
     def get_last_price(self, asset, quote=None, exchange=None): return 100.0
     def get_last_prices(self, assets, quote=None, exchange=None): return {}
+    def get_yesterday_dividends(self, assets, quote=None): return None
+    def get_datetime(self, adjust_for_delay=False): return datetime.datetime.now().astimezone(LUMIBOT_DEFAULT_PYTZ)
 
 
 class MockLiveBroker(Broker):


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the expected number of trading days in the test and enhance the resilience test by importing a default timezone and adding two mock data source methods.

### Why are these changes being made?

The expected number of trading days was updated due to the discovery that January 1st, 2025 is a holiday, reducing the count from 21 to 20; this was validated against the NYSE trading calendar. The resilience test enhancements address gaps where timezone and date-related functionalities were omitted, improving the test's reliability in handling date-time operations specific to the lumibot library.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->