### PR TITLE
fix unit tests due to alpaca crypto endpoint timezone change

### DIFF
--- a/lumibot/example_strategies/crypto_50_50.py
+++ b/lumibot/example_strategies/crypto_50_50.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         )
         exit()
 
-    tzinfo = pytz.timezone('America/Chicago')
+    tzinfo = pytz.timezone('UTC')
     backtesting_start = tzinfo.localize(datetime(2024, 1, 1))
     backtesting_end = tzinfo.localize(datetime(2024, 2, 1))
     timestep = 'minute'

--- a/tests/test_alpaca_data.py
+++ b/tests/test_alpaca_data.py
@@ -282,8 +282,8 @@ class TestAlpacaData(BaseDataSourceTester):
             )
 
     @pytest.mark.xfail(reason="crypto timestamp precision varies between environments")
-    def test_get_historical_prices_daily_bars_crypto_america_chicago(self):
-        tzinfo = pytz.timezone('America/Chicago')
+    def test_get_historical_prices_daily_bars_crypto_utc(self):
+        tzinfo = pytz.timezone('UTC')
         data_source = self._create_data_source(tzinfo=tzinfo)
         asset = Asset('BTC', asset_type='crypto')
         quote_asset = Asset('USD', asset_type='forex')
@@ -307,7 +307,7 @@ class TestAlpacaData(BaseDataSourceTester):
                 bars=bars,
                 now=now,
                 data_source_tz=data_source.tzinfo,
-                time_check=dt.time(19, 0),
+                time_check=dt.time(0, 0),
                 market=market
             )
 
@@ -337,8 +337,8 @@ class TestAlpacaData(BaseDataSourceTester):
                 market=market,
             )
 
-    def test_get_historical_prices_minute_bars_crypto_america_chicago(self):
-        tzinfo = pytz.timezone('America/Chicago')
+    def test_get_historical_prices_minute_bars_crypto_utc(self):
+        tzinfo = pytz.timezone('UTC')
         data_source = self._create_data_source(tzinfo=tzinfo)
         asset = Asset('BTC', asset_type='crypto')
         quote_asset = Asset('USD', asset_type='forex')

--- a/tests/test_drift_rebalancer.py
+++ b/tests/test_drift_rebalancer.py
@@ -1962,7 +1962,7 @@ class TestDriftRebalancer:
             market: str = 'NYSE',
             timestep: str = 'day',
             sleeptime: str = '1D',
-            tzinfo: pytz.tzinfo = pytz.timezone('America/Chicago'),
+            tzinfo: pytz.tzinfo = pytz.timezone('UTC'),
             auto_adjust: bool = True,
             warm_up_trading_days: int = 0,
     ):
@@ -2032,7 +2032,7 @@ class TestDriftRebalancer:
             market: str = '24/7',
             timestep: str = 'day',
             sleeptime: str = '1D',
-            tzinfo: pytz.tzinfo = pytz.timezone('America/Chicago'),
+            tzinfo: pytz.tzinfo = pytz.timezone('UTC'),
             auto_adjust: bool = True,
             warm_up_trading_days: int = 0,
     ):
@@ -2099,7 +2099,7 @@ class TestDriftRebalancer:
         assert filled_orders.iloc[1]["side"] == "buy"
         assert filled_orders.iloc[1]["symbol"] == "ETH"
 
-        assert strat_obj.stats['portfolio_value'][-1] == 105596.4107392428
+        assert strat_obj.stats['portfolio_value'][-1] == 105989.22631127515
 
     @pytest.mark.skipif(
         not ALPACA_TEST_CONFIG['API_KEY'] or ALPACA_TEST_CONFIG['API_KEY'] == '<your key here>',
@@ -2110,7 +2110,7 @@ class TestDriftRebalancer:
             market: str = '24/7',
             timestep: str = 'day',
             sleeptime: str = '1D',
-            tzinfo: pytz.tzinfo = pytz.timezone('America/Chicago'),
+            tzinfo: pytz.tzinfo = pytz.timezone('UTC'),
             auto_adjust: bool = True,
             warm_up_trading_days: int = 0,
     ):
@@ -2181,7 +2181,7 @@ class TestDriftRebalancer:
         assert filled_orders.iloc[1]["side"] == "buy"
         assert filled_orders.iloc[1]["symbol"] == "ETH"
 
-        assert strat_obj.stats['portfolio_value'][-1] == 105341.29698417989
+        assert strat_obj.stats['portfolio_value'][-1] == 105733.6594608977
 
     @patch("lumibot.strategies.Strategy")
     def test_get_last_price_or_raise_returns_decimal(self, MockStrategy):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -197,11 +197,10 @@ def test_get_trading_times_minute_24_7_utc():
     assert result[-1].time().minute == 59
     assert all(dtm.tzinfo.zone == tzinfo.zone for dtm in result)
 
-
-def test_get_trading_times_minute_24_7_america_chicago():
+def test_get_trading_times_minute_24_7_UTC():
     start_date = dt.datetime(2024, 1, 8)
     end_date = dt.datetime(2024, 1, 10)
-    tzinfo = pytz.timezone('America/Chicago')
+    tzinfo = pytz.timezone('UTC')
     pcal = get_trading_days(
         market='24/7',
         start_date=start_date,


### PR DESCRIPTION
Alpaca changed the way it returns crypto daily bars, now sending them at midnight UTC. Which is great! But all the tests that I wrote to make sure everything worked with their weird-ass Chicago midnight timezone broke. So now those are removed, and we're just testing for UTC midnight.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Switch timezones from 'America/Chicago' to 'UTC' for unit tests and strategy scripts following a change in the Alpaca crypto endpoint.

### Why are these changes being made?
The Alpaca crypto endpoint now operates in UTC, requiring corresponding adjustments in timezones across the codebase to ensure consistency and correct functionality of date-related operations. The removed tests were based on the old timezone and are redundant or incompatible with the new UTC-based system.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->