### PR TITLE
ThetaData: speed up option quote path (4.4.17)

### DIFF
--- a/docs/BACKTESTING_ARCHITECTURE.md
+++ b/docs/BACKTESTING_ARCHITECTURE.md
@@ -479,19 +479,12 @@ To add download status tracking to other data sources (Yahoo, Polygon, etc.):
    from lumibot.tools.thetadata_helper import (
        get_download_status, set_download_status, clear_download_status
    )
+   ```
 
 ## Backtest Performance Notes (Prod)
 
 Minute-cadence option strategies can execute **~100k+ iterations** per backtest window. In production
 (`Bot Manager` + CloudWatch/stdout logging), log volume is often the dominant performance bottleneck.
-
-### Backtest log throttling
-
-To keep backtests fast without fully disabling logs, LumiBot supports a simple INFO-log rate limit:
-
-- `BACKTESTING_LOG_MAX_PER_SECOND` (int, default `0` = disabled)
-- When `IS_BACKTESTING=True` and `LOG_BACKTEST_PROGRESS_TO_FILE=True`, a conservative default throttle may be enabled
-  even if `BACKTESTING_QUIET_LOGS=false` (so progress/UI logs stay visible without flooding CloudWatch).
 
 ### Per-iteration heartbeat logs
 
@@ -500,7 +493,6 @@ opt-in:
 
 - `BACKTESTING_LOG_ITERATION_HEARTBEAT=true` enables per-iteration start/end logs
 - Default during backtesting: disabled
-   ```
 
 2. Call `set_download_status()` during fetch operations with current progress
 

--- a/docs/BACKTESTING_ARCHITECTURE.md
+++ b/docs/BACKTESTING_ARCHITECTURE.md
@@ -479,6 +479,27 @@ To add download status tracking to other data sources (Yahoo, Polygon, etc.):
    from lumibot.tools.thetadata_helper import (
        get_download_status, set_download_status, clear_download_status
    )
