### PR TITLE
Fixed children order initialization

### DIFF
--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -735,6 +735,7 @@ class Order:
                     side=self.side,
                     limit_price=self.limit_price,
                     order_type=Order.OrderType.LIMIT,
+                    quote=self.quote, 
                 )
                 stop_order = Order(
                     # Stop Type will be filled in automatically for child based on the Stop Modifiers
@@ -746,6 +747,7 @@ class Order:
                     stop_limit_price=self.stop_limit_price,
                     trail_price=self.trail_price,
                     trail_percent=self.trail_percent,
+                    quote=self.quote, 
                 )
                 # Set dependencies so that the two orders will cancel the other in BackTesting
                 limit_order.dependent_order = stop_order
@@ -780,6 +782,7 @@ class Order:
                             side=child_side,
                             limit_price=secondary_limit_price,
                             order_type=Order.OrderType.LIMIT,
+                            quote=self.quote, 
                         )
                     )
                 if secondary_stop_price is not None:
@@ -794,6 +797,7 @@ class Order:
                             stop_limit_price=secondary_stop_limit_price,
                             trail_price=secondary_trail_price,
                             trail_percent=secondary_trail_percent,
+                            quote=self.quote, 
                         )
                     )
 
@@ -830,6 +834,7 @@ class Order:
                             side=child_side,
                             limit_price=secondary_limit_price,
                             order_type=Order.OrderType.LIMIT,
+                            quote=self.quote, 
                         )
                     )
                 elif secondary_stop_price is not None:
@@ -844,6 +849,7 @@ class Order:
                             stop_limit_price=secondary_stop_limit_price,
                             trail_price=secondary_trail_price,
                             trail_percent=secondary_trail_percent,
+                            quote=self.quote, 
                         )
                     )
 


### PR DESCRIPTION
Fixed children order initialization by adding the quote parameter (as self.quote). This will avoid breaking backtesting with e.g. crypto assets

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add the `quote` parameter initialization to the child orders in the `_set_order_class_children` method within the `Order` class.

### Why are these changes being made?
The changes address an omission where the `quote` parameter was not being initialized for child orders, potentially leading to incomplete order configuration in certain scenarios. This ensures consistency and completeness in order initialization, supporting more robust order management logic.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->