### PR TITLE
Logging and Multileg qty fix

### DIFF
--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -901,9 +901,11 @@ class Order:
         quantity = Decimal(value)
         self._quantity = quantity
 
-        # Update the quantity for all child orders
-        for child_order in self.child_orders:
-            child_order.quantity = quantity
+        # Update the quantity for all OCO child orders. Multileg orders will have child orders that
+        # can have different quantities, so do not update them here.
+        if self.order_class != self.OrderClass.MULTILEG and self.child_orders:
+            for child_order in self.child_orders:
+                child_order.quantity = quantity
 
     def __hash__(self):
         return hash(self.identifier)

--- a/lumibot/tools/lumibot_logger.py
+++ b/lumibot/tools/lumibot_logger.py
@@ -231,23 +231,25 @@ class LumibotFormatter(logging.Formatter):
     """
     
     def __init__(self):
+        super().__init__()
+
         # Define format strings for different log levels
-        self.info_format = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+        # In the vast majority of cases, log_message() is used by strategies so the %(name)s setting isn't useful
+        # and simply clutters the output because it always points to _strategy.py.
+        self.info_format = "%(asctime)s | %(levelname)s | %(message)s"
         self.warning_format = "%(asctime)s | %(levelname)s | %(pathname)s:%(funcName)s:%(lineno)d | %(message)s"
         self.error_format = "%(asctime)s | %(levelname)s | %(pathname)s:%(funcName)s:%(lineno)d | %(message)s"
         
-        # Create formatters for each level
+        # Create formatters for each level. Use default datefmt for ISO format so that milliseconds are included to
+        # assist with performance evaluations when running Live.
         self.info_formatter = logging.Formatter(
             self.info_format,
-            datefmt='%Y-%m-%d %H:%M:%S'
         )
         self.warning_formatter = logging.Formatter(
             self.warning_format,
-            datefmt='%Y-%m-%d %H:%M:%S'
         )
         self.error_formatter = logging.Formatter(
             self.error_format,
-            datefmt='%Y-%m-%d %H:%M:%S'
         )
     
     def format(self, record):

--- a/lumibot/tools/lumibot_logger.py
+++ b/lumibot/tools/lumibot_logger.py
@@ -515,6 +515,40 @@ def set_log_level(level: str):
         raise ValueError(f"Invalid log level: {level}. Must be one of: DEBUG, INFO, WARNING, ERROR, CRITICAL")
 
 
+def set_console_log_level(level: str):
+    """
+    Set the log level for the console handler of the root logger.
+
+    This allows you to change the verbosity of console output without affecting
+    the global log level.
+
+    Parameters
+    ----------
+    level : str
+        The log level to set for console output ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL').
+
+    Examples
+    --------
+    >>> from lumibot.tools.lumibot_logger import set_console_log_level
+    >>> set_console_log_level('DEBUG')  # Enable debug logging in console
+    >>> set_console_log_level('ERROR')  # Only show errors and critical messages in console
+    """
+    _ensure_handlers_configured()
+
+    # Check both "root" and "lumibot" logger to ensure we get the correct root logger.
+    # Currently, "lumibot" is used in _ensure_handlers_configured() to set up the console handler, but "root" is
+    # used by the set_log_level() function.
+    for root_logger_name in ["root", "lumibot"]:
+        root_logger = logging.getLogger(root_logger_name)
+        for handler in root_logger.handlers:
+            if isinstance(handler, logging.StreamHandler) and handler.__class__.__name__ == "StreamHandler":
+                try:
+                    handler.setLevel(level)
+                except AttributeError:
+                    raise ValueError(f"Invalid log level: {level}. Must be one of: "
+                                     f"DEBUG, INFO, WARNING, ERROR, CRITICAL")
+
+
 def add_file_handler(file_path: str, level: str = 'INFO'):
     """
     Add a file handler to the root logger to also log to a file.
@@ -539,7 +573,7 @@ def add_file_handler(file_path: str, level: str = 'INFO'):
         raise ValueError(f"Invalid log level: {level}")
     
     # Create file handler
-    file_handler = logging.FileHandler(file_path)
+    file_handler = logging.FileHandler(file_path, mode='w', encoding='utf-8')
     file_handler.setLevel(file_level)
     file_handler.setFormatter(LumibotFormatter())
     

