### PR TITLE
Handle ThetaData EOD range limits

### DIFF
--- a/scripts/check_eod_chunking.py
+++ b/scripts/check_eod_chunking.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Utility script to verify ThetaData EOD chunking against the shared downloader.
+
+Usage:
+    DATADOWNLOADER_BASE_URL=http://44.192.43.146:8080 \\
+    DATADOWNLOADER_API_KEY=... \\
+    DATADOWNLOADER_SKIP_LOCAL_START=true \\
+    THETADATA_USERNAME=... \\
+    THETADATA_PASSWORD=... \\
+    python scripts/check_eod_chunking.py --symbol MSFT --start 2023-01-03 --end 2024-12-31
+"""
+
+import argparse
+import datetime as dt
+import os
+import sys
+
+import pytz
+
+from lumibot.entities import Asset
+from lumibot.tools import thetadata_helper
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description="Smoke-test long ThetaData EOD spans.")
+    parser.add_argument("--symbol", required=True, help="Ticker symbol to download")
+    parser.add_argument(
+        "--asset-type",
+        default="stock",
+        choices=sorted(thetadata_helper.EOD_ENDPOINTS.keys()),
+        help="Asset type for the symbol (default: stock)",
+    )
+    parser.add_argument(
+        "--start",
+        required=True,
+        help="Start date (YYYY-MM-DD)",
+    )
+    parser.add_argument(
+        "--end",
+        required=True,
+        help="End date (YYYY-MM-DD)",
+    )
+    return parser.parse_args()
+
+
+def _parse_date(value: str) -> dt.datetime:
+    return pytz.UTC.localize(dt.datetime.strptime(value, "%Y-%m-%d"))
+
+
+def main():
+    args = _parse_args()
+
+    base_url = os.environ.get("DATADOWNLOADER_BASE_URL")
+    api_key = os.environ.get("DATADOWNLOADER_API_KEY")
+
+    if not base_url or not api_key:
+        sys.stderr.write("Downloader base URL/API key must be set via environment variables.\n")
+        sys.exit(2)
+
+    os.environ.setdefault("DATADOWNLOADER_SKIP_LOCAL_START", "true")
+
+    start = _parse_date(args.start)
+    end = _parse_date(args.end)
+
+    asset_kwargs = {"asset_type": args.asset_type, "symbol": args.symbol}
+    asset = Asset(**asset_kwargs)
+
+    df = thetadata_helper.get_historical_eod_data(
+        asset=asset,
+        start_dt=start,
+        end_dt=end,
+        username=os.environ.get("THETADATA_USERNAME", ""),
+        password=os.environ.get("THETADATA_PASSWORD", ""),
+    )
+
+    if df is None or df.empty:
+        print("No rows returned.")
+        sys.exit(1)
+
+    print(
+        f"Downloaded {len(df)} rows for {asset.symbol} "
+        f"from {df.index.min()} to {df.index.max()} via {base_url}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_downloader_integration.py
+++ b/tests/test_downloader_integration.py
@@ -1,8 +1,11 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.mark.downloader
@@ -28,6 +31,10 @@ def test_remote_downloader_stock_smoke(tmp_path):
             "THETADATA_PASSWORD": password,
         }
     )
+    if env.get("PYTHONPATH"):
+        env["PYTHONPATH"] = f"{REPO_ROOT}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = str(REPO_ROOT)
 
     script = r"""
 import datetime
@@ -70,3 +77,70 @@ print(f"remote rows={len(df)} first_ts={df.index[0]}")
     )
 
     assert "remote rows=" in result.stdout
+
+
+@pytest.mark.downloader
+def test_remote_downloader_handles_long_eod_spans(tmp_path):
+    """Ensure the downloader handles >365-day EOD ranges via chunking."""
+    base_url = os.environ.get("DATADOWNLOADER_BASE_URL")
+    api_key = os.environ.get("DATADOWNLOADER_API_KEY")
+    username = os.environ.get("THETADATA_USERNAME")
+    password = os.environ.get("THETADATA_PASSWORD")
+
+    if not base_url or not api_key:
+        pytest.skip("Downloader base URL/API key not configured")
+    if not username or not password:
+        pytest.skip("ThetaData dev credentials not available")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "DATADOWNLOADER_BASE_URL": base_url,
+            "DATADOWNLOADER_API_KEY": api_key,
+            "DATADOWNLOADER_SKIP_LOCAL_START": "true",
+            "THETADATA_USERNAME": username,
+            "THETADATA_PASSWORD": password,
+        }
+    )
+    if env.get("PYTHONPATH"):
+        env["PYTHONPATH"] = f"{REPO_ROOT}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = str(REPO_ROOT)
+
+    script = r"""
+import datetime
+import pytz
+from lumibot.entities import Asset
+from lumibot.tools import thetadata_helper
+
+assert thetadata_helper.REMOTE_DOWNLOADER_ENABLED, "Remote downloader flag must be set"
+
+asset = Asset(asset_type="index", symbol="SPX")
+start = pytz.UTC.localize(datetime.datetime(2023, 1, 3))
+end = pytz.UTC.localize(datetime.datetime(2024, 12, 31, 23, 59))
+
+df = thetadata_helper.get_historical_eod_data(
+    asset=asset,
+    start_dt=start,
+    end_dt=end,
+    username="%s",
+    password="%s",
+)
+
+assert df is not None and len(df) > 400, f"Expected multi-year EOD rows, got {0 if df is None else len(df)}"
+print(f"long_eod_rows={len(df)} first={df.index.min()} last={df.index.max()}")
+"""
+
+    smoke_path = tmp_path / "downloader_eod_smoke.py"
+    smoke_path.write_text(script % (username, password), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(smoke_path)],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=True,
+        timeout=240,
+    )
+
+    assert "long_eod_rows=" in result.stdout


### PR DESCRIPTION
## Summary
- chunk ThetaData EOD pulls into <=365-day windows for all assets
- add downloader fixture/tests plus CLI script for multi-year smoke tests
- ensure downloader integration hits prod terminal with dev creds, no local Theta

## Testing
- CI=true ~/bin/safe-timeout 600s pytest tests/test_thetadata_helper.py
- DATADOWNLOADER_*=... CI=true ~/bin/safe-timeout 900s pytest -m downloader tests/test_downloader_integration.py
- DATADOWNLOADER_*=... PYTHONPATH=... ~/bin/safe-timeout 300s /opt/homebrew/opt/python@3.12/bin/python3.12 scripts/check_eod_chunking.py --symbol SPX --asset-type index --start 2023-01-03 --end 2024-12-31