### PR TITLE
ProjectX contract lookup defaults to API calls

### DIFF
--- a/tests/test_projectx_helpers.py
+++ b/tests/test_projectx_helpers.py
@@ -287,15 +287,22 @@ class TestProjectXClient:
 
         mock_contracts = [
             {
-                "ContractId": "CON.F.US.MES.U25",
-                "Symbol": "MES"
+                "contractId": "CON.F.US.MES.Z25",
+                "id": "CON.F.US.MES.Z25",
+                "symbol": "MES",
+                "name": "MESZ25",
             }
         ]
         mock_client.api.contract_search = MagicMock(return_value={"success": True, "contracts": mock_contracts})
 
         with patch.object(Asset, 'get_potential_futures_contracts', return_value=['MESU25', 'MES.U25', 'MESU2025']):
             contract_id = mock_client.find_contract_by_symbol("MES")
-            assert contract_id == "CON.F.US.MES.U25"
+            assert contract_id == "CON.F.US.MES.Z25"
+
+            # No API info found, fallback to asset logic
+            mock_client.api.contract_search.return_value = {"success": True, "contracts": []}
+            contract_id = mock_client.find_contract_by_symbol("MES")
+            assert contract_id == "CON.F.US.MES.U25"  # From mocked Asset
 
     def test_contract_id_conversion_no_hardcoded_mappings(self, mock_client):
         """


### PR DESCRIPTION
This pull request refactors and improves the logic for resolving contract IDs from asset symbols in the ProjectX integration, removing hardcoded mappings and enhancing caching and API search strategies. The changes prioritize dynamic resolution using the ProjectX API, with fallbacks to asset-based logic, and ensure that results are cached for efficiency. Unit tests are updated to reflect and validate the new contract resolution workflow.

Problem Statement: 
* ProjectX only returns data for a single Future contract per ticker.  (i.e. ESZ5)
   * all other contracts (i.e. ESH6) fail to return any data at all, even though they are technically valid.
* Near the end of the quarter (i.e. today!), Lumibot is internally miscalculating which ticker to use and is picking one that ProjectX doesn't support yet.

**Contract ID Resolution and Caching Improvements:**

* Reworked `_get_contract_id_from_asset` in both `projectx.py` and `projectx_data.py` to prioritize API-based contract resolution, cache results, and only fall back to asset-based logic if the API search fails. Hardcoded contract mappings are fully removed. (`lumibot/brokers/projectx.py`, `lumibot/data_sources/projectx_data.py`, `lumibot/tools/projectx_helpers.py`) [[1]](diffhunk://#diff-1acb2a3f15fc19c2e0d0572af1c42b95a3533431647da783e7c0cd6bb81bf5d8L834-R852) [[2]](diffhunk://#diff-1acb2a3f15fc19c2e0d0572af1c42b95a3533431647da783e7c0cd6bb81bf5d8L865-R888) [[3]](diffhunk://#diff-d49b9aebd1cfc56bb0371c5a03733aecdb29c8dfea705aa80d6c95c45db67874L374-R380) [[4]](diffhunk://#diff-d49b9aebd1cfc56bb0371c5a03733aecdb29c8dfea705aa80d6c95c45db67874L409-L412) [[5]](diffhunk://#diff-83c205b14e912f1ce79d5b728b7cee6a405541ae407797eac37e0e836a62853cR964-R988) [[6]](diffhunk://#diff-83c205b14e912f1ce79d5b728b7cee6a405541ae407797eac37e0e836a62853cL999-R1024)
* Added and improved contract and asset caches (`_contract_cache`, `_asset_cache`) to avoid repeated lookups and ensure consistent contract ID resolution across methods. (`lumibot/brokers/projectx.py`) [[1]](diffhunk://#diff-1acb2a3f15fc19c2e0d0572af1c42b95a3533431647da783e7c0cd6bb81bf5d8R154-R156) [[2]](diffhunk://#diff-1acb2a3f15fc19c2e0d0572af1c42b95a3533431647da783e7c0cd6bb81bf5d8L1078-L1084)

**Broker and Data Source Integration:**

* Updated broker methods to use the data source’s contract resolution method, ensuring a single, consistent path for contract lookups. (`lumibot/brokers/projectx.py`) [[1]](diffhunk://#diff-1acb2a3f15fc19c2e0d0572af1c42b95a3533431647da783e7c0cd6bb81bf5d8L306-R310) [[2]](diffhunk://#diff-1acb2a3f15fc19c2e0d0572af1c42b95a3533431647da783e7c0cd6bb81bf5d8L347-R351)

**Testing and Validation:**

* Updated and added tests to ensure that contract ID resolution no longer uses hardcoded mappings, validates caching, and checks correct fallback behavior between API and asset logic. Removed obsolete tests that depended on hardcoded mappings. (`tests/test_projectx.py`, `tests/test_projectx_data.py`, `tests/test_projectx_helpers.py`) [[1]](diffhunk://#diff-70b82f2403dfbffb687b900d03679ca436e75f236d09e62298ef216c53dabfe5R197-R218) [[2]](diffhunk://#diff-81016f9cf883b9480c222049d316126d3a1c5f2c0248fbd14450a59cb15b2235L45-L77) [[3]](diffhunk://#diff-81016f9cf883b9480c222049d316126d3a1c5f2c0248fbd14450a59cb15b2235R165-R192) [[4]](diffhunk://#diff-81016f9cf883b9480c222049d316126d3a1c5f2c0248fbd14450a59cb15b2235L347-L363) [[5]](diffhunk://#diff-9fd6da6a63014ecd6771069cc0ca9be318ce3f5005bc4cb688fd7e936edc1d73L290-R305)

These changes make contract ID resolution more robust, future-proof, and maintainable by relying on dynamic data and proper caching, while ensuring correctness through comprehensive testing.