### PR TITLE
Respect MARKET env var in all brokers; added DATA_SOURCE_DELAY env var

### DIFF
--- a/lumibot/backtesting/alpaca_backtesting.py
+++ b/lumibot/backtesting/alpaca_backtesting.py
@@ -98,9 +98,16 @@ class AlpacaBacktesting(DataSourceBacktesting):
             pandas_data=None,
         )
 
+        self.market = (
+                kwargs.get("market", None)
+                or (config.get("MARKET") if config else None)
+                or os.environ.get("MARKET")
+                or "NASDAQ"
+        )
+
         self._timestep: str = kwargs.get('timestep', 'day')
         warm_up_trading_days: int = kwargs.get('warm_up_trading_days', 0)
-        self._market: str = kwargs.get('market', "NYSE")
+
         self._auto_adjust: bool = kwargs.get('auto_adjust', True)
         self.CACHE_SUBFOLDER = 'alpaca'
         self._data_store: dict[str, pd.DataFrame] = {}
@@ -169,7 +176,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             warm_up_start_dt = date_n_trading_days_from_date(
                 n_days=warm_up_trading_days,
                 start_datetime=start_dt,
-                market=self._market,
+                market=self.market,
             )
             # Combine with a default time (midnight)
             warm_up_start_dt = datetime.combine(warm_up_start_dt, datetime.min.time())
@@ -185,7 +192,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             raise ValueError("Invalid timestep passed. Must be 'day' or 'minute'.")
 
         self._trading_days = get_trading_days(
-            self._market,
+            self.market,
             self._data_datetime_start,
             self._data_datetime_end + timedelta(days=1),  # end_date is exclusive in this function
             tzinfo=self._tzinfo
@@ -404,7 +411,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             quote_asset = self.LUMIBOT_DEFAULT_QUOTE_ASSET
 
         if market is None:
-            market = self._market
+            market = self.market
 
         if data_datetime_start is None:
             data_datetime_start = self._data_datetime_start
@@ -625,7 +632,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             timestep = self._timestep
 
         if market is None:
-            market = self._market
+            market = self.market
 
         if tzinfo is None:
             tzinfo = self._tzinfo

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -24,7 +24,6 @@ class BacktestingBroker(Broker):
                          option_source=option_source, connect_stream=connect_stream, **kwargs)
         # Calling init methods
         self.max_workers = max_workers
-        self.market = "NASDAQ"
         self.option_source = option_source
 
         # Legacy strategy.backtest code will always pass in a config even for Brokers that don't need it, so

--- a/lumibot/brokers/bitunix.py
+++ b/lumibot/brokers/bitunix.py
@@ -1,4 +1,5 @@
 import logging, time, traceback
+import os
 from decimal import Decimal
 from typing import Optional, List, Dict, Tuple, Any
 import pandas as pd
@@ -65,7 +66,8 @@ class Bitunix(Broker):
         
         # Track current leverage per symbol to avoid redundant API calls
         self.current_leverage: Dict[str, int] = {}
-        self.market = "24/7"  # Crypto exchanges are typically 24/7
+        # Override default market setting for to be 24/7, but still respect config/env if set
+        self.market = (config.get("MARKET") if config else None) or os.environ.get("MARKET") or "24/7"
 
         if not api_key or not api_secret:
             raise ValueError("API_KEY and API_SECRET must be provided in config")

--- a/lumibot/brokers/ccxt.py
+++ b/lumibot/brokers/ccxt.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 from decimal import ROUND_DOWN, Decimal, getcontext
 from typing import Union
 
@@ -20,7 +21,8 @@ class Ccxt(Broker):
             data_source = CcxtData(config, max_workers=max_workers, chunk_size=chunk_size)
         super().__init__(name="ccxt", config=config, data_source=data_source, max_workers=max_workers, **kwargs)
 
-        self.market = "24/7"
+        # Override default market setting for crypto to be 24/7, but still respect config/env if set
+        self.market = (config.get("MARKET") if config else None) or os.environ.get("MARKET") or "24/7"
         self.fetch_open_orders_last_request_time = None
         self.binance_all_orders_rate_limit = 5
         if not isinstance(self.data_source, CcxtData):

--- a/lumibot/brokers/interactive_brokers.py
+++ b/lumibot/brokers/interactive_brokers.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 import random
 import time
 from collections import deque
@@ -68,7 +69,8 @@ class InteractiveBrokers(Broker):
 
         # For checking duplicate order status events from IB.
         self.order_status_duplicates = []
-        self.market = "NYSE"  # The default market is NYSE.
+        # The default market is NYSE.
+        self.market = (config.get("MARKET") if config else None) or os.environ.get("MARKET") or "NYSE"
 
         # Connection to interactive brokers
         self.ib = None

