### PR TITLE
Set live parameter to False in projectx_data.py

### DIFF
--- a/lumibot/data_sources/projectx_data.py
+++ b/lumibot/data_sources/projectx_data.py
@@ -123,7 +123,7 @@ class ProjectXData(DataSource):
                 unit_number=1,
                 limit=1,
                 include_partial_bar=True,
-                live=True,
+                live=False,
                 is_est=True,
             )
 


### PR DESCRIPTION
Last week's projectx changes flipped the retrieveBars call's "live" parameter from False to True. Can we change it back because the API call errors out and doesn't return any historical bars for me. The ProjectX just defines that param as "Whether to retrieve bars using the sim or live data subscription." I can't find any other info on it. If it's ok to set back to False here's the PR .

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Set the live parameter to False in lumibot/data_sources/projectx_data.py when calling get_last_price.

### Why are these changes being made?

To ensure the projectx data fetch uses non-live data for last price retrieval, avoiding live updates in this context. No other behavior changes beyond switching to non-live data sourcing.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->