+
+## Backtest Performance Notes (Prod)
+
+Minute-cadence option strategies can execute **~100k+ iterations** per backtest window. In production
+(`Bot Manager` + CloudWatch/stdout logging), log volume is often the dominant performance bottleneck.
+
+### Backtest log throttling
+
+To keep backtests fast without fully disabling logs, LumiBot supports a simple INFO-log rate limit:
+
+- `BACKTESTING_LOG_MAX_PER_SECOND` (int, default `0` = disabled)
+- When `IS_BACKTESTING=True` and `LOG_BACKTEST_PROGRESS_TO_FILE=True`, a conservative default throttle may be enabled
+  even if `BACKTESTING_QUIET_LOGS=false` (so progress/UI logs stay visible without flooding CloudWatch).
+
+### Per-iteration heartbeat logs
+
+The StrategyExecutor “heartbeat” logs (start/end of each iteration) are extremely noisy for backtests and are now
+opt-in:
+
+- `BACKTESTING_LOG_ITERATION_HEARTBEAT=true` enables per-iteration start/end logs
+- Default during backtesting: disabled
    ```
 
 2. Call `set_download_status()` during fetch operations with current progress

--- a/docs/BACKTESTING_TESTS.md
+++ b/docs/BACKTESTING_TESTS.md
@@ -1,0 +1,40 @@
+# Backtesting Tests (Unit + Integration + Acceptance)
+
+This project relies on a layered test strategy:
+
+1. **Unit tests** (fast, deterministic): validate core entities and backtest engine rules.
+2. **Backtest integration tests** (slower, high value): run real strategies against backtesting data sources.
+3. **Acceptance backtests** (manual, end-to-end): run from `Strategy Library/` and inspect artifacts
+   (`*_trades.html`, `*_tearsheet.html`, `*_stats.csv`) for realism and regressions.
+
+## Test authority (“Legacy tests win”)
+
+When tests fail, **how you fix them depends on how old the test is**:
+
+- **> 1 year old:** treat as **LEGACY / high-authority**. Fix the **code**, not the test.
+- **6–12 months:** investigate carefully; usually fix the code.
+- **< 6 months:** the test may still be evolving; confirm intent before changing.
+
+This prevents “performance fixes” from silently changing broker-like semantics.
+
+## Acceptance backtests (ThetaData)
+
+The acceptance suite lives in:
+
+- `Strategy Library/Demos/*` (do not edit demo strategy files)
+- `Strategy Library/logs/*` (artifacts)
+
+See the session handoff for the current required windows and what to validate:
+
+- `docs/handoffs/THETADATA_SESSION_HANDOFF_2025-12-26.md`
+
+## Performance regressions
+
+Performance changes are only accepted when:
+
+- Unit tests stay green
+- Backtest integration tests stay green
+- Acceptance backtests remain **broker-like** (no lookahead bias, stable option MTM, realistic fills)
+
+If you’re unsure whether a behaviour change is “more accurate” vs “just faster”, prefer accuracy and add a regression
+test to lock in the correct semantics.

--- a/docs/investigations/THETADATA_INVESTIGATION_2025-12-27_SPX_STRADDLE_PERF.md
+++ b/docs/investigations/THETADATA_INVESTIGATION_2025-12-27_SPX_STRADDLE_PERF.md
@@ -1,0 +1,40 @@
+# ThetaData Backtesting Perf — SPX Short Straddle (2025-12-27)
+
+## Goal
+
+Make the 1-year SPX Short Straddle Intraday backtest run reliably in production (no “stalls”) and materially faster on a warm cache, without changing demo strategy code.
+
+## Repro
+
+Strategy Library command (warm cache focus):
+
+```bash
+cd "/Users/robertgrzesik/Documents/Development/Strategy Library"
+env PYTHONPATH="/Users/robertgrzesik/Documents/Development/lumivest_bot_server/strategies/lumibot" \
+  IS_BACKTESTING=True BACKTESTING_DATA_SOURCE=thetadata \
+  DATADOWNLOADER_BASE_URL=http://data-downloader.lumiwealth.com:8080 \
+  BACKTESTING_START=2024-12-31 BACKTESTING_END=2025-12-20 \
+  python3 "Demos/SPX Short Straddle Intraday (Copy).py"
+```
+
+## Findings
+
+- ThetaData option **quote history does not include last-trade price** (it includes NBBO + metadata). Any trade-only value must come from OHLC/history endpoints.
+- A “quote-only first, OHLC later” pattern caused a heavy `pd.concat` code path in `ThetaDataBacktestingPandas._update_pandas_data()` to repeatedly concatenate frames with mismatched columns, triggering a Pandas `FutureWarning` and measurable slowdown.
+
+## Changes applied (high level)
+
+- Prefer quote marks (bid/ask) inside `OptionsHelper` for strike/delta computations and spread checks, only falling back to last-trade when quote-derived marks are unavailable.
+- Allow `Data.get_quote()` to return quote fields even when OHLCV columns are absent (returns `None` for missing OHLCV keys rather than `{}`).
+- For ThetaData backtests, fetch option OHLC+quote together in `ThetaDataBacktestingPandas.get_quote()` to avoid the “quote-only then OHLC” merge path that caused the concat warning storm.
+
+## Local timing snapshot (warm cache)
+
+- Baseline year run: ~462s wall time
+- After fixes above: ~445s wall time
+
+## Follow-ups / next leverage
+
+- If we want to avoid option OHLC downloads entirely (when a strategy truly doesn’t need trade prints), we should store **quote-only vs OHLC** datasets separately (no column-mismatch merges), or implement a safe prefetch/update strategy that doesn’t trigger concat dtype warnings.
+- Production wall-time gap vs local likely reflects instance CPU + cache hit rate + downloader latency; adding detailed per-backtest timing breakdowns (download vs sim) to the status payload will make this measurable.
+

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -1522,6 +1522,23 @@ class BacktestingBroker(Broker):
 
             # Get the OHLCV data for the asset if we're using the PANDAS data source
             elif self.data_source.SOURCE == "PANDAS":
+                # ThetaData option market orders: prefer NBBO quote fills to avoid forcing
+                # minute OHLC downloads (trades can be sparse and fetching OHLC is expensive).
+                if (
+                    self._is_thetadata_source()
+                    and self._is_option_asset(getattr(order, "asset", None))
+                    and order.order_type == Order.OrderType.MARKET
+                ):
+                    quote_fill_price = self._try_fill_with_quote(order, strategy, None, None, None)
+                    if quote_fill_price is not None:
+                        self._execute_filled_order(
+                            order=order,
+                            price=quote_fill_price,
+                            filled_quantity=filled_quantity,
+                            strategy=strategy,
+                        )
+                        continue
+
                 # This is a hack to get around the fact that we need to get the previous day's data to prevent lookahead bias.
                 ohlc = self.data_source.get_historical_prices(
                     asset=asset,

--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -181,15 +181,17 @@ class ThetaDataBacktestingPandas(PandasData):
                 if ts_unit == "day":
                     start_date = dt_index.min().date()
                     end_date = dt_index.max().date()
-                    base_tz = getattr(dt_index, "tz", None)
                     start_dt = datetime.combine(start_date, datetime.min.time())
                     end_dt = datetime.combine(end_date, datetime.max.time())
-                    if base_tz is not None:
+                    base_tz = getattr(dt_index, "tz", None) or pytz.UTC
+                    # IMPORTANT: for pytz timezones, use `localize()` (not `replace(tzinfo=...)`)
+                    # to avoid "LMT" offsets like -04:56 which break coverage comparisons.
+                    if hasattr(base_tz, "localize"):
+                        start_dt = base_tz.localize(start_dt)
+                        end_dt = base_tz.localize(end_dt)
+                    else:
                         start_dt = start_dt.replace(tzinfo=base_tz)
                         end_dt = end_dt.replace(tzinfo=base_tz)
-                    else:
-                        start_dt = start_dt.replace(tzinfo=pytz.UTC)
-                        end_dt = end_dt.replace(tzinfo=pytz.UTC)
                     start = start_dt
                     end = end_dt
                 else:
@@ -232,6 +234,12 @@ class ThetaDataBacktestingPandas(PandasData):
             metadata["tail_placeholder"] = False
             if not metadata["empty_fetch"]:
                 metadata["empty_fetch"] = False
+
+        # Preserve runtime cache flags that should not be reset by metadata refreshes
+        # (e.g., day-mode metadata rebuilds during _update_pandas_data).
+        for flag_key in ("prefetch_complete", "ffilled", "sidecar_loaded"):
+            if flag_key in previous_meta:
+                metadata[flag_key] = previous_meta.get(flag_key)
 
         if getattr(asset, "asset_type", None) == Asset.AssetType.OPTION:
             metadata["expiration"] = asset.expiration
@@ -1073,6 +1081,12 @@ class ThetaDataBacktestingPandas(PandasData):
             )
 
             if cache_covers:
+                # Mark as forward-filled/complete for reuse semantics. Tests and downstream cache
+                # logic expect these flags to stay truthy once a dataset is considered usable.
+                if existing_meta is not None:
+                    if not existing_meta.get("ffilled"):
+                        existing_meta["ffilled"] = True
+                    existing_meta["prefetch_complete"] = True
                 if (
                     expiration_dt is not None
                     and end_requirement is not None

--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -751,20 +751,21 @@ class ThetaDataBacktestingPandas(PandasData):
             has_quotes = self._frame_has_quote_columns(existing_data.df)
             self._record_metadata(canonical_key, existing_data.df, existing_data.timestep, asset_separated, has_quotes=has_quotes)
             existing_meta = self._dataset_metadata.get(canonical_key)
-            try:
-                df_idx = pd.to_datetime(existing_data.df.index)
-                logger.debug(
-                    "[THETA][DEBUG][DAY_METADATA_REBUILD] asset=%s/%s df_min=%s df_max=%s rows=%s rebuilt_start=%s rebuilt_end=%s",
-                    asset_separated,
-                    quote_asset,
-                    df_idx.min(),
-                    df_idx.max(),
-                    len(df_idx),
-                    existing_meta.get("start") if existing_meta else None,
-                    existing_meta.get("end") if existing_meta else None,
-                )
-            except Exception:
-                logger.debug("[THETA][DEBUG][DAY_METADATA_REBUILD] failed to log dataframe bounds", exc_info=True)
+            if logger.isEnabledFor(logging.DEBUG):
+                try:
+                    df_idx = pd.to_datetime(existing_data.df.index)
+                    logger.debug(
+                        "[THETA][DEBUG][DAY_METADATA_REBUILD] asset=%s/%s df_min=%s df_max=%s rows=%s rebuilt_start=%s rebuilt_end=%s",
+                        asset_separated,
+                        quote_asset,
+                        df_idx.min(),
+                        df_idx.max(),
+                        len(df_idx),
+                        existing_meta.get("start") if existing_meta else None,
+                        existing_meta.get("end") if existing_meta else None,
+                    )
+                except Exception:
+                    logger.debug("[THETA][DEBUG][DAY_METADATA_REBUILD] failed to log dataframe bounds", exc_info=True)
 
         # Fast-path reuse: if we already have a dataframe that covers the needed window, skip all fetch/ffill work.
         # IMPORTANT: Only reuse if the cached data's timestep matches what we're requesting.
@@ -795,47 +796,76 @@ class ThetaDataBacktestingPandas(PandasData):
             if require_ohlc_data and not cached_has_ohlc:
                 reuse_ok = False
 
-            df_idx = existing_data.df.index
-            if len(df_idx):
-                idx = pd.to_datetime(df_idx)
-                if idx.tz is None:
-                    idx = idx.tz_localize(pytz.UTC)
-                else:
-                    idx = idx.tz_convert(pytz.UTC)
-                coverage_start = idx.min()
-                coverage_end = idx.max()
-                # Use date-level comparison for both day and minute data, but ensure both
-                # timestamps are in the same timezone before extracting date. Otherwise
-                # UTC midnight (Nov 3 00:00 UTC = Nov 2 19:00 EST) would incorrectly match
-                # a local date requirement of Nov 3.
-                if coverage_end is not None and end_requirement is not None:
-                    # Convert both to the same timezone (use end_requirement's timezone)
-                    target_tz = end_requirement.tzinfo
-                    if target_tz is not None and coverage_end.tzinfo is not None:
-                        coverage_end_local = coverage_end.astimezone(target_tz)
-                    else:
-                        coverage_end_local = coverage_end
-                    coverage_end_cmp = coverage_end_local.date()
-                    end_requirement_cmp = end_requirement.date()
-                else:
-                    coverage_end_cmp = coverage_end.date() if coverage_end is not None else None
-                    end_requirement_cmp = end_requirement.date() if end_requirement is not None else None
-                end_ok = coverage_end_cmp is not None and end_requirement_cmp is not None and coverage_end_cmp >= end_requirement_cmp
+            # PERF: avoid per-call pandas index conversions. Prefer cached metadata or Data's
+            # datetime_start/end (constant-time) rather than `pd.to_datetime(df.index)` each bar.
+            coverage_start = cached_meta.get("data_start") or cached_meta.get("start")
+            coverage_end = cached_meta.get("data_end") or cached_meta.get("end")
 
-                if reuse_ok and (
-                    coverage_start is not None
-                    and requested_start is not None
-                    and coverage_start <= requested_start + effective_start_buffer
-                    and end_ok
-                ):
-                    # CRITICAL FIX (2025-12-07): For options, verify the cached data is for
-                    # the EXACT same strike/expiration. Options are unique instruments and
-                    # data for one strike cannot be reused for another.
-                    if is_option:
-                        # Get the asset that was used to cache this data
-                        cached_asset = None
-                        if isinstance(dataset_key, tuple) and len(dataset_key) >= 1:
-                            cached_asset = dataset_key[0]
+            if coverage_start is None or coverage_end is None:
+                try:
+                    if coverage_start is None:
+                        coverage_start = self._normalize_default_timezone(getattr(existing_data, "datetime_start", None))
+                    if coverage_end is None:
+                        coverage_end = self._normalize_default_timezone(getattr(existing_data, "datetime_end", None))
+                except Exception:
+                    pass
+
+            if coverage_start is None or coverage_end is None:
+                df_idx = existing_data.df.index
+                if len(df_idx):
+                    idx = pd.to_datetime(df_idx)
+                    if len(idx):
+                        coverage_start = self._normalize_default_timezone(idx.min())
+                        coverage_end = self._normalize_default_timezone(idx.max())
+
+            if coverage_start is not None and coverage_end is not None:
+                # If this dataset lacked sidecar metadata (common for older caches), persist the
+                # computed bounds once so subsequent reuse checks are O(1).
+                if not cached_meta.get("data_start") or not cached_meta.get("data_end"):
+                    meta = dict(cached_meta)
+                    meta.setdefault("timestep", ts_unit)
+                    meta.setdefault("has_quotes", cached_has_quotes)
+                    meta.setdefault("has_ohlc", cached_has_ohlc)
+                    meta["data_start"] = meta.get("data_start") or coverage_start
+                    meta["data_end"] = meta.get("data_end") or coverage_end
+                    meta["data_rows"] = meta.get("data_rows") or len(existing_data.df)
+                    meta["start"] = meta.get("start") or coverage_start
+                    meta["end"] = meta.get("end") or coverage_end
+                    meta["rows"] = meta.get("rows") or len(existing_data.df)
+                    self._dataset_metadata[canonical_key] = meta
+                    cached_meta = meta
+
+            if coverage_end is not None and end_requirement is not None:
+                try:
+                    coverage_end_cmp = coverage_end.date()
+                    end_requirement_cmp = end_requirement.date()
+                except Exception:
+                    coverage_end_cmp = coverage_end
+                    end_requirement_cmp = end_requirement
+            else:
+                coverage_end_cmp = coverage_end.date() if coverage_end is not None else None
+                end_requirement_cmp = end_requirement.date() if end_requirement is not None else None
+
+            end_ok = (
+                coverage_end_cmp is not None
+                and end_requirement_cmp is not None
+                and coverage_end_cmp >= end_requirement_cmp
+            )
+
+            if reuse_ok and (
+                coverage_start is not None
+                and requested_start is not None
+                and coverage_start <= requested_start + effective_start_buffer
+                and end_ok
+            ):
+                # CRITICAL FIX (2025-12-07): For options, verify the cached data is for
+                # the EXACT same strike/expiration. Options are unique instruments and
+                # data for one strike cannot be reused for another.
+                if is_option:
+                    # Get the asset that was used to cache this data
+                    cached_asset = None
+                    if isinstance(dataset_key, tuple) and len(dataset_key) >= 1:
+                        cached_asset = dataset_key[0]
 
                         # Verify strike and expiration match exactly
                         if cached_asset is None or not isinstance(cached_asset, Asset):
@@ -1564,8 +1594,23 @@ class ThetaDataBacktestingPandas(PandasData):
             if merged_df is None or merged_df.empty:
                 merged_df = existing_data.df.copy()
             else:
-                merged_df = pd.concat([existing_data.df, merged_df]).sort_index()
-                merged_df = merged_df[~merged_df.index.duplicated(keep="last")]
+                # PERF/ROBUSTNESS: Avoid concat-with-all-NA warnings and preserve existing columns when
+                # the newly fetched frame is quote-only (no OHLC). The previous concat+dedupe behavior
+                # could drop existing OHLC values if the "new" row had NaNs for those columns.
+                existing_df = existing_data.df
+                new_df = merged_df
+                if existing_df.index.has_duplicates:
+                    existing_df = existing_df.loc[~existing_df.index.duplicated(keep="last")]
+                if new_df.index.has_duplicates:
+                    new_df = new_df.loc[~new_df.index.duplicated(keep="last")]
+
+                union_cols = existing_df.columns.union(new_df.columns)
+                existing_aligned = existing_df.reindex(columns=union_cols)
+                new_aligned = new_df.reindex(columns=union_cols)
+
+                # New data should override existing values, but only where it is non-null.
+                # (combine_first preserves existing values when the new frame has NaNs for a column.)
+                merged_df = new_aligned.combine_first(existing_aligned).sort_index()
 
         merged_df = _prep_frame(merged_df)
         (
@@ -2084,6 +2129,19 @@ class ThetaDataBacktestingPandas(PandasData):
                 asset,
             )
 
+        # PERF: cache last trade results within the same backtest datetime.
+        # Backtest internals and user strategies may ask for the same asset's last price multiple
+        # times per bar (e.g., option selection + fills + risk checks). In backtesting, the
+        # last-trade at a given dt is immutable.
+        last_price_cache_dt = getattr(self, "_last_price_cache_dt", None)
+        if last_price_cache_dt != dt:
+            self._last_price_cache_dt = dt
+            self._last_price_cache = {}
+        cache_key = (asset, quote, exchange, timestep)
+        cached = getattr(self, "_last_price_cache", {}).get(cache_key, None)
+        if cache_key in getattr(self, "_last_price_cache", {}):
+            return cached
+
         # Trade-only: do not require quote columns. Quotes are used explicitly via get_quote()/snapshots
         # for mark-to-market and fills, never via get_last_price().
         self._update_pandas_data(asset, quote, sample_length, timestep, dt, require_quote_data=False)
@@ -2212,6 +2270,11 @@ class ThetaDataBacktestingPandas(PandasData):
             frame_last_dt,
             float(frame_last_close) if frame_last_close is not None else None,
         )
+
+        try:
+            self._last_price_cache[cache_key] = value
+        except Exception:
+            pass
 
         return value
 
@@ -2482,24 +2545,26 @@ class ThetaDataBacktestingPandas(PandasData):
         if cached is not None:
             return cached
 
-        # Log quote request details for debugging (options vs other assets)
-        if hasattr(asset, 'asset_type') and asset.asset_type == Asset.AssetType.OPTION:
-            logger.debug(
-                "[THETA][QUOTE] Option request: symbol=%s expiration=%s strike=%s right=%s dt=%s timestep=%s",
-                asset.symbol,
-                asset.expiration,
-                asset.strike,
-                asset.right,
-                dt.isoformat() if hasattr(dt, 'isoformat') else dt,
-                timestep
-            )
-        else:
-            logger.debug(
-                "[THETA][QUOTE] Asset request: symbol=%s dt=%s timestep=%s",
-                getattr(asset, "symbol", asset) if not isinstance(asset, str) else asset,
-                dt.isoformat() if hasattr(dt, 'isoformat') else dt,
-                timestep
-            )
+        # Log quote request details for debugging (options vs other assets).
+        # Guard to avoid allocating strings/dicts when debug logging is disabled.
+        if logger.isEnabledFor(logging.DEBUG):
+            if hasattr(asset, "asset_type") and asset.asset_type == Asset.AssetType.OPTION:
+                logger.debug(
+                    "[THETA][QUOTE] Option request: symbol=%s expiration=%s strike=%s right=%s dt=%s timestep=%s",
+                    asset.symbol,
+                    asset.expiration,
+                    asset.strike,
+                    asset.right,
+                    dt.isoformat() if hasattr(dt, "isoformat") else dt,
+                    timestep,
+                )
+            else:
+                logger.debug(
+                    "[THETA][QUOTE] Asset request: symbol=%s dt=%s timestep=%s",
+                    getattr(asset, "symbol", asset) if not isinstance(asset, str) else asset,
+                    dt.isoformat() if hasattr(dt, "isoformat") else dt,
+                    timestep,
+                )
 
         # PERFORMANCE: `get_quote()` is called extremely frequently for option-heavy strategies
         # (e.g., intraday straddle MTM checks). `_update_pandas_data()` is correct but expensive,
@@ -2532,6 +2597,17 @@ class ThetaDataBacktestingPandas(PandasData):
             should_refresh = True
 
         if should_refresh:
+            require_ohlc_data = True
+            try:
+                _, ts_unit = self.convert_timestep_str_to_timedelta(timestep)
+                if (
+                    getattr(asset, "asset_type", None) == Asset.AssetType.OPTION
+                    and ts_unit in {"minute", "hour", "second"}
+                ):
+                    require_ohlc_data = False
+            except Exception:
+                require_ohlc_data = True
+
             self._update_pandas_data(
                 asset,
                 quote,
@@ -2539,7 +2615,7 @@ class ThetaDataBacktestingPandas(PandasData):
                 timestep,
                 dt,
                 require_quote_data=True,
-                require_ohlc_data=True,
+                require_ohlc_data=require_ohlc_data,
             )
 
         quote_obj = None
@@ -2635,17 +2711,18 @@ class ThetaDataBacktestingPandas(PandasData):
                         quote_obj.price = float(last_trade)
 
         # [INSTRUMENTATION] Final quote result with all details
-        logger.debug(
-            "[THETA][DEBUG][QUOTE][THETA][DEBUG][PANDAS][RESULT] asset=%s quote=%s current_dt=%s bid=%s ask=%s mid=%s last=%s source=%s",
-            getattr(asset, "symbol", asset) if not isinstance(asset, str) else asset,
-            getattr(quote, "symbol", quote),
-            dt,
-            getattr(quote_obj, "bid", None) if quote_obj else None,
-            getattr(quote_obj, "ask", None) if quote_obj else None,
-            getattr(quote_obj, "mid_price", None) if quote_obj else None,
-            getattr(quote_obj, "last_price", None) if quote_obj else None,
-            getattr(quote_obj, "source", None) if quote_obj else None,
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "[THETA][DEBUG][QUOTE][THETA][DEBUG][PANDAS][RESULT] asset=%s quote=%s current_dt=%s bid=%s ask=%s mid=%s last=%s source=%s",
+                getattr(asset, "symbol", asset) if not isinstance(asset, str) else asset,
+                getattr(quote, "symbol", quote),
+                dt,
+                getattr(quote_obj, "bid", None) if quote_obj else None,
+                getattr(quote_obj, "ask", None) if quote_obj else None,
+                getattr(quote_obj, "mid_price", None) if quote_obj else None,
+                getattr(quote_obj, "last_price", None) if quote_obj else None,
+                getattr(quote_obj, "source", None) if quote_obj else None,
+            )
 
         if quote_obj is not None:
             try:

--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -219,6 +219,7 @@ class ThetaDataBacktestingPandas(PandasData):
         }
         metadata["empty_fetch"] = frame is None or frame.empty
         metadata["has_quotes"] = bool(has_quotes)
+        metadata["has_ohlc"] = self._frame_has_ohlc_columns(frame)
 
         if frame is not None and not frame.empty and "missing" in frame.columns:
             placeholder_flags = frame["missing"].fillna(False).astype(bool)
@@ -243,7 +244,7 @@ class ThetaDataBacktestingPandas(PandasData):
         self._dataset_metadata[key] = metadata
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
-                "[THETA][DEBUG][METADATA][WRITE] key=%s ts=%s start=%s end=%s data_start=%s data_end=%s rows=%s placeholders=%s has_quotes=%s",
+                "[THETA][DEBUG][METADATA][WRITE] key=%s ts=%s start=%s end=%s data_start=%s data_end=%s rows=%s placeholders=%s has_quotes=%s has_ohlc=%s",
                 key,
                 ts_unit,
                 metadata.get("start"),
@@ -253,6 +254,7 @@ class ThetaDataBacktestingPandas(PandasData):
                 metadata.get("rows"),
                 metadata.get("placeholders"),
                 metadata.get("has_quotes"),
+                metadata.get("has_ohlc"),
             )
 
     def _frame_has_quote_columns(self, frame: Optional[pd.DataFrame]) -> bool:
@@ -260,6 +262,33 @@ class ThetaDataBacktestingPandas(PandasData):
             return False
         quote_markers = {"bid", "ask", "bid_size", "ask_size", "last_trade_time", "last_bid_time", "last_ask_time"}
         return any(col in frame.columns for col in quote_markers)
+
+    def _frame_has_ohlc_columns(self, frame: Optional[pd.DataFrame]) -> bool:
+        if frame is None or frame.empty:
+            return False
+        required = {"open", "high", "low", "close"}
+        if not required.issubset(set(frame.columns)):
+            return False
+
+        # Some internal repair paths can create OHLC columns filled with nulls; treat that as "no OHLC".
+        try:
+            for col in required:
+                series = frame.get(col)
+                if series is None:
+                    continue
+                if pd.to_numeric(series, errors="coerce").notna().any():
+                    return True
+        except Exception:
+            for col in required:
+                series = frame.get(col)
+                if series is None:
+                    continue
+                try:
+                    if series.notna().any():
+                        return True
+                except Exception:
+                    continue
+        return False
 
     def _finalize_day_frame(
         self,
@@ -524,7 +553,16 @@ class ThetaDataBacktestingPandas(PandasData):
         )
         return meta
 
-    def _update_pandas_data(self, asset, quote, length, timestep, start_dt=None, require_quote_data: bool = False):
+    def _update_pandas_data(
+        self,
+        asset,
+        quote,
+        length,
+        timestep,
+        start_dt=None,
+        require_quote_data: bool = False,
+        require_ohlc_data: bool = True,
+    ):
         """
         Get asset data and update the self.pandas_data dictionary.
 
@@ -740,6 +778,23 @@ class ThetaDataBacktestingPandas(PandasData):
         is_option = getattr(asset_separated, 'asset_type', None) == 'option'
 
         if existing_data is not None and existing_data.timestep == ts_unit:
+            # Fast-reuse must respect the *type* of data requested: quote-only caches should not
+            # satisfy OHLC-only requests (trade-only APIs like get_last_price / get_historical_prices).
+            cached_meta = self._dataset_metadata.get(canonical_key) or {}
+            cached_has_quotes = bool(cached_meta.get("has_quotes")) or self._frame_has_quote_columns(existing_data.df)
+            meta_has_ohlc = cached_meta.get("has_ohlc")
+            if meta_has_ohlc is None:
+                cached_has_ohlc = self._frame_has_ohlc_columns(existing_data.df)
+            elif bool(meta_has_ohlc):
+                cached_has_ohlc = self._frame_has_ohlc_columns(existing_data.df)
+            else:
+                cached_has_ohlc = False
+            reuse_ok = True
+            if require_quote_data and not cached_has_quotes:
+                reuse_ok = False
+            if require_ohlc_data and not cached_has_ohlc:
+                reuse_ok = False
+
             df_idx = existing_data.df.index
             if len(df_idx):
                 idx = pd.to_datetime(df_idx)
@@ -767,7 +822,7 @@ class ThetaDataBacktestingPandas(PandasData):
                     end_requirement_cmp = end_requirement.date() if end_requirement is not None else None
                 end_ok = coverage_end_cmp is not None and end_requirement_cmp is not None and coverage_end_cmp >= end_requirement_cmp
 
-                if (
+                if reuse_ok and (
                     coverage_start is not None
                     and requested_start is not None
                     and coverage_start <= requested_start + effective_start_buffer
@@ -846,6 +901,7 @@ class ThetaDataBacktestingPandas(PandasData):
         existing_start = None
         existing_end = None
         existing_has_quotes = bool(existing_meta.get("has_quotes")) if existing_meta else False
+        existing_has_ohlc = bool(existing_meta.get("has_ohlc", True)) if existing_meta else True
 
         if existing_data is not None and existing_meta and existing_meta.get("timestep") == ts_unit:
             existing_start = existing_meta.get("start")
@@ -968,6 +1024,8 @@ class ThetaDataBacktestingPandas(PandasData):
                 start_ok
                 and existing_rows >= requested_length
                 and end_ok
+                and (not require_quote_data or existing_has_quotes)
+                and (not require_ohlc_data or existing_has_ohlc)
             )
 
             # DEBUG-LOG: Final cache decision
@@ -1099,7 +1157,12 @@ class ThetaDataBacktestingPandas(PandasData):
                     and (coverage_start - start_for_fetch) < effective_start_buffer
                 )
                 if start_buffer_ok and not end_missing:
-                    return None
+                    if require_quote_data and not existing_has_quotes:
+                        pass
+                    elif require_ohlc_data and not existing_has_ohlc:
+                        pass
+                    else:
+                        return None
 
             # When daily bars are requested we should never "downgrade" to minute/hour requests.
             # Doing so forces the helper to download massive minute ranges and resample, which is
@@ -1131,8 +1194,9 @@ class ThetaDataBacktestingPandas(PandasData):
             end_requirement,
         )
         df_quote = None
-        quotes_enabled = require_quote_data or existing_has_quotes
-        wants_quotes = bool(getattr(self, "_use_quote_data", False)) and ts_unit in {"minute", "hour", "second"} and quotes_enabled
+        wants_ohlc = bool(require_ohlc_data)
+        use_quotes_flag = bool(getattr(self, "_use_quote_data", False)) or bool(require_quote_data)
+        wants_quotes = bool(use_quotes_flag) and ts_unit in {"minute", "hour", "second"} and bool(require_quote_data)
 
         def _fetch_ohlc():
             return thetadata_helper.get_price_data(
@@ -1168,47 +1232,76 @@ class ThetaDataBacktestingPandas(PandasData):
                 preserve_full_history=True,
             )
 
-        if wants_quotes:
-            # Performance: OHLC + QUOTE requests are independent network calls. Fetch them concurrently
-            # for first-touch cache misses (common for 0DTE option strategies), then merge.
-            from concurrent.futures import ThreadPoolExecutor
+        df_ohlc = None
+        if wants_ohlc:
+            if wants_quotes:
+                # Performance: OHLC + QUOTE requests are independent network calls. Fetch them concurrently
+                # for first-touch cache misses (common for 0DTE option strategies), then merge.
+                from concurrent.futures import ThreadPoolExecutor
 
-            with ThreadPoolExecutor(max_workers=2) as executor:
-                future_ohlc = executor.submit(_fetch_ohlc)
-                future_quote = executor.submit(_fetch_quote)
-                df_ohlc = future_ohlc.result()
-                df_quote = future_quote.result()
+                with ThreadPoolExecutor(max_workers=2) as executor:
+                    future_ohlc = executor.submit(_fetch_ohlc)
+                    future_quote = executor.submit(_fetch_quote)
+                    df_ohlc = future_ohlc.result()
+                    df_quote = future_quote.result()
+            else:
+                df_ohlc = _fetch_ohlc()
+
+            if df_ohlc is None or df_ohlc.empty:
+                expired_reason = (
+                    expiration_dt is not None
+                    and end_requirement is not None
+                    and expiration_dt == end_requirement
+                )
+                if expired_reason:
+                    logger.debug(
+                        "[THETA][DEBUG][THETADATA-PANDAS] No new OHLC rows for %s/%s (%s); option expired on %s. Keeping cached data.",
+                        asset_separated,
+                        quote_asset,
+                        ts_unit,
+                        asset_separated.expiration,
+                    )
+                    if existing_meta is not None:
+                        existing_meta["expiration_notice"] = True
+                    return None
+                raise ValueError(
+                    f"No OHLC data returned for {asset_separated} / {quote_asset} ({ts_unit}) "
+                    f"start={start_datetime} end={end_requirement}; refusing to proceed with empty dataset."
+                )
+
+            df = df_ohlc
         else:
-            df_ohlc = _fetch_ohlc()
-
-        if df_ohlc is None or df_ohlc.empty:
-            expired_reason = (
-                expiration_dt is not None
-                and end_requirement is not None
-                and expiration_dt == end_requirement
-            )
-            if expired_reason:
-                logger.debug(
-                    "[THETA][DEBUG][THETADATA-PANDAS] No new OHLC rows for %s/%s (%s); option expired on %s. Keeping cached data.",
+            # Quote-only fetch (used for option MTM / quote checks). Missing quotes are not fatal:
+            # the caller can fall back to OHLC (last trade) or forward-fill MTM as needed.
+            if wants_quotes:
+                try:
+                    df_quote = _fetch_quote()
+                except Exception:
+                    logger.exception(
+                        "ThetaData quote download failed for %s / %s (%s)",
+                        asset_separated,
+                        quote_asset,
+                        ts_unit,
+                    )
+                    return None
+            if df_quote is None or getattr(df_quote, "empty", True):
+                logger.warning(
+                    "No QUOTE data returned for %s / %s (%s); continuing without updating cache.",
                     asset_separated,
                     quote_asset,
                     ts_unit,
-                    asset_separated.expiration,
                 )
-                if existing_meta is not None:
-                    existing_meta["expiration_notice"] = True
                 return None
-            raise ValueError(
-                f"No OHLC data returned for {asset_separated} / {quote_asset} ({ts_unit}) "
-                f"start={start_datetime} end={end_requirement}; refusing to proceed with empty dataset."
-            )
+            df = df_quote
 
-        df = df_ohlc
-        quotes_attached = False
+        quotes_attached = bool((not wants_ohlc) and wants_quotes)
+        quotes_ffilled = False
+        quotes_ffill_rows = None
+        quotes_ffill_remaining = None
 
         # Quote data (bid/ask) is only available for intraday data (minute, hour, second)
         # For daily+ data, only use OHLC
-        if wants_quotes:
+        if wants_ohlc and wants_quotes:
             if df_quote is None:
                 # Sequential fallback: should be rare, but keeps behavior robust if executor path didn't run.
                 try:
@@ -2143,8 +2236,27 @@ class ThetaDataBacktestingPandas(PandasData):
                 "[THETA][DEBUG][TIMESTEP_ALIGN] get_price_snapshot aligned from minute to day for asset=%s",
                 asset,
             )
+
+        # PERF: cache snapshots within the same backtest datetime.
+        # Portfolio valuation (and other internals) may request snapshots repeatedly within a bar.
+        snapshot_cache_dt = getattr(self, "_price_snapshot_cache_dt", None)
+        if snapshot_cache_dt != dt:
+            self._price_snapshot_cache_dt = dt
+            self._price_snapshot_cache = {}
+        snapshot_cache_key = (asset, quote, timestep)
+        snapshot_cache = getattr(self, "_price_snapshot_cache", {})
+        if snapshot_cache_key in snapshot_cache:
+            return snapshot_cache.get(snapshot_cache_key)
+
         asset_for_check = asset[0] if isinstance(asset, tuple) else asset
         require_quote_data = getattr(asset_for_check, "asset_type", None) == "option"
+        require_ohlc_data = True
+        try:
+            _, ts_unit = self.convert_timestep_str_to_timedelta(timestep)
+            if require_quote_data and ts_unit in {"minute", "hour", "second"}:
+                require_ohlc_data = False
+        except Exception:
+            require_ohlc_data = True
         self._update_pandas_data(
             asset,
             quote,
@@ -2152,6 +2264,7 @@ class ThetaDataBacktestingPandas(PandasData):
             timestep,
             dt,
             require_quote_data=require_quote_data,
+            require_ohlc_data=require_ohlc_data,
         )
         _, ts_unit = self.get_start_datetime_and_ts_unit(
             sample_length, timestep, dt, start_buffer=START_BUFFER
@@ -2182,6 +2295,10 @@ class ThetaDataBacktestingPandas(PandasData):
                 quote or Asset("USD", "forex"),
                 snapshot,
             )
+            try:
+                self._price_snapshot_cache[snapshot_cache_key] = snapshot
+            except Exception:
+                pass
             return snapshot
         except ValueError as e:
             # Handle case where requested date is after available data (e.g., end of backtest)
@@ -2192,6 +2309,10 @@ class ThetaDataBacktestingPandas(PandasData):
                     asset,
                     quote or Asset("USD", "forex"),
                 )
+                try:
+                    self._price_snapshot_cache[snapshot_cache_key] = None
+                except Exception:
+                    pass
                 return None
             raise
 
@@ -2411,7 +2532,27 @@ class ThetaDataBacktestingPandas(PandasData):
             should_refresh = True
 
         if should_refresh:
-            self._update_pandas_data(asset, quote, 1, timestep, dt, require_quote_data=True)
+            require_ohlc = True
+            try:
+                _, ts_unit = self.convert_timestep_str_to_timedelta(timestep)
+                base_asset = asset[0] if isinstance(asset, tuple) else asset
+                if (
+                    getattr(base_asset, "asset_type", None) == Asset.AssetType.OPTION
+                    and ts_unit in {"minute", "hour", "second"}
+                ):
+                    require_ohlc = False
+            except Exception:
+                require_ohlc = True
+
+            self._update_pandas_data(
+                asset,
+                quote,
+                1,
+                timestep,
+                dt,
+                require_quote_data=True,
+                require_ohlc_data=require_ohlc,
+            )
 
         quote_obj = None
         # Fast-path: build a Quote directly from the cached Data object without calling

--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -2532,18 +2532,6 @@ class ThetaDataBacktestingPandas(PandasData):
             should_refresh = True
 
         if should_refresh:
-            require_ohlc = True
-            try:
-                _, ts_unit = self.convert_timestep_str_to_timedelta(timestep)
-                base_asset = asset[0] if isinstance(asset, tuple) else asset
-                if (
-                    getattr(base_asset, "asset_type", None) == Asset.AssetType.OPTION
-                    and ts_unit in {"minute", "hour", "second"}
-                ):
-                    require_ohlc = False
-            except Exception:
-                require_ohlc = True
-
             self._update_pandas_data(
                 asset,
                 quote,
@@ -2551,7 +2539,7 @@ class ThetaDataBacktestingPandas(PandasData):
                 timestep,
                 dt,
                 require_quote_data=True,
-                require_ohlc_data=require_ohlc,
+                require_ohlc_data=True,
             )
 
         quote_obj = None
@@ -2637,6 +2625,10 @@ class ThetaDataBacktestingPandas(PandasData):
 
                 if bid is not None and ask is not None and bid > 0 and ask > 0:
                     quote_obj.price = (bid + ask) / 2.0
+                elif bid is not None and bid > 0:
+                    quote_obj.price = bid
+                elif ask is not None and ask > 0:
+                    quote_obj.price = ask
                 else:
                     last_trade = self.get_last_price(asset, timestep=timestep, quote=quote, exchange=exchange)
                     if last_trade is not None:

--- a/lumibot/components/options_helper.py
+++ b/lumibot/components/options_helper.py
@@ -112,6 +112,39 @@ class OptionsHelper:
 
         return math.isfinite(price) and price > 0 and not evaluation.spread_too_wide
 
+    @staticmethod
+    def _float_positive(value: Any) -> Optional[float]:
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(numeric) or numeric <= 0:
+            return None
+        return numeric
+
+    def _get_option_mark_from_quote(
+        self,
+        option_asset: Asset,
+    ) -> Tuple[Optional[float], Optional[float], Optional[float]]:
+        """Return (mark_price, bid, ask) derived from quotes; never calls get_last_price()."""
+        try:
+            quote = self.strategy.get_quote(option_asset)
+        except Exception:
+            return None, None, None
+
+        bid = self._float_positive(getattr(quote, "bid", None))
+        ask = self._float_positive(getattr(quote, "ask", None))
+
+        if bid is not None and ask is not None:
+            return (bid + ask) / 2.0, bid, ask
+        if bid is not None:
+            return bid, bid, None
+        if ask is not None:
+            return ask, None, ask
+
+        price = self._float_positive(getattr(quote, "price", None))
+        return price, bid, ask
+
     # ============================================================
     # Basic Utility Functions
     # ============================================================
@@ -274,10 +307,12 @@ class OptionsHelper:
 
                     # Verify this option has price data
                     try:
-                        quote = self.strategy.get_quote(option)
-                        has_valid_quote = quote and (quote.bid is not None or quote.ask is not None)
-                        if has_valid_quote:
-                            self.strategy.log_message(f"Found valid option: {option.symbol} {option.right} {option.strike} exp {option.expiration}", color="green")
+                        mark_price, bid, ask = self._get_option_mark_from_quote(option)
+                        if mark_price is not None:
+                            self.strategy.log_message(
+                                f"Found valid option: {option.symbol} {option.right} {option.strike} exp {option.expiration} (bid={bid}, ask={ask})",
+                                color="green",
+                            )
                             return option
                     except Exception as e:
                         self.strategy.log_message(f"Error getting quote for {option.symbol}: {e}", color="yellow")
@@ -313,6 +348,12 @@ class OptionsHelper:
                     underlying_asset=underlying_asset,
                 )
 
+                try:
+                    mark_price, _, _ = self._get_option_mark_from_quote(option)
+                    if mark_price is not None:
+                        return option
+                except Exception:
+                    pass
                 try:
                     price = self.strategy.get_last_price(option)
                     if price is not None:
@@ -370,10 +411,20 @@ class OptionsHelper:
                 right=right,
                 underlying_asset=underlying_asset,
             )
-            if self.strategy.get_last_price(option) is None:
+            option_price, _, _ = self._get_option_mark_from_quote(option)
+            if option_price is None:
+                try:
+                    option_price = self._float_positive(self.strategy.get_last_price(option))
+                except Exception:
+                    option_price = None
+            if option_price is None:
                 self.strategy.log_message(f"No price for option at strike {strike}. Skipping.", color="yellow")
                 continue
-            greeks = self.strategy.get_greeks(option, underlying_price=underlying_price)
+
+            greeks = self.strategy.get_greeks(option, underlying_price=underlying_price, asset_price=option_price)
+            if greeks is None:
+                self.strategy.log_message(f"Could not calculate Greeks for {option.symbol} at strike {strike}", color="yellow")
+                continue
             delta = greeks.get("delta")
             strike_deltas[strike] = delta
             self.strategy.log_message(f"Strike {strike}: delta = {delta}", color="blue")
@@ -425,29 +476,18 @@ class OptionsHelper:
                 return None
             return numeric
 
-        option_price = _coerce_price(self.strategy.get_last_price(option))
-        used_quote_price = False
+        option_price, _, _ = self._get_option_mark_from_quote(option)
         if option_price is None:
-            quote = None
             try:
-                quote = self.strategy.get_quote(option)
+                option_price = _coerce_price(self.strategy.get_last_price(option))
             except Exception:
-                quote = None
-
-            bid = _coerce_price(getattr(quote, "bid", None)) if quote else None
-            ask = _coerce_price(getattr(quote, "ask", None)) if quote else None
-            if bid is not None and ask is not None:
-                option_price = (bid + ask) / 2
-                used_quote_price = True
+                option_price = None
 
         if option_price is None:
             self.strategy.log_message(f"No price for option {option.symbol} at strike {strike}", color="yellow")
             return None
 
-        greeks_kwargs = {"underlying_price": underlying_price}
-        if used_quote_price:
-            greeks_kwargs["asset_price"] = option_price
-        greeks = self.strategy.get_greeks(option, **greeks_kwargs)
+        greeks = self.strategy.get_greeks(option, underlying_price=underlying_price, asset_price=option_price)
         # Handle None from get_greeks - can happen when option price or underlying price unavailable
         if greeks is None:
             self.strategy.log_message(
@@ -698,9 +738,11 @@ class OptionsHelper:
                 color="red",
             )
 
-        if quote and quote.bid is not None and quote.ask is not None:
-            bid = self._coerce_price(quote.bid, "bid", data_quality_flags, sanitization_notes)
-            ask = self._coerce_price(quote.ask, "ask", data_quality_flags, sanitization_notes)
+        if quote is not None:
+            if getattr(quote, "bid", None) is not None:
+                bid = self._coerce_price(getattr(quote, "bid", None), "bid", data_quality_flags, sanitization_notes)
+            if getattr(quote, "ask", None) is not None:
+                ask = self._coerce_price(getattr(quote, "ask", None), "ask", data_quality_flags, sanitization_notes)
             has_bid_ask = bid is not None and ask is not None
 
         if has_bid_ask and bid is not None and ask is not None:
@@ -715,13 +757,19 @@ class OptionsHelper:
                     spread_too_wide = spread_pct > max_spread_pct
         else:
             missing_bid_ask = True
+            # One-sided quotes can still be useful as execution anchors and should not force an
+            # expensive last-trade fetch.
+            if ask is not None:
+                buy_price = ask
+            if bid is not None:
+                sell_price = bid
 
         # Last price as secondary signal / fallback anchor.
         #
         # PERFORMANCE: Do not fetch trade-derived OHLC/last when bid/ask is already actionable.
         # ThetaData can provide NBBO without trades, and calling get_last_price() can trigger
         # expensive historical OHLC downloads (especially in backtests).
-        if not has_bid_ask:
+        if allow_fallback and buy_price is None and sell_price is None:
             try:
                 last_price = self.strategy.get_last_price(option_asset)
             except Exception as exc:
@@ -737,7 +785,7 @@ class OptionsHelper:
                 if last_price is None:
                     missing_last_price = True
 
-        if not has_bid_ask and allow_fallback and last_price is not None:
+        if allow_fallback and last_price is not None and buy_price is None and sell_price is None:
             buy_price = last_price
             sell_price = last_price
             used_last_price_fallback = True
@@ -842,13 +890,21 @@ class OptionsHelper:
             A dictionary containing symbol, strike, expiration, right, side, and last price.
         """
         asset = order.asset
+        mark_price = None
+        bid = None
+        ask = None
+        if getattr(asset, "asset_type", None) == Asset.AssetType.OPTION:
+            mark_price, bid, ask = self._get_option_mark_from_quote(asset)
         details = {
             "symbol": asset.symbol,
             "strike": getattr(asset, "strike", None),
             "expiration": getattr(asset, "expiration", None),
             "right": getattr(asset, "right", None),
             "side": order.side,
-            "last_price": self.strategy.get_last_price(asset)
+            "last_price": self.strategy.get_last_price(asset) if mark_price is None else None,
+            "bid": bid,
+            "ask": ask,
+            "mark_price": mark_price,
         }
         self.strategy.log_message(f"Order details: {details}", color="blue")
         return details
@@ -1086,13 +1142,15 @@ class OptionsHelper:
 
                     # Fallback: Check for last traded price data
                     try:
-                        price = self.strategy.get_last_price(test_option)
-                        if price is not None:
-                            self.strategy.log_message(
-                                f"Found valid expiry {exp_date} with price data for {call_or_put_caps}",
-                                color="blue",
-                            )
-                            return exp_date
+                        mark_price, _, _ = self._get_option_mark_from_quote(test_option)
+                        if mark_price is None:
+                            price = self.strategy.get_last_price(test_option)
+                            if price is not None:
+                                self.strategy.log_message(
+                                    f"Found valid expiry {exp_date} with price data for {call_or_put_caps}",
+                                    color="blue",
+                                )
+                                return exp_date
                     except Exception:
                         pass
                 else:
@@ -1165,13 +1223,17 @@ class OptionsHelper:
             underlying_asset.symbol, asset_type="option", expiration=expiry,
             strike=call_strike, right="call", underlying_asset=underlying_asset
         )
-        call_sell_price = self.strategy.get_last_price(call_sell_asset)
+        call_sell_price, _, _ = self._get_option_mark_from_quote(call_sell_asset)
+        if call_sell_price is None:
+            call_sell_price = self.strategy.get_last_price(call_sell_asset)
         call_sell_order = self.strategy.create_order(call_sell_asset, quantity_to_trade, "sell")
         call_buy_asset = Asset(
             underlying_asset.symbol, asset_type="option", expiration=expiry,
             strike=call_strike + wing_size, right="call", underlying_asset=underlying_asset
         )
-        call_buy_price = self.strategy.get_last_price(call_buy_asset)
+        call_buy_price, _, _ = self._get_option_mark_from_quote(call_buy_asset)
+        if call_buy_price is None:
+            call_buy_price = self.strategy.get_last_price(call_buy_asset)
         call_buy_order = self.strategy.create_order(call_buy_asset, quantity_to_trade, "buy")
         if call_sell_price is None or call_buy_price is None:
             self.strategy.log_message("Call order build failed due to missing prices.", color="red")
@@ -1207,13 +1269,17 @@ class OptionsHelper:
             underlying_asset.symbol, asset_type="option", expiration=expiry,
             strike=put_strike, right="put", underlying_asset=underlying_asset
         )
-        put_sell_price = self.strategy.get_last_price(put_sell_asset)
+        put_sell_price, _, _ = self._get_option_mark_from_quote(put_sell_asset)
+        if put_sell_price is None:
+            put_sell_price = self.strategy.get_last_price(put_sell_asset)
         put_sell_order = self.strategy.create_order(put_sell_asset, quantity_to_trade, "sell")
         put_buy_asset = Asset(
             underlying_asset.symbol, asset_type="option", expiration=expiry,
             strike=put_strike - wing_size, right="put", underlying_asset=underlying_asset
         )
-        put_buy_price = self.strategy.get_last_price(put_buy_asset)
+        put_buy_price, _, _ = self._get_option_mark_from_quote(put_buy_asset)
+        if put_buy_price is None:
+            put_buy_price = self.strategy.get_last_price(put_buy_asset)
         put_buy_order = self.strategy.create_order(put_buy_asset, quantity_to_trade, "buy")
         if put_sell_price is None or put_buy_price is None:
             self.strategy.log_message("Put order build failed due to missing prices.", color="red")
@@ -1879,7 +1945,11 @@ class OptionsHelper:
         self.strategy.log_message("Calculating spread profit percentage.", color="blue")
         current_value = 0.0
         for order in orders:
-            price = self.strategy.get_last_price(order.asset)
+            price = None
+            if getattr(order.asset, "asset_type", None) == Asset.AssetType.OPTION:
+                price, _, _ = self._get_option_mark_from_quote(order.asset)
+            if price is None:
+                price = self.strategy.get_last_price(order.asset)
             if price is None:
                 self.strategy.log_message(f"Price unavailable for {order.asset.symbol}; cannot calculate spread profit.", color="red")
                 return None

--- a/lumibot/components/options_helper.py
+++ b/lumibot/components/options_helper.py
@@ -421,7 +421,11 @@ class OptionsHelper:
                 self.strategy.log_message(f"No price for option at strike {strike}. Skipping.", color="yellow")
                 continue
 
-            greeks = self.strategy.get_greeks(option, underlying_price=underlying_price, asset_price=option_price)
+            try:
+                greeks = self.strategy.get_greeks(option, underlying_price=underlying_price, asset_price=option_price)
+            except TypeError:
+                # Some unit tests (and custom strategy stubs) mock get_greeks without the asset_price kwarg.
+                greeks = self.strategy.get_greeks(option, underlying_price=underlying_price)
             if greeks is None:
                 self.strategy.log_message(f"Could not calculate Greeks for {option.symbol} at strike {strike}", color="yellow")
                 continue
@@ -487,7 +491,11 @@ class OptionsHelper:
             self.strategy.log_message(f"No price for option {option.symbol} at strike {strike}", color="yellow")
             return None
 
-        greeks = self.strategy.get_greeks(option, underlying_price=underlying_price, asset_price=option_price)
+        try:
+            greeks = self.strategy.get_greeks(option, underlying_price=underlying_price, asset_price=option_price)
+        except TypeError:
+            # Some unit tests (and custom strategy stubs) mock get_greeks without the asset_price kwarg.
+            greeks = self.strategy.get_greeks(option, underlying_price=underlying_price)
         # Handle None from get_greeks - can happen when option price or underlying price unavailable
         if greeks is None:
             self.strategy.log_message(

--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -674,6 +674,10 @@ class Data:
         """
         if not getattr(self, "_quote_required_cols_present", True):
             # Log once per Data instance; avoid per-call warning spam in tight loops.
+            #
+            # IMPORTANT: Quote history datasets (e.g., ThetaData option NBBO) may not contain OHLCV
+            # columns, but we still want to surface bid/ask. Missing price columns simply return
+            # None for those fields.
             if not getattr(self, "_quote_presence_logged", False):
                 missing_price_cols = [col for col in _DATA_REQUIRED_PRICE_COLS if col not in self.datalines]
                 logger.warning(
@@ -682,7 +686,6 @@ class Data:
                     missing_price_cols,
                 )
                 self._quote_presence_logged = True
-            return {}
 
         missing_quote_cols = getattr(self, "_quote_missing_cols", None)
         if missing_quote_cols and not getattr(self, "_quote_presence_logged", False):

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -27,6 +27,23 @@ from ._strategy import _Strategy
 
 matplotlib.use("Agg")
 
+_LOG_THROTTLE_IMPORTANT_KEYWORDS = (
+    "filled",
+    "fill ",
+    "submitted",
+    "placing",
+    "closing",
+    "attempting entry",
+    "entry time matched",
+    "entry attempt",
+    "order",
+    "cash_settled",
+    "error",
+    "exception",
+    "[diag]",
+    "[theta]",
+)
+
 class Strategy(_Strategy):
     @property
     def name(self):
@@ -377,12 +394,72 @@ class Strategy(_Strategy):
             # Send the message to Discord
             self.send_discord_message(message)
 
-        # Performance optimization: skip logging if INFO is not enabled
-        # This respects BACKTESTING_QUIET_LOGS via StrategyLoggerAdapter.isEnabledFor()
-        # When BACKTESTING_QUIET_LOGS=true (default), this returns False and saves CPU cycles
-        # When BACKTESTING_QUIET_LOGS=false, this returns True and logs are displayed
+        # Performance optimization: skip work if INFO is not enabled.
+        # This respects BACKTESTING_QUIET_LOGS via StrategyLoggerAdapter.isEnabledFor().
         if not self.logger.isEnabledFor(logging.INFO):
-            return
+            return message
+
+        # Backtesting performance: INFO logs can dominate runtime for minute-cadence strategies,
+        # especially when CloudWatch/stdout is the sink (Bot Manager prod backtests).
+        #
+        # We keep the existing behaviour by default, but when running backtests we enable a
+        # conservative rate-limit that only affects low-signal chatter. Important logs (errors,
+        # warnings, and trading actions) bypass the limiter.
+        #
+        # Controls:
+        # - BACKTESTING_LOG_MAX_PER_SECOND: explicit override (0 disables throttling)
+        # - Default behaviour: if IS_BACKTESTING=True and LOG_BACKTEST_PROGRESS_TO_FILE=True,
+        #   throttle to 10 msgs/sec unless explicitly disabled.
+        try:
+            is_backtesting = os.environ.get("IS_BACKTESTING", "").lower() == "true"
+            if is_backtesting:
+                explicit_limit = os.environ.get("BACKTESTING_LOG_MAX_PER_SECOND")
+                if explicit_limit is None:
+                    # Bot Manager backtest containers set LOG_BACKTEST_PROGRESS_TO_FILE=True.
+                    # Use that as a signal to enable safe throttling by default.
+                    default_limit = 10 if os.environ.get("LOG_BACKTEST_PROGRESS_TO_FILE", "").lower() == "true" else 0
+                    max_per_second = default_limit
+                else:
+                    try:
+                        max_per_second = int(float(explicit_limit))
+                    except (TypeError, ValueError):
+                        max_per_second = 0
+
+                if max_per_second > 0:
+                    # Allowlist: never throttle high-signal logs.
+                    important = broadcast or (color in {"red", "yellow"})
+                    if not important:
+                        msg_lower = message.lower() if isinstance(message, str) else str(message).lower()
+                        important = any(k in msg_lower for k in _LOG_THROTTLE_IMPORTANT_KEYWORDS)
+
+                    if not important:
+                        state = getattr(self, "_log_throttle_state", None)
+                        if state is None:
+                            state = {
+                                "window_start": 0.0,
+                                "emitted": 0,
+                                "suppressed": 0,
+                            }
+                            setattr(self, "_log_throttle_state", state)
+
+                        now = time.monotonic()
+                        # 1-second fixed window.
+                        if now - state["window_start"] >= 1.0:
+                            # Emit a one-line summary when we suppressed logs in the prior window.
+                            suppressed = int(state.get("suppressed", 0) or 0)
+                            if suppressed > 0:
+                                self.logger.info(f"[LOG_THROTTLE] suppressed {suppressed} info log(s) in the last 1s")
+                            state["window_start"] = now
+                            state["emitted"] = 0
+                            state["suppressed"] = 0
+
+                        if state["emitted"] >= max_per_second:
+                            state["suppressed"] += 1
+                            return message
+                        state["emitted"] += 1
+        except Exception:
+            # Logging must never break strategy execution.
+            pass
 
         if color:
             if color in COLORS:

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 import math
+import os
 import time
 import traceback
 from datetime import datetime, timedelta
@@ -78,6 +79,12 @@ class StrategyExecutor(Thread):
 
         # Cache for market type detection to avoid repeated expensive calendar lookups
         self._market_type_cache = {}
+
+        # Backtests can run millions of iterations; per-iteration "heartbeat" logs dominate runtime
+        # when the sink is stdout/CloudWatch. Keep them opt-in during backtesting.
+        self._log_iteration_heartbeat = True
+        if self.broker.IS_BACKTESTING_BROKER:
+            self._log_iteration_heartbeat = os.environ.get("BACKTESTING_LOG_ITERATION_HEARTBEAT", "").lower() == "true"
 
     def _is_continuous_market(self, market_name):
         """
@@ -705,17 +712,18 @@ class StrategyExecutor(Thread):
         self.strategy.send_account_summary_to_discord()
 
         self._strategy_context = None
-        # Optimization: Use astimezone instead of localize for better performance
-        # datetime.now() already returns a naive datetime, so we can use astimezone
-        # This avoids the expensive localize operation that's called 355k times
-        if start_dt.tzinfo is None:
-            # If naive, use the faster replace+astimezone approach
-            start_dt_tz = start_dt.replace(tzinfo=LUMIBOT_DEFAULT_PYTZ)
-        else:
-            # If already has timezone, just convert
-            start_dt_tz = start_dt.astimezone(LUMIBOT_DEFAULT_PYTZ)
-        start_str = start_dt_tz.strftime("%Y-%m-%d %I:%M:%S %p %Z")
-        self.strategy.log_message(f"Bot is running. Executing the on_trading_iteration lifecycle method at {start_str}", color="green")
+        log_iteration_heartbeat = self._log_iteration_heartbeat
+        if log_iteration_heartbeat:
+            # Optimization: avoid tz conversions/strftime unless we are actually logging.
+            if start_dt.tzinfo is None:
+                start_dt_tz = start_dt.replace(tzinfo=LUMIBOT_DEFAULT_PYTZ)
+            else:
+                start_dt_tz = start_dt.astimezone(LUMIBOT_DEFAULT_PYTZ)
+            start_str = start_dt_tz.strftime("%Y-%m-%d %I:%M:%S %p %Z")
+            self.strategy.log_message(
+                f"Bot is running. Executing the on_trading_iteration lifecycle method at {start_str}",
+                color="green",
+            )
         on_trading_iteration = append_locals(self.strategy.on_trading_iteration)
 
         # Time-consuming
@@ -731,8 +739,6 @@ class StrategyExecutor(Thread):
             self.process_queue()
 
             end_dt = datetime.now()
-            end_dt_tz = LUMIBOT_DEFAULT_PYTZ.localize(end_dt.replace(tzinfo=None))
-            end_str = end_dt_tz.strftime("%Y-%m-%d %I:%M:%S %p %Z")
             runtime = (end_dt - start_dt).total_seconds()
 
             # Variable Backup
@@ -743,14 +749,24 @@ class StrategyExecutor(Thread):
             # occur at the correct time.
             self.cron_count = self._seconds_to_sleeptime_count(int(runtime), sleep_units)
             next_run_time = self.get_next_ap_scheduler_run_time()
-            if next_run_time is not None:
+            if next_run_time is not None and log_iteration_heartbeat:
                 # Format the date to be used in the log message.
+                if end_dt.tzinfo is None:
+                    end_dt_tz = end_dt.replace(tzinfo=LUMIBOT_DEFAULT_PYTZ)
+                else:
+                    end_dt_tz = end_dt.astimezone(LUMIBOT_DEFAULT_PYTZ)
+                end_str = end_dt_tz.strftime("%Y-%m-%d %I:%M:%S %p %Z")
                 dt_str = next_run_time.strftime("%Y-%m-%d %I:%M:%S %p %Z")
                 self.strategy.log_message(
                     f"Trading iteration ended at {end_str}, next check in time is {dt_str}. Took {runtime:.2f}s", color="blue"
                 )
 
-            else:
+            elif log_iteration_heartbeat:
+                if end_dt.tzinfo is None:
+                    end_dt_tz = end_dt.replace(tzinfo=LUMIBOT_DEFAULT_PYTZ)
+                else:
+                    end_dt_tz = end_dt.astimezone(LUMIBOT_DEFAULT_PYTZ)
+                end_str = end_dt_tz.strftime("%Y-%m-%d %I:%M:%S %p %Z")
                 self.strategy.log_message(f"Trading iteration ended at {end_str}", color="blue")
         except Exception as e:
             # If backtesting, raise the exception

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlencode, urlparse
 
-import numpy as np
 import pandas as pd
 import pandas_market_calendars as mcal
 import pytz
@@ -1625,45 +1624,44 @@ def append_missing_markers(
 
     if df_all is None or len(df_all) == 0:
         df_all = pd.DataFrame(columns=base_columns + ["missing"])
-        df_all.index = pd.DatetimeIndex([], name="datetime")
+        df_all.index = pd.DatetimeIndex([], name="datetime", tz="UTC")
 
     df_all = ensure_missing_column(df_all)
 
-    rows = []
-    for d in missing_dates:
-        dt = _market_close_utc_for_date(d)
-        row = {col: pd.NA for col in df_all.columns if col != "missing"}
-        row["datetime"] = dt
-        row["missing"] = True
-        rows.append(row)
+    placeholder_index = pd.DatetimeIndex(
+        [_market_close_utc_for_date(d) for d in missing_dates],
+        name="datetime",
+    )
 
-    if rows:
-        CONNECTION_DIAGNOSTICS["placeholder_writes"] = CONNECTION_DIAGNOSTICS.get("placeholder_writes", 0) + len(rows)
+    if len(placeholder_index):
+        CONNECTION_DIAGNOSTICS["placeholder_writes"] = CONNECTION_DIAGNOSTICS.get("placeholder_writes", 0) + len(placeholder_index)
 
         # DEBUG-LOG: Placeholder injection
         logger.debug(
             "[THETA][DEBUG][PLACEHOLDER][INJECT] count=%d dates=%s",
-            len(rows),
+            len(placeholder_index),
             ", ".join(sorted({d.isoformat() for d in missing_dates}))
         )
 
-        placeholder_df = pd.DataFrame(rows).set_index("datetime")
-        for col in df_all.columns:
-            if col not in placeholder_df.columns:
-                if col == "missing":
-                    placeholder_df[col] = True
-                else:
-                    # Use np.nan instead of pd.NA to avoid FutureWarning about concat with all-NA columns
-                    placeholder_df[col] = np.nan
-        placeholder_df = placeholder_df[df_all.columns]
-        if len(df_all) == 0:
-            df_all = placeholder_df
-        else:
-            df_all = pd.concat([df_all, placeholder_df]).sort_index()
+        # PERF: Avoid pandas FutureWarning spam from concatenating all-NA placeholder frames.
+        # Reindex onto the union of existing + placeholder timestamps instead.
+        try:
+            df_all_index = df_all.index
+            if not isinstance(df_all_index, pd.DatetimeIndex):
+                df_all = df_all.copy()
+                df_all.index = pd.to_datetime(df_all.index, utc=True)
+            elif getattr(df_all_index, "tz", None) is None:
+                df_all = df_all.copy()
+                df_all.index = pd.to_datetime(df_all.index, utc=True)
+        except Exception:
+            pass
+
+        df_all = df_all.reindex(df_all.index.union(placeholder_index)).sort_index()
+        df_all.loc[placeholder_index, "missing"] = True
         df_all = df_all[~df_all.index.duplicated(keep="last")]
         logger.debug(
             "[THETA][DEBUG][THETADATA-CACHE] recorded %d placeholder day(s): %s",
-            len(rows),
+            len(placeholder_index),
             ", ".join(sorted({d.isoformat() for d in missing_dates})),
         )
 
@@ -1819,6 +1817,21 @@ def get_price_data(
     # Preserve original bounds for final filtering
     requested_start = start
     requested_end = end
+
+    # Defensive: callers should never request an inverted window, but it can occur when clamping
+    # to option expiration or applying offsets. Return an empty frame rather than crashing deep
+    # inside calendar scheduling.
+    try:
+        if start is not None and end is not None and start > end:
+            logger.warning(
+                "[THETA][WARN][REQUEST] Ignoring inverted request window for %s: start=%s end=%s",
+                getattr(asset, "symbol", asset),
+                start,
+                end,
+            )
+            return pd.DataFrame()
+    except Exception:
+        pass
 
     # Check if we already have data for this asset in the cache file
     df_all = None
@@ -2755,6 +2768,18 @@ def get_trading_dates(asset: Asset, start: datetime, end: datetime):
     """
     start_date = start.date() if hasattr(start, 'date') else start
     end_date = end.date() if hasattr(end, 'date') else end
+    try:
+        if start_date > end_date:
+            logger.debug(
+                "[THETA][DEBUG][TRADING_DATES] start_date=%s after end_date=%s for asset=%s; returning empty list",
+                start_date,
+                end_date,
+                getattr(asset, "symbol", asset),
+            )
+            return []
+    except Exception:
+        # If dates are not comparable, fall through and let the calendar path raise.
+        pass
     return list(_cached_trading_dates(asset.asset_type, start_date, end_date))
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.16",
+    version="4.4.17",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.15",
+    version="4.4.16",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/tests/backtest/test_quote_fill_fallback.py
+++ b/tests/backtest/test_quote_fill_fallback.py
@@ -74,3 +74,64 @@ def test_try_fill_with_quote_respects_limit_price():
 
     assert price is None
     assert not hasattr(order, "_price_source")
+
+
+def test_thetadata_option_market_order_prefers_quote_fill_without_ohlc(monkeypatch):
+    """ThetaData option market orders should fill from NBBO without forcing OHLC downloads."""
+    quote = Quote(
+        asset=Asset("SPXW", asset_type=Asset.AssetType.OPTION, expiration=None, strike=None, right="CALL"),
+        bid=10.0,
+        ask=11.0,
+        timestamp=datetime.datetime.now(datetime.timezone.utc),
+    )
+
+    broker = BacktestingBroker.__new__(BacktestingBroker)
+    broker.logger = get_logger("thetadata_quote_fill_market_test")
+    broker.hybrid_prefetcher = None
+    broker.prefetcher = None
+
+    class _OrderList:
+        def __init__(self, items):
+            self._items = list(items)
+
+        def get_list(self):
+            return list(self._items)
+
+    class _DummyDataSource:
+        SOURCE = "PANDAS"
+        _timestep = "minute"
+
+        def get_datetime(self):
+            return datetime.datetime(2024, 1, 2, 9, 30, tzinfo=datetime.timezone.utc)
+
+        def get_historical_prices(self, *args, **kwargs):
+            raise AssertionError("OHLC should not be fetched when quote fill succeeds")
+
+    broker.data_source = _DummyDataSource()
+    broker.get_quote = MagicMock(return_value=quote)
+    broker._is_thetadata_source = MagicMock(return_value=True)
+    broker._trade_event_log_df = None
+    broker.process_expired_option_contracts = MagicMock()
+
+    order = Order(
+        strategy="TestStrategy",
+        asset=quote.asset,
+        quantity=Decimal("1"),
+        side=Order.OrderSide.SELL,
+        order_type=Order.OrderType.MARKET,
+    )
+    order.quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+    broker._unprocessed_orders = _OrderList([])
+    broker._new_orders = _OrderList([order])
+    broker._execute_filled_order = MagicMock()
+    broker.cancel_order = MagicMock()
+
+    strategy = DummyStrategy(parameters={"max_spread_pct": 1.0})
+    strategy.name = "TestStrategy"
+
+    broker.process_pending_orders(strategy)
+
+    broker._execute_filled_order.assert_called_once()
+    fill_kwargs = broker._execute_filled_order.call_args.kwargs
+    assert fill_kwargs["price"] == pytest.approx(10.0)

--- a/tests/backtest/test_thetadata_option_quote_fill_when_ohlc_missing.py
+++ b/tests/backtest/test_thetadata_option_quote_fill_when_ohlc_missing.py
@@ -1,0 +1,111 @@
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from lumibot.backtesting.backtesting_broker import BacktestingBroker
+from lumibot.entities import Asset, Order, Quote
+from lumibot.tools.lumibot_logger import get_logger
+
+
+class _StubDataSource:
+    """Minimal DataSource stub for unit-testing BacktestingBroker order processing."""
+
+    SOURCE = "PANDAS"
+    IS_BACKTESTING_DATA_SOURCE = True
+
+    def __init__(self, now: datetime.datetime):
+        self._now = now
+        self._timestep = "minute"
+
+    def get_datetime(self):
+        return self._now
+
+    def get_historical_prices(self, *args, **kwargs):
+        # Simulate sparse ThetaData option OHLC (None/empty), while quotes may still exist.
+        return None
+
+
+class _ListWrapper:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def get_list(self):
+        return list(self._items)
+
+
+class DummyStrategy:
+    """Bare-minimum Strategy stub required by BacktestingBroker.process_pending_orders."""
+
+    def __init__(self):
+        self.name = "TestStrategy"
+        self.parameters = {"max_spread_pct": 0.25}
+        self.messages = []
+
+    def log_message(self, message, color=None):
+        self.messages.append((message, color))
+
+
+def test_thetadata_option_market_order_fills_from_quote_when_ohlc_missing():
+    """Regression test: ThetaData option minute OHLC can be missing while NBBO exists.
+
+    If OHLC is missing, the broker should still attempt quote-based fills for option orders.
+
+    NOTE (test authority):
+    - This test guards against the "canceled BUY_TO_CLOSE -> cash_settled at expiry" failure mode that
+      materially changes PnL and can make backtests non-deterministic.
+    - After this has been in the suite for ~1 year, treat it as LEGACY/high-authority: fix code first.
+    """
+
+    now = datetime.datetime(2025, 1, 21, 15, 55, tzinfo=datetime.timezone.utc)
+    data_source = _StubDataSource(now)
+
+    broker = BacktestingBroker.__new__(BacktestingBroker)
+    broker.data_source = data_source
+    broker.logger = get_logger("thetadata_quote_fill_missing_ohlc_test")
+    broker.hybrid_prefetcher = None
+    broker.prefetcher = None
+    broker._trade_event_log_df = None
+
+    broker._is_thetadata_source = MagicMock(return_value=True)
+
+    option_asset = Asset(
+        "SPXW",
+        asset_type=Asset.AssetType.OPTION,
+        expiration=datetime.date(2025, 1, 21),
+        strike=5880.0,
+        right="CALL",
+    )
+    order = Order(
+        strategy="TestStrategy",
+        asset=option_asset,
+        quantity=Decimal("1"),
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.MARKET,
+    )
+    order.quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+    broker._unprocessed_orders = _ListWrapper([])
+    broker._new_orders = _ListWrapper([order])
+
+    broker.get_quote = MagicMock(
+        return_value=Quote(
+            asset=option_asset,
+            bid=169.2,
+            ask=170.0,
+            timestamp=now,
+        )
+    )
+
+    broker._execute_filled_order = MagicMock()
+    broker.process_expired_option_contracts = MagicMock()
+
+    strategy = DummyStrategy()
+
+    broker.process_pending_orders(strategy)
+
+    broker._execute_filled_order.assert_called_once()
+    _, kwargs = broker._execute_filled_order.call_args
+    assert kwargs["order"] is order
+    assert kwargs["price"] == pytest.approx(170.0)

--- a/tests/test_backtesting_capture_locals_env_toggle.py
+++ b/tests/test_backtesting_capture_locals_env_toggle.py
@@ -1,0 +1,40 @@
+class DummyBroker:
+    IS_BACKTESTING_BROKER = True
+
+
+class DummyStrategy:
+    def __init__(self):
+        self.broker = DummyBroker()
+
+    def on_trading_iteration(self):
+        local_value = 123
+        return local_value
+
+
+def test_backtesting_capture_locals_default_off(monkeypatch):
+    monkeypatch.delenv("BACKTESTING_CAPTURE_LOCALS", raising=False)
+
+    from lumibot.strategies.strategy_executor import StrategyExecutor
+
+    strategy = DummyStrategy()
+    executor = StrategyExecutor(strategy)
+
+    assert executor._capture_locals is False
+    assert executor._on_trading_iteration_callable == strategy.on_trading_iteration
+    assert not hasattr(executor._on_trading_iteration_callable, "locals")
+
+
+def test_backtesting_capture_locals_enabled(monkeypatch):
+    monkeypatch.setenv("BACKTESTING_CAPTURE_LOCALS", "true")
+
+    from lumibot.strategies.strategy_executor import StrategyExecutor
+
+    strategy = DummyStrategy()
+    executor = StrategyExecutor(strategy)
+
+    assert executor._capture_locals is True
+    assert executor._on_trading_iteration_callable != strategy.on_trading_iteration
+
+    executor._on_trading_iteration_callable()
+    assert hasattr(executor._on_trading_iteration_callable, "locals")
+    assert isinstance(executor._on_trading_iteration_callable.locals, (dict, type(None)))

--- a/tests/test_options_helper_quote_prefers_quotes.py
+++ b/tests/test_options_helper_quote_prefers_quotes.py
@@ -1,0 +1,75 @@
+from datetime import date
+
+import pytest
+
+from lumibot.components.options_helper import OptionsHelper
+from lumibot.entities import Asset, Quote
+
+
+class _DummyDataSource:
+    option_quote_fallback_allowed = True
+
+
+class _DummyBroker:
+    data_source = _DummyDataSource()
+
+
+class _DummyStrategy:
+    def __init__(self, bid=None, ask=None):
+        self.broker = _DummyBroker()
+        self._bid = bid
+        self._ask = ask
+        self.last_price_calls = 0
+        self.greeks_calls = []
+
+    def log_message(self, *_args, **_kwargs):
+        return None
+
+    def get_quote(self, asset, **_kwargs):
+        return Quote(asset=asset, bid=self._bid, ask=self._ask, price=None)
+
+    def get_last_price(self, _asset, **_kwargs):
+        self.last_price_calls += 1
+        raise AssertionError("get_last_price() should not be called when quote data is usable")
+
+    def get_greeks(self, _asset, asset_price=None, underlying_price=None, **_kwargs):
+        self.greeks_calls.append({"asset_price": asset_price, "underlying_price": underlying_price})
+        return {"delta": 0.5}
+
+
+def test_evaluate_option_market_one_sided_quote_skips_last_price():
+    option = Asset(
+        "SPY",
+        asset_type="option",
+        expiration=date(2025, 1, 17),
+        strike=400,
+        right="call",
+        underlying_asset=Asset("SPY", "stock"),
+    )
+    strategy = _DummyStrategy(bid=1.23, ask=None)
+    helper = OptionsHelper(strategy)
+
+    evaluation = helper.evaluate_option_market(option)
+
+    assert strategy.last_price_calls == 0
+    assert evaluation.sell_price == pytest.approx(1.23)
+    assert evaluation.buy_price is None
+
+
+def test_get_delta_for_strike_prefers_quote_price():
+    underlying = Asset("SPY", "stock")
+    strategy = _DummyStrategy(bid=1.0, ask=1.2)
+    helper = OptionsHelper(strategy)
+
+    delta = helper.get_delta_for_strike(
+        underlying_asset=underlying,
+        underlying_price=500.0,
+        strike=500.0,
+        expiry=date(2025, 1, 17),
+        right="call",
+    )
+
+    assert delta == pytest.approx(0.5)
+    assert strategy.last_price_calls == 0
+    assert strategy.greeks_calls
+    assert strategy.greeks_calls[0]["asset_price"] == pytest.approx(1.1)

--- a/tests/test_thetadata_day_timestamp_alignment.py
+++ b/tests/test_thetadata_day_timestamp_alignment.py
@@ -1,4 +1,5 @@
 import datetime
+import warnings
 
 import pandas as pd
 import pytz
@@ -42,3 +43,18 @@ def test_append_missing_markers_uses_market_close_time():
     ts_ny = df.index[0].tz_convert(ny)
     assert ts_ny.date() == datetime.date(2025, 10, 1)
     assert ts_ny.hour == 16 and ts_ny.minute == 0
+
+
+def test_append_missing_markers_does_not_emit_concat_futurewarning():
+    df_all = pd.DataFrame(
+        {"open": [1.0], "high": [1.0], "low": [1.0], "close": [1.0], "volume": [1], "missing": [False]},
+        index=pd.DatetimeIndex([pd.Timestamp("2025-10-02", tz="UTC")], name="datetime"),
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", FutureWarning)
+        result = thetadata_helper.append_missing_markers(df_all, [datetime.date(2025, 10, 1)])
+
+    assert result is not None
+    assert len(result) == 2
+    assert not any(issubclass(w.category, FutureWarning) for w in caught)

--- a/tests/test_thetadata_price_snapshot_memoization.py
+++ b/tests/test_thetadata_price_snapshot_memoization.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+
+import pytz
+
+
+def test_thetadata_price_snapshot_memoized_within_dt(monkeypatch):
+    """Ensure repeated get_price_snapshot calls within a bar reuse cached results."""
+    from lumibot.backtesting.thetadata_backtesting_pandas import ThetaDataBacktestingPandas
+    from lumibot.entities import Asset
+
+    # Avoid side effects (process kills / queue ids) in unit tests.
+    monkeypatch.setattr(ThetaDataBacktestingPandas, "kill_processes_by_name", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("lumibot.tools.thetadata_queue_client.set_queue_client_id", lambda *_a, **_k: None)
+    monkeypatch.setattr("lumibot.tools.thetadata_helper.reset_theta_terminal_tracking", lambda *_a, **_k: None)
+
+    start = datetime(2024, 1, 1, tzinfo=pytz.UTC)
+    end = datetime(2024, 1, 2, tzinfo=pytz.UTC)
+    source = ThetaDataBacktestingPandas(datetime_start=start, datetime_end=end, pandas_data={})
+    source._datetime = datetime(2024, 1, 1, 10, 0, tzinfo=pytz.UTC)
+
+    asset = Asset("SPY", "stock")
+    dataset_key = ("dummy", "USD", "minute")
+
+    class DummyData:
+        def __init__(self):
+            self.calls = 0
+
+        def get_price_snapshot(self, _dt):
+            self.calls += 1
+            return {"bid": 1.0, "ask": 2.0, "close": 1.5}
+
+    dummy_data = DummyData()
+    source.pandas_data[dataset_key] = dummy_data
+
+    monkeypatch.setattr(source, "find_asset_in_data_store", lambda *_a, **_k: dataset_key)
+
+    update_calls = {"count": 0}
+
+    def _fake_update(*_a, **_k):
+        update_calls["count"] += 1
+
+    monkeypatch.setattr(source, "_update_pandas_data", _fake_update)
+
+    snap1 = source.get_price_snapshot(asset, timestep="minute")
+    snap2 = source.get_price_snapshot(asset, timestep="minute")
+
+    assert update_calls["count"] == 1
+    assert dummy_data.calls == 1
+    assert snap1 == snap2
+

--- a/tests/test_thetadata_quote_only_fetch.py
+++ b/tests/test_thetadata_quote_only_fetch.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+import warnings
 
 import pandas as pd
 import pytz
@@ -120,3 +121,61 @@ def test_thetadata_quote_only_cache_does_not_satisfy_ohlc_requirements(monkeypat
 
     assert "ohlc" in calls
 
+
+def test_thetadata_quote_only_merge_preserves_existing_ohlc(monkeypatch):
+    """Merging quote-only refreshes must not wipe existing OHLC columns."""
+    from lumibot.backtesting.thetadata_backtesting_pandas import ThetaDataBacktestingPandas
+    from lumibot.entities import Asset, Data
+
+    monkeypatch.setattr(ThetaDataBacktestingPandas, "kill_processes_by_name", lambda *_a, **_k: None)
+    monkeypatch.setattr("lumibot.tools.thetadata_queue_client.set_queue_client_id", lambda *_a, **_k: None)
+    monkeypatch.setattr("lumibot.tools.thetadata_helper.reset_theta_terminal_tracking", lambda *_a, **_k: None)
+
+    start = datetime(2024, 1, 1, tzinfo=pytz.UTC)
+    end = datetime(2024, 1, 2, tzinfo=pytz.UTC)
+    dt = datetime(2024, 1, 1, 9, 31, tzinfo=pytz.UTC)
+
+    option = Asset("SPXW", "option", expiration=date(2024, 1, 19), strike=4500.0, right="CALL")
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+    existing_df = pd.DataFrame(
+        {"open": [5.0], "high": [5.2], "low": [4.8], "close": [5.1], "volume": [10]},
+        index=pd.DatetimeIndex([dt], name="datetime"),
+    )
+    existing_data = Data(asset=option, df=existing_df, quote=quote, timestep="minute")
+
+    source = ThetaDataBacktestingPandas(datetime_start=start, datetime_end=end, pandas_data=[existing_data])
+    source._datetime = dt
+
+    def _fake_get_price_data(_asset, _start, _end, *, datastyle, **_kwargs):
+        if datastyle != "quote":
+            raise AssertionError("Only quote data should be fetched in this scenario")
+        return _build_minute_df(
+            {
+                "bid": (1.0, 1.1),
+                "ask": (2.0, 2.1),
+            },
+            dt,
+        )
+
+    monkeypatch.setattr("lumibot.tools.thetadata_helper.get_price_data", _fake_get_price_data)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", FutureWarning)
+        source._update_pandas_data(
+            option,
+            quote=None,
+            length=1,
+            timestep="minute",
+            start_dt=source._datetime,
+            require_quote_data=True,
+            require_ohlc_data=False,
+        )
+
+    assert not any(issubclass(w.category, FutureWarning) for w in caught)
+
+    key = source.find_asset_in_data_store(option, quote, "minute")
+    assert key is not None
+    df_after = source.pandas_data[key].df
+    assert float(df_after.loc[dt, "close"]) == 5.1
+    assert float(df_after.loc[dt, "bid"]) == 1.0

--- a/tests/test_thetadata_quote_only_fetch.py
+++ b/tests/test_thetadata_quote_only_fetch.py
@@ -1,0 +1,122 @@
+from datetime import date, datetime
+
+import pandas as pd
+import pytz
+
+
+def _build_minute_df(columns, start_dt):
+    rows = [
+        dict(datetime=start_dt, **{k: v[0] for k, v in columns.items()}),
+        dict(datetime=start_dt.replace(minute=start_dt.minute + 1), **{k: v[1] for k, v in columns.items()}),
+    ]
+    return pd.DataFrame(rows)
+
+
+def test_thetadata_quote_only_fetch_skips_ohlc(monkeypatch):
+    """When quote-only is requested, do not hit the OHLC endpoint."""
+    from lumibot.backtesting.thetadata_backtesting_pandas import ThetaDataBacktestingPandas
+    from lumibot.entities import Asset
+
+    monkeypatch.setattr(ThetaDataBacktestingPandas, "kill_processes_by_name", lambda *_a, **_k: None)
+    monkeypatch.setattr("lumibot.tools.thetadata_queue_client.set_queue_client_id", lambda *_a, **_k: None)
+    monkeypatch.setattr("lumibot.tools.thetadata_helper.reset_theta_terminal_tracking", lambda *_a, **_k: None)
+
+    start = datetime(2024, 1, 1, tzinfo=pytz.UTC)
+    end = datetime(2024, 1, 2, tzinfo=pytz.UTC)
+    source = ThetaDataBacktestingPandas(datetime_start=start, datetime_end=end, pandas_data={})
+    source._datetime = datetime(2024, 1, 1, 9, 31, tzinfo=pytz.UTC)
+
+    option = Asset("SPXW", "option", expiration=date(2024, 1, 19), strike=4500.0, right="CALL")
+
+    calls = []
+
+    def _fake_get_price_data(_asset, _start, _end, *, datastyle, **_kwargs):
+        calls.append(datastyle)
+        if datastyle == "ohlc":
+            raise AssertionError("OHLC should not be fetched for quote-only requests")
+        return _build_minute_df(
+            {
+                "bid": (1.0, 1.1),
+                "ask": (2.0, 2.1),
+                "bid_size": (10, 11),
+                "ask_size": (12, 13),
+            },
+            source._datetime,
+        )
+
+    monkeypatch.setattr("lumibot.tools.thetadata_helper.get_price_data", _fake_get_price_data)
+
+    source._update_pandas_data(
+        option,
+        quote=None,
+        length=1,
+        timestep="minute",
+        start_dt=source._datetime,
+        require_quote_data=True,
+        require_ohlc_data=False,
+    )
+
+    assert "quote" in calls
+    assert "ohlc" not in calls
+
+
+def test_thetadata_quote_only_cache_does_not_satisfy_ohlc_requirements(monkeypatch):
+    """If we only cached quotes, a later OHLC-required call must still fetch OHLC."""
+    from lumibot.backtesting.thetadata_backtesting_pandas import ThetaDataBacktestingPandas
+    from lumibot.entities import Asset
+
+    monkeypatch.setattr(ThetaDataBacktestingPandas, "kill_processes_by_name", lambda *_a, **_k: None)
+    monkeypatch.setattr("lumibot.tools.thetadata_queue_client.set_queue_client_id", lambda *_a, **_k: None)
+    monkeypatch.setattr("lumibot.tools.thetadata_helper.reset_theta_terminal_tracking", lambda *_a, **_k: None)
+
+    start = datetime(2024, 1, 1, tzinfo=pytz.UTC)
+    end = datetime(2024, 1, 2, tzinfo=pytz.UTC)
+    source = ThetaDataBacktestingPandas(datetime_start=start, datetime_end=end, pandas_data={})
+    source._datetime = datetime(2024, 1, 1, 9, 31, tzinfo=pytz.UTC)
+
+    option = Asset("SPXW", "option", expiration=date(2024, 1, 19), strike=4500.0, right="CALL")
+
+    def _quote_df(*_a, **_k):
+        return _build_minute_df({"bid": (1.0, 1.1), "ask": (2.0, 2.1)}, source._datetime)
+
+    def _ohlc_df(*_a, **_k):
+        return _build_minute_df(
+            {"open": (1.0, 1.1), "high": (1.2, 1.3), "low": (0.9, 1.0), "close": (1.1, 1.2), "volume": (0, 0)},
+            source._datetime,
+        )
+
+    # First: quote-only cache fill.
+    monkeypatch.setattr("lumibot.tools.thetadata_helper.get_price_data", lambda *_a, datastyle, **_k: _quote_df())
+    source._update_pandas_data(
+        option,
+        quote=None,
+        length=1,
+        timestep="minute",
+        start_dt=source._datetime,
+        require_quote_data=True,
+        require_ohlc_data=False,
+    )
+
+    calls = []
+
+    def _fake_get_price_data(_asset, _start, _end, *, datastyle, **_kwargs):
+        calls.append(datastyle)
+        if datastyle == "quote":
+            return _quote_df()
+        return _ohlc_df()
+
+    monkeypatch.setattr("lumibot.tools.thetadata_helper.get_price_data", _fake_get_price_data)
+
+    # Second: OHLC-required call should still fetch OHLC despite existing quote-only cache.
+    source._update_pandas_data(
+        option,
+        quote=None,
+        length=1,
+        timestep="minute",
+        start_dt=source._datetime,
+        require_quote_data=False,
+        require_ohlc_data=True,
+    )
+
+    assert "ohlc" in calls
+

--- a/tests/test_thetadata_trading_dates_inverted_window.py
+++ b/tests/test_thetadata_trading_dates_inverted_window.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+import pytz
+
+from lumibot.entities import Asset
+from lumibot.tools import thetadata_helper
+
+
+def test_get_trading_dates_inverted_window_returns_empty():
+    asset = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    start = datetime(2025, 1, 2, tzinfo=pytz.UTC)
+    end = datetime(2025, 1, 1, tzinfo=pytz.UTC)
+
+    assert thetadata_helper.get_trading_dates(asset, start, end) == []
+


### PR DESCRIPTION
Stacked on #919.\n\n- Speed up ThetaData option-heavy backtests by avoiding expensive per-minute refresh work when quote cache already covers dt.\n- Avoid expensive duplicate-column de-dup by dropping redundant quote metadata columns before merge.\n\nManual spot-checks:\n- SPX Short Straddle Intraday 2024-12-31→2025-12-20: ~23m locally (cold-ish), ~1m for 2mo warm window.\n- Backdoor Butterfly 0DTE 2025-01-01→2025-12-01: completed OK.\n\nTests:\n- pytest -q tests/test_thetadata_spx_index_options.py tests/test_thetadata_helper.py\n- pytest -q tests/backtest/test_theta_strategies_integration.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quote-based fills for options when OHLC data is missing; configurable backtest iteration heartbeat and optional locals capture; graceful progress heartbeat with shutdown.

* **Performance Improvements**
  * Faster combined OHLC+quote fetching, in-memory per-bar memoization, reduced log spam, batched queue-driven option chain requests, and thread-safe progress writes.

* **Documentation**
  * Added backtest performance notes, backtesting tests guide, and an investigation report.

* **Tests**
  * Expanded coverage for quote-fill behavior, caching/memoization, queue-driven chains, heartbeat, and locals capture.

* **Other**
  * Package version bumped to 4.4.17.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->