### PR TITLE
Add documentation to position extra properties.

### DIFF
--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 
 import pandas_market_calendars as mcal
 from alpaca.trading.client import TradingClient
-from alpaca.trading.enums import QueryOrderStatus
+from alpaca.trading.enums import QueryOrderStatus, PositionSide
 from alpaca.trading.requests import GetOrdersRequest, ReplaceOrderRequest
 from alpaca.trading.stream import TradingStream
 from dateutil import tz
@@ -404,6 +404,13 @@ class Alpaca(Broker):
             avg_fill_price = None
 
         position = Position(strategy, asset, quantity, orders=orders, avg_fill_price=avg_fill_price)
+
+        position.pnl = float(broker_position.unrealized_pl) if broker_position.unrealized_pl else None
+        position.current_price = float(broker_position.current_price) if broker_position.current_price else None
+        position.side = Position.PositionSide.LONG if broker_position.side == PositionSide.LONG else Position.PositionSide.SHORT
+        position.market_value = float(broker_position.market_value) if broker_position.market_value else None
+        
+
         return position
 
     def _pull_broker_position(self, asset):

--- a/lumibot/entities/position.py
+++ b/lumibot/entities/position.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 
 import lumibot.entities as entities
+from lumibot.entities.asset import StrEnum #todo: this should be centralized, and not repeated in Asset and Position
 
 
 class Position:
@@ -26,7 +27,35 @@ class Position:
         The assets that are free in the portfolio. (Crypto: only)
     avg_fill_price : float
         The average fill price of the position.
+    current_price : float
+        The current price of the asset.
+    market_value : float
+        The market value of the position.
+    pnl : float
+        The profit and loss of the position.
+    pnl_percent : float
+        The profit and loss of the position as a percentage of the average fill price.
+    asset_type : str
+        The type of the asset.
+    exchange : str
+        The exchange that the position is on.
+    currency : str
+        The currency that the position is denominated in.
+    multiplier : float
+        The multiplier of the asset.
+    expiration : datetime.date
+        The expiration of the asset. (Options and futures: only). Probably better to use on position.asset
+    strike : float
+        The strike price of the asset. (Options: only). Probably better to use on position.asset
+    option_type : str
+        The type of the option. (Options: only). Probably better to use on position.asset
+    side : PositionSide
+        The side of the position (LONG or SHORT)
     """
+
+    class PositionSide(StrEnum):
+        LONG = "LONG"
+        SHORT = "SHORT"
 
     def __init__(
             self,
@@ -38,6 +67,11 @@ class Position:
             available=0,
             avg_fill_price=None
         ):
+        """Creates a position.
+
+        NOTE: There are some properties that can be assigned to a position entity outside of the constructor (pnl, current_price, etc)
+
+        """
         self.strategy = strategy
         self.asset = asset
         self.symbol = self.asset.symbol
@@ -223,13 +257,13 @@ class Position:
             result['currency'] = self.currency
         if hasattr(self, 'multiplier'):
             result['multiplier'] = self.multiplier
-        if hasattr(self, 'expiration'):
+        if hasattr(self, 'expiration'):  #should probably use position.asset instead
             result['expiration'] = str(self.expiration) if self.expiration else None
-        if hasattr(self, 'strike'):
+        if hasattr(self, 'strike'): #should probably use position.asset instead
             result['strike'] = float(self.strike) if self.strike else None
-        if hasattr(self, 'option_type'):
+        if hasattr(self, 'option_type'): #should probably use position.asset instead
             result['option_type'] = self.option_type
-        if hasattr(self, 'underlying_symbol'):
+        if hasattr(self, 'underlying_symbol'): #should probably use position.asset instead
             result['underlying_symbol'] = self.underlying_symbol
 
         # Handle orders carefully - ensure to_dict() is called properly


### PR DESCRIPTION
Add some documentation to the existing extra properties for Position. 
Add an enum interface for Position.side
Update Alpaca to use some of the extra properties


Other broker files can later be updated to populate these values from the broker if supported.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add documentation and support for extra position properties (pnl, current_price, market_value, side) and introduce a PositionSide enum; wire these fields through the Alpaca broker parsing and extend the Position entity with descriptive docstrings and notes.

### Why are these changes being made?
Expose richer position telemetry and provide a clear, documented structure for additional position-related attributes, aligning broker data with the internal Position model. Minor notes clarify where certain properties may belong to the asset vs the position for future refactor.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->