--- a/lumibot/brokers/interactive_brokers_rest.py
+++ b/lumibot/brokers/interactive_brokers_rest.py
@@ -1,4 +1,6 @@
 import logging
+import os
+
 from termcolor import colored
 from ..brokers import Broker
 from ..entities import Order, Asset, Position
@@ -68,7 +70,6 @@ class InteractiveBrokersREST(Broker):
     def __init__(self, config, data_source=None, poll_interval=5.0):
         # Set polling_interval before super().__init__() since it's needed in _get_stream_object
         self.polling_interval = poll_interval
-        self.market = "NYSE"  # The default market is NYSE.
 
         if data_source is None:
             data_source = InteractiveBrokersRESTData(config)
@@ -78,6 +79,9 @@ class InteractiveBrokersREST(Broker):
             data_source=data_source, 
             config=config
         )
+
+        # The default market is NYSE.
+        self.market = (config.get("MARKET") if config else None) or os.environ.get("MARKET") or "NYSE"
 
     # --------------------------------------------------------------
     # Broker methods

--- a/lumibot/data_sources/data_source.py
+++ b/lumibot/data_sources/data_source.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
@@ -45,7 +46,21 @@ class DataSource(ABC):
         self.name = "data_source"
         self._timestep = None
         self._api_key = api_key
-        self._delay = timedelta(minutes=delay) if delay else None
+
+        # Use DATA_SOURCE_DELAY environment variable if it exists and delay is not explicitly provided
+        if delay is None:
+            env_delay = os.environ.get("DATA_SOURCE_DELAY")
+            if env_delay is not None:
+                try:
+                    delay = int(env_delay)
+                except ValueError:
+                    # If the environment variable is not a valid integer, ignore it
+                    pass
+            else:
+                # Default to 0 if no environment variable is set
+                delay = 0
+
+        self._delay = timedelta(minutes=delay) if delay is not None else None
 
         if tzinfo is None:
             tzinfo = pytz.timezone(self.DEFAULT_TIMEZONE)

--- a/lumibot/data_sources/tradier_data.py
+++ b/lumibot/data_sources/tradier_data.py
@@ -67,7 +67,7 @@ class TradierData(DataSource):
             access_token: str,
             paper: bool = True,
             max_workers: int = 20,
-            delay: int = 0,
+            delay: int = None,
             tzinfo: pytz.timezone = pytz.timezone(LUMIBOT_DEFAULT_TIMEZONE),
             remove_incomplete_current_bar: bool = False,
             **kwargs
@@ -83,7 +83,7 @@ class TradierData(DataSource):
         - max_workers (int, optional): The maximum number of workers for parallel processing.
           Defaults to 20.
         - delay (int, optional): A delay parameter to control how many minutes to delay non-crypto data for.
-          Set to 0 for no delay. Defaults to 0.
+          If not specified, uses DATA_SOURCE_DELAY environment variable or defaults to 0.
         - tzinfo (pytz.timezone, optional): Timezone for data adjustments. Determines how datetime objects
           are adjusted when retrieving historical data. Defaults to the `LUMIBOT_DEFAULT_TIMEZONE`.
         - remove_incomplete_current_bar (bool, optional): Default False.
@@ -402,7 +402,7 @@ class TradierData(DataSource):
         # If the dataframe is empty, return an empty dictionary
         if quotes_df is None or quotes_df.empty:
             return {}
-        
+
         # Get the quote from the dataframe and convert it to a dictionary
         quote = quotes_df.iloc[0].to_dict()
 

--- a/lumibot/tools/pandas.py
+++ b/lumibot/tools/pandas.py
@@ -63,7 +63,7 @@ def set_pandas_float_display_precision(precision: int = 5):
 
 def prettify_dataframe_with_decimals(df: pd.DataFrame, decimal_places: int = 5) -> str:
     def decimal_formatter(x):
-        if isinstance(x, (Decimal, float, int, np.float64)):
+        if isinstance(x, (Decimal, float, int, np.float64, np.int64)):
             return f"{x:.{decimal_places}f}"
         return x
 

--- a/tests/test_alpaca_data.py
+++ b/tests/test_alpaca_data.py
@@ -1,7 +1,9 @@
 import logging
+import os
 import pytest
 import math
 import datetime as dt
+from datetime import timedelta
 import pytz
 from unittest.mock import MagicMock
 
@@ -720,3 +722,50 @@ class TestAlpacaData(BaseDataSourceTester):
 
         with pytest.raises(ValueError, match="API_SECRET not found in config when API_KEY is provided"):
             AlpacaData(incomplete_config)
