### PR TITLE
small bug fix

### DIFF
--- a/lumibot/data_sources/projectx_data.py
+++ b/lumibot/data_sources/projectx_data.py
@@ -122,7 +122,7 @@ class ProjectXData(DataSource):
 
     def get_bars(self, asset: Asset, length: int, timespan: str = "minute",
                 timeshift: int = None, chunk_size: int = None,
-                max_workers: int = None) -> Bars:
+                max_workers: int = None, timestep: str = None, **kwargs) -> Bars:
         """
         Get historical bars for an asset.
 
@@ -138,6 +138,10 @@ class ProjectXData(DataSource):
             Bars object containing the historical data
         """
         try:
+            # Support alias parameter name 'timestep' used by generic DataSource helpers
+            if timestep and not timespan:
+                timespan = timestep
+
             # Get contract ID for the asset
             contract_id = self._get_contract_id_from_asset(asset)
             if not contract_id:

--- a/tests/test_projectx_timestep_alias.py
+++ b/tests/test_projectx_timestep_alias.py
@@ -1,0 +1,52 @@
+import types
+import pandas as pd
+import pytest
+from datetime import datetime, timedelta
+
+from lumibot.entities import Asset
+from lumibot.data_sources.projectx_data import ProjectXData
+
+class DummyClient:
+    def history_retrieve_bars(self, contract_id, start_datetime, end_datetime, unit, unit_number, limit, include_partial_bar, live, is_est):
+        # Return a minimal DataFrame resembling expected structure
+        idx = pd.date_range(end=end_datetime, periods=unit_number, freq='T')
+        data = {
+            'open': [1.0]*len(idx),
+            'high': [1.1]*len(idx),
+            'low': [0.9]*len(idx),
+            'close': [1.05]*len(idx),
+            'volume': [100]*len(idx),
+        }
+        df = pd.DataFrame(data, index=idx)
+        df.index.name = 'datetime'
+        return df.reset_index()
+
+@pytest.fixture
+def projectx(monkeypatch):
+    cfg = {
+        'firm': 'TEST',
+        'api_key': 'KEY',
+        'username': 'USER',
+        'base_url': 'http://example'
+    }
+    # Monkeypatch ProjectXClient before instantiation to avoid real auth/network
+    from lumibot.data_sources import projectx_data as px_module
+    monkeypatch.setattr(px_module, 'ProjectXClient', lambda _cfg: types.SimpleNamespace())
+    px = ProjectXData(config=cfg)
+    # Inject dummy client with history retrieval
+    px.client = DummyClient()
+    # Stub contract id resolver
+    px._get_contract_id_from_asset = lambda asset: 'CONTRACT1'
+    return px
+
+
+def test_projectx_get_bars_accepts_timestep_alias(projectx):
+    asset = Asset(symbol='ES', asset_type='future')
+    # Call path that previously passed timestep kw expecting failure
+    bars = projectx.get_bars(asset=asset, length=1, timestep='minute')
+    assert bars is not None
+    assert not bars.df.empty
+    # Ensure fallback to timespan parameter usage
+    bars2 = projectx.get_bars(asset=asset, length=1, timespan='minute')
+    assert bars2 is not None
+


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add support for an alias parameter 'timestep' in the `get_bars` method and include associated unit tests to ensure functionality.

### Why are these changes being made?
The change addresses a flexibility issue by allowing the `get_bars` method to accept a `timestep` parameter as an alias for `timespan`, accommodating a common parameter naming convention used by generic DataSource helpers. This improvement enhances code interoperability and streamlines the integration process with existing helper functions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->