### PR TITLE
update parsing function used for alpaca

### DIFF
--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -389,6 +389,7 @@ class Alpaca(Broker):
                 symbol=position.symbol.replace("USD", ""),
                 asset_type=Asset.AssetType.CRYPTO,
             )
+
         elif position.asset_class == "option":
             asset = Asset(
                 symbol=position.symbol,


### PR DESCRIPTION
What: Currently, the self.get_positions() function is dependant on the broker in live/paper trading to get the current positions. In backtesting, since the assets/positions are already formatted correctly, this isnt a concern, but when live/paper trading, the options object needs to be correcly parsed.

This PRupdates the _parse_broker_position function to use symbol2asset