### PR TITLE
Make the account summary 24 hours min requirement check more robust by using 24 hours minus 5 mins.

### DIFF
--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1660,8 +1660,8 @@ class _Strategy:
         else:
             time_since_last_account_summary = None
 
-        # Check if it has been at least 24 hours since the last account summary
-        if self.last_account_summary_dt is None or time_since_last_account_summary.total_seconds() >= 86400: # 24 hours
+        # Check if it has been at least 24 hours - 5mins since the last account summary
+        if self.last_account_summary_dt is None or time_since_last_account_summary.total_seconds() >= (86400 - 300):
             # Set the last account summary datetime to now
             self.last_account_summary_dt = now
 


### PR DESCRIPTION
Sometimes it won't send me the account summary in the morning because of the 24 hours min gap check failed.