### PR TITLE
Error out with multileg limit orders on unsupported brokers. 

### DIFF
--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -1374,7 +1374,7 @@ class Broker(ABC):
         if hasattr(self, '_submit_orders'):
             return self._submit_orders(orders, **kwargs)
         else:
-            #if kwargs indicates multileg orders with a limit price, we should error out instead of submitting legs individually
+            #if kwargs indicates multileg orders with a limit price, and broker does not support it, we should error out instead of submitting legs individually
             if kwargs.get('is_multileg') and kwargs.get('order_type') == Order.OrderType.LIMIT:
                 raise NotImplementedError("Multileg limit orders are not supported by this broker")
 


### PR DESCRIPTION
Error out with multileg limit orders on unsupported brokers.  Otherwise you can end up with a partial position.