### PR TITLE
ProjectX data fix 

### DIFF
--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -1421,7 +1421,7 @@ class Broker(ABC):
             or getattr(order, "order_id", None)
             for order in orders
         ]
-        self.logger.info(
+        self.logger.debug(
             "cancel_open_orders(strategy=%s) -> active=%d ids=%s",
             strategy,
             len(orders),

--- a/lumibot/data_sources/projectx_data.py
+++ b/lumibot/data_sources/projectx_data.py
@@ -113,12 +113,12 @@ class ProjectXData(DataSource):
             if not contract_id:
                 return None
 
-            end_dt = datetime.now()
-            start_dt = end_dt - timedelta(minutes=1)
+            end_dt = datetime.now().replace(second=59, microsecond=999999)
+            start_dt = (end_dt - timedelta(minutes=1)).replace(second=0, microsecond=0)
             df = self.client.history_retrieve_bars(
                 contract_id=contract_id,
-                start_datetime=start_dt.isoformat(),
-                end_datetime=end_dt.isoformat(),
+                start_datetime=start_dt,
+                end_datetime=end_dt,
                 unit=self.TIME_UNIT_MAPPING["minute"],
                 unit_number=1,
                 limit=1,
@@ -225,10 +225,12 @@ class ProjectXData(DataSource):
             else:
                 start_datetime = end_datetime - timedelta(days=length)
 
+            start_datetime.replace(second=0, microsecond=0)
+            end_datetime.replace(second=59, microsecond=999999)
             df = self.client.history_retrieve_bars(
                 contract_id=contract_id,
-                start_datetime=start_datetime.isoformat(),
-                end_datetime=end_datetime.isoformat(),
+                start_datetime=start_datetime,
+                end_datetime=end_datetime,
                 unit=unit,
                 unit_number=unit_number,
                 limit=length + 100,

--- a/lumibot/data_sources/tradier_data.py
+++ b/lumibot/data_sources/tradier_data.py
@@ -257,7 +257,7 @@ class TradierData(DataSource):
             # For minute bars, calculate additional days needed accounting for weekends/holidays
             # minutes_per_day = 390  # ~6.5 hours of trading per day
             minutes_per_day = 24 * 60 / timestep_qty  # Need to include premarket and after hours
-            days_needed = (length // minutes_per_day) + 1
+            days_needed = int(length // minutes_per_day) + 1
 
         start_date = date_n_trading_days_from_date(
             n_days=days_needed,

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -1839,10 +1839,11 @@ class Strategy(_Strategy):
                 or getattr(order, "order_id", None)
                 for order in active_orders
             ]
-            self.log_message(
-                f"cancel_open_orders -> active={len(active_orders)} ids={order_ids}",
-                color="yellow",
-            )
+            if order_ids:
+                self.log_message(
+                    f"cancel_open_orders -> active={len(active_orders)} ids={order_ids}",
+                    color="yellow",
+                )
         except Exception as exc:  # pragma: no cover - defensive logging
             self.logger.exception("Failed to enumerate open orders before cancellation: %s", exc)
         return self.broker.cancel_open_orders(self.name)


### PR DESCRIPTION
For get_last_price(), get_quote(), and get_historic… al_prices() not returning correct data due to start/end datetime issues. Also included a small fix for Tradier enddate calculations using a float when it should be an int.

This pull request introduces improvements to datetime handling for historical data retrieval, enhances logging, and adds new unit tests to ensure correct datetime normalization. The most significant changes are grouped below by theme.

### Datetime Handling and Data Retrieval Improvements

* Refactored the `history_retrieve_bars` method in `lumibot/tools/projectx_helpers.py` to accept both `str` and `datetime` inputs for `start_datetime` and `end_datetime`, and introduced the `_to_utc_iso` helper to normalize these values to UTC ISO format, improving robustness and flexibility of time handling. [[1]](diffhunk://#diff-83c205b14e912f1ce79d5b728b7cee6a405541ae407797eac37e0e836a62853cL579-R592) [[2]](diffhunk://#diff-83c205b14e912f1ce79d5b728b7cee6a405541ae407797eac37e0e836a62853cL877-R871) [[3]](diffhunk://#diff-83c205b14e912f1ce79d5b728b7cee6a405541ae407797eac37e0e836a62853cR1107-R1144)
* Updated `lumibot/data_sources/projectx_data.py` to pass `datetime` objects directly to `history_retrieve_bars` and adjusted minute bar boundaries for more precise querying. [[1]](diffhunk://#diff-d49b9aebd1cfc56bb0371c5a03733aecdb29c8dfea705aa80d6c95c45db67874L116-R121) [[2]](diffhunk://#diff-d49b9aebd1cfc56bb0371c5a03733aecdb29c8dfea705aa80d6c95c45db67874R228-R233)

### Logging Improvements

* Changed logging in `cancel_open_orders` of `lumibot/brokers/broker.py` from `info` to `debug` level for less noisy logs during order cancellation.
* Added conditional logging in `lumibot/strategies/strategy.py` to only log active order IDs if present, reducing unnecessary log entries.

### Testing Enhancements

* Added a new test class `TestProjectXDatetime` in `tests/test_projectx_helpers.py` to verify the correctness of the `_to_utc_iso` helper with various input types and timezone scenarios. [[1]](diffhunk://#diff-9fd6da6a63014ecd6771069cc0ca9be318ce3f5005bc4cb688fd7e936edc1d73R1-R9) [[2]](diffhunk://#diff-9fd6da6a63014ecd6771069cc0ca9be318ce3f5005bc4cb688fd7e936edc1d73R590-R609)

### Minor Calculation Fix

* Fixed a type issue in `get_historical_prices` of `lumibot/data_sources/tradier_data.py` by ensuring `days_needed` is an integer, improving calculation reliability.