### PR TITLE
ProjectX Time Unit Mappings API Fix

### DIFF
--- a/lumibot/data_sources/projectx_data.py
+++ b/lumibot/data_sources/projectx_data.py
@@ -38,11 +38,12 @@ class ProjectXData(DataSource):
 
     # ProjectX time unit mappings
     TIME_UNIT_MAPPING = {
-        "minute": 1,    # Minute bars
-        "hour": 2,      # Hourly bars
-        "day": 3,       # Daily bars
-        "week": 4,      # Weekly bars
-        "month": 5,     # Monthly bars
+        "second": 1,    # Second bars
+        "minute": 2,    # Minute bars
+        "hour": 3,      # Hourly bars
+        "day": 4,       # Daily bars
+        "week": 5,      # Weekly bars
+        "month": 6,     # Monthly bars
     }
 
     def __init__(self, config: dict = None, **kwargs):


### PR DESCRIPTION
Fixed time unit mappings for retrieve-bars api
https://gateway.docs.projectx.com/docs/api-reference/market-data/retrieve-bars

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the `TIME_UNIT_MAPPING` dictionary in `ProjectXData` to include a mapping for "second" and adjust the indices accordingly for existing time units.

### Why are these changes being made?

These changes correct the existing `TIME_UNIT_MAPPING` by adding support for "second" bars, aligning the indices to properly reflect the new mappings, ensuring accurate time unit representation for data processing. This modification facilitates the API's function to handle new data granularity and corrects previous inconsistencies in unit indexing.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->