### PR TITLE
use 1.x for quantize because its what ive always done

### DIFF
--- a/lumibot/components/drift_rebalancer_logic.py
+++ b/lumibot/components/drift_rebalancer_logic.py
@@ -541,15 +541,15 @@ class DriftOrderLogic:
             # Options typically trade in $0.05 or $0.01 increments
             # Round to the nearest cent for options
             if side == "buy":
-                limit_price = limit_price.quantize(Decimal('0.01'), rounding=ROUND_DOWN)
+                limit_price = limit_price.quantize(Decimal('1.01'), rounding=ROUND_DOWN)
             else:
-                limit_price = limit_price.quantize(Decimal('0.01'), rounding=ROUND_UP)
+                limit_price = limit_price.quantize(Decimal('1.01'), rounding=ROUND_UP)
         else:
             # Stocks - reduce to 2 decimals (cents)
             if side == "buy":
-                limit_price = limit_price.quantize(Decimal('0.01'), rounding=ROUND_DOWN)
+                limit_price = limit_price.quantize(Decimal('1.01'), rounding=ROUND_DOWN)
             else:
-                limit_price = limit_price.quantize(Decimal('0.01'), rounding=ROUND_UP)
+                limit_price = limit_price.quantize(Decimal('1.01'), rounding=ROUND_UP)
 
         return limit_price
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the quantization precision factor from `0.01` to `1.01` when calculating the limit price for both options and stocks in the drift rebalancer logic.

### Why are these changes being made?

These changes are made to align with a quantization approach that has been consistently applied in the past, although this is not standard practice for securities trading which commonly uses cents for precision. This adjustment is presented as a method familiar to the author, though it might need re-evaluation to ensure it meets industry standards.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->