### PR TITLE
Align DataBento futures rolling with COMEX schedule

### DIFF
--- a/lumibot/data_sources/databento_data_polars.py
+++ b/lumibot/data_sources/databento_data_polars.py
@@ -24,8 +24,12 @@ except ImportError:  # pragma: no cover - optional dependency
 from .data_source import DataSource
 from .polars_mixin import PolarsMixin
 from lumibot.entities import Asset, Bars, Quote
-from lumibot.tools import databento_helper_polars
-from lumibot.tools.databento_helper_polars import _ensure_polars_datetime_timezone as _ensure_polars_tz
+from lumibot.tools import databento_helper_polars, futures_roll
+from lumibot.tools.databento_helper_polars import (
+    _ensure_polars_datetime_timezone as _ensure_polars_tz,
+    _format_futures_symbol_for_databento,
+    _generate_databento_symbol_alternatives,
+)
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
@@ -512,38 +516,30 @@ class DataBentoDataPolars(PolarsMixin, DataSource):
     
     def _resolve_futures_symbol(self, asset: Asset, reference_date: datetime = None) -> str:
         """Resolve asset to specific futures contract symbol"""
-        if asset.asset_type in [Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE]:
-            # For continuous futures, resolve to specific contract
-            if asset.asset_type == Asset.AssetType.CONT_FUTURE:
-                if hasattr(asset, 'resolve_continuous_futures_contract'):
-                    return asset.resolve_continuous_futures_contract(
-                        reference_date=reference_date,
-                        year_digits=1,
-                    )
-            
-            # Manual resolution for common futures
-            symbol = asset.symbol.upper()
-            month = reference_date.month if reference_date else datetime.now().month
-            year = reference_date.year if reference_date else datetime.now().year
-            
-            # Quarterly contracts
-            if month <= 3:
-                month_code = 'H'
-            elif month <= 6:
-                month_code = 'M'
-            elif month <= 9:
-                month_code = 'U'
-            else:
-                month_code = 'Z'
-            
-            year_digit = year % 10
-            
-            if symbol in ["ES", "NQ", "RTY", "YM", "MES", "MNQ", "MYM", "M2K", "CL", "GC", "SI"]:
-                return f"{symbol}{month_code}{year_digit}"
-            
+        if asset.asset_type not in [Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE]:
             return asset.symbol
-        
-        return asset.symbol
+
+        ref_dt = reference_date or datetime.now(timezone.utc)
+
+        if asset.asset_type == Asset.AssetType.FUTURE and asset.expiration:
+            return _format_futures_symbol_for_databento(asset, reference_date=reference_date)
+
+        if asset.asset_type == Asset.AssetType.CONT_FUTURE:
+            resolved_contract = futures_roll.resolve_symbol_for_datetime(
+                asset,
+                ref_dt,
+                year_digits=2,
+            )
+        else:
+            temp_asset = Asset(asset.symbol, Asset.AssetType.CONT_FUTURE)
+            resolved_contract = futures_roll.resolve_symbol_for_datetime(
+                temp_asset,
+                ref_dt,
+                year_digits=2,
+            )
+
+        databento_symbol = _generate_databento_symbol_alternatives(asset.symbol, resolved_contract)
+        return databento_symbol[0] if databento_symbol else resolved_contract
     
     def get_historical_prices(
         self,

--- a/lumibot/tools/databento_helper.py
+++ b/lumibot/tools/databento_helper.py
@@ -784,6 +784,22 @@ def _fetch_and_update_futures_multiplier(
             logger.info(f"[MULTIPLIER] AFTER update: asset.multiplier = {asset.multiplier}")
         else:
             logger.error(f"[MULTIPLIER] ✗ Definition missing unit_of_measure_qty field! Fields: {list(definition.keys())}")
+
+        if (
+            asset.asset_type == Asset.AssetType.FUTURE
+            and getattr(asset, "expiration", None) in (None, "")
+        ):
+            expiration_value = definition.get('expiration')
+            if expiration_value:
+                try:
+                    expiration_ts = pd.to_datetime(expiration_value, utc=True, errors='coerce')
+                except Exception as exc:
+                    logger.debug(f"[MULTIPLIER] Unable to parse expiration '{expiration_value}' for {asset.symbol}: {exc}")
+                    expiration_ts = None
+
+                if expiration_ts is not None and not pd.isna(expiration_ts):
+                    asset.expiration = expiration_ts.date()
+                    logger.debug(f"[MULTIPLIER] ✓ Captured expiration for {asset.symbol}: {asset.expiration}")
     else:
         logger.error(f"[MULTIPLIER] ✗ Failed to get definition from DataBento for {resolved_symbol}")
 

--- a/tests/test_futures_roll.py
+++ b/tests/test_futures_roll.py
@@ -36,3 +36,23 @@ def test_resolve_symbols_for_range_produces_sequential_contracts():
 
     symbols = futures_roll.resolve_symbols_for_range(asset, start, end, year_digits=1)
     assert symbols == ["MESU5", "MESZ5", "MESH6"], symbols
+
+
+def test_comex_gold_rolls_on_third_last_business_day_offset():
+    asset_symbol = "GC"
+
+    year, month = futures_roll.determine_contract_year_month(asset_symbol, _dt(2025, 2, 14))
+    assert (year, month) == (2025, 2)
+
+    # Seven business days before the third last business day of February 2025 is Feb 17
+    year, month = futures_roll.determine_contract_year_month(asset_symbol, _dt(2025, 2, 17))
+    assert (year, month) == (2025, 4)
+
+
+def test_comex_gold_symbol_sequence_uses_even_month_cycle():
+    asset = Asset("GC", asset_type=Asset.AssetType.CONT_FUTURE)
+    start = _dt(2025, 1, 1)
+    end = _dt(2025, 8, 1)
+
+    symbols = futures_roll.resolve_symbols_for_range(asset, start, end, year_digits=1)
+    assert symbols == ["GCG5", "GCJ5", "GCM5", "GCQ5"], symbols


### PR DESCRIPTION
## Summary
- extend roll registry to cover GC and SI with correct business-day triggers
- refactor DataBento adapters to reuse centralized roll logic and capture expirations
- add regression coverage for gold roll sequencing