### PR TITLE
Add remote Theta downloader support

### DIFF
--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1534,6 +1534,13 @@ class _Strategy:
         base_filename = f"{name + '_' if name is not None else ''}{datestring}_{random_string}"
 
         logdir = "logs"
+        env_save_logfile = os.environ.get("SAVE_LOGFILE")
+        if env_save_logfile is not None:
+            normalized = env_save_logfile.strip().lower()
+            if normalized in ("true", "1", "yes", "y"):
+                save_logfile = True
+            elif normalized in ("false", "0", "no", "n"):
+                save_logfile = False
         if logfile is None and save_logfile:
             logfile = f"{logdir}/{base_filename}_logs.csv"
         if stats_file is None and save_stats_file:


### PR DESCRIPTION
* add DATADOWNLOADER_* env plumbing so Theta helper can use the shared downloader service and skip local ThetaTerminal launches
* attach downloader API key headers, harden readiness probes, and make SAVE_LOGFILE configurable via env
* expand thetadata helper tests to cover remote-mode code paths and downloader header injection

## Testing
- THETADATA_USERNAME/THETADATA_PASSWORD set via .env ➜ pytest tests/test_thetadata_helper.py tests/test_backtesting_broker.py
- curl -H "X-Downloader-Key: ****" http://44.192.43.146:8080/healthz
- curl -H "X-Downloader-Key: ****" "http://44.192.43.146:8080/v3/option/list/expirations?symbol=PLTR&format=json"
- PYTHONPATH=$PWD DATADOWNLOADER_*=... python3 /tmp/downloader_smoke.py (PLTR, 2024-09-16..18 backtest routed through downloader)