### PR TITLE
ThetaData: fix SPXW backtest stalls + speed improvements (4.4.16)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.15",
+    version="4.4.16",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",


### PR DESCRIPTION
Fixes prod backtest hangs and speeds up ThetaData backtesting (no strategy edits).

Key changes:
- Fix SPXW index OHLC stalls by aliasing index-history roots (SPXW→SPX, RUTW→RUT, VIXW→VIX, NDXP→NDX)
- Add bounded waits + clearer errors for downloader queue requests (avoid infinite hangs)
- Speed up option chain building (batched strike-list queue requests) + better cached-chain reuse for index underlyings
- Avoid quote→last_price double-fetch for options when NBBO is actionable; fetch OHLC+QUOTE concurrently when both are needed

Validation (local):
- Full-year SPX Short Straddle (2024-12-31→2025-12-20) completes without stalling and produces artifacts
- Acceptance backtests ran (AAPL Deep Dip Calls, Leaps Buy Hold, TQQQ SMA200 Theta/Yahoo parity, Backdoor Butterfly 0DTE, MELI drawdown calls)
- Targeted pytest suite: 51 passed, 2 skipped

Version bump: 4.4.16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adaptive backtesting lookback for short-option intraday runs and improved option quote resolution that prefers bid/ask NBBO with safe fallbacks.
  * Faster and more resilient option chain/history retrieval with index-symbol normalization and batched strike queries.

* **Performance**
  * Concurrent OHLC and quote fetching and smarter cache reuse to reduce first-fetch latency.

* **Misc**
  * Package version bumped to 4.4.16.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->