### PR TITLE
Fix broken schwab and add some more position detail

### DIFF
--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -526,13 +526,8 @@ class Schwab(Broker):
 
                 # Extract position-specific details
                 average_price = schwab_position.get('averagePrice', 0.0)
-
-                if 'longOpenProfitLoss' in schwab_position:
-                    pnl = schwab_position['longOpenProfitLoss']
-                elif 'shortOpenProfitLoss' in schwab_position:
-                    pnl = schwab_position['shortOpenProfitLoss']
-                else:
-                    pnl = None
+                pnl = schwab_position.get('longOpenProfitLoss') or schwab_position.get('shortOpenProfitLoss') or None
+                market_value = schwab_position.get('marketValue', None)
 
                 # Only create position object if we have a valid asset
                 if asset is not None:
@@ -544,11 +539,12 @@ class Schwab(Broker):
 
                     # If we already have this asset in our dict, update the quantity
                     if key in pos_dict:
-                        pos_dict[key].quantity += net_quantity
+                        existing_position = pos_dict[key]
+                        existing_position.quantity += net_quantity
                         if pnl is not None:
-                            pos_dict[key].pnl += pnl
-                        if schwab_position.get('marketValue', None) is not None:
-                            pos_dict[key].market_value += schwab_position['marketValue']
+                           existing_position.pnl += pnl
+                        if market_value is not None:
+                            existing_position.market_value += market_value
                     else:
                         # Create a new Position object
                         pos_dict[key] = Position(
@@ -559,7 +555,7 @@ class Schwab(Broker):
                         )
                         
                         pos_dict[key].pnl = pnl
-                        pos_dict[key].market_value = schwab_position.get('marketValue', None)
+                        pos_dict[key].market_value = market_value
 
             # Log the number of positions found
             logger.debug(f"Pulled {len(pos_dict)} unique positions from Schwab")


### PR DESCRIPTION
Schwab is currently broken due to the use of a logger that is not an instance of the strategy adapter logger. Fixed

Add some more position detail for schwab positions.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix Schwab position pulling to surface P&L and market value, and update existing positions accordingly; also comment out logger initialization for Schwab to avoid unused logger. 

### Why are these changes being made?
Add more position detail (P&L and market value) sourced from Schwab responses and ensure existing positions accumulate these fields correctly when updating. This improves visibility into per-position profitability without altering core logic beyond enriching the Position data.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->