+
+    def test_default_delay_value(self):
+        """Test that the default delay value is 16 minutes when not specified."""
+        # Save the original environment variable value
+        original_env_value = os.environ.get("DATA_SOURCE_DELAY")
+
+        try:
+            # Ensure the environment variable is not set
+            if "DATA_SOURCE_DELAY" in os.environ:
+                del os.environ["DATA_SOURCE_DELAY"]
+
+            # Create a data source without specifying delay
+            data_source = self._create_data_source()
+
+            # Check that the delay is 16 minutes
+            assert data_source._delay == timedelta(minutes=16), f"Expected delay to be 16 minutes, but got {data_source._delay}"
+
+        finally:
+            # Restore the original environment variable value
+            if original_env_value is not None:
+                os.environ["DATA_SOURCE_DELAY"] = original_env_value
+            elif "DATA_SOURCE_DELAY" in os.environ:
+                del os.environ["DATA_SOURCE_DELAY"]
+
+    def test_data_source_delay_env_var(self):
+        """Test that AlpacaData uses the DATA_SOURCE_DELAY environment variable when set."""
+        # Save the original environment variable value
+        original_env_value = os.environ.get("DATA_SOURCE_DELAY")
+
+        try:
+            # Set the environment variable to a test value
+            test_delay = "25"
+            os.environ["DATA_SOURCE_DELAY"] = test_delay
+
+            # Create a data source without specifying delay
+            data_source = self._create_data_source()
+
+            # Check that the delay matches the environment variable value
+            assert data_source._delay == timedelta(minutes=int(test_delay)), \
+                f"Expected delay to be {test_delay} minutes, but got {data_source._delay}"
+
+        finally:
+            # Restore the original environment variable value
+            if original_env_value is not None:
+                os.environ["DATA_SOURCE_DELAY"] = original_env_value
+            elif "DATA_SOURCE_DELAY" in os.environ:
+                del os.environ["DATA_SOURCE_DELAY"]

--- a/tests/test_tradier_data.py
+++ b/tests/test_tradier_data.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pytest
 import math
 from datetime import datetime, timedelta, time
@@ -314,3 +315,26 @@ class TestTradierData(BaseDataSourceTester):
 
         bars = data_source.get_historical_prices(asset=o_asset, length=length, timestep=timestep)
         assert len(bars.df) > 0
+
+    def test_default_delay_value(self):
+        """Test that the default delay value is 0 minutes when not specified."""
+        # Save the original environment variable value
+        original_env_value = os.environ.get("DATA_SOURCE_DELAY")
+
+        try:
+            # Ensure the environment variable is not set
+            if "DATA_SOURCE_DELAY" in os.environ:
+                del os.environ["DATA_SOURCE_DELAY"]
+
+            # Create a data source without specifying delay
+            data_source = self._create_data_source()
+
+            # Check that the delay is 16 minutes
+            assert data_source._delay == timedelta(minutes=0), f"Expected delay to be 0 minutes, but got {data_source._delay}"
+
+        finally:
+            # Restore the original environment variable value
+            if original_env_value is not None:
+                os.environ["DATA_SOURCE_DELAY"] = original_env_value
+            elif "DATA_SOURCE_DELAY" in os.environ:
+                del os.environ["DATA_SOURCE_DELAY"]


### PR DESCRIPTION
There are 3 distinct changes in this PR:

Previously, the broker.market member variable was inconsistently set across all brokers. Many didnt respect the MARKET environment variable and made assumptions about which market to set. The default values for all brokers has been preserved, however they all can now be overridden but the env var.

Additionally, all data source take a`delay` init parameter however its very hard to set that due to the way data sources are  automatically created everywhere (in credentials, in the brokers, in the strategy....). So I added a DATA_SOURCE_DELAY env var and changed the data_source default delay value. The result is that all default delay values persist (including alpaca's 16 minute delay) but if you wanted to override that (because you bought the paid alpaca data package) you can set it with the DATA_SOURCE_DELAY env var.

Finally, updated prettify_dataframe_with_decimals to handle ints.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce support for the `MARKET` environment variable across all brokers to specify default market settings and add a new `DATA_SOURCE_DELAY` environment variable to control data delay configuration.

### Why are these changes being made?

These changes are implemented to provide a more flexible and convenient configuration for market settings and data delay. By leveraging environment variables, users can configure their trading platforms with preferred market settings (`MARKET`) and handle data delays (`DATA_SOURCE_DELAY`) due to limitations or requirements of certain data sources. The `MARKET` variable respects existing configurations but provides a fallback, ensuring consistency across diverse broker implementations. Adding test coverage ensures the functionality of these new variables, maintaining code robustness.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->