### PR TITLE
feat: add fundamental value example strategy

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include lumibot/resources *
+recursive-include lumibot/example_strategies/config *.yaml

--- a/examples/run_fundamental_value.py
+++ b/examples/run_fundamental_value.py
@@ -1,0 +1,112 @@
+"""Execute the FundamentalValueStrategy either in backtest or live mode.
+
+Usage (backtest):
+    python examples/run_fundamental_value.py --backtest
+
+Usage (live):
+    python examples/run_fundamental_value.py --live
+
+Optional arguments:
+    --config PATH            Custom YAML listing tickers (defaults to bundled config)
+    --start YYYY-MM-DD       Backtest start date
+    --end YYYY-MM-DD         Backtest end date
+    --margin FLOAT           Margin of safety (0-1)
+    --allocation FLOAT       Target portfolio allocation per symbol (0-1)
+
+Example commands:
+    # Equal-weight backtest for 2024 using default tickers
+    python examples/run_fundamental_value.py --backtest --start 2024-01-01 --end 2024-12-31
+
+    # Backtest with bundled watch list and 20% margin of safety
+    python examples/run_fundamental_value.py \
+        --backtest \
+        --config lumibot/example_strategies/config/fundamental_value.yaml \
+        --margin 0.2
+
+    # Live / paper trading with Alpaca using the bundled watch list and custom allocation
+    python examples/run_fundamental_value.py \
+        --live \
+        --allocation 0.4 \
+        --config lumibot/example_strategies/config/fundamental_value.yaml
+
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from lumibot.backtesting import YahooDataBacktesting
+from lumibot.brokers import Alpaca
+from lumibot.credentials import ALPACA_CONFIG
+from lumibot.example_strategies.fundamental_value import FundamentalValueStrategy
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the Lumibot Fundamental Value strategy")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--backtest", action="store_true", help="Run a Yahoo Finance backtest (default)")
+    mode.add_argument("--live", action="store_true", help="Run live/paper trading via Alpaca")
+
+    parser.add_argument("--config", type=str, help="YAML file with ticker list")
+    parser.add_argument("--start", type=str, help="Backtest start date, e.g. 2023-01-01")
+    parser.add_argument("--end", type=str, help="Backtest end date, e.g. 2023-12-31")
+    parser.add_argument("--margin", type=float, help="Margin of safety between 0.0 and 1.0")
+    parser.add_argument("--allocation", type=float, help="Target allocation per symbol between 0.0 and 1.0")
+
+    return parser.parse_args()
+
+
+def build_parameters(args: argparse.Namespace) -> dict:
+    parameters: dict = {}
+    if args.config:
+        parameters["config_path"] = str(Path(args.config).expanduser())
+    if args.margin is not None:
+        parameters["margin_of_safety"] = float(args.margin)
+    if args.allocation is not None:
+        parameters["target_allocation"] = float(args.allocation)
+    return parameters
+
+
+def run_backtest(args: argparse.Namespace) -> None:
+    start_dt = datetime.strptime(args.start, "%Y-%m-%d") if args.start else datetime(2023, 1, 1)
+    end_dt = datetime.strptime(args.end, "%Y-%m-%d") if args.end else datetime(2023, 12, 31)
+
+    print(f"Running backtest from {start_dt.date()} to {end_dt.date()} using Yahoo data")
+    results = FundamentalValueStrategy.backtest(
+        YahooDataBacktesting,
+        start_dt,
+        end_dt,
+        benchmark_asset="SPY",
+        parameters=build_parameters(args),
+    )
+    print(results)
+
+
+def run_live(args: argparse.Namespace) -> None:
+    if not ALPACA_CONFIG:
+        raise RuntimeError("ALPACA_CONFIG is not set; please configure your Alpaca credentials.")
+
+    broker = Alpaca(ALPACA_CONFIG)
+    strategy = FundamentalValueStrategy(
+        broker=broker,
+        parameters=build_parameters(args),
+    )
+
+    print("Starting live/paper trading. Press Ctrl+C to stop.")
+    strategy.run_live()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if args.live:
+        run_live(args)
+    else:
+        run_backtest(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/lumibot/example_strategies/README.md
+++ b/lumibot/example_strategies/README.md
@@ -1,0 +1,93 @@
+# Lumibot Example Strategies
+
+The `lumibot/example_strategies` package is the recommended home for sample
+strategies that demonstrate different patterns. Keeping them together makes it
+straightforward to discover canonical implementations (for example,
+`fundamental_value.FundamentalValueStrategy`).
+
+## Fundamental Value Strategy
+
+`FundamentalValueStrategy` showcases how to combine external fundamental data
+with Lumibot. Tickers are maintained in
+`config/fundamental_value.yaml`, allowing you to update the watch list without
+editing code.
+
+### Requirements
+
+- Install Lumibot in editable mode (ensures dependencies like `yfinance` and
+  `PyYAML` are available):
+
+  ```bash
+  pip install -e .
+  ```
+
+- Ensure outbound network access at runtime so the strategy can query Yahoo
+  Finance for fundamentals.
+
+### Configure Tickers
+
+Edit `lumibot/example_strategies/config/fundamental_value.yaml` and list the
+symbols you want to analyze:
+
+```yaml
+tickers:
+  - AAPL
+  - NVDA
+  - MSFT
+```
+
+To use a custom YAML file instead, pass its path through the strategy
+parameters (see below).
+
+### Run a Backtest
+
+```python
+from datetime import datetime
+
+from lumibot.backtesting import YahooDataBacktesting
+from lumibot.example_strategies.fundamental_value import FundamentalValueStrategy
+
+start = datetime(2023, 1, 1)
+end = datetime(2023, 12, 31)
+
+results = FundamentalValueStrategy.backtest(
+    YahooDataBacktesting,
+    start,
+    end,
+    benchmark_asset="SPY",
+)
+
+print(results)
+```
+
+Options you can override with the `parameters` argument:
+
+- `config_path`: Point to an alternate YAML file.
+- `target_allocation`: Fraction of the portfolio to deploy per buy signal
+  (defaults to equal weighting).
+- `margin_of_safety`: Discount applied to intrinsic value (e.g. `0.2` for 20%).
+- `fundamental_refresh_hours`: Minimum hours before fundamentals are reloaded
+  for a symbol.
+
+### Live or Paper Trading
+
+Provide a broker instance and call `run_live()`:
+
+```python
+from lumibot.brokers import Alpaca
+from lumibot.credentials import ALPACA_CONFIG
+from lumibot.example_strategies.fundamental_value import FundamentalValueStrategy
+
+strategy = FundamentalValueStrategy(
+    broker=Alpaca(ALPACA_CONFIG),
+    parameters={
+        "config_path": "~/my_watchlist.yaml",
+        "margin_of_safety": 0.15,
+    },
+)
+
+strategy.run_live()
+```
+
+Make sure your broker credentials are configured and that the chosen broker
+supports all instruments in your YAML file.

--- a/lumibot/example_strategies/__init__.py
+++ b/lumibot/example_strategies/__init__.py
@@ -1,0 +1,7 @@
+"""Canonical home for built-in and example strategies.
+
+Add new reference implementations under this package to keep them easy to
+discover (e.g. ``fundamental_value.FundamentalValueStrategy``).
+"""
+
+__all__ = []

--- a/lumibot/example_strategies/config/fundamental_value.yaml
+++ b/lumibot/example_strategies/config/fundamental_value.yaml
@@ -1,0 +1,6 @@
+# Default tickers tracked by FundamentalValueStrategy.
+# Provide a list of ticker symbols to analyze each iteration.
+tickers:
+  - AAPL
+  - NVDA
+  - MSFT

--- a/lumibot/example_strategies/fundamental_value.py
+++ b/lumibot/example_strategies/fundamental_value.py
@@ -1,0 +1,318 @@
+"""Fundamental value investing example strategy.
+
+This strategy demonstrates how to combine external fundamental data with
+Lumibot's trading lifecycle. Tickers are defined in a YAML configuration file
+and refreshed automatically when the file changes. Fundamental metrics are
+retrieved from Yahoo Finance via the ``yfinance`` package, an intrinsic value is
+calculated using the Graham number, and simple buy/sell signals are generated
+by comparing intrinsic value to the latest market price.
+
+Usage:
+    >>> from lumibot.example_strategies.fundamental_value import FundamentalValueStrategy
+
+The default configuration file lives alongside this module under
+``config/fundamental_value.yaml`` but a custom path can be supplied via the
+``config_path`` parameter.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import yfinance as yf
+import yaml
+
+from lumibot.strategies.strategy import Strategy
+
+
+@dataclass
+class FundamentalSnapshot:
+    """Container for the metrics we collect for each symbol."""
+
+    symbol: str
+    market_price: Optional[float]
+    intrinsic_value: Optional[float]
+    eps: Optional[float]
+    pe_ratio: Optional[float]
+    book_value: Optional[float]
+    dividend_yield: Optional[float]
+    timestamp: datetime
+
+
+class FundamentalValueStrategy(Strategy):
+    """Simple value strategy driven by EPS/PE and Graham intrinsic value."""
+
+    parameters = {
+        "config_path": None,  # Optional override for the YAML configuration file
+        "fundamental_refresh_hours": 24,
+        # ``target_allocation`` is interpreted as the desired fraction of the
+        # portfolio to hold per symbol when a buy signal is active. When left to
+        # ``None`` it falls back to ``1 / number_of_tickers`` dynamically.
+        "target_allocation": None,
+        # Optional margin of safety applied to the computed intrinsic value.
+        "margin_of_safety": 0.0,
+    }
+
+    def initialize(self, config_path: Optional[str] = None) -> None:
+        self.sleeptime = "1D"
+
+        configured_path = config_path or self.parameters.get("config_path")
+        if configured_path:
+            self.config_path = Path(configured_path).expanduser().resolve()
+        else:
+            self.config_path = (
+                Path(__file__).resolve().parent / "config" / "fundamental_value.yaml"
+            )
+
+        refresh_hours = float(self.parameters.get("fundamental_refresh_hours", 24))
+        self._fundamental_cache_ttl = timedelta(hours=max(refresh_hours, 1))
+        self._fundamental_cache: Dict[str, FundamentalSnapshot] = {}
+        self._config_mtime: Optional[float] = None
+        self._tracked_tickers: List[str] = []
+
+        self.margin_of_safety = float(self.parameters.get("margin_of_safety", 0.0))
+
+        # Load tickers immediately so that runtime errors surface early.
+        self._reload_config(force=True)
+
+    # ===== Lifecycle =====
+
+    def on_trading_iteration(self) -> None:
+        # Refresh configuration if the YAML file has changed.
+        self._reload_config()
+        if not self._tracked_tickers:
+            self.log_message("No tickers configured; skipping iteration.")
+            self.await_market_to_close()
+            return
+
+        per_symbol_allocation = self._compute_target_allocation()
+        portfolio_value = self.get_portfolio_value()
+        cash_available = self.get_cash()
+        fundamentals_for_iteration: Dict[str, FundamentalSnapshot] = {}
+
+        buy_signals: List[str] = []
+        sell_signals: List[str] = []
+
+        for symbol in self._tracked_tickers:
+            snapshot = self._get_fundamental_snapshot(symbol)
+            fundamentals_for_iteration[symbol] = snapshot
+
+            if snapshot.market_price is None or snapshot.intrinsic_value is None:
+                self.log_message(
+                    f"Skipping {symbol}: missing fundamental data (price={snapshot.market_price}, intrinsic={snapshot.intrinsic_value})."
+                )
+                continue
+
+            self.log_message(
+                " | ".join(
+                    [
+                        f"{symbol}",
+                        f"price={snapshot.market_price:.2f}",
+                        f"intrinsic={snapshot.intrinsic_value:.2f}",
+                        f"eps={snapshot.eps if snapshot.eps is not None else 'n/a'}",
+                        f"pe={snapshot.pe_ratio if snapshot.pe_ratio is not None else 'n/a'}",
+                        f"book={snapshot.book_value if snapshot.book_value is not None else 'n/a'}",
+                    ]
+                )
+            )
+
+            if snapshot.intrinsic_value < snapshot.market_price:
+                buy_signals.append(symbol)
+            else:
+                sell_signals.append(symbol)
+
+        # Execute buy orders first so that cash accounting is straightforward.
+        for symbol in buy_signals:
+            snapshot = fundamentals_for_iteration.get(symbol)
+            if not snapshot or snapshot.market_price is None:
+                continue
+
+            target_value = portfolio_value * per_symbol_allocation
+            current_position = self.get_position(symbol)
+            current_value = 0.0
+            if current_position and current_position.quantity:
+                current_value = current_position.quantity * snapshot.market_price
+
+            difference = target_value - current_value
+            if difference <= 0:
+                continue
+
+            max_affordable = int(cash_available // snapshot.market_price)
+            if max_affordable <= 0:
+                continue
+
+            requested_qty = max(int(difference // snapshot.market_price), 1)
+            quantity = min(requested_qty, max_affordable)
+            if quantity <= 0:
+                continue
+
+            buy_order = self.create_order(symbol, quantity, "buy")
+            self.submit_order(buy_order)
+            cash_available -= quantity * snapshot.market_price
+
+        # Sell signals off-load entire positions to simplify state.
+        for symbol in sell_signals:
+            position = self.get_position(symbol)
+            if position and position.quantity:
+                sell_order = self.create_order(symbol, position.quantity, "sell")
+                self.submit_order(sell_order)
+
+        self.await_market_to_close()
+
+    # ===== Helpers =====
+
+    def _compute_target_allocation(self) -> float:
+        configured = self.parameters.get("target_allocation")
+        if configured is not None:
+            try:
+                configured_value = float(configured)
+                return max(min(configured_value, 1.0), 0.0)
+            except (TypeError, ValueError):
+                self.log_message(
+                    f"Invalid target_allocation '{configured}' supplied; defaulting to equal weighting."
+                )
+
+        if not self._tracked_tickers:
+            return 0.0
+        return 1.0 / len(self._tracked_tickers)
+
+    def _reload_config(self, force: bool = False) -> None:
+        try:
+            mtime = self.config_path.stat().st_mtime
+        except FileNotFoundError:
+            message = f"Ticker configuration file not found at {self.config_path}."
+            if force:
+                raise FileNotFoundError(message) from None
+            self.log_message(message)
+            self._tracked_tickers = []
+            return
+
+        if not force and self._config_mtime is not None and mtime <= self._config_mtime:
+            return
+
+        with self.config_path.open("r", encoding="utf-8") as stream:
+            try:
+                config = yaml.safe_load(stream) or {}
+            except yaml.YAMLError as exc:
+                if force:
+                    raise ValueError(f"Failed to parse YAML config at {self.config_path}: {exc}") from exc
+                self.log_message(f"Failed to parse YAML config: {exc}")
+                return
+
+        tickers = self._normalize_ticker_list(config.get("tickers", []))
+        if not tickers:
+            message = f"No tickers found in configuration {self.config_path}."
+            if force:
+                raise ValueError(message)
+            self.log_message(message)
+            self._tracked_tickers = []
+            return
+
+        self._tracked_tickers = tickers
+        self._config_mtime = mtime
+        self.log_message(
+            f"Tracking {len(self._tracked_tickers)} ticker(s) from {self.config_path.name}: {', '.join(self._tracked_tickers)}"
+        )
+
+    @staticmethod
+    def _normalize_ticker_list(raw: Iterable) -> List[str]:
+        tickers: List[str] = []
+        for item in raw or []:
+            symbol: Optional[str]
+            if isinstance(item, dict):
+                symbol = item.get("symbol") or item.get("ticker")
+            else:
+                symbol = str(item)
+
+            if not symbol:
+                continue
+            cleaned = symbol.strip().upper()
+            if cleaned:
+                tickers.append(cleaned)
+
+        return tickers
+
+    def _get_fundamental_snapshot(self, symbol: str) -> FundamentalSnapshot:
+        now = self.get_datetime()
+        if now is None:
+            now = datetime.now(timezone.utc)
+        elif now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+
+        cached = self._fundamental_cache.get(symbol)
+        if cached and now - cached.timestamp < self._fundamental_cache_ttl:
+            return cached
+
+        ticker = yf.Ticker(symbol)
+        try:
+            info = ticker.get_info()
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            self.log_message(f"Failed to download fundamentals for {symbol}: {exc}")
+            info = {}
+
+        eps = self._to_float(info.get("trailingEps")) or self._to_float(info.get("forwardEps"))
+        pe_ratio = self._to_float(info.get("trailingPE")) or self._to_float(info.get("forwardPE"))
+        book_value = self._to_float(info.get("bookValue"))
+        dividend_yield = self._to_float(info.get("dividendYield"))
+
+        margin_multiplier = 1.0 - max(min(self.margin_of_safety, 0.99), 0.0)
+        intrinsic_value = self._calculate_intrinsic_value(eps, book_value)
+        if intrinsic_value is not None:
+            intrinsic_value *= margin_multiplier
+
+        market_price = self._latest_price(symbol, info)
+
+        snapshot = FundamentalSnapshot(
+            symbol=symbol,
+            market_price=market_price,
+            intrinsic_value=intrinsic_value,
+            eps=eps,
+            pe_ratio=pe_ratio,
+            book_value=book_value,
+            dividend_yield=dividend_yield,
+            timestamp=now,
+        )
+
+        self._fundamental_cache[symbol] = snapshot
+        return snapshot
+
+    def _latest_price(self, symbol: str, info: Dict) -> Optional[float]:
+        # Prefer Lumibot's data source for pricing to maintain consistency with
+        # the backtesting/live environment.
+        try:
+            price = self.get_last_price(symbol)
+            if price is not None:
+                return float(price)
+        except Exception:
+            pass
+
+        for key in ("currentPrice", "regularMarketPrice", "previousClose"):
+            value = self._to_float(info.get(key))
+            if value is not None:
+                return value
+
+        return None
+
+    @staticmethod
+    def _calculate_intrinsic_value(eps: Optional[float], book_value: Optional[float]) -> Optional[float]:
+        if eps is None or book_value is None:
+            return None
+        if eps <= 0 or book_value <= 0:
+            return None
+        try:
+            return math.sqrt(22.5 * eps * book_value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _to_float(value: Optional[float]) -> Optional[float]:
+        try:
+            if value is None:
+                return None
+            return float(value)
+        except (TypeError, ValueError):
+            return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ alpaca-py>=0.42.0
 alpha_vantage
 ibapi==9.81.1.post1
 yfinance>=0.2.61
+PyYAML>=6.0
 matplotlib>=3.3.3
 quandl
 numpy>=1.20.0

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(
         "alpha_vantage",
         "ibapi==9.81.1.post1",
         "yfinance>=0.2.61",
+        "PyYAML>=6.0",
         "matplotlib>=3.3.3",
         "quandl",
         # NumPy 1.20.0+ supports modern features, 2.0+ adds compatibility for latest ecosystem


### PR DESCRIPTION
This is the first strategy I made as a dummy.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a new Fundamental Value example strategy along with its configuration, runnable example, documentation, and packaging updates.

### Why are these changes being made?

Introduce a runnable demonstration of integrating fundamental data (via Yahoo Finance) with Lumibot, including configurable tickers, margin of safety, and per-symbol allocation; keep the example self-contained and easily discoverable. Also update dependencies and packaging to include YAML config support.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->