--- a/lumibot/traders/trader.py
+++ b/lumibot/traders/trader.py
@@ -171,7 +171,7 @@ class Trader:
     def _set_logger(self):
         """Setting Logging to both console and a file if logfile is specified"""
         # Import here to avoid circular imports
-        from lumibot.tools.lumibot_logger import set_log_level, add_file_handler
+        from lumibot.tools.lumibot_logger import set_log_level, set_console_log_level, add_file_handler
         
         # Set external library log levels to reduce noise
         get_logger("urllib3").setLevel(logging.ERROR)
@@ -189,8 +189,9 @@ class Trader:
                 set_log_level("ERROR")
             else:
                 set_log_level("INFO")
+                set_console_log_level("ERROR")  # Only show errors in console for backtesting
         else:
-            # Live trades should always have full logging.
+            # Live trades should always have full logging for both console and file
             set_log_level("INFO")
 
         # Setting file logging if specified

--- a/tests/test_lumibot_logger.py
+++ b/tests/test_lumibot_logger.py
@@ -50,7 +50,6 @@ def test_file_handler_uses_lumibot_formatter():
         
         assert "File handler info test" in contents
         assert "| INFO |" in contents
-        assert "lumibot.tests.test_lumibot_logger" in contents
     finally:
         # Clean up
         if os.path.exists(tmp_name):


### PR DESCRIPTION
This pull request includes updates to improve logging functionality and enhance order handling logic. Key changes include refining logging formats and levels, introducing a new method to adjust console log verbosity, and clarifying behavior for updating child orders in specific scenarios.  This fixes several identified issues, however there are two big issues remaining:
1. Console printing gets reset after the first day of backtest completes 
2. Constant warnings are printed when running Live with sleeptime='10S'

### Logging Improvements:
* [`lumibot/tools/lumibot_logger.py`](diffhunk://#diff-c028dbd6ed61adf4917f70c7dfa258f7a0f31c116bb82e1ef39d73d4c9f21eb5R234-L250): Updated the `LumibotFormatter` to simplify the `info_format` by removing the `%(name)s` field, which was deemed unnecessary for most use cases. Additionally, the default date format now includes milliseconds to aid in performance evaluations.
* [`lumibot/tools/lumibot_logger.py`](diffhunk://#diff-c028dbd6ed61adf4917f70c7dfa258f7a0f31c116bb82e1ef39d73d4c9f21eb5R520-R553): Added a new method, `set_console_log_level`, to allow independent configuration of console log verbosity without altering the global log level.
* [`lumibot/tools/lumibot_logger.py`](diffhunk://#diff-c028dbd6ed61adf4917f70c7dfa258f7a0f31c116bb82e1ef39d73d4c9f21eb5L542-R578): Modified the `add_file_handler` method to specify UTF-8 encoding and overwrite the file (`mode='w'`) for consistent behavior.
* [`lumibot/traders/trader.py`](diffhunk://#diff-c551be590f8500712bc70530d39fa2322b562a265e660a17734d7fe27f4d7e61L174-R174): Integrated `set_console_log_level` into the `_set_logger` method to restrict console logs to errors during backtesting while maintaining full logging for live trades. [[1]](diffhunk://#diff-c551be590f8500712bc70530d39fa2322b562a265e660a17734d7fe27f4d7e61L174-R174) [[2]](diffhunk://#diff-c551be590f8500712bc70530d39fa2322b562a265e660a17734d7fe27f4d7e61R192-R194)

### Order Handling Enhancement:
* [`lumibot/entities/order.py`](diffhunk://#diff-f776222cd7ee7d71098643cb225062b44ccecf8e311c2b13301ef4cbb77302c4L904-R906): Adjusted the `quantity` method to ensure that only OCO (One Cancels the Other) child orders are updated when the parent order quantity changes. Multileg orders, which may have varying child order quantities, are now excluded from this automatic update.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the logging configuration and fix the quantity update issue for multileg orders by only applying quantity updates to OCO child orders, and improve the logging functionality by adding a console log level setter and updating the default formats.

### Why are these changes being made?

The modifications to the order quantity logic ensure that only OCO child orders are updated while preserving differing quantities of multileg order types, addressing a potential logical error. The logging updates improve log clarity by reducing unnecessary clutter from strategy names in log messages, allowing different verbosity levels between console and global outputs, and handling logs more efficiently by setting the encoding for file handlers to UTF-8.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->