### PR TITLE
Fix position tracking for buy_to_close orders in backtesting

### DIFF
--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -448,6 +448,12 @@ class BacktestingBroker(Broker):
         """
         BackTesting needs to create/update positions when orders are filled becuase there is no broker to do it
         """
+        # If the order has a "buy_to_open" or "buy_to_close" side, then we should change it to "buy"
+        if order.is_buy_order():
+            order.side = Order.OrderSide.BUY
+        # If the order has a "sell_to_open" or "sell_to_close" side, then we should change it to "sell"
+        if order.is_sell_order():
+            order.side = Order.OrderSide.SELL
         # This is a parent order, typically for a Multileg strategy. The parent order itself is expected to be
         # filled after all child orders are filled.
         if order.is_parent() and order.order_class in [Order.OrderClass.MULTILEG, Order.OrderClass.OCO]:


### PR DESCRIPTION
**Bug fix:** Properly handle buy_to_close and sell_to_close orders in backtesting position tracking

## Issue

When using buy_to_close orders to close short positions in backtesting, the positions were not being properly tracked due to a mismatch in order side handling. The issue occurred because [`_process_crypto_quote()`](https://github.com/Lumiwealth/lumibot/blob/dev/lumibot/brokers/broker.py#L918) was checking for `"buy"` string directly, but our order sides could be `"buy_to_close"` or `"buy_to_open"`.

## Changes

- Modified [`_process_filled_order()`](https://github.com/Lumiwealth/lumibot/blob/dev/lumibot/backtesting/backtesting_broker.py#L447) to normalize order sides before processing:
  - `buy_to_close` and `buy_to_open` are normalized to `BUY`
  - `sell_to_close` and `sell_to_open` are normalized to `SELL`

## Impact

This fixes position tracking in backtesting, particularly for :

- Closing short positions with buy_to_close orders
- Preventing "ghost" positions that appeared to remain open after being closed
- Ensuring accurate position quantities in the backtesting stats

## Example
Before the fix, a short position closed with buy_to_close would show :

```
# trades.csv
time,strategy,identifier,symbol,side,type,status,multiplier,time_in_force,asset.strike,asset.multiplier,asset.asset_type,price,filled_quantity,trade_cost
2024-09-03 00:00:00-04:00,MLTrader,b8dc6ee9e20942448cb0465b68d20fa0,ETH-USD,sell,market,new,1,gtc,0.0,1,crypto,,,
2024-09-03 00:00:00-04:00,MLTrader,b8dc6ee9e20942448cb0465b68d20fa0,ETH-USD,sell,market,fill,1,gtc,0.0,1,crypto,2516.0,1.9879515138228698,0.0
2024-09-03 20:00:00-04:00,MLTrader,98a7fd29651140d8b4b27d883c89ae4e,ETH-USD,buy_to_close,stop,canceled,1,day,0.0,1,crypto,,,
2024-09-03 20:00:00-04:00,MLTrader,a01b76650e0748beb72fc75f1ed718d1,ETH-USD,buy_to_close,limit,fill,1,day,0.0,1,crypto,2425.28,1.9879515138228698,0.0

# stats.csv
2024-09-03 20:00:00-04:00,1,0,1.0,10354.621912727398,15175.96096017173,"[{'asset': ETH-USD, 'quantity': -1.9879515138228698}]",0.005466791649808789
2024-09-03 21:00:00-04:00,2,0,1.0,10469.923100529128,19997.30000761606,"[{'asset': ETH-USD, 'quantity': -3.9759030276457397}]",0.011135238811569526  # position remains and is doubled !
```

## Testing

- Verified with both short and long position sequences
- Tested with market and limit orders using `take_profit_price` and `stop_loss_price`