### PR TITLE
CI recheck for DataBento snapshot

### DIFF
--- a/docs/futures_roll_policy.md
+++ b/docs/futures_roll_policy.md
@@ -48,3 +48,7 @@
 - Expanded test coverage exercising the new rule set.
 
 This approach gives us one authoritative roll policy, tuned per instrument, and keeps both brokers and data sources in sync while remaining extensible for future providers (Polygon futures, ThetaData, etc.).
+
+.. note::
+
+   Temporary documentation tweak to trigger a fresh CI run; no functional changes intended.


### PR DESCRIPTION
Adds a temporary doc note so CI reruns against the DataBento cherry-pick state. No functional changes.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Temporarily tweak documentation to trigger a fresh CI run without any functional changes.

### Why are these changes being made?
To revalidate CI, ensuring the DataBento snapshot is up to date; no code behavior changes are introduced.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->