### PR TITLE
SMART_LIMIT + slippage + backtesting reliability/perf (4.4.18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ schwab_token.json
 # AI assistant instruction files (contain local paths)
 CLAUDE.md
 AGENTS.md
+
+# Allow scoped agent instructions for the test suite.
+!tests/AGENTS.md

--- a/docs/BACKTESTING_ARCHITECTURE.md
+++ b/docs/BACKTESTING_ARCHITECTURE.md
@@ -4,6 +4,14 @@
 
 LumiBot is a trading and backtesting framework. This document focuses on the **backtesting architecture**, specifically how data flows from external sources (Yahoo, ThetaData, Polygon) into the backtesting engine.
 
+**CORE PRINCIPLE: Backtesting must mimic live broker behavior.**
+
+If the backtest execution model (data semantics, fill model, order handling, fees, pricing) diverges meaningfully from how real brokers behave, the backtest is not trustworthy.
+
+We optimize for:
+1) **Accuracy / realism first** (broker-like behavior; no hidden optimism or lookahead leaks)
+2) **Speed second** (make it fast *without changing semantics*)
+
 ## Related Docs
 
 - Handoffs: `docs/handoffs/`
@@ -183,6 +191,12 @@ LumiBot intentionally separates *trade-based* pricing from *quote/mark* pricing:
     - quote-based fills in illiquid markets (ThetaData backtests only).
 
 This is essential to ensure ThetaData backtests behave like live brokers: brokers return stale last trades, and only quote endpoints provide NBBO/mark.
+
+### SMART_LIMIT Backtest Fills
+
+- SMART_LIMIT fills use **mid ± slippage** when bid/ask is available (mid + slippage for buys, mid - slippage for sells).
+- If bid/ask is missing, SMART_LIMIT **downgrades to market** (next-bar open) and logs a warning.
+- Inside-spread fills are allowed because they occur regularly in live markets.
 
 ## Backtesting Portfolio Valuation (Mark-to-Market)
 

--- a/docs/investigations/SMART_LIMIT_ORDER_DESIGN.md
+++ b/docs/investigations/SMART_LIMIT_ORDER_DESIGN.md
@@ -1,0 +1,658 @@
+# SMART_LIMIT Order Type — Design, Research, and Implementation Checklist
+
+Status: implementation in progress (tracking decisions + progress)
+Last updated: 2025-12-30
+
+This document is the working design spec for a new **SMART_LIMIT** order type in LumiBot.
+It captures:
+- Why we’re adding it
+- The research behind the design (industry comparisons)
+- How it should behave in **live** vs **backtesting**
+- How it must serialize for **Botspot/Bot Manager progress** and **LumiWealth cloud updates**
+- The engineering plan, test plan, and documentation plan
+- A temporary checklist to execute against (remove checklist later; keep the rest of the doc)
+
+---
+
+## Problem Statement (Why this exists)
+
+We’ve reached a point where “market order fills” being modeled as crossing the spread (buy at ask, sell at bid)
+is both:
+- **More realistic** (especially for options), and
+- **Materially worse** for backtest performance for strategies that relied on optimistic fills.
+
+That’s not a bug — it’s the spread cost being surfaced.
+
+But real traders rarely use market orders for options (and often not for spreads). Instead they:
+- place a limit order around the midpoint, and
+- “walk” the limit price toward the bid/ask until they fill or time out.
+
+We need to provide an ergonomic, broker-agnostic way to model and execute this behavior:
+- so strategies can be written with realistic execution in mind,
+- and so backtests can remain broker-like and not “mid-price fantasy” unless explicitly chosen.
+
+In short: **SMART_LIMIT is a first-class execution primitive**.
+
+---
+
+## Goals
+
+### Functional goals
+
+1) Add `OrderType.SMART_LIMIT` that is **capability-driven**, not asset-type-driven:
+   - Works for **any asset** where the active broker/data source can provide **bid/ask** and can submit/modify/cancel **limit orders**.
+   - When bid/ask is unavailable for a given asset/time (data gaps, provider limitations), SMART_LIMIT must **degrade gracefully** (do not crash) with an explicit warning that execution realism is reduced.
+
+**Note:** SMART_LIMIT is asset-agnostic by design. If bid/ask exists, it works — no asset-type whitelist.
+
+2) Align behavior with industry expectations (Option Alpha “SmartPricing” / Schwab “Walk Limit” concept):
+   - start near mid
+   - cancel/replace (or modify) through a sequence of prices
+   - bound aggressiveness via a “Final Price” rule
+   - time out and cancel by default
+
+3) Work in both environments:
+   - **Live trading**: “real” timed repricing using broker quotes
+   - **Backtesting**: best-effort simulation consistent with available historical data
+
+4) Preserve accuracy:
+   - execution should never be “better than possible”
+   - multi-leg should be treated as a package (net price), not silently “legging” unless explicitly chosen
+
+5) Preserve reliability:
+   - no crashes when quotes are missing (degrade with explicit warnings)
+   - stable serialization for cloud updates/progress
+
+### Non-goals (for this project)
+
+- Rebuilding the backtest engine to run at 1-second resolution globally.
+- Adding a new “Strategy clock” concept. We should reuse existing scheduling infrastructure.
+- Large-scale rewrites of demo strategies in `Strategy Library/Demos` (these are acceptance fixtures; only make minimal, deliberate changes when needed for correctness/testing).
+
+---
+
+## Constraints / Guardrails
+
+- Never run `git checkout`.
+- Backtests must use the stable downloader URL for ThetaData:
+  - `DATADOWNLOADER_BASE_URL=http://data-downloader.lumiwealth.com:8080`
+- Do not break:
+  - legacy unit tests
+  - acceptance backtests
+  - Polygon backtests (even if not the focus)
+- Keep backtests fast; any added work should be narrowly scoped to active orders.
+
+---
+
+## Terminology
+
+### SMART_LIMIT (LumiBot)
+
+New order type that:
+- starts at/near midpoint of the spread
+- repeatedly reprices the same logical order toward an allowed final price
+- cancels if not filled within a timeout
+
+### Option Alpha: SmartPricing (reference behavior)
+
+Option Alpha documents SmartPricing as:
+- a sequence of timed limit orders that traverse the bid/ask spread to a “Final Price”
+- starting near the mid-price
+- moving toward the bid when selling / toward the ask when buying
+- cancel/replace per step
+- keeping the final price working for 2 minutes then canceling
+
+Preset timings:
+- **Normal**: up to 4 prices, 10 seconds each
+- **Fast**: up to 3 prices, 5 seconds each
+- **Patient**: up to 5 prices, 20 seconds each
+
+References:
+- https://optionalpha.com/help/smartpricing
+- https://optionalpha.com/blog/new-smart-pricing-options-to-improve-trade-fill-prices
+
+### Schwab: Walk Limit (conceptual sibling)
+
+Schwab’s “Walk Limit” is the same concept: cancel/replace limit orders as price changes.
+
+### “SOR” vs “smart execution”
+
+True “Smart Order Routing” is usually broker/venue-side routing.
+What we’re building in LumiBot is closer to **smart execution / smart pricing**,
+but we may still call the order type `SMART_LIMIT` because it matches the trader mental model.
+
+---
+
+## How LumiBot Works Today (relevant architecture)
+
+This is the minimum mental model needed to implement SMART_LIMIT without reinventing the platform.
+
+### Order creation and submission
+
+- `Strategy.create_order(...)` creates an `Order` object.
+  - file: `lumibot/strategies/strategy.py`
+- `Strategy.submit_order(...)` sends orders to `broker.submit_order(...)` or `broker.submit_orders(...)`.
+  - file: `lumibot/strategies/strategy.py`
+- Live brokers submit through a broker-side orders thread (`Broker._orders_thread`).
+  - file: `lumibot/brokers/broker.py`
+
+### Live “secondary clock” exists already
+
+In live trading:
+- `StrategyExecutor.check_queue()` runs in a background thread and ticks ~every 0.5s today.
+  - file: `lumibot/strategies/strategy_executor.py`
+- This is already a separate loop from `on_trading_iteration`, and is the correct place to run an
+  “execution manager” that reprices working SMART_LIMIT orders.
+
+Important: SMART_LIMIT must not depend on the check_queue sleep duration staying constant.
+It should use `time.monotonic()` scheduling and only act when `now >= next_action_at`.
+
+### Backtesting order evaluation loop exists
+
+In backtesting:
+- `BacktestingBroker.process_pending_orders()` is called every bar.
+  - file: `lumibot/backtesting/backtesting_broker.py`
+- This function already handles:
+  - order fills based on OHLC
+  - quote-based fallback fills (used for ThetaData option realism)
+  - trailing-stop updates per bar
+
+This is the correct place to add SMART_LIMIT simulation for backtesting.
+
+### Multi-leg in LumiBot (current state)
+
+Live:
+- Some brokers accept multi-leg “combo” orders (e.g., Tradier `_submit_multileg_order`).
+  - file: `lumibot/brokers/tradier.py`
+- Brokers may support modify/replace for existing orders:
+  - `Broker.modify_order()` exists (broker-specific behavior).
+  - file: `lumibot/brokers/broker.py`
+
+Backtesting:
+- Multi-leg orders are currently represented as:
+  - individual child orders (legs), and
+  - a synthetic parent order used for tracking.
+  - file: `lumibot/backtesting/backtesting_broker.py` (`_submit_orders(is_multileg=True)` creates parent order)
+
+If SMART_LIMIT is supposed to be accurate for multi-leg, we likely need to simulate it at the **package (net)**
+level in backtesting, not as independent leg fills.
+
+---
+
+## Serialization Requirements (Botspot progress + LumiWealth cloud)
+
+SMART_LIMIT parameters must serialize through:
+
+1) Progress logging / DynamoDB payloads:
+   - StrategyExecutor calls `Order.to_minimal_dict()` for progress updates.
+   - file: `lumibot/entities/order.py` (`to_minimal_dict`)
+   - We may need to add minimal SMART_LIMIT fields there (preset + current step maybe).
+
+2) LumiWealth cloud portfolio updates:
+   - `Strategy.send_update_to_cloud()` uses `[order.to_dict() for order in orders]`.
+   - file: `lumibot/strategies/_strategy.py` (`send_update_to_cloud`)
+   - `Order.to_dict()` includes any field that is:
+     - not underscore-prefixed
+     - JSON-serializable, or
+     - has a `to_dict()` method.
+   - file: `lumibot/entities/order.py` (`to_dict`)
+
+Implication:
+- SMART_LIMIT config should be a **real object** with:
+  - `to_dict()` returning primitives only
+  - `from_dict()` to reconstruct (optional but recommended)
+- And we must keep payload size reasonable (avoid embedding large internal state).
+
+---
+
+## Proposed Public API (typed; no “mystery dicts”)
+
+### Order type
+
+- Add `Order.OrderType.SMART_LIMIT = "smart_limit"`.
+  - file: `lumibot/entities/order.py`
+
+### Presets (mirror Option Alpha naming)
+
+Option Alpha uses:
+- `FAST`, `NORMAL`, `PATIENT`
+
+We should match this exact naming to:
+- align trader expectations
+- make it easy to translate OA → LumiBot usage
+
+### SmartLimitConfig object
+
+We need more than just a preset in practice:
+- final-price behavior matters
+- timeout behavior matters
+- rounding behavior matters
+- multi-leg net pricing depends on “credit vs debit”
+
+But we should keep v1 small and default-heavy.
+
+Proposed shape:
+
+- `SmartLimitPreset` (Enum): FAST, NORMAL, PATIENT
+- `SmartLimitTimeoutBehavior` (Enum):
+  - CANCEL (default; OA-style)
+  - optional future: FALLBACK_TO_MARKET (not default)
+- `SmartLimitFinalPriceRule` (Enum + typed params):
+  - PERCENT_OF_SPREAD (default OA = 100%)
+  - DOLLARS_FROM_MID (optional)
+  - TYPICAL_SLIPPAGE_CAP (optional, can be implemented later)
+- `SmartLimitConfig` (dataclass-like):
+  - `preset: SmartLimitPreset`
+  - `final_price_rules: list[SmartLimitFinalPriceRuleSpec]` (optional; default 100% spread)
+  - `timeout_behavior: SmartLimitTimeoutBehavior = CANCEL`
+  - `final_hold_seconds: int = 120` (OA)
+  - `max_total_seconds: int | None` (optional; defaults from preset + final_hold)
+  - `rounding: SmartLimitRoundingPolicy` (see rounding section)
+
+`Strategy.create_order(..., smart_limit=...)` should accept:
+- `smart_limit=None` (default)
+- `smart_limit=SmartLimitPreset.NORMAL` (simple)
+- `smart_limit=SmartLimitConfig(...)` (advanced)
+
+The `Order` stores:
+- `order_type = SMART_LIMIT`
+- a `smart_limit` attribute holding a **SmartLimitConfig** instance.
+
+Serialization:
+- `SmartLimitConfig.to_dict()` and `SmartLimitConfig.from_dict()`.
+
+---
+
+## Slippage (Backtesting) — Option Alpha parity and LumiBot plan
+
+### What Option Alpha does (important benchmark)
+
+Option Alpha’s backtester (0DTE / next-day) uses 1-minute historical data and generally models fills as:
+- **mid-price fills with user-specified “slippage from mid”**
+- not a true order-book / per-second microstructure simulation
+
+Their own content emphasizes that slippage is a configurable assumption used to stress test realism.
+They also pre-fill “typical” slippage values for some underlyings in their UI (e.g., small cents values),
+but it is still an explicit user setting (not dynamically derived from the spread each trade).
+
+### LumiBot plan (piggyback on the TradingFee pattern, but do NOT misuse TradingFee)
+
+We already have a clean pattern for “execution cost configuration” via:
+- `buy_trading_fees` / `sell_trading_fees` passed into `Strategy.backtest(...)`
+- applied in the backtesting broker via `calculate_trade_cost(...)`
+
+We should add an analogous, typed, explicitly-named mechanism for **slippage** rather than overloading fees:
+
+- New entity: `TradingSlippage` (or similar name)
+  - must be strongly typed (object), with `to_dict()` for serialization
+  - intended for backtesting fill modeling (not live)
+  - supports at least “dollars from mid” to match OA
+
+- New strategy/backtest parameters (mirroring TradingFee UX):
+  - `buy_trading_slippages` / `sell_trading_slippages`
+  - default is zero slippage when unset
+
+How it integrates with SMART_LIMIT:
+- SMART_LIMIT backtesting default fill model is **mid ± slippage_from_mid** (single-leg or net mid for multi-leg),
+  constrained by SMART_LIMIT “Final Price” rules.
+- If the order provides explicit slippage settings, use them.
+- Otherwise, use the strategy-level defaults (`buy_trading_slippages` / `sell_trading_slippages`).
+
+Why this is better than forcing it into TradingFee:
+- slippage changes the effective execution price (and therefore cost basis and PnL shape)
+- fees are a separate cash debit and should remain separate
+- mixing the two makes results harder to reason about and breaks expectations
+
+### Slippage math (explicit; to be documented in public docs)
+
+For a single-leg order with bid/ask:
+- `mid = (bid + ask) / 2`
+- Buy fill target: `mid + slippage_amount`
+- Sell fill target: `mid - slippage_amount`
+
+For a multi-leg package:
+- compute **net bid**, **net ask**, **net mid** from legs
+- apply slippage to the **net mid** (not per-leg)
+
+The slippage amount is **absolute price units** (e.g., $0.05), not a percent,
+to match Option Alpha’s “dollars from mid” model.
+
+Trade logging:
+- Backtest trade logs include a `trade_slippage` column (CSV + HTML tooltips),
+  alongside existing `trade_cost`/fees.
+
+---
+
+## Execution Model (Live)
+
+SMART_LIMIT live behavior should mimic OA:
+- create a limit order at a first price (near mid)
+- if not filled after step duration, cancel/replace at next price
+- stop at final price and keep it working for 2 minutes
+- cancel if still unfilled (default)
+
+### Where it runs
+
+Do not change strategy cadence. Use the existing background loop:
+- `StrategyExecutor.check_queue()` is a continuous loop used in live.
+  - It currently sleeps `0.5s` between iterations.
+  - SMART_LIMIT should not depend on this sleep duration.
+
+We should implement an internal **execution manager** that:
+- is called from the check_queue loop
+- scans for active SMART_LIMIT orders
+- advances their state machine when time thresholds are reached
+
+### Timekeeping
+
+Use `time.monotonic()` for scheduling:
+- Each SMART_LIMIT order tracks:
+  - `next_action_at` (monotonic seconds)
+  - `step_index`
+  - `ladder_prices` (or a generator seed)
+
+### Broker interactions
+
+Prefer modify/replace when broker supports it:
+- `Broker.modify_order(order, limit_price=...)`
+
+Fallback:
+- cancel + submit a new order (must maintain a “logical order id” in LumiBot)
+
+Important: multi-leg support depends on broker capabilities:
+- Multi-leg vs legging is a **broker capability** question (and exists today independent of SMART_LIMIT).
+- SMART_LIMIT should follow the existing multi-leg pathway:
+  - If the broker supports true combo orders, SMART_LIMIT reprices the **package/net** limit.
+  - If the broker does not support combos for that instrument, LumiBot may be forced to “leg” — that must emit a **loud warning** because the execution semantics differ from a package fill.
+
+---
+
+## Execution Model (Backtesting)
+
+Backtesting must be broker-like but is constrained by data resolution.
+
+### The core reality
+
+If we only have 1-minute bars/quotes, we cannot know the true intra-minute fill timing.
+No engine can “perfectly” simulate 5s/10s/20s repricing without higher-resolution historical data.
+
+Industry norm:
+- Approximate execution using:
+  - bar-high/low crossings (for limit/stop fills), and/or
+  - slippage-from-mid caps (Option Alpha style).
+
+### What we can do in LumiBot today
+
+We already support:
+- limit orders remaining open across bars
+- quote-based fills (for ThetaData options)
+- cancel/replace logic in backtesting (conceptually; modify emits events)
+
+SMART_LIMIT backtest plan:
+- Represent SMART_LIMIT as an order that periodically updates its `limit_price` based on:
+  - current quote bid/ask (preferred), else
+  - last trade / bar OHLC (fallback)
+- On each backtest bar:
+  1) compute target limit price for current step
+  2) update order’s working limit
+  3) check fill conditions using the same rules we use for limit orders
+
+Critical principle: **Backtesting must mimic live broker behavior as closely as possible.**
+We should keep the **Option Alpha step schedule** (5s/10s/20s + 120s final hold) as the model target.
+Given minute data constraints, we will simulate that schedule in a way that:
+- stays deterministic,
+- allows **fills inside the spread** (because that happens in real markets),
+- and does not explode runtime (only active SMART_LIMIT orders incur extra work).
+
+### Inside-the-spread fills (required)
+
+Real-life limit orders often fill inside the spread (especially in liquid names), so SMART_LIMIT backtesting must allow it.
+
+Practical modeling options (to finalize during implementation):
+1) **Mid + slippage model (Option Alpha-style)**:
+   - Compute mid from bid/ask (or net mid for multi-leg).
+   - Apply a configurable slippage allowance (or derive one from spread/typical slippage).
+   - Mark the SMART_LIMIT attempt filled at the first ladder step that reaches that “expected fill price”.
+   - If the “expected fill price” exceeds the configured Final Price bound, the order does not fill and times out/cancels.
+   - This is fast, deterministic, and matches how many platforms handle 1-minute backtests.
+2) **Trade-print crossing model (when trade-last exists)**:
+   - If the data source provides a trade-last for the bar timestamp (ThetaData often does), consider a limit filled
+     when trade-last crosses the limit (buy: trade_last <= limit; sell: trade_last >= limit).
+   - This allows inside-spread fills without assuming “always fills at mid”.
+
+We should pick one primary model (and document it) rather than mixing ad-hoc rules.
+
+### Non-quote data sources (fallback)
+
+SMART_LIMIT requires bid/ask to be meaningful. When bid/ask is unavailable:
+- We **degrade gracefully** (no crash).
+- SMART_LIMIT **downgrades to Market** and emits a warning explaining why.
+- This can affect Polygon backtests before ~2020 (limited quote history).
+
+### Multi-leg backtesting (critical)
+
+We should simulate SMART_LIMIT multi-leg as a **net (package) limit order**:
+- compute net bid/ask/mid from leg quotes:
+  - buy leg uses ask for worst-case pay
+  - sell leg uses bid for worst-case receive
+- walk the net price ladder
+- fill all legs “atomically” at the same simulated timestamp when net fill occurs
+
+This likely requires refactoring existing “multileg parent + independent child fills” behavior
+inside the backtesting broker so SMART_LIMIT combos do not silently leg.
+
+---
+
+## Final Price Rules (Option Alpha parity)
+
+Option Alpha’s default final price is:
+- 100% of the bid/ask spread (i.e., allow walking to the bid for sells / ask for buys)
+
+They also support multiple final-price caps and choose the “best” (least aggressive) cap.
+We can implement parity incrementally:
+
+Phase 1 (must):
+- `PERCENT_OF_SPREAD = 100%` default
+
+Phase 2 (nice to have):
+- allow selecting multiple caps (percent spread, $ from mid) and choose best
+
+---
+
+## Tick Size / Rounding (don’t hardcode; infer + fallback)
+
+This is mandatory for correctness; otherwise brokers reject orders.
+
+### Options tick sizes (overview)
+
+- Many options are “penny eligible”, but not all.
+- Tick sizes can depend on whether the class is in the penny program and the premium level.
+- For SPX specifically, Cboe specs indicate:
+  - under 3.00 → 0.05
+  - otherwise → 0.10
+  - and complex net pricing often has additional constraints
+
+References:
+- Cboe SPX specs: https://www.cboe.com/tradable_products/sp_500/spx_options/specifications
+- Options Education (penny increments): https://www.optionseducation.org/news/penny-increments
+
+### Strategy for LumiBot
+
+1) **Infer tick increment from observed quotes when available**:
+   - If bid/ask end in .05 increments, use 0.05
+   - If bid/ask end in .10 increments, use 0.10
+   - If bid/ask appear penny, use 0.01
+   This works for both:
+   - SPX-family
+   - non-penny stock options
+   - many other cases (including “stocks that trade in nickels” situations)
+
+2) **Fallback rules when we cannot infer**:
+   - Options: allow broker conformance to round/reject; we can also add a small static rule set for SPX/RUT/VIX/NDX family to be safe.
+   - Futures: use contract tick size where available (some brokers already fetch tick sizes for futures).
+   - Stocks: generally 0.01, but allow quote inference if quoting increments differ.
+
+3) **Package rounding (multi-leg)**:
+   - net limit price must respect package tick size constraints
+   - in backtesting, we must replicate the constraint to avoid optimistic fills
+
+---
+
+## Missing Quotes / Data Gaps (degrade, don’t crash)
+
+When bid/ask quotes are missing for an asset:
+- SMART_LIMIT should degrade gracefully and emit an explicit warning, not crash.
+- Default downgrade is **Market** (do not synthesize mid from OHLC).
+
+The key is:
+- do not silently pretend we have quotes
+- do not crash the strategy/backtest
+- surface the limitation in logs and (optionally) in progress payloads
+
+---
+
+## Observability / Progress Reporting
+
+We need SMART_LIMIT to be debuggable:
+- log transitions (created → step advanced → final hold → canceled/filled)
+- but do not spam per-bar logs by default
+
+Note:
+- We explicitly do **not** want any “log max per second” dropping logic.
+- Logging should remain opt-in / level-driven.
+
+For Botspot/Bot Manager:
+- consider adding a small “execution status” field to the progress payload:
+  - current step
+  - final price rule used
+  - current working limit price
+This should be minimal to keep payload size under control.
+
+---
+
+## Documentation Plan (two layers)
+
+### Layer 1: Human docs (`docs/`) — this document + future updates
+
+- This document lives in `docs/investigations/` and should remain after implementation.
+- Update `docs/BACKTESTING_ARCHITECTURE.md` to reference SMART_LIMIT once implemented.
+- Create a focused “how execution is simulated” section for SMART_LIMIT and how it differs from MARKET/ LIMIT.
+
+### Layer 2: Public docs (`docsrc/`) + docstrings
+
+We must update:
+- `Strategy.create_order()` docstring:
+  - new `smart_limit` argument
+  - examples for simple preset and advanced config
+- `OrderType` docs:
+  - describe SMART_LIMIT
+  - describe default cancel behavior
+  - describe multi-leg semantics
+
+Sphinx updates:
+- add a dedicated page in `docsrc/` explaining SMART_LIMIT
+- add a small mention on `docsrc/index.rst` (not “loud”, but present)
+
+---
+
+## Testing Plan
+
+### Unit tests (fast)
+
+1) Serialization:
+   - `SmartLimitConfig.to_dict()` produces primitives only
+   - `Order.to_dict()` includes smart_limit config without errors
+   - `send_update_to_cloud()` payload building does not choke on SMART_LIMIT orders
+
+2) Ladder generation:
+   - preset produces correct number of steps
+   - correct direction for buy vs sell
+   - final price obeys cap rules
+   - rounding is applied correctly
+
+3) Multi-leg net price:
+   - compute net bid/ask/mid deterministically from leg quotes
+   - enforce net tick rounding
+
+### Backtesting integration tests (deterministic)
+
+Using synthetic quotes/bars:
+- MARKET (bid/ask cross) vs SMART_LIMIT vs plain LIMIT
+- SMART_LIMIT:
+  - does not fill outside possible prices
+  - cancels on timeout
+  - respects final price bounds
+
+Multi-leg:
+- fills legs atomically at net price
+- does not “leg” unless explicitly configured (if we add that mode)
+
+### Acceptance backtests
+
+Run the known ThetaData acceptance suite (existing process in `docs/handoffs/...`).
+Pay special attention to strategies that trade:
+- options frequently
+- index options
+- multi-leg positions
+
+Legacy backtests run everything. If a backtest has been in the suite for >1 year, treat it as high‑priority and do not skip it.
+
+---
+
+## Open Questions / Decisions (to resolve before implementation)
+
+1) Broker capability inventory:
+   - Confirm per-broker modify/replace support for limit orders.
+   - Document any brokers that require cancel+new for repricing.
+
+2) Tick size inference:
+   - Are we comfortable with quote-inference as the primary method?
+   - How do we handle assets where quotes are stale / synthetic?
+
+---
+
+## Checklist (temporary; remove later)
+
+### Planning / research
+- [x] Confirm Option Alpha SmartPricing behavior details (presets, final hold, final price defaults).
+- [x] Confirm Option Alpha backtester slippage behavior (mid fills + user-defined slippage; no book simulation).
+- [ ] Inventory LumiBot brokers we support and confirm multi-leg combo + modify/replace capabilities where applicable.
+- [x] Document SMART_LIMIT backtest fill model (mid + slippage).
+- [x] Decide tick-size rounding rules (quote inference + fallback rules).
+
+### Core implementation
+- [x] Add `OrderType.SMART_LIMIT` (`lumibot/entities/order.py`).
+- [x] Add `SmartLimitPreset` enum and `SmartLimitConfig` object with `to_dict()`/`from_dict()`.
+- [x] Extend `Strategy.create_order()` to accept `smart_limit=` and populate the Order.
+- [x] Ensure `Order.to_dict()` includes smart_limit cleanly and remains small.
+- [x] Ensure `Order.to_minimal_dict()` includes minimal SMART_LIMIT status for progress reporting (optional).
+- [x] Add `TradingSlippage` and strategy-level defaults (`buy_trading_slippages` / `sell_trading_slippages`).
+- [x] Log `trade_slippage` in trades CSV/HTML alongside fees.
+
+### Live execution
+- [x] Add a live execution manager that runs in `StrategyExecutor.check_queue()` loop.
+- [x] Implement cancel/replace / modify path with monotonic scheduling (`next_action_at`).
+- [x] Implement multi-leg package repricing for brokers that support multileg combos.
+- [x] Degrade gracefully with warnings when quotes are missing.
+
+### Backtesting execution
+- [x] Implement SMART_LIMIT state machine in `BacktestingBroker.process_pending_orders()`.
+- [x] Implement multi-leg net price simulation (atomic fills) for SMART_LIMIT combos.
+- [x] Ensure fills remain broker-like and do not create lookahead leaks to user strategy APIs.
+- [x] Gracefully stop when backtest end date exceeds available trading days (no infinite loop).
+
+### Tests
+- [x] Add unit tests for serialization, rounding, ladder generation.
+- [x] Add integration tests for SMART_LIMIT behavior in backtesting (single-leg + multi-leg).
+- [x] Add tests for downgrade-to-market when quotes are missing.
+- [x] Add tests for slippage application (buy/sell + multi-leg net).
+- [x] Reinforce non-SMART_LIMIT multi-leg behavior remains unchanged.
+- [x] Add tests for future end-date termination (no freeze).
+- [x] Run targeted existing tests and acceptance backtests; confirm no regressions.
+
+### Docs
+- [x] Update docstrings for `create_order()` and `OrderType` with SMART_LIMIT usage examples.
+- [x] Add a public docs page under `docsrc/` describing SMART_LIMIT.
+- [x] Add a small mention on `docsrc/index.rst` (not “loud”).
+- [x] Add a docs page describing slippage (or fold into SMART_LIMIT docs if brief).
+- [x] Update `docs/BACKTESTING_ARCHITECTURE.md` to reference SMART_LIMIT simulation once implemented.

--- a/docsrc/entities.order.rst
+++ b/docsrc/entities.order.rst
@@ -84,6 +84,24 @@ To create trailing_stop orders, add either a trail_price or a trail_percent keyw
    order_2 = self.create_order(symbol, quantity, side, trail_percent=my_trail_percent)
    self.submit_order(order_2)
 
+
+**smart limit order**
+
+SMART_LIMIT orders walk the bid/ask spread using a timed ladder and are designed
+to achieve realistic fills for options and other wide-spread assets.
+
+.. code-block:: python
+
+   from lumibot.entities import SmartLimitConfig, SmartLimitPreset
+
+   config = SmartLimitConfig(preset=SmartLimitPreset.NORMAL, slippage=0.05)
+   order = self.create_order(symbol, quantity, side, smart_limit=config)
+   self.submit_order(order)
+
+In backtests, SMART_LIMIT fills at mid ± slippage. If the config does not specify
+slippage, the strategy-level defaults (``buy_trading_slippages`` /
+``sell_trading_slippages``) are used.
+
 Order With Legs
 """""""""""""""""""""
 

--- a/docsrc/entities.rst
+++ b/docsrc/entities.rst
@@ -15,4 +15,6 @@ Here's a list of the main entities in Lumibot:
    entities.order
    entities.position
    entities.trading_fee
+   entities.trading_slippage
+   entities.smart_limit
    entities.chains

--- a/docsrc/entities.smart_limit.rst
+++ b/docsrc/entities.smart_limit.rst
@@ -1,0 +1,8 @@
+Smart Limit Config
+-------------------------------
+
+.. automodule:: lumibot.entities.smart_limit
+   :noindex:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docsrc/entities.trading_slippage.rst
+++ b/docsrc/entities.trading_slippage.rst
@@ -1,0 +1,22 @@
+Trading Slippage
+-------------------------------
+
+TradingSlippage is a backtesting-only execution cost used by SMART_LIMIT fills.
+You can provide slippage at the strategy level:
+
+.. code-block:: python
+
+   from lumibot.entities import TradingSlippage
+
+   slippage = TradingSlippage(amount=0.05)
+   MyStrategy.backtest(
+       ...,
+       buy_trading_slippages=[slippage],
+       sell_trading_slippages=[slippage],
+   )
+
+.. automodule:: lumibot.entities.trading_slippage
+   :noindex:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -180,6 +180,7 @@ Table of Contents
    strategy_methods
    strategy_properties
    entities
+   smart_limit
    futures
    backtesting
    brokers

--- a/docsrc/smart_limit.rst
+++ b/docsrc/smart_limit.rst
@@ -1,0 +1,62 @@
+Smart Limit Orders
+==================
+
+SMART_LIMIT orders are midpoint-chasing limit orders that walk the bid/ask spread
+using a timed ladder (Option Alpha “SmartPricing” parity). They are meant to model
+realistic execution without forcing market orders through wide option spreads.
+
+Overview
+--------
+
+- Uses bid/ask to compute a midpoint and final price bound.
+- Walks from mid toward the bid/ask using preset step timing.
+- Cancels after the final hold window if unfilled.
+- If bid/ask is missing, SMART_LIMIT downgrades to a market order and emits a warning.
+
+Presets (Option Alpha parity)
+-----------------------------
+
+- **FAST**: 3 price levels, 5 seconds per step
+- **NORMAL**: 4 price levels, 10 seconds per step
+- **PATIENT**: 5 price levels, 20 seconds per step
+- Final hold: 120 seconds
+
+Backtesting behavior
+--------------------
+
+SMART_LIMIT fills at **mid + slippage** for buys and **mid - slippage** for sells.
+This matches the standard midpoint fill approximation used by platforms like
+Option Alpha when only bar data is available.
+
+If the SMART_LIMIT config does **not** specify slippage, backtests will fall back
+to strategy-level defaults (``buy_trading_slippages`` / ``sell_trading_slippages``),
+which accept ``TradingSlippage`` objects and default to zero when unset.
+
+If bid/ask quotes are missing in a backtest, SMART_LIMIT downgrades to a market
+order fill (next-bar open).
+
+Trade logs for backtests include a ``trade_slippage`` column (CSV) and show slippage
+in trade marker tooltips (HTML).
+
+Usage
+-----
+
+.. code-block:: python
+
+   from lumibot.entities import SmartLimitConfig, SmartLimitPreset
+
+   config = SmartLimitConfig(
+       preset=SmartLimitPreset.NORMAL,
+       slippage=0.05,  # $0.05 from mid
+   )
+
+   order = self.create_order("SPY", 100, "buy", smart_limit=config)
+   self.submit_order(order)
+
+Multi-leg orders
+----------------
+
+SMART_LIMIT supports multi-leg orders as a package (net bid/ask/mid). In backtests,
+the package fills atomically at the net midpoint plus slippage. For multi-leg SMART_LIMIT
+orders, build a parent Order with ``order_class=Order.OrderClass.MULTILEG`` and provide
+the child leg orders on ``child_orders``.

--- a/lumibot/__init__.py
+++ b/lumibot/__init__.py
@@ -2,15 +2,43 @@ import os
 import sys
 import warnings
 import importlib
+import re
+from pathlib import Path
 
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
 
+
+def _read_version_from_setup_py() -> str | None:
+    """Best-effort: when running from a source checkout via PYTHONPATH, prefer setup.py's version.
+
+    This avoids the common confusion where importlib.metadata returns the *installed* wheel
+    version (e.g. 4.4.16) while the runtime is actually importing source (e.g. 4.4.18).
+    """
+
+    try:
+        module_path = Path(__file__).resolve()
+        for parent in module_path.parents:
+            setup_py = parent / "setup.py"
+            if not setup_py.is_file():
+                continue
+            text = setup_py.read_text(encoding="utf-8", errors="ignore")
+            match = re.search(r"version\s*=\s*['\"]([^'\"]+)['\"]", text)
+            if match:
+                return match.group(1).strip()
+    except Exception:
+        pass
+    return None
+
+
 # Get and display the version
 try:
-    from importlib.metadata import version
-    __version__ = version("lumibot")
+    __version__ = _read_version_from_setup_py()
+    if __version__ is None:
+        from importlib.metadata import version
+
+        __version__ = version("lumibot")
 except ImportError:
     # Fallback for Python < 3.8
     try:

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -1863,7 +1863,6 @@ class BacktestingBroker(Broker):
                 df_original = ohlc.df
 
                 # Handle both pandas and polars DataFrames
-                prefer_future_bar = getattr(getattr(self, "data_source", None), "_timestep", None) == "day"
                 if hasattr(df_original, 'select'):  # Polars DataFrame
                     # Find datetime column
                     dt_col = None
@@ -1874,10 +1873,7 @@ class BacktestingBroker(Broker):
                     if dt_col is None:
                         dt_col = 'datetime'  # fallback
 
-                    # For day-cadence backtests, fills should be based on the *next* bar to avoid
-                    # lookahead (orders created on a day bar execute on the next day bar).
-                    comparator = pl.col(dt_col) > self.datetime if prefer_future_bar else pl.col(dt_col) >= self.datetime
-                    df = df_original.filter(comparator)
+                    df = df_original.filter(pl.col(dt_col) >= self.datetime)
 
                     # If the dataframe is empty, get the last row
                     if len(df) == 0:
@@ -1891,12 +1887,7 @@ class BacktestingBroker(Broker):
                     close = df["close"][0]
                     volume = df["volume"][0]
                 else:  # Pandas DataFrame
-                    # For day-cadence backtests, fills should be based on the *next* bar to avoid
-                    # lookahead (orders created on a day bar execute on the next day bar).
-                    if prefer_future_bar:
-                        df = df_original[df_original.index > self.datetime]
-                    else:
-                        df = df_original[df_original.index >= self.datetime]
+                    df = df_original[df_original.index >= self.datetime]
 
                     # If the dataframe is empty, then we should get the last row of the original dataframe
                     # because it is the best data we have

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -2,7 +2,7 @@ import math
 import traceback
 import threading
 from collections import OrderedDict, defaultdict
-from datetime import timedelta
+from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Optional, Union
 
@@ -12,7 +12,8 @@ import pytz
 
 from lumibot.brokers import Broker
 from lumibot.data_sources import DataSourceBacktesting
-from lumibot.entities import Asset, Order, Position, TradingFee
+from lumibot.entities import Asset, Order, Position, SmartLimitConfig, TradingFee
+from lumibot.tools.smart_limit_utils import build_price_ladder, compute_final_price, compute_mid, expected_fill_price, infer_tick_size, round_to_tick
 from lumibot.tools.lumibot_logger import get_logger
 from lumibot.trading_builtins import CustomStream
 
@@ -147,6 +148,23 @@ class BacktestingBroker(Broker):
         self._market_open_cache = {}
         # Track per-strategy futures lots for accurate margin/P&L when flipping
         self._futures_lot_ledgers = defaultdict(list)
+        # Track end-of-data to prevent infinite loops when end date is in the future
+        self._end_of_trading_days_reached = False
+
+    def _mark_end_of_trading_days(self, now):
+        if self._end_of_trading_days_reached:
+            return
+
+        self._end_of_trading_days_reached = True
+        logger.warning(
+            "Backtesting reached end of available trading days data; stopping at %s",
+            now,
+        )
+        if self.data_source.datetime_end > now:
+            self.data_source.datetime_end = now
+        if self.option_source and hasattr(self.option_source, "datetime_end"):
+            if self.option_source.datetime_end > now:
+                self.option_source.datetime_end = now
     def initialize_market_calendars(self, trading_days_df):
         """Initialize trading calendar and eagerly build caches for backtesting."""
         super().initialize_market_calendars(trading_days_df)
@@ -255,6 +273,35 @@ class BacktestingBroker(Broker):
     def get_historical_account_value(self):
         pass
 
+    def get_active_tracked_orders(self, strategy: str) -> list[Order]:
+        """Return active (open/submitted/new) orders for the given strategy.
+
+        Backtests can accumulate tens of thousands of filled orders over long windows.
+        Scanning all tracked orders and calling ``Order.is_active()`` each bar is a major
+        performance bottleneck, so this method sources active orders directly from the
+        broker's active-order buckets.
+        """
+        active_orders: list[Order] = []
+        try:
+            buckets = (
+                self._unprocessed_orders.get_list(),
+                self._new_orders.get_list(),
+                self._partially_filled_orders.get_list(),
+            )
+        except Exception:
+            # Fallback to the slower path if internal buckets are unavailable.
+            orders = self.get_tracked_orders(strategy=strategy)
+            return [o for o in orders if o.is_active()] if orders else []
+
+        for bucket in buckets:
+            for order in bucket:
+                if getattr(order, "strategy", None) != strategy:
+                    continue
+                # Buckets should already contain only active orders, but keep a defensive check.
+                if order.is_active():
+                    active_orders.append(order)
+        return active_orders
+
     # =========Internal functions==================
 
     def _update_datetime(self, update_dt, cash=None, portfolio_value=None, positions=None, initial_budget=None, orders=None):
@@ -315,6 +362,9 @@ class BacktestingBroker(Broker):
         Needs to be overloaded for backtesting to
         check if the limit datetime was reached"""
 
+        if self._end_of_trading_days_reached:
+            return False
+
         # If we are at the end of the data source, we should stop
         if self.datetime >= self.data_source.datetime_end:
             return False
@@ -352,7 +402,7 @@ class BacktestingBroker(Broker):
         now = self.datetime
         search = self._trading_days[now < self._trading_days.market_open]
         if search.empty:
-            logger.critical("Cannot predict future")
+            self._mark_end_of_trading_days(now)
             return None
 
         return search.market_open[0].to_pydatetime()
@@ -363,7 +413,7 @@ class BacktestingBroker(Broker):
 
         search = self._trading_days[now < self._trading_days.index]
         if search.empty:
-            logger.info("Cannot predict future")
+            self._mark_end_of_trading_days(now)
             return None
 
         trading_day = search.iloc[0]
@@ -451,7 +501,6 @@ class BacktestingBroker(Broker):
 
         # If None is returned, it means we've reached the end of available trading days
         if time_to_open is None:
-            logger.info("Backtesting reached end of available trading days data")
             logger.debug(f"[BROKER DEBUG] time_to_open is None, returning early")
             return
 
@@ -699,15 +748,16 @@ class BacktestingBroker(Broker):
             for child in order.child_orders:
                 _cancel_inline(child)
 
-        open_orders = self.get_tracked_orders(strategy=strategy_name)
+        # PERF: Only active orders can be canceled; scanning full order history is
+        # extremely expensive in long intraday option strategies.
+        open_orders = self.get_active_tracked_orders(strategy=strategy_name)
 
         # Build a set of all child order identifiers to skip them in the main loop
         # (they will be handled by their parent orders)
         child_order_identifiers = set()
         for tracked_order in open_orders:
-            if tracked_order.child_orders:
-                for child in tracked_order.child_orders:
-                    child_order_identifiers.add(child.identifier)
+            for child in getattr(tracked_order, "child_orders", []) or []:
+                child_order_identifiers.add(child.identifier)
 
         for tracked_order in open_orders:
             if tracked_order.identifier in exclude_identifiers:
@@ -718,8 +768,6 @@ class BacktestingBroker(Broker):
             if tracked_order.identifier in child_order_identifiers:
                 continue
             if tracked_order.asset != asset:
-                continue
-            if not tracked_order.is_active():
                 continue
             if in_stream_thread:
                 _cancel_inline(tracked_order)
@@ -743,8 +791,7 @@ class BacktestingBroker(Broker):
             self._unprocessed_orders.remove(order.identifier, key="identifier")
             self._partially_filled_orders.remove(order.identifier, key="identifier")
 
-            if order not in self._filled_orders:
-                self._filled_orders.append(order)
+            self._track_filled_order(order)
 
             return None
 
@@ -768,6 +815,25 @@ class BacktestingBroker(Broker):
             parent_order = self.get_tracked_order(order.parent_identifier, use_placeholders=True)
             self._update_parent_order_status(parent_order)
         return position
+
+    def _track_filled_order(self, order: Order) -> None:
+        """Record a filled order without incurring O(n) SafeList membership scans."""
+        if order is None:
+            return
+        identifier = getattr(order, "identifier", None)
+        if identifier is None:
+            self._filled_orders.append(order)
+            return
+
+        filled_ids = getattr(self, "_filled_order_identifiers", None)
+        if filled_ids is None:
+            filled_ids = set()
+            setattr(self, "_filled_order_identifiers", filled_ids)
+
+        if identifier in filled_ids:
+            return
+        filled_ids.add(identifier)
+        self._filled_orders.append(order)
 
     def _process_partially_filled_order(self, order, price, quantity):
         """
@@ -841,8 +907,7 @@ class BacktestingBroker(Broker):
             self._unprocessed_orders.remove(order.identifier, key="identifier")
             self._partially_filled_orders.remove(order.identifier, key="identifier")
 
-            if order not in self._filled_orders:
-                self._filled_orders.append(order)
+            self._track_filled_order(order)
 
     def _submit_order(self, order):
         """Submit an order for an asset"""
@@ -909,16 +974,48 @@ class BacktestingBroker(Broker):
             # Each leg uses a different option asset, just use the base symbol.
             symbol = orders[0].asset.symbol
             parent_asset = Asset(symbol=symbol)
+            parent_order_type = kwargs.get("order_type", orders[0].order_type)
+            parent_smart_limit = None
+
+            if str(parent_order_type) == str(Order.OrderType.SMART_LIMIT):
+                # Package SMART_LIMIT: treat the multileg parent as the smart order and fill the
+                # child legs atomically when the parent becomes executable.
+                parent_order_type = Order.OrderType.SMART_LIMIT
+                parent_smart_limit = (
+                    kwargs.get("smart_limit")
+                    or getattr(orders[0], "smart_limit", None)
+                    or SmartLimitConfig()
+                )
+                for child in orders:
+                    setattr(child, "_smart_limit_managed_by_parent", True)
+
+            # Tradier multileg orders pass broker-specific order types like "credit"/"debit"/"even"
+            # which are not executable order types in LumiBot. The multileg parent is a placeholder,
+            # so normalize to a standard type to avoid raising.
+            if parent_smart_limit is None:
+                if isinstance(parent_order_type, str) and parent_order_type.lower() in {"credit", "debit", "even"}:
+                    parent_order_type = Order.OrderType.LIMIT
+                else:
+                    try:
+                        parent_order_type = (
+                            parent_order_type
+                            if isinstance(parent_order_type, Order.OrderType) or parent_order_type is None
+                            else Order.OrderType(parent_order_type)
+                        )
+                    except ValueError:
+                        parent_order_type = Order.OrderType.MARKET
             parent_order = Order(
                 asset=parent_asset,
                 strategy=orders[0].strategy,
                 order_class=Order.OrderClass.MULTILEG,
                 side=orders[0].side,
                 quantity=orders[0].quantity,
-                order_type=orders[0].order_type,
+                order_type=parent_order_type,
                 tag=orders[0].tag,
                 status=Order.OrderStatus.SUBMITTED
             )
+            if parent_smart_limit is not None:
+                parent_order.smart_limit = parent_smart_limit
 
             for o in orders:
                 o.parent_identifier = parent_order.identifier
@@ -938,7 +1035,12 @@ class BacktestingBroker(Broker):
             order=order,
         )
         # Cancel all child orders as well
-        for child in order.child_orders:
+        for child in order.child_orders or []:
+            if child is None:
+                continue
+            # Never overwrite already-closed child orders (e.g., OCO winners).
+            if not child.is_active():
+                continue
             self.cancel_order(child)
 
     def _modify_order(self, order: Order, limit_price: Union[float, None] = None,
@@ -1122,6 +1224,8 @@ class BacktestingBroker(Broker):
         filled_quantity: Decimal,
         strategy,
     ) -> None:
+        parent_identifier = getattr(order, "parent_identifier", None)
+
         if order.dependent_order:
             order.dependent_order.dependent_order_filled = True
             strategy.broker.cancel_order(order.dependent_order)
@@ -1192,6 +1296,20 @@ class BacktestingBroker(Broker):
             and not (asset_type == Asset.AssetType.CRYPTO and quote_asset_type == Asset.AssetType.FOREX)
         ):
             self._apply_trade_cost(strategy, trade_cost)
+
+        # If this was an OCO child fill, mark the OCO parent filled after the child
+        # fill is recorded so legacy ordering expectations remain stable.
+        if parent_identifier:
+            parent_order = self.get_tracked_order(parent_identifier, use_placeholders=True)
+            if parent_order is not None and parent_order.order_class == Order.OrderClass.OCO and not parent_order.is_filled():
+                try:
+                    self._placeholder_orders.remove(parent_order.identifier, key="identifier")
+                except Exception:
+                    pass
+                parent_order.status = self.FILLED_ORDER
+                parent_order.set_filled()
+                if parent_order not in self._filled_orders:
+                    self._filled_orders.append(parent_order)
 
     def _process_crypto_quote(self, order, quantity, price):
         """Override to skip quote processing for assets that use direct cash updates or margin-based trading."""
@@ -1300,7 +1418,7 @@ class BacktestingBroker(Broker):
             if trading_fee.taker is True and order_type_value in {"market", "stop"}:
                 trade_cost += trading_fee.flat_fee
                 trade_cost += Decimal(str(price)) * Decimal(str(order.quantity)) * trading_fee.percent_fee
-            elif trading_fee.maker is True and order_type_value in {"limit", "stop_limit"}:
+            elif trading_fee.maker is True and order_type_value in {"limit", "stop_limit", "smart_limit"}:
                 trade_cost += trading_fee.flat_fee
                 trade_cost += Decimal(str(price)) * Decimal(str(order.quantity)) * trading_fee.percent_fee
 
@@ -1419,8 +1537,13 @@ class BacktestingBroker(Broker):
             if order.order_class == Order.OrderClass.OCO:
                 continue
 
-            # Multileg parent orders will wait for child orders to fill before processing
-            if order.order_class == Order.OrderClass.MULTILEG:
+            # SMART_LIMIT multileg children should be filled atomically by their parent order.
+            if getattr(order, "_smart_limit_managed_by_parent", False):
+                continue
+
+            # Multileg parent orders are placeholders unless they are explicitly
+            # configured as a package SMART_LIMIT (i.e. have a SmartLimitConfig).
+            if order.order_class == Order.OrderClass.MULTILEG and getattr(order, "smart_limit", None) is None:
                 # If this is the final fill for a multileg order, mark the parent order as filled
                 if all([o.is_filled() for o in order.child_orders]):
                     parent_qty = sum([abs(o.quantity) for o in order.child_orders])
@@ -1451,6 +1574,84 @@ class BacktestingBroker(Broker):
             timeshift = None
             dt = None
             open = high = low = close = volume = None
+
+            # PERFORMANCE: Prefer quote-based fills when bid/ask are present so we avoid
+            # fetching trade-only OHLC bars (which can be sparse/missing, especially for
+            # options). When bid/ask are unavailable we fall back to the OHLC-based model.
+            if order.order_type in (Order.OrderType.MARKET, Order.OrderType.LIMIT) and (order.is_buy_order() or order.is_sell_order()):
+                try:
+                    quote = self.get_quote(order.asset, quote=order.quote)
+                except Exception:
+                    quote = None
+
+                bid = self._coerce_price(getattr(quote, "bid", None)) if quote is not None else None
+                ask = self._coerce_price(getattr(quote, "ask", None)) if quote is not None else None
+                if bid is not None and self._is_invalid_price(bid):
+                    bid = None
+                if ask is not None and self._is_invalid_price(ask):
+                    ask = None
+
+                is_buy = order.is_buy_order()
+
+                if order.order_type == Order.OrderType.MARKET:
+                    required_price = ask if is_buy else bid
+                    if required_price is not None and not self._is_invalid_price(required_price):
+                        setattr(order, "_price_source", "quote")
+                        self._execute_filled_order(
+                            order=order,
+                            price=required_price,
+                            filled_quantity=filled_quantity,
+                            strategy=strategy,
+                        )
+                        continue
+
+                elif bid is not None and ask is not None:
+                    fill_price: Optional[float] = None
+                    limit_price = self._coerce_price(order.limit_price)
+                    crossed = False
+                    if limit_price is not None:
+                        if is_buy:
+                            if limit_price >= ask:
+                                fill_price = ask
+                                crossed = True
+                            elif limit_price >= bid:
+                                fill_price = limit_price
+                        else:
+                            if limit_price <= bid:
+                                fill_price = bid
+                                crossed = True
+                            elif limit_price <= ask:
+                                fill_price = limit_price
+
+                    if fill_price is not None and not self._is_invalid_price(fill_price):
+                        spread_key = "max_spread_buy_pct" if is_buy else "max_spread_sell_pct"
+                        spread_limit = self._get_spread_limit(strategy, spread_key)
+                        if spread_limit is None:
+                            spread_limit = self._get_spread_limit(strategy, "max_spread_pct")
+                        # Only apply spread gating to *inside-spread* limit fills.
+                        # Marketable limits (>=ask for buys, <=bid for sells) should fill regardless
+                        # of spread width, otherwise strategies can get stuck with uncloseable legs.
+                        if spread_limit is not None and not crossed and fill_price == limit_price:
+                            mid = (ask + bid) / 2
+                            if mid > 0:
+                                spread_pct = (ask - bid) / mid
+                                if spread_pct > spread_limit:
+                                    fill_price = None
+
+                    if fill_price is not None and not self._is_invalid_price(fill_price):
+                        setattr(order, "_price_source", "quote")
+                        self._execute_filled_order(
+                            order=order,
+                            price=fill_price,
+                            filled_quantity=filled_quantity,
+                            strategy=strategy,
+                        )
+                        continue
+
+                    # Quote was available but did not satisfy fill conditions; keep the order open
+                    # and retry on the next bar without forcing an OHLC download.
+                    if bid is not None and ask is not None:
+                        continue
 
             #############################
             # Get OHLCV data for the asset
@@ -1522,13 +1723,9 @@ class BacktestingBroker(Broker):
 
             # Get the OHLCV data for the asset if we're using the PANDAS data source
             elif self.data_source.SOURCE == "PANDAS":
-                # ThetaData option market orders: prefer NBBO quote fills to avoid forcing
-                # minute OHLC downloads (trades can be sparse and fetching OHLC is expensive).
-                if (
-                    self._is_thetadata_source()
-                    and self._is_option_asset(getattr(order, "asset", None))
-                    and order.order_type == Order.OrderType.MARKET
-                ):
+                # Market orders: prefer quote-based fills when bid/ask are available to avoid
+                # expensive OHLC downloads and reflect real-world execution more closely.
+                if order.order_type == Order.OrderType.MARKET:
                     quote_fill_price = self._try_fill_with_quote(order, strategy, None, None, None)
                     if quote_fill_price is not None:
                         self._execute_filled_order(
@@ -1538,6 +1735,41 @@ class BacktestingBroker(Broker):
                             strategy=strategy,
                         )
                         continue
+
+                # LIMIT orders: if the limit is immediately marketable against the current NBBO,
+                # fill from quotes and skip the OHLC fetch. This is especially important for options,
+                # where OHLC bars can be sparse/missing and would otherwise trigger a slow downloader call.
+                if order.order_type == Order.OrderType.LIMIT:
+                    try:
+                        quote = self.get_quote(order.asset, quote=order.quote)
+                    except Exception:
+                        quote = None
+
+                    bid = self._coerce_price(getattr(quote, "bid", None)) if quote is not None else None
+                    ask = self._coerce_price(getattr(quote, "ask", None)) if quote is not None else None
+                    limit_price = self._coerce_price(getattr(order, "limit_price", None))
+
+                    if limit_price is not None:
+                        if order.is_buy_order():
+                            if ask is not None and not self._is_invalid_price(ask) and limit_price >= ask:
+                                setattr(order, "_price_source", "quote")
+                                self._execute_filled_order(
+                                    order=order,
+                                    price=ask,
+                                    filled_quantity=filled_quantity,
+                                    strategy=strategy,
+                                )
+                                continue
+                        elif order.is_sell_order():
+                            if bid is not None and not self._is_invalid_price(bid) and limit_price <= bid:
+                                setattr(order, "_price_source", "quote")
+                                self._execute_filled_order(
+                                    order=order,
+                                    price=bid,
+                                    filled_quantity=filled_quantity,
+                                    strategy=strategy,
+                                )
+                                continue
 
                 # This is a hack to get around the fact that we need to get the previous day's data to prevent lookahead bias.
                 ohlc = self.data_source.get_historical_prices(
@@ -1549,24 +1781,71 @@ class BacktestingBroker(Broker):
                 )
                 # Check if we got any ohlc data
                 if ohlc is None or ohlc.empty:
-                    # ThetaData option minute OHLC can be sparse/empty even when NBBO quotes exist.
-                    #
-                    # If we immediately cancel here, the order never reaches the quote-fill fallback path
-                    # (`_try_fill_with_quote`) and we can wind up with determinism issues:
-                    # - BUY_TO_CLOSE orders get canceled at 15:55
-                    # - contracts then cash-settle at expiry (large intrinsic losses)
-                    #
-                    # For ThetaData options only, attempt a quote-based fill when OHLC is missing.
-                    if self._is_thetadata_source() and self._is_option_asset(getattr(order, "asset", None)):
-                        quote_fill_price = self._try_fill_with_quote(order, strategy, None, None, None)
-                        if quote_fill_price is not None:
+                    # SmartLimit should attempt quote-based fills regardless of asset type or data source.
+                    if str(order.order_type) == str(Order.OrderType.SMART_LIMIT):
+                        smart_price, smart_timed_out = self._smart_limit_backtest_price(
+                            order, strategy, None, None, None
+                        )
+                        if smart_timed_out:
+                            self.cancel_order(order)
+                            continue
+
+                        # Package SMART_LIMIT orders (multileg parents) must never fill on their own.
+                        # When OHLC is missing (common for placeholder multileg assets), use quotes to
+                        # fill the child legs atomically and then mark the parent filled for logging.
+                        if (
+                            order.order_class == Order.OrderClass.MULTILEG
+                            and order.child_orders
+                            and getattr(order, "smart_limit", None) is not None
+                        ):
+                            if smart_price is None or self._is_invalid_price(smart_price):
+                                # Not executable yet; keep the order open.
+                                continue
+
+                            filled = self._fill_multileg_smart_limit_children(order, strategy, float(smart_price))
+                            if not filled:
+                                filled = self._fill_multileg_children_at_market_open(order, strategy)
+
+                            if filled:
+                                parent_qty = sum(abs(o.quantity) for o in order.child_orders)
+                                child_prices = [
+                                    o.get_fill_price() if o.is_buy_order() else -o.get_fill_price()
+                                    for o in order.child_orders
+                                ]
+                                parent_price = sum(child_prices)
+                                parent_multiplier = getattr(getattr(order, "asset", None), "multiplier", 1) or 1
+
+                                self.stream.dispatch(
+                                    self.FILLED_ORDER,
+                                    wait_until_complete=True,
+                                    order=order,
+                                    price=parent_price,
+                                    filled_quantity=parent_qty,
+                                    multiplier=parent_multiplier,
+                                )
+                            continue
+
+                        if smart_price is not None and not self._is_invalid_price(smart_price):
                             self._execute_filled_order(
                                 order=order,
-                                price=quote_fill_price,
+                                price=smart_price,
                                 filled_quantity=filled_quantity,
                                 strategy=strategy,
                             )
-                            continue
+                        # Keep the order open and retry on the next bar if no fill.
+                        continue
+
+                    # OHLC can be sparse/empty even when quotes exist. Attempt a quote-based fill
+                    # before canceling so orders can still execute when bid/ask is actionable.
+                    quote_fill_price = self._try_fill_with_quote(order, strategy, None, None, None)
+                    if quote_fill_price is not None:
+                        self._execute_filled_order(
+                            order=order,
+                            price=quote_fill_price,
+                            filled_quantity=filled_quantity,
+                            strategy=strategy,
+                        )
+                        continue
 
                     if strategy is not None:
                         display_symbol = getattr(order.asset, "symbol", order.asset)
@@ -1584,6 +1863,7 @@ class BacktestingBroker(Broker):
                 df_original = ohlc.df
 
                 # Handle both pandas and polars DataFrames
+                prefer_future_bar = getattr(getattr(self, "data_source", None), "_timestep", None) == "day"
                 if hasattr(df_original, 'select'):  # Polars DataFrame
                     # Find datetime column
                     dt_col = None
@@ -1594,8 +1874,10 @@ class BacktestingBroker(Broker):
                     if dt_col is None:
                         dt_col = 'datetime'  # fallback
 
-                    # Filter for current time or future
-                    df = df_original.filter(pl.col(dt_col) >= self.datetime)
+                    # For day-cadence backtests, fills should be based on the *next* bar to avoid
+                    # lookahead (orders created on a day bar execute on the next day bar).
+                    comparator = pl.col(dt_col) > self.datetime if prefer_future_bar else pl.col(dt_col) >= self.datetime
+                    df = df_original.filter(comparator)
 
                     # If the dataframe is empty, get the last row
                     if len(df) == 0:
@@ -1609,8 +1891,12 @@ class BacktestingBroker(Broker):
                     close = df["close"][0]
                     volume = df["volume"][0]
                 else:  # Pandas DataFrame
-                    # Make sure that we are only getting the prices for the current time exactly or in the future
-                    df = df_original[df_original.index >= self.datetime]
+                    # For day-cadence backtests, fills should be based on the *next* bar to avoid
+                    # lookahead (orders created on a day bar execute on the next day bar).
+                    if prefer_future_bar:
+                        df = df_original[df_original.index > self.datetime]
+                    else:
+                        df = df_original[df_original.index >= self.datetime]
 
                     # If the dataframe is empty, then we should get the last row of the original dataframe
                     # because it is the best data we have
@@ -1645,6 +1931,54 @@ class BacktestingBroker(Broker):
                         order.price_triggered = True
                 elif order.price_triggered:
                     price = self.limit_order(order.limit_price, simple_side, open, high, low)
+
+            elif str(order.order_type) == str(Order.OrderType.SMART_LIMIT):
+                price, cancel_order = self._smart_limit_backtest_price(order, strategy, open, high, low)
+                if cancel_order:
+                    self.cancel_order(order)
+                    continue
+
+                # Package SMART_LIMIT orders (multileg parent) are *scheduling containers*.
+                #
+                # They must never fill on their own because that produces misleading trade logs
+                # (parent filled, legs not filled) and prevents the strategy from seeing the
+                # actual leg fills in `on_filled_order()`.
+                if (
+                    order.order_class == Order.OrderClass.MULTILEG
+                    and order.child_orders
+                    and getattr(order, "smart_limit", None) is not None
+                ):
+                    if price is None or self._is_invalid_price(price):
+                        # Not executable yet; keep waiting.
+                        continue
+
+                    filled = self._fill_multileg_smart_limit_children(order, strategy, float(price))
+                    if not filled:
+                        # Quotes missing (or invalid). SMART_LIMIT should downgrade to a market-style
+                        # fill. For multileg orders that means filling each leg from its own OHLC open.
+                        filled = self._fill_multileg_children_at_market_open(order, strategy)
+
+                    if filled:
+                        parent_qty = sum(abs(o.quantity) for o in order.child_orders)
+                        child_prices = [
+                            o.get_fill_price() if o.is_buy_order() else -o.get_fill_price()
+                            for o in order.child_orders
+                        ]
+                        parent_price = sum(child_prices)
+                        parent_multiplier = getattr(getattr(order, "asset", None), "multiplier", 1) or 1
+
+                        self.stream.dispatch(
+                            self.FILLED_ORDER,
+                            wait_until_complete=True,
+                            order=order,
+                            price=parent_price,
+                            filled_quantity=parent_qty,
+                            multiplier=parent_multiplier,
+                        )
+
+                    # Always continue: either legs were filled (and we dispatched a parent fill for logging),
+                    # or we could not fill and need to retry later. Never fill the parent directly.
+                    continue
 
             elif order.order_type == Order.OrderType.TRAIL:
                 current_trail_stop_price = order.get_current_trail_stop_price()
@@ -1694,8 +2028,18 @@ class BacktestingBroker(Broker):
                     )
                 continue
 
-        # After handling all pending orders, cash settle any residual expired contracts.
-        self.process_expired_option_contracts(strategy)
+        # Expired contracts settlement is only meaningful at (or after) the end of a session.
+        #
+        # Calling `process_expired_option_contracts()` on every bar is extremely expensive in long
+        # intraday backtests (it scans positions + active orders) and does not change behavior
+        # because the function intentionally skips settlement until after the close.
+        #
+        # - Intraday backtests: settlement is handled once per day by `StrategyExecutor._strategy_sleep()`
+        #   when it advances the clock to the close.
+        # - Daily backtests: `process_pending_orders()` runs once per day, so it is safe to settle here.
+        timestep = getattr(getattr(self, "data_source", None), "_timestep", None)
+        if timestep == "day":
+            self.process_expired_option_contracts(strategy)
 
     def _coerce_price(self, value):
         """Convert numeric inputs to float when possible for safe comparisons."""
@@ -1740,18 +2084,11 @@ class BacktestingBroker(Broker):
     def _should_attempt_quote_fallback(self, order, open_, high_, low_) -> bool:
         """Determine whether to attempt quote-based fills.
 
-        We primarily use quote fills for ThetaData when OHLC bars are missing. Additionally, for ThetaData
-        option day-bars, trade prints can be sparse (limits may not cross a trade even when NBBO is actionable),
-        so we allow quote fills for option limit orders in daily cadence when a quote is available.
+        Quotes can provide actionable fills even when OHLC bars are missing or trade prints
+        are sparse. We rely on bid/ask availability rather than asset type or data source.
         """
-        if not self._is_thetadata_source():
-            return False
         if self._bar_has_missing_prices(open_, high_, low_):
             return True
-
-        asset = getattr(order, "asset", None) if order is not None else None
-        if not self._is_option_asset(asset):
-            return False
 
         timestep = getattr(self.data_source, "_timestep", None)
         return timestep == "day"
@@ -1777,12 +2114,31 @@ class BacktestingBroker(Broker):
                 return None
         return None
 
+    def _get_strategy_slippage_amount(self, strategy, order: Order) -> float:
+        if strategy is None or order is None:
+            return 0.0
+
+        slippages = []
+        if order.is_buy_order():
+            slippages = getattr(strategy, "buy_trading_slippages", [])
+        else:
+            slippages = getattr(strategy, "sell_trading_slippages", [])
+
+        total = 0.0
+        for slippage in slippages or []:
+            if hasattr(slippage, "amount"):
+                total += float(slippage.amount)
+            else:
+                try:
+                    total += float(slippage)
+                except (TypeError, ValueError):
+                    continue
+        return total
+
     def _try_fill_with_quote(self, order, strategy, open_=None, high_=None, low_=None) -> Optional[float]:
-        """Attempt to fill an order using ThetaData quotes when OHLC bars are missing."""
-        if not self._is_thetadata_source():
-            return None
-        is_option = self._is_option_asset(getattr(order, "asset", None))
-        if not (self._bar_has_missing_prices(open_, high_, low_) or is_option):
+        """Attempt to fill an order using quotes when OHLC bars are missing."""
+        timestep = getattr(self.data_source, "_timestep", None)
+        if not (self._bar_has_missing_prices(open_, high_, low_) or timestep == "day"):
             return None
         if order.order_type not in (Order.OrderType.LIMIT, Order.OrderType.STOP_LIMIT, Order.OrderType.MARKET):
             return None
@@ -1792,7 +2148,7 @@ class BacktestingBroker(Broker):
         try:
             quote = self.get_quote(order.asset, quote=order.quote)
         except Exception as exc:  # pragma: no cover - defensive log for unexpected broker states
-            self.logger.debug("ThetaData quote lookup failed for %s: %s", getattr(order.asset, "symbol", order.asset), exc)
+            self.logger.debug("Quote lookup failed for %s: %s", getattr(order.asset, "symbol", order.asset), exc)
             return None
 
         if quote is None:
@@ -1808,14 +2164,17 @@ class BacktestingBroker(Broker):
             fill_price = ask if is_buy else bid
         else:
             limit_price = self._coerce_price(order.limit_price)
+            crossed = False
             if is_buy:
                 if ask is not None and limit_price is not None and limit_price >= ask:
                     fill_price = ask
+                    crossed = True
                 elif bid is not None and limit_price is not None and limit_price >= bid:
                     fill_price = limit_price
             else:
                 if bid is not None and limit_price is not None and limit_price <= bid:
                     fill_price = bid
+                    crossed = True
                 elif ask is not None and limit_price is not None and limit_price <= ask:
                     fill_price = limit_price
 
@@ -1826,6 +2185,12 @@ class BacktestingBroker(Broker):
         spread_limit = self._get_spread_limit(strategy, spread_key)
         if spread_limit is None:
             spread_limit = self._get_spread_limit(strategy, "max_spread_pct")
+        if spread_limit is not None and bid is not None and ask is not None and order.order_type != Order.OrderType.MARKET:
+            # Only gate inside-spread fills. Marketable limits should fill regardless.
+            limit_price = self._coerce_price(order.limit_price)
+            if crossed or (limit_price is None) or (fill_price != limit_price):
+                spread_limit = None
+
         if spread_limit is not None and bid is not None and ask is not None:
             mid = (ask + bid) / 2
             if mid > 0:
@@ -1833,7 +2198,7 @@ class BacktestingBroker(Broker):
                 if spread_pct > spread_limit:
                     if strategy is not None:
                         strategy.log_message(
-                            f"Skipped ThetaData quote fill for {order.identifier} "
+                            f"Skipped quote fill for {order.identifier} "
                             f"(spread {spread_pct:.2%} exceeds {spread_limit:.2%}).",
                             color="yellow",
                         )
@@ -1841,12 +2206,260 @@ class BacktestingBroker(Broker):
 
         if strategy is not None:
             strategy.log_message(
-                f"Filled {order.identifier} via ThetaData quote @ {fill_price:.2f}.",
+                f"Filled {order.identifier} via quote @ {fill_price:.2f}.",
                 color="yellow",
             )
 
         setattr(order, "_price_source", "quote")
         return fill_price
+
+    def _smart_limit_backtest_price(self, order, strategy, open_, high_, low_) -> tuple[Optional[float], bool]:
+        smart_limit = getattr(order, "smart_limit", None)
+        if smart_limit is None:
+            return None, False
+
+        state = getattr(order, "_smart_limit_state", None)
+        if state is None:
+            created_at = getattr(order, "_date_created", None) or self.datetime
+            state = {"created_at": created_at, "missing_quote_warned": False}
+            order._smart_limit_state = state
+
+        created_at = state.get("created_at")
+        elapsed_seconds = None
+        if isinstance(created_at, datetime):
+            elapsed_seconds = (self.datetime - created_at).total_seconds()
+        elif isinstance(created_at, (int, float)):
+            # Primarily used for live SMART_LIMIT orders (monotonic clock). Backtests should
+            # typically use timezone-aware datetimes, but handle floats defensively.
+            elapsed_seconds = time.monotonic() - float(created_at)
+
+        if elapsed_seconds is not None:
+            # Mirror the live SMART_LIMIT timeout model (Option Alpha style):
+            # - steps-1 reprices at step_seconds cadence
+            # - final step holds for final_hold_seconds, then cancels
+            max_total_seconds = smart_limit.get_step_seconds() * (smart_limit.get_step_count() - 1)
+            max_total_seconds += smart_limit.get_final_hold_seconds()
+            if elapsed_seconds >= max_total_seconds:
+                if strategy is not None and not state.get("timed_out_warned", False):
+                    strategy.log_message(
+                        f"[SMART_LIMIT] Timed out after {elapsed_seconds:.0f}s; canceling order {order.identifier}.",
+                        color="yellow",
+                    )
+                    state["timed_out_warned"] = True
+                return None, True
+
+        bid = ask = None
+        if order.order_class == Order.OrderClass.MULTILEG and order.child_orders:
+            net_bid = 0.0
+            net_ask = 0.0
+            order_side = "buy" if order.is_buy_order() else "sell"
+            for leg in order.child_orders:
+                try:
+                    quote = self.get_quote(leg.asset, quote=leg.quote)
+                except Exception:
+                    quote = None
+                leg_bid = self._coerce_price(getattr(quote, "bid", None)) if quote is not None else None
+                leg_ask = self._coerce_price(getattr(quote, "ask", None)) if quote is not None else None
+                if leg_bid is None or leg_ask is None:
+                    net_bid = net_ask = None
+                    break
+                if order_side == "buy":
+                    if leg.is_buy_order():
+                        net_bid += leg_bid
+                        net_ask += leg_ask
+                    else:
+                        net_bid -= leg_ask
+                        net_ask -= leg_bid
+                else:
+                    if leg.is_buy_order():
+                        net_bid -= leg_ask
+                        net_ask -= leg_bid
+                    else:
+                        net_bid += leg_bid
+                        net_ask += leg_ask
+            bid = net_bid
+            ask = net_ask
+            if bid is not None and ask is not None:
+                # Avoid float accumulation artifacts (e.g. 0.799999999999) which can break
+                # tick-size inference for net multileg prices.
+                bid = round(float(bid), 6)
+                ask = round(float(ask), 6)
+        else:
+            try:
+                quote = self.get_quote(order.asset, quote=order.quote)
+            except Exception:
+                quote = None
+
+            bid = self._coerce_price(getattr(quote, "bid", None)) if quote is not None else None
+            ask = self._coerce_price(getattr(quote, "ask", None)) if quote is not None else None
+
+        if bid is None or ask is None or self._is_invalid_price(bid) or self._is_invalid_price(ask):
+            if not state.get("missing_quote_warned", False):
+                if strategy is not None:
+                    strategy.log_message(
+                        f"[SMART_LIMIT] Missing bid/ask for {order.asset}; downgrading to market.",
+                        color="yellow",
+                    )
+                state["missing_quote_warned"] = True
+            order.trade_slippage = 0.0
+            return open_, False
+
+        side = "buy" if order.is_buy_order() else "sell"
+        tick = infer_tick_size(bid, ask)
+        mid = compute_mid(bid, ask)
+        final_price = compute_final_price(bid, ask, side, smart_limit.final_price_pct)
+        slippage_amount = smart_limit.get_slippage_amount()
+        if smart_limit.slippage is None:
+            slippage_amount = self._get_strategy_slippage_amount(strategy, order)
+
+        # Backtesting model: fill at mid +/- slippage (inside the spread) whenever bid/ask are available.
+        #
+        # We intentionally do not simulate the live cancel/replace timing ladder here because most
+        # backtests run on minute bars (no sub-minute quote path). This keeps backtests fast, stable,
+        # and aligned with the common "mid fill" assumption used by competitors.
+        fill_price = expected_fill_price(mid, slippage_amount, side)
+        if side == "buy":
+            fill_price = min(fill_price, ask)
+        else:
+            fill_price = max(fill_price, bid)
+        fill_price = round_to_tick(fill_price, tick, side=side)
+
+        if side == "buy" and fill_price > final_price:
+            return None, False
+        if side == "sell" and fill_price < final_price:
+            return None, False
+
+        multiplier = (
+            getattr(order.child_orders[0].asset, "multiplier", 1)
+            if order.order_class == Order.OrderClass.MULTILEG and order.child_orders
+            else getattr(order.asset, "multiplier", 1)
+        ) or 1
+        order.trade_slippage = abs(fill_price - mid) * float(order.quantity) * multiplier
+        setattr(order, "_price_source", "smart_limit")
+        return fill_price, False
+
+    def _fill_multileg_smart_limit_children(self, order: Order, strategy, net_fill_price: float) -> bool:
+        """Fill SMART_LIMIT multileg child orders atomically using mid+slippage semantics.
+
+        The parent order is a scheduling container. Once it becomes executable, we fill each
+        leg at a price inside its own NBBO such that the net package price matches the parent
+        SMART_LIMIT fill model (mid +/- slippage).
+        """
+        if not order.child_orders:
+            return False
+
+        side = "buy" if order.is_buy_order() else "sell"
+
+        legs = []
+        total_slack = 0.0
+        net_mid = 0.0
+
+        for leg in order.child_orders:
+            try:
+                quote = self.get_quote(leg.asset, quote=leg.quote)
+            except Exception:
+                quote = None
+            bid = self._coerce_price(getattr(quote, "bid", None)) if quote is not None else None
+            ask = self._coerce_price(getattr(quote, "ask", None)) if quote is not None else None
+            if bid is None or ask is None or self._is_invalid_price(bid) or self._is_invalid_price(ask):
+                return False
+
+            leg_mid = round(compute_mid(bid, ask), 6)
+            slack = max(0.0, (ask - bid) / 2.0)
+            total_slack += slack
+
+            sign = 1.0 if (leg.is_buy_order() if side == "buy" else leg.is_sell_order()) else -1.0
+            net_mid += sign * leg_mid
+
+            legs.append({"order": leg, "bid": bid, "ask": ask, "mid": leg_mid, "slack": slack})
+
+        # Use configured slippage directly to avoid float cancellation issues when deriving
+        # slippage from net_fill_price - net_mid.
+        smart_limit = getattr(order, "smart_limit", None)
+        slippage_amount = smart_limit.get_slippage_amount() if smart_limit is not None else 0.0
+        if smart_limit is not None and smart_limit.slippage is None:
+            slippage_amount = self._get_strategy_slippage_amount(strategy, order)
+
+        delta = abs(float(slippage_amount))
+        ratio = (delta / total_slack) if total_slack > 0 else 0.0
+
+        for leg_info in legs:
+            leg = leg_info["order"]
+            leg_mid = leg_info["mid"]
+            adj = leg_info["slack"] * ratio
+
+            raw_fill = leg_mid + adj if leg.is_buy_order() else leg_mid - adj
+            raw_fill = round(raw_fill, 6)
+            tick = infer_tick_size(leg_info["bid"], leg_info["ask"])
+            fill_price = round_to_tick(raw_fill, tick, side="buy" if leg.is_buy_order() else "sell")
+
+            multiplier = getattr(leg.asset, "multiplier", 1) or 1
+            try:
+                qty = float(abs(float(leg.quantity)))
+            except Exception:
+                qty = float(abs(leg.quantity))
+
+            leg.trade_slippage = abs(fill_price - leg_mid) * qty * multiplier
+            setattr(leg, "_price_source", "smart_limit")
+
+            self._execute_filled_order(
+                order=leg,
+                price=float(fill_price),
+                filled_quantity=leg.quantity,
+                strategy=strategy,
+            )
+
+        return True
+
+    def _fill_multileg_children_at_market_open(self, order: Order, strategy) -> bool:
+        """Fallback for multileg SMART_LIMIT when quotes are missing.
+
+        Fill each child order at its own OHLC open (market-style) so the backtest
+        doesn't stall or fill only the parent placeholder.
+        """
+        if not order.child_orders:
+            return False
+
+        for leg in order.child_orders:
+            asset = leg.asset if getattr(leg.asset, "asset_type", None) != "crypto" else (leg.asset, leg.quote)
+            try:
+                ohlc = self.data_source.get_historical_prices(
+                    asset=asset,
+                    length=2,
+                    quote=leg.quote,
+                    timeshift=-2,
+                    timestep=getattr(self.data_source, "_timestep", "minute"),
+                )
+            except Exception:
+                ohlc = None
+
+            if ohlc is None or getattr(ohlc, "df", None) is None:
+                return False
+
+            open_price = None
+            df = ohlc.df
+            try:
+                if hasattr(df, "index"):
+                    open_price = df["open"].iloc[-1]
+                else:
+                    open_price = df["open"][-1]
+            except Exception:
+                open_price = None
+
+            open_price = self._coerce_price(open_price)
+            if open_price is None or self._is_invalid_price(open_price):
+                return False
+
+            leg.trade_slippage = 0.0
+            setattr(leg, "_price_source", "market")
+            self._execute_filled_order(
+                order=leg,
+                price=float(open_price),
+                filled_quantity=leg.quantity,
+                strategy=strategy,
+            )
+
+        return True
 
     def limit_order(self, limit_price, side, open_, high, low):
         """Limit order logic."""

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -251,6 +251,13 @@ class BacktestingBroker(Broker):
         sessions = self._daily_sessions.get(day, [])
 
         for start, end in sessions:
+            # Daily backtests (PandasData w/ timestep="day") often produce calendars where
+            # ``market_open == market_close`` (single timestamp per day). Treat that instant
+            # as "open" so StrategyExecutor doesn't skip all iterations.
+            if start == end:
+                if now == start:
+                    return True
+                continue
             if start <= now < end:
                 return True
         return False

--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -1,4 +1,6 @@
+import json
 import logging
+import os
 import subprocess
 from datetime import datetime, timedelta
 from decimal import Decimal
@@ -36,7 +38,8 @@ class ThetaDataBacktestingPandas(PandasData):
 
     IS_BACKTESTING_BROKER = True
 
-    # Do not fall back to last_price when bid/ask quotes are unavailable for options
+    # Do not fall back to trade-derived OHLC when bid/ask quotes are unavailable for options.
+    # Backtests should not trigger expensive option OHLC downloads as an implicit quote fallback.
     option_quote_fallback_allowed = False
 
     def __init__(
@@ -49,12 +52,17 @@ class ThetaDataBacktestingPandas(PandasData):
         use_quote_data=True,
         **kwargs,
     ):
-        # Pass allow_option_quote_fallback to parent to enable fallback mechanism
+        # Do not enable option quote fallback to trade-derived OHLC in ThetaData backtests.
+        # ThetaData option NBBO is the preferred source for pricing; when bid/ask is missing we
+        # treat the contract as unpriceable at that moment rather than downloading sparse trades.
         super().__init__(datetime_start=datetime_start, datetime_end=datetime_end, pandas_data=pandas_data,
-                         allow_option_quote_fallback=True, **kwargs)
+                         allow_option_quote_fallback=False, **kwargs)
 
         # Default to minute; broker can flip to day for daily strategies.
         self._timestep = self.MIN_TIMESTEP
+        # PERF: Avoid scanning the entire pandas_data store on every quote/snapshot call to infer day-mode.
+        # This flag is set eagerly when day data is loaded.
+        self._effective_day_mode = None
 
         if username is None:
             username = THETADATA_CONFIG.get("THETADATA_USERNAME")
@@ -69,6 +77,7 @@ class ThetaDataBacktestingPandas(PandasData):
 
         self._dataset_metadata: Dict[tuple, Dict[str, object]] = {}
         self._chain_constraints = None
+        self._negative_option_cache = set()
 
         # Set data_source to self since this class acts as both broker and data source
         self.data_source = self
@@ -223,21 +232,43 @@ class ThetaDataBacktestingPandas(PandasData):
         metadata["has_quotes"] = bool(has_quotes)
         metadata["has_ohlc"] = self._frame_has_ohlc_columns(frame)
 
+        last_real_ts = None
         if frame is not None and not frame.empty and "missing" in frame.columns:
             placeholder_flags = frame["missing"].fillna(False).astype(bool)
             metadata["placeholders"] = int(placeholder_flags.sum())
             metadata["tail_placeholder"] = bool(placeholder_flags.iloc[-1])
             if placeholder_flags.shape[0] and bool(placeholder_flags.all()):
                 metadata["empty_fetch"] = True
+            try:
+                real_rows = frame.loc[~placeholder_flags]
+                if not real_rows.empty:
+                    last_real_ts = pd.to_datetime(real_rows.index).max()
+            except Exception:
+                last_real_ts = None
         else:
             metadata["placeholders"] = 0
             metadata["tail_placeholder"] = False
             if not metadata["empty_fetch"]:
                 metadata["empty_fetch"] = False
 
+        if last_real_ts is not None:
+            metadata["last_real_ts"] = self._normalize_default_timezone(last_real_ts.to_pydatetime())
+        else:
+            metadata["last_real_ts"] = None
+
+        if metadata.get("empty_fetch") and getattr(asset, "asset_type", None) == Asset.AssetType.OPTION:
+            metadata["negative_cache"] = True
+
         # Preserve runtime cache flags that should not be reset by metadata refreshes
         # (e.g., day-mode metadata rebuilds during _update_pandas_data).
-        for flag_key in ("prefetch_complete", "ffilled", "sidecar_loaded"):
+        for flag_key in (
+            "prefetch_complete",
+            "ffilled",
+            "sidecar_loaded",
+            "negative_cache",
+            "quotes_missing_permanent",
+            "tail_missing_permanent",
+        ):
             if flag_key in previous_meta:
                 metadata[flag_key] = previous_meta.get(flag_key)
 
@@ -306,26 +337,30 @@ class ThetaDataBacktestingPandas(PandasData):
         timeshift: Optional[timedelta],
         asset: Optional[Asset] = None,  # DEBUG-LOG: Added for logging
     ) -> Optional[pd.DataFrame]:
+        debug_enabled = logger.isEnabledFor(logging.DEBUG)
+
         # DEBUG-LOG: Method entry with full parameter context
-        logger.debug(
-            "[THETA][DEBUG][PANDAS][FINALIZE][ENTRY] asset=%s current_dt=%s requested_length=%s timeshift=%s input_shape=%s input_columns=%s input_index_type=%s input_has_tz=%s input_index_sample=%s",
-            getattr(asset, 'symbol', asset) if asset else 'UNKNOWN',
-            current_dt.isoformat() if hasattr(current_dt, 'isoformat') else current_dt,
-            requested_length,
-            timeshift,
-            pandas_df.shape if pandas_df is not None else 'NONE',
-            list(pandas_df.columns) if pandas_df is not None else 'NONE',
-            type(pandas_df.index).__name__ if pandas_df is not None else 'NONE',
-            getattr(pandas_df.index, 'tz', None) if pandas_df is not None else 'NONE',
-            list(pandas_df.index[:5]) if pandas_df is not None and len(pandas_df) > 0 else 'EMPTY'
-        )
+        if debug_enabled:
+            logger.debug(
+                "[THETA][DEBUG][PANDAS][FINALIZE][ENTRY] asset=%s current_dt=%s requested_length=%s timeshift=%s input_shape=%s input_columns=%s input_index_type=%s input_has_tz=%s input_index_sample=%s",
+                getattr(asset, "symbol", asset) if asset else "UNKNOWN",
+                current_dt,
+                requested_length,
+                timeshift,
+                pandas_df.shape if pandas_df is not None else "NONE",
+                list(pandas_df.columns) if pandas_df is not None else "NONE",
+                type(pandas_df.index).__name__ if pandas_df is not None else "NONE",
+                getattr(pandas_df.index, "tz", None) if pandas_df is not None else "NONE",
+                list(pandas_df.index[:5]) if pandas_df is not None and len(pandas_df) > 0 else "EMPTY",
+            )
 
         if pandas_df is None or pandas_df.empty:
             # DEBUG-LOG: Early return for empty input
-            logger.debug(
-                "[THETA][DEBUG][PANDAS][FINALIZE][EMPTY_INPUT] asset=%s returning_none_or_empty=True",
-                getattr(asset, 'symbol', asset) if asset else 'UNKNOWN'
-            )
+            if debug_enabled:
+                logger.debug(
+                    "[THETA][DEBUG][PANDAS][FINALIZE][EMPTY_INPUT] asset=%s returning_none_or_empty=True",
+                    getattr(asset, "symbol", asset) if asset else "UNKNOWN",
+                )
             return pandas_df
 
         frame = pandas_df.copy()
@@ -335,14 +370,15 @@ class ThetaDataBacktestingPandas(PandasData):
         frame.index = pd.to_datetime(frame.index)
 
         # DEBUG-LOG: Timezone state before localization
-        logger.debug(
-            "[THETA][DEBUG][PANDAS][FINALIZE][TZ_CHECK] asset=%s frame_index_tz=%s target_tz=%s needs_localization=%s frame_shape=%s",
-            getattr(asset, 'symbol', asset) if asset else 'UNKNOWN',
-            frame.index.tz,
-            self.tzinfo,
-            frame.index.tz is None,
-            frame.shape
-        )
+        if debug_enabled:
+            logger.debug(
+                "[THETA][DEBUG][PANDAS][FINALIZE][TZ_CHECK] asset=%s frame_index_tz=%s target_tz=%s needs_localization=%s frame_shape=%s",
+                getattr(asset, "symbol", asset) if asset else "UNKNOWN",
+                frame.index.tz,
+                self.tzinfo,
+                frame.index.tz is None,
+                frame.shape,
+            )
 
         if frame.index.tz is None:
             frame.index = frame.index.tz_localize(pytz.UTC)
@@ -350,47 +386,51 @@ class ThetaDataBacktestingPandas(PandasData):
         normalized_for_cutoff = localized_index.normalize()
 
         # DEBUG-LOG: After localization
-        logger.debug(
-            "[THETA][DEBUG][PANDAS][FINALIZE][LOCALIZED] asset=%s localized_index_tz=%s localized_sample=%s",
-            getattr(asset, 'symbol', asset) if asset else 'UNKNOWN',
-            localized_index.tz,
-            list(localized_index[:3]) if len(localized_index) > 0 else 'EMPTY'
-        )
+        if debug_enabled:
+            logger.debug(
+                "[THETA][DEBUG][PANDAS][FINALIZE][LOCALIZED] asset=%s localized_index_tz=%s localized_sample=%s",
+                getattr(asset, "symbol", asset) if asset else "UNKNOWN",
+                localized_index.tz,
+                list(localized_index[:3]) if len(localized_index) > 0 else "EMPTY",
+            )
 
         cutoff = self.to_default_timezone(current_dt).replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=1)
         cutoff_mask = normalized_for_cutoff <= cutoff
 
         # DEBUG-LOG: Cutoff filtering state
-        logger.debug(
-            "[THETA][DEBUG][PANDAS][FINALIZE][CUTOFF] asset=%s cutoff=%s cutoff_mask_true=%s cutoff_mask_false=%s",
-            getattr(asset, 'symbol', asset) if asset else 'UNKNOWN',
-            cutoff,
-            int(cutoff_mask.sum()) if hasattr(cutoff_mask, 'sum') else 'N/A',
-            int((~cutoff_mask).sum()) if hasattr(cutoff_mask, 'sum') else 'N/A'
-        )
+        if debug_enabled:
+            logger.debug(
+                "[THETA][DEBUG][PANDAS][FINALIZE][CUTOFF] asset=%s cutoff=%s cutoff_mask_true=%s cutoff_mask_false=%s",
+                getattr(asset, "symbol", asset) if asset else "UNKNOWN",
+                cutoff,
+                int(cutoff_mask.sum()) if hasattr(cutoff_mask, "sum") else "N/A",
+                int((~cutoff_mask).sum()) if hasattr(cutoff_mask, "sum") else "N/A",
+            )
 
         if timeshift and not isinstance(timeshift, int):
             cutoff_mask &= normalized_for_cutoff <= (cutoff - timeshift)
             # DEBUG-LOG: After timeshift adjustment
-            logger.debug(
-                "[THETA][DEBUG][PANDAS][FINALIZE][TIMESHIFT_ADJUSTED] asset=%s timeshift=%s new_cutoff=%s cutoff_mask_true=%s",
-                getattr(asset, 'symbol', asset) if asset else 'UNKNOWN',
-                timeshift,
-                cutoff - timeshift,
-                int(cutoff_mask.sum()) if hasattr(cutoff_mask, 'sum') else 'N/A'
-            )
+            if debug_enabled:
+                logger.debug(
+                    "[THETA][DEBUG][PANDAS][FINALIZE][TIMESHIFT_ADJUSTED] asset=%s timeshift=%s new_cutoff=%s cutoff_mask_true=%s",
+                    getattr(asset, "symbol", asset) if asset else "UNKNOWN",
+                    timeshift,
+                    cutoff - timeshift,
+                    int(cutoff_mask.sum()) if hasattr(cutoff_mask, "sum") else "N/A",
+                )
 
         frame = frame.loc[cutoff_mask]
         localized_index = localized_index[cutoff_mask]
         normalized_for_cutoff = normalized_for_cutoff[cutoff_mask]
 
         # DEBUG-LOG: After cutoff filtering
-        logger.debug(
-            "[THETA][DEBUG][PANDAS][FINALIZE][AFTER_CUTOFF] asset=%s shape=%s index_range=%s",
-            getattr(asset, 'symbol', asset) if asset else 'UNKNOWN',
-            frame.shape,
-            (localized_index[0], localized_index[-1]) if len(localized_index) > 0 else ('EMPTY', 'EMPTY')
-        )
+        if debug_enabled:
+            logger.debug(
+                "[THETA][DEBUG][PANDAS][FINALIZE][AFTER_CUTOFF] asset=%s shape=%s index_range=%s",
+                getattr(asset, "symbol", asset) if asset else "UNKNOWN",
+                frame.shape,
+                (localized_index[0], localized_index[-1]) if len(localized_index) > 0 else ("EMPTY", "EMPTY"),
+            )
 
         if timeshift and isinstance(timeshift, int):
             if timeshift > 0:
@@ -403,24 +443,26 @@ class ThetaDataBacktestingPandas(PandasData):
         raw_frame = frame.copy()
 
         # DEBUG-LOG: After normalization
-        logger.debug(
-            "[THETA][DEBUG][PANDAS][FINALIZE][NORMALIZED_INDEX] asset=%s shape=%s index_sample=%s",
-            getattr(asset, 'symbol', asset) if asset else 'UNKNOWN',
-            frame.shape,
-            list(normalized_index[:3]) if len(normalized_index) > 0 else 'EMPTY'
-        )
+        if debug_enabled:
+            logger.debug(
+                "[THETA][DEBUG][PANDAS][FINALIZE][NORMALIZED_INDEX] asset=%s shape=%s index_sample=%s",
+                getattr(asset, "symbol", asset) if asset else "UNKNOWN",
+                frame.shape,
+                list(normalized_index[:3]) if len(normalized_index) > 0 else "EMPTY",
+            )
 
         expected_last_dt = self.to_default_timezone(current_dt).replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=1)
         expected_last_dt_utc = expected_last_dt.astimezone(pytz.UTC)
         target_index = pd.date_range(end=expected_last_dt_utc, periods=requested_length, freq="D", tz=pytz.UTC).tz_convert(self.tzinfo)
 
         # DEBUG-LOG: Target index details
-        logger.debug(
-            "[THETA][DEBUG][PANDAS][FINALIZE][TARGET_INDEX] asset=%s target_length=%s target_range=%s",
-            getattr(asset, 'symbol', asset) if asset else 'UNKNOWN',
-            len(target_index),
-            (target_index[0], target_index[-1]) if len(target_index) > 0 else ('EMPTY', 'EMPTY')
-        )
+        if debug_enabled:
+            logger.debug(
+                "[THETA][DEBUG][PANDAS][FINALIZE][TARGET_INDEX] asset=%s target_length=%s target_range=%s",
+                getattr(asset, "symbol", asset) if asset else "UNKNOWN",
+                len(target_index),
+                (target_index[0], target_index[-1]) if len(target_index) > 0 else ("EMPTY", "EMPTY"),
+            )
 
         if "missing" not in frame.columns:
             frame["missing"] = False
@@ -442,13 +484,14 @@ class ThetaDataBacktestingPandas(PandasData):
             placeholder_mask = frame.isna().all(axis=1)
 
         # DEBUG-LOG: Placeholder mask computation
-        logger.debug(
-            "[THETA][DEBUG][PANDAS][FINALIZE][PLACEHOLDER_MASK] asset=%s placeholder_true=%s placeholder_false=%s value_columns=%s",
-            getattr(asset, 'symbol', asset) if asset else 'UNKNOWN',
-            int(placeholder_mask.sum()) if hasattr(placeholder_mask, 'sum') else 'N/A',
-            int((~placeholder_mask).sum()) if hasattr(placeholder_mask, 'sum') else 'N/A',
-            value_columns
-        )
+        if debug_enabled:
+            logger.debug(
+                "[THETA][DEBUG][PANDAS][FINALIZE][PLACEHOLDER_MASK] asset=%s placeholder_true=%s placeholder_false=%s value_columns=%s",
+                getattr(asset, "symbol", asset) if asset else "UNKNOWN",
+                int(placeholder_mask.sum()) if hasattr(placeholder_mask, "sum") else "N/A",
+                int((~placeholder_mask).sum()) if hasattr(placeholder_mask, "sum") else "N/A",
+                value_columns,
+            )
 
         frame.loc[placeholder_mask, "missing"] = True
         frame["missing"] = frame["missing"].fillna(False)
@@ -481,30 +524,32 @@ class ThetaDataBacktestingPandas(PandasData):
             frame["missing"] = False
 
         # DEBUG-LOG: Final missing flag state
-        try:
-            missing_count = int(frame["missing"].sum())
-            logger.debug(
-                "[THETA][DEBUG][PANDAS][FINALIZE][MISSING_FINAL] asset=%s missing_true=%s missing_false=%s total_rows=%s",
-                getattr(asset, 'symbol', asset) if asset else 'UNKNOWN',
-                missing_count,
-                len(frame) - missing_count,
-                len(frame)
-            )
-        except Exception as e:
-            logger.debug(
-                "[THETA][DEBUG][PANDAS][FINALIZE][MISSING_FINAL] asset=%s error=%s",
-                getattr(asset, 'symbol', asset) if asset else 'UNKNOWN',
-                str(e)
-            )
+        if debug_enabled:
+            try:
+                missing_count = int(frame["missing"].sum())
+                logger.debug(
+                    "[THETA][DEBUG][PANDAS][FINALIZE][MISSING_FINAL] asset=%s missing_true=%s missing_false=%s total_rows=%s",
+                    getattr(asset, "symbol", asset) if asset else "UNKNOWN",
+                    missing_count,
+                    len(frame) - missing_count,
+                    len(frame),
+                )
+            except Exception as e:
+                logger.debug(
+                    "[THETA][DEBUG][PANDAS][FINALIZE][MISSING_FINAL] asset=%s error=%s",
+                    getattr(asset, "symbol", asset) if asset else "UNKNOWN",
+                    str(e),
+                )
 
         # DEBUG-LOG: Return value
-        logger.debug(
-            "[THETA][DEBUG][PANDAS][FINALIZE][RETURN] asset=%s shape=%s columns=%s index_range=%s",
-            getattr(asset, 'symbol', asset) if asset else 'UNKNOWN',
-            frame.shape,
-            list(frame.columns),
-            (frame.index[0], frame.index[-1]) if len(frame) > 0 else ('EMPTY', 'EMPTY')
-        )
+        if debug_enabled:
+            logger.debug(
+                "[THETA][DEBUG][PANDAS][FINALIZE][RETURN] asset=%s shape=%s columns=%s index_range=%s",
+                getattr(asset, "symbol", asset) if asset else "UNKNOWN",
+                frame.shape,
+                list(frame.columns),
+                (frame.index[0], frame.index[-1]) if len(frame) > 0 else ("EMPTY", "EMPTY"),
+            )
 
         return frame
 
@@ -596,11 +641,35 @@ class ThetaDataBacktestingPandas(PandasData):
         if isinstance(asset_separated, tuple):
             asset_separated, quote_asset = asset_separated
 
+        asset_type_value = str(getattr(asset_separated, "asset_type", "")).lower()
+        symbol_upper = str(getattr(asset_separated, "symbol", "") or "").upper()
+        index_symbols = {
+            "SPX", "SPXW",
+            "RUT", "RUTW",
+            "VIX", "VIXW",
+            "NDX", "NDXP",
+            "XSP", "DJX", "OEX", "XEO",
+        }
+        is_option_asset = asset_type_value == "option"
+        # Index symbols are represented as plain Assets (asset_type="stock") in many strategies,
+        # so we key off the symbol list. Do NOT treat option contracts on an index (e.g., SPX 0DTE)
+        # as "index assets" for cache/coverage logic.
+        is_index_asset = asset_type_value == "index" or (not is_option_asset and symbol_upper in index_symbols)
+
         if asset_separated.asset_type == "option":
             expiry = asset_separated.expiration
             if self.is_weekend(expiry):
                 logger.info(f"\nSKIP: Expiry {expiry} date is a weekend, no contract exists: {asset_separated}")
                 return None
+
+        if is_option_asset and asset_separated in self._negative_option_cache:
+            logger.info(
+                "[THETA][CACHE][NEGATIVE] asset=%s/%s (%s) marked permanently missing; skipping refetch.",
+                asset_separated,
+                quote_asset,
+                timestep,
+            )
+            return None
 
         # Get the start datetime and timestep unit.
         #
@@ -624,6 +693,8 @@ class ThetaDataBacktestingPandas(PandasData):
         start_datetime, ts_unit = self.get_start_datetime_and_ts_unit(
             length, timestep, start_dt, start_buffer=effective_start_buffer
         )
+        if ts_unit == "day":
+            self._effective_day_mode = True
         current_dt = self.get_datetime()
 
         requested_length = max(length, 1)
@@ -668,6 +739,52 @@ class ThetaDataBacktestingPandas(PandasData):
                 )
             else:
                 end_requirement = end_anchor
+                # PERFORMANCE + RELIABILITY: For point-in-time intraday option quote/price checks,
+                # fetching only up to the current simulation timestamp can cause repeated "stale/refetch"
+                # loops (especially pre-market when no bars exist yet). Prefetch through the session close
+                # for the current trading day so the same contract doesn't refetch every minute.
+                if (
+                    getattr(asset_separated, "asset_type", None) == "option"
+                    and start_dt is not None
+                    and isinstance(length, int)
+                    and length <= 5
+                    and ts_unit in {"minute", "hour"}
+                ):
+                    try:
+                        # PERF: `get_trading_days()` is expensive (calendar lookup + schedule build).
+                        # Point-in-time option quote/price checks can call `_update_pandas_data()` tens
+                        # of thousands of times in a single backtest, so cache the per-session close
+                        # datetime by (market, date).
+                        from lumibot.tools.helpers import get_trading_days
+
+                        market = os.environ.get("BACKTESTING_MARKET", "NYSE")
+                        close_cache = getattr(self, "_session_close_cache", None)
+                        if close_cache is None:
+                            close_cache = {}
+                            self._session_close_cache = close_cache
+
+                        cache_date = end_requirement.date() if hasattr(end_requirement, "date") else end_requirement
+                        cache_key = (market, cache_date)
+                        cached_close = close_cache.get(cache_key)
+                        if cached_close is None and cache_key not in close_cache:
+                            schedule = get_trading_days(
+                                market=market,
+                                start_date=end_requirement,
+                                end_date=end_requirement + timedelta(days=2),
+                                tzinfo=self.tzinfo,
+                            )
+                            cached_close = None
+                            if not schedule.empty:
+                                cached_close = schedule.iloc[0]["market_close"]
+                            close_cache[cache_key] = cached_close
+
+                        if cached_close is not None and cached_close > end_requirement:
+                            end_requirement = cached_close
+                    except Exception:
+                        logger.debug(
+                            "[THETA][DEBUG][END_REQUIREMENT] failed to align intraday option end_requirement",
+                            exc_info=True,
+                        )
         else:
             end_requirement = (
                 end_anchor
@@ -939,6 +1056,7 @@ class ThetaDataBacktestingPandas(PandasData):
         existing_start = None
         existing_end = None
         existing_has_quotes = bool(existing_meta.get("has_quotes")) if existing_meta else False
+        existing_quotes_missing = bool(existing_meta.get("quotes_missing_permanent")) if existing_meta else False
         existing_has_ohlc = bool(existing_meta.get("has_ohlc", True)) if existing_meta else True
 
         if existing_data is not None and existing_meta and existing_meta.get("timestep") == ts_unit:
@@ -954,20 +1072,21 @@ class ThetaDataBacktestingPandas(PandasData):
                     existing_end = self._normalize_default_timezone(existing_data.df.index[-1])
 
             # DEBUG-LOG: Cache validation entry
-            logger.debug(
-                "[DEBUG][BACKTEST][THETA][DEBUG][PANDAS][CACHE_VALIDATION][ENTRY] asset=%s timestep=%s | "
-                "REQUESTED: start=%s start_threshold=%s end_requirement=%s length=%d | "
-                "EXISTING: start=%s end=%s rows=%d",
-                asset_separated.symbol if hasattr(asset_separated, 'symbol') else str(asset_separated),
-                ts_unit,
-                requested_start.isoformat() if requested_start else None,
-                start_threshold.isoformat() if start_threshold else None,
-                end_requirement.isoformat() if end_requirement else None,
-                requested_length,
-                existing_start.isoformat() if existing_start else None,
-                existing_end.isoformat() if existing_end else None,
-                existing_rows
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "[DEBUG][BACKTEST][THETA][DEBUG][PANDAS][CACHE_VALIDATION][ENTRY] asset=%s timestep=%s | "
+                    "REQUESTED: start=%s start_threshold=%s end_requirement=%s length=%d | "
+                    "EXISTING: start=%s end=%s rows=%d",
+                    asset_separated.symbol if hasattr(asset_separated, "symbol") else str(asset_separated),
+                    ts_unit,
+                    requested_start,
+                    start_threshold,
+                    end_requirement,
+                    requested_length,
+                    existing_start,
+                    existing_end,
+                    existing_rows,
+                )
 
             # NOTE: Removed "existing_start <= start_threshold" check (2025-12-06)
             # This check invalidated cache for assets like TQQQ where the requested start date
@@ -980,39 +1099,42 @@ class ThetaDataBacktestingPandas(PandasData):
             start_ok = existing_start is not None
 
             # DEBUG-LOG: Start validation result
-            logger.debug(
-                "[DEBUG][BACKTEST][THETA][DEBUG][PANDAS][START_VALIDATION] asset=%s | "
-                "start_ok=%s | "
-                "existing_start=%s start_threshold=%s | "
-                "reasoning=%s",
-                asset_separated.symbol if hasattr(asset_separated, 'symbol') else str(asset_separated),
-                start_ok,
-                existing_start.isoformat() if existing_start else None,
-                start_threshold.isoformat() if start_threshold else None,
-                "existing_start is not None (threshold check removed - see NOTE above)" if start_ok else "existing_start is None"
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "[DEBUG][BACKTEST][THETA][DEBUG][PANDAS][START_VALIDATION] asset=%s | "
+                    "start_ok=%s | "
+                    "existing_start=%s start_threshold=%s | "
+                    "reasoning=%s",
+                    asset_separated.symbol if hasattr(asset_separated, "symbol") else str(asset_separated),
+                    start_ok,
+                    existing_start,
+                    start_threshold,
+                    "existing_start is not None (threshold check removed - see NOTE above)" if start_ok else "existing_start is None",
+                )
 
             tail_placeholder = existing_meta.get("tail_placeholder", False)
             end_ok = True
 
             # DEBUG-LOG: End validation entry
-            logger.debug(
-                "[DEBUG][BACKTEST][THETA][DEBUG][PANDAS][END_VALIDATION][ENTRY] asset=%s | "
-                "end_requirement=%s existing_end=%s tail_placeholder=%s",
-                asset_separated.symbol if hasattr(asset_separated, 'symbol') else str(asset_separated),
-                end_requirement.isoformat() if end_requirement else None,
-                existing_end.isoformat() if existing_end else None,
-                tail_placeholder
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "[DEBUG][BACKTEST][THETA][DEBUG][PANDAS][END_VALIDATION][ENTRY] asset=%s | "
+                    "end_requirement=%s existing_end=%s tail_placeholder=%s",
+                    asset_separated.symbol if hasattr(asset_separated, "symbol") else str(asset_separated),
+                    end_requirement,
+                    existing_end,
+                    tail_placeholder,
+                )
 
             if end_requirement is not None:
                 if existing_end is None:
                     end_ok = False
-                    logger.debug(
-                        "[DEBUG][BACKTEST][THETA][DEBUG][PANDAS][END_VALIDATION][RESULT] asset=%s | "
-                        "end_ok=FALSE | reason=existing_end_is_None",
-                        asset_separated.symbol if hasattr(asset_separated, 'symbol') else str(asset_separated)
-                    )
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.debug(
+                            "[DEBUG][BACKTEST][THETA][DEBUG][PANDAS][END_VALIDATION][RESULT] asset=%s | "
+                            "end_ok=FALSE | reason=existing_end_is_None",
+                            asset_separated.symbol if hasattr(asset_separated, "symbol") else str(asset_separated),
+                        )
                 else:
                     # FIX: For both day and minute data, use date-only comparison
                     # For day data: prevents false negatives when existing_end is midnight and end_requirement is later
@@ -1035,34 +1157,60 @@ class ThetaDataBacktestingPandas(PandasData):
 
                     if existing_end_cmp >= end_requirement_cmp - end_tolerance:
                         end_ok = True
-                        logger.debug(
-                            "[DEBUG][BACKTEST][THETA][DEBUG][PANDAS][END_VALIDATION][RESULT] asset=%s | "
-                            "end_ok=TRUE | reason=existing_end_meets_requirement | "
-                            "existing_end=%s end_requirement=%s tolerance=%s ts_unit=%s",
-                            asset_separated.symbol if hasattr(asset_separated, 'symbol') else str(asset_separated),
-                            existing_end.isoformat(),
-                            end_requirement.isoformat(),
-                            end_tolerance,
-                            ts_unit
-                        )
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "[DEBUG][BACKTEST][THETA][DEBUG][PANDAS][END_VALIDATION][RESULT] asset=%s | "
+                                "end_ok=TRUE | reason=existing_end_meets_requirement | "
+                                "existing_end=%s end_requirement=%s tolerance=%s ts_unit=%s",
+                                asset_separated.symbol if hasattr(asset_separated, "symbol") else str(asset_separated),
+                                existing_end,
+                                end_requirement,
+                                end_tolerance,
+                                ts_unit,
+                            )
                     else:
                         # existing_end is still behind the required window
                         end_ok = False
-                        logger.debug(
-                            "[DEBUG][BACKTEST][THETA][DEBUG][PANDAS][END_VALIDATION][RESULT] asset=%s | "
-                            "end_ok=FALSE | reason=existing_end_less_than_requirement | "
-                            "existing_end=%s end_requirement=%s ts_unit=%s",
-                            asset_separated.symbol if hasattr(asset_separated, 'symbol') else str(asset_separated),
-                            existing_end.isoformat(),
-                            end_requirement.isoformat(),
-                            ts_unit
-                        )
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "[DEBUG][BACKTEST][THETA][DEBUG][PANDAS][END_VALIDATION][RESULT] asset=%s | "
+                                "end_ok=FALSE | reason=existing_end_less_than_requirement | "
+                                "existing_end=%s end_requirement=%s ts_unit=%s",
+                                asset_separated.symbol if hasattr(asset_separated, "symbol") else str(asset_separated),
+                                existing_end,
+                                end_requirement,
+                                ts_unit,
+                            )
+
+            if (
+                require_quote_data
+                and existing_meta
+                and existing_meta.get("prefetch_complete")
+                and not existing_has_quotes
+            ):
+                if not existing_quotes_missing:
+                    existing_meta["quotes_missing_permanent"] = True
+                    self._dataset_metadata[canonical_key] = existing_meta
+                    existing_quotes_missing = True
+                    logger.info(
+                        "[THETA][CACHE][QUOTES_MISSING] asset=%s/%s (%s) no quote columns after fetch; "
+                        "treating as permanent for this run.",
+                        asset_separated,
+                        quote_asset,
+                        ts_unit,
+                    )
+
+            quotes_ok = (
+                (not require_quote_data)
+                or existing_has_quotes
+                or existing_quotes_missing
+            )
 
             cache_covers = (
                 start_ok
                 and existing_rows >= requested_length
                 and end_ok
-                and (not require_quote_data or existing_has_quotes)
+                and quotes_ok
                 and (not require_ohlc_data or existing_has_ohlc)
             )
 
@@ -1121,6 +1269,8 @@ class ThetaDataBacktestingPandas(PandasData):
                 reasons.append("rows")
             if not end_ok:
                 reasons.append("end")
+            if require_quote_data and not existing_has_quotes and not existing_quotes_missing:
+                reasons.append("quotes")
             logger.debug(
                 "[THETA][DEBUG][THETADATA-PANDAS] refreshing cache for %s/%s (%s); reasons=%s "
                 "(existing_start=%s requested_start=%s existing_end=%s end_requirement=%s existing_rows=%s needed_rows=%s)",
@@ -1136,6 +1286,26 @@ class ThetaDataBacktestingPandas(PandasData):
                 requested_length,
             )
             if existing_meta is not None and existing_meta.get("prefetch_complete"):
+                if is_option_asset and (existing_meta.get("empty_fetch") or existing_meta.get("negative_cache")):
+                    logger.info(
+                        "[THETA][CACHE][NEGATIVE] asset=%s/%s (%s) placeholder-only cache; skipping refetch. existing_end=%s target_end=%s",
+                        asset_separated,
+                        quote_asset,
+                        ts_unit,
+                        existing_end,
+                        end_requirement,
+                    )
+                    return None
+                if is_index_asset and end_ok and existing_rows >= requested_length:
+                    logger.info(
+                        "[THETA][CACHE][REUSE] asset=%s/%s (%s) coverage meets requirement; skipping refetch. existing_end=%s target_end=%s",
+                        asset_separated,
+                        quote_asset,
+                        ts_unit,
+                        existing_end,
+                        end_requirement,
+                    )
+                    return None
                 # The cache was marked complete but doesn't cover our required end date.
                 # This can happen if the cache is stale or backtest dates changed.
                 # Clear the prefetch_complete flag and try to fetch more data.
@@ -1743,6 +1913,29 @@ class ThetaDataBacktestingPandas(PandasData):
         if legacy_meta is not None:
             legacy_meta.update(meta)
             self._dataset_metadata[legacy_key] = legacy_meta
+
+        if require_quote_data and is_option_asset and not meta.get("has_quotes") and meta.get("data_rows"):
+            if not meta.get("quotes_missing_permanent"):
+                meta["quotes_missing_permanent"] = True
+                self._dataset_metadata[canonical_key] = meta
+                if legacy_meta is not None:
+                    legacy_meta.update(meta)
+                    self._dataset_metadata[legacy_key] = legacy_meta
+                logger.info(
+                    "[THETA][CACHE][QUOTES_MISSING] asset=%s/%s (%s) fetched without quotes; "
+                    "treating missing quotes as permanent for this run.",
+                    asset_separated,
+                    quote_asset,
+                    ts_unit,
+                )
+
+        if is_option_asset and meta.get("empty_fetch"):
+            self._negative_option_cache.add(asset_separated)
+            meta["negative_cache"] = True
+            self._dataset_metadata[canonical_key] = meta
+            if legacy_meta is not None:
+                legacy_meta.update(meta)
+                self._dataset_metadata[legacy_key] = legacy_meta
         if ts_unit == "day" and placeholder_mask is not None and len(placeholder_mask):
             try:
                 tail_missing = bool(placeholder_mask.iloc[-1])
@@ -1883,6 +2076,21 @@ class ThetaDataBacktestingPandas(PandasData):
                     ts_unit,
                     end_requirement,
                 )
+            elif is_index_asset:
+                clamp_end = meta.get("last_real_ts") or meta.get("data_end") or meta.get("end")
+                if clamp_end is not None and end_requirement is not None:
+                    if clamp_end < end_requirement:
+                        logger.warning(
+                            "[THETA][COVERAGE][TAIL_PLACEHOLDER] asset=%s/%s (%s) ends with placeholders; "
+                            "clamping backtest end to %s (target_end=%s).",
+                            asset_separated,
+                            quote_asset,
+                            ts_unit,
+                            clamp_end,
+                            end_requirement,
+                        )
+                        self.datetime_end = clamp_end
+                meta["tail_missing_permanent"] = True
             else:
                 raise ValueError(
                     f"[THETA][COVERAGE][TAIL_PLACEHOLDER] asset={asset_separated}/{quote_asset} ({ts_unit}) ends with placeholders "
@@ -2301,12 +2509,19 @@ class ThetaDataBacktestingPandas(PandasData):
         # FIX (2025-12-12): Also check if any existing data uses "day" timestep to detect day mode
         current_mode = getattr(self, "_timestep", None)
 
-        # Additional check: if any data in the store uses "day" timestep, we're in day mode
+        # PERF: determine "effective day mode" once per backtest instead of scanning the entire store on
+        # every snapshot call (pandas_data can contain tens of thousands of option frames).
         if current_mode != "day":
-            for data in self.pandas_data.values():
-                if hasattr(data, "timestep") and data.timestep == "day":
-                    current_mode = "day"
-                    break
+            effective_day_mode = getattr(self, "_effective_day_mode", None)
+            if effective_day_mode is None:
+                effective_day_mode = any(
+                    getattr(data, "timestep", None) == "day" for data in self.pandas_data.values()
+                )
+                self._effective_day_mode = effective_day_mode
+            if effective_day_mode:
+                current_mode = "day"
+        else:
+            self._effective_day_mode = True
         if current_mode == "day" and timestep == "minute":
             timestep = "day"
             logger.debug(
@@ -2328,24 +2543,56 @@ class ThetaDataBacktestingPandas(PandasData):
         asset_for_check = asset[0] if isinstance(asset, tuple) else asset
         require_quote_data = getattr(asset_for_check, "asset_type", None) == "option"
         require_ohlc_data = True
+        ts_unit = None
         try:
             _, ts_unit = self.convert_timestep_str_to_timedelta(timestep)
             if require_quote_data and ts_unit in {"minute", "hour", "second"}:
                 require_ohlc_data = False
         except Exception:
             require_ohlc_data = True
-        self._update_pandas_data(
-            asset,
-            quote,
-            sample_length,
-            timestep,
-            dt,
-            require_quote_data=require_quote_data,
-            require_ohlc_data=require_ohlc_data,
-        )
-        _, ts_unit = self.get_start_datetime_and_ts_unit(
-            sample_length, timestep, dt, start_buffer=START_BUFFER
-        )
+
+        # PERF: Portfolio valuation can request snapshots for many assets each bar. Avoid calling
+        # `_update_pandas_data()` when the in-memory frame already covers `dt` and has the required
+        # columns (quote-only for options, OHLC for everything else).
+        should_refresh = True
+        candidate_data = None
+        if ts_unit is not None:
+            try:
+                quote_asset = quote if quote is not None else Asset("USD", "forex")
+                canonical_key, legacy_key = self._build_dataset_keys(asset_for_check, quote_asset, ts_unit)
+                candidate_data = self.pandas_data.get(canonical_key) or self.pandas_data.get(legacy_key)
+                if candidate_data is not None and getattr(candidate_data, "timestep", None) == ts_unit:
+                    candidate_df = getattr(candidate_data, "df", None)
+                    if candidate_df is not None and not candidate_df.empty:
+                        has_required = True
+                        if require_quote_data and not self._frame_has_quote_columns(candidate_df):
+                            has_required = False
+                        if require_ohlc_data and not self._frame_has_ohlc_columns(candidate_df):
+                            has_required = False
+                        if has_required:
+                            data_end = getattr(candidate_data, "datetime_end", None)
+                            if data_end is None:
+                                data_end = self._normalize_default_timezone(candidate_df.index.max())
+                            if data_end is not None and dt <= data_end:
+                                should_refresh = False
+            except Exception:
+                should_refresh = True
+
+        if should_refresh:
+            self._update_pandas_data(
+                asset,
+                quote,
+                sample_length,
+                timestep,
+                dt,
+                require_quote_data=require_quote_data,
+                require_ohlc_data=require_ohlc_data,
+            )
+        if ts_unit is None:
+            try:
+                _, ts_unit = self.convert_timestep_str_to_timedelta(timestep)
+            except Exception:
+                ts_unit = None
 
         tuple_key = self.find_asset_in_data_store(asset, quote, ts_unit)
         data = None
@@ -2533,12 +2780,18 @@ class ThetaDataBacktestingPandas(PandasData):
         # for historical options, but does have EOD data.
         current_mode = getattr(self, "_timestep", None)
 
-        # Additional check: if any data in the store uses "day" timestep, we're in day mode
+        # PERF: avoid scanning the entire pandas_data store on every quote call.
         if current_mode != "day":
-            for data in self.pandas_data.values():
-                if hasattr(data, "timestep") and data.timestep == "day":
-                    current_mode = "day"
-                    break
+            effective_day_mode = getattr(self, "_effective_day_mode", None)
+            if effective_day_mode is None:
+                effective_day_mode = any(
+                    getattr(data, "timestep", None) == "day" for data in self.pandas_data.values()
+                )
+                self._effective_day_mode = effective_day_mode
+            if effective_day_mode:
+                current_mode = "day"
+        else:
+            self._effective_day_mode = True
 
         if current_mode == "day" and timestep == "minute":
             timestep = "day"
@@ -2591,10 +2844,7 @@ class ThetaDataBacktestingPandas(PandasData):
         try:
             quote_asset = quote if quote is not None else Asset("USD", "forex")
             _, ts_unit = self.convert_timestep_str_to_timedelta(timestep)
-            if (
-                getattr(asset, "asset_type", None) == Asset.AssetType.OPTION
-                and ts_unit in {"minute", "hour", "second"}
-            ):
+            if ts_unit in {"minute", "hour", "second"}:
                 canonical_key, legacy_key = self._build_dataset_keys(asset, quote_asset, ts_unit)
                 candidate_data = self.pandas_data.get(canonical_key)
                 if candidate_data is None:
@@ -2694,7 +2944,7 @@ class ThetaDataBacktestingPandas(PandasData):
 
         # ThetaData quote history for options can omit trade-derived fields (e.g., close/last), while still providing
         # actionable NBBO. Avoid forcing an OHLC download just to fill Quote.price: prefer quote-derived marks when
-        # bid/ask exist, and only fall back to last trade when NBBO is unavailable.
+        # bid/ask exist, and do NOT fall back to last trade (which can trigger an OHLC download).
         if quote_obj is not None and getattr(asset, "asset_type", None) == Asset.AssetType.OPTION:
             try:
                 numeric_price = float(quote_obj.price) if quote_obj.price is not None else None
@@ -2720,9 +2970,10 @@ class ThetaDataBacktestingPandas(PandasData):
                 elif ask is not None and ask > 0:
                     quote_obj.price = ask
                 else:
-                    last_trade = self.get_last_price(asset, timestep=timestep, quote=quote, exchange=exchange)
-                    if last_trade is not None:
-                        quote_obj.price = float(last_trade)
+                    # Leave price unset when NBBO is unavailable. Consumers that require an execution
+                    # anchor should use bid/ask when present; trade-only last price remains accessible
+                    # via `get_last_price()` but is intentionally not pulled as part of quote retrieval.
+                    quote_obj.price = None
 
         # [INSTRUMENTATION] Final quote result with all details
         if logger.isEnabledFor(logging.DEBUG):
@@ -2776,12 +3027,38 @@ class ThetaDataBacktestingPandas(PandasData):
         """
         from lumibot.entities import Chains
 
-        constraints = getattr(self, "_chain_constraints", None)
+        current_date = self.get_datetime().date()
+        constraints = getattr(self, "_chain_constraints", None) or {}
+
+        # PERF: `get_chains_cached()` hits parquet (local/S3) and `Chains(...)` normalizes expiry keys.
+        # Option-heavy strategies can call `get_chains()` hundreds of times per trading day, which
+        # becomes the dominant CPU cost in year-long backtests. Cache per (symbol, date, constraints)
+        # within the backtest process; invalidate automatically as the simulated date advances.
+        cache_date = getattr(self, "_chains_cache_date", None)
+        if cache_date != current_date:
+            self._chains_cache_date = current_date
+            self._chains_cache = {}
+
+        try:
+            constraints_key = json.dumps(constraints, sort_keys=True, default=str)
+        except Exception:
+            constraints_key = str(constraints)
+
+        cache_key = (getattr(asset, "symbol", str(asset)), str(getattr(asset, "asset_type", "")), current_date, constraints_key)
+        cached = getattr(self, "_chains_cache", {}).get(cache_key)
+        if cached is not None:
+            return cached
+
         chains_dict = thetadata_helper.get_chains_cached(
             asset=asset,
-            current_date=self.get_datetime().date(),
+            current_date=current_date,
             chain_constraints=constraints,
         )
 
-        # Wrap in Chains entity for modern API
-        return Chains(chains_dict)
+        chains = Chains(chains_dict)
+        try:
+            self._chains_cache[cache_key] = chains
+        except Exception:
+            pass
+
+        return chains

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -1,3 +1,5 @@
+import logging
+import json
 import os
 import time
 import threading
@@ -87,7 +89,12 @@ class Broker(ABC):
         self._filled_positions = SafeList(self._lock)
         self._subscribers = SafeList(self._lock)
         self._is_stream_subscribed = False
-        self._trade_event_log_df = pd.DataFrame()
+        # PERF: appending to a pandas DataFrame with concat on every trade event is extremely slow
+        # (option-heavy intraday backtests can generate 100k+ events). Store rows in a Python list
+        # and materialize a DataFrame lazily when needed.
+        self._trade_event_log_enabled = True
+        self._trade_event_log_rows = []
+        self._trade_event_log_df_cache = pd.DataFrame()
         self._hold_trade_events = False
         self._held_trades = []
         self._config = config
@@ -640,6 +647,38 @@ class Broker(ABC):
                            chains['Chains']['CALL'][exp_date] = [strike1, strike2, ...]
                          Expiration Date Format: 2023-07-31
         """
+        # PERF: Strategies can call `get_chains()` hundreds of times per trading day. Normalizing the
+        # chain (copying strike maps + sorting) is expensive and, in backtests, the chain for a given
+        # (asset, date, constraints) is immutable. Cache the normalized result within a backtest to
+        # avoid repeating that work.
+        cache_key = None
+        if getattr(self, "IS_BACKTESTING_BROKER", False):
+            try:
+                cache_date = self.data_source.get_datetime().date()
+            except Exception:
+                cache_date = None
+
+            constraints = getattr(self.data_source, "_chain_constraints", None) or {}
+            try:
+                constraints_key = json.dumps(constraints, sort_keys=True, default=str)
+            except Exception:
+                constraints_key = str(constraints)
+
+            cache_key = (
+                getattr(asset, "symbol", str(asset)),
+                str(getattr(asset, "asset_type", "")),
+                cache_date,
+                constraints_key,
+            )
+
+            if getattr(self, "_chains_cache_date", None) != cache_date:
+                self._chains_cache_date = cache_date
+                self._chains_cache = {}
+
+            cached = getattr(self, "_chains_cache", {}).get(cache_key)
+            if cached is not None:
+                return cached
+
         raw_chains = self.data_source.get_chains(asset)
         normalized_chains = normalize_option_chains(raw_chains)
 
@@ -650,6 +689,12 @@ class Broker(ABC):
                     "yellow",
                 )
             )
+
+        if cache_key is not None:
+            try:
+                self._chains_cache[cache_key] = normalized_chains
+            except Exception:
+                pass
 
         return normalized_chains
 
@@ -837,12 +882,13 @@ class Broker(ABC):
                     if order.was_transmitted():
                         flat_orders = self._flatten_order(order)
                         for flat_order in flat_orders:
-                            self.logger.info(
-                                colored(
-                                    f"Order {flat_order} was sent to broker {self.name}",
-                                    color="green",
+                            if self.logger.isEnabledFor(logging.INFO):
+                                self.logger.info(
+                                    colored(
+                                        f"Order {flat_order} was sent to broker {self.name}",
+                                        color="green",
+                                    )
                                 )
-                            )
                             self._unprocessed_orders.append(flat_order)
 
                 # Trigger periodic cleanup after processing orders
@@ -967,8 +1013,27 @@ class Broker(ABC):
 
         position = self.get_tracked_position(order.strategy, order.asset)
         if position is not None:
-            # Add the order to the already existing position
-            position.add_order(order)  # Don't update quantity here, it's handled by querying broker
+            # Live brokers will update positions via polling, but in backtesting there is no broker-side
+            # reconciliation. Cash settlement must therefore adjust the position quantity immediately so
+            # expired contracts don't remain open forever (which can cause long backtests to "freeze"
+            # due to exploding open positions).
+            if getattr(self, "IS_BACKTESTING_BROKER", False):
+                try:
+                    position.add_order(order, Decimal(str(quantity)))
+                except Exception:
+                    # Fallback: still record the settlement order even if quantity normalization failed.
+                    position.add_order(order)
+
+                if position.quantity == 0:
+                    try:
+                        self._filled_positions.remove(position)
+                    except Exception:
+                        # SafeList/remove semantics vary by broker; leaving a 0-qty position is acceptable.
+                        pass
+            else:
+                # Add the order to the already existing position; don't update quantity here because it's
+                # handled by querying broker positions in live trading.
+                position.add_order(order)
 
     def _process_crypto_quote(self, order, quantity, price):
         """Used to process the quote side of a crypto trade."""
@@ -1263,6 +1328,37 @@ class Broker(ABC):
         for order in self._tracked_orders:
             if (strategy_name is None or order.strategy == strategy_name) and (asset is None or order.asset == asset):
                 result.append(order)
+        return result
+
+    def get_active_tracked_orders(self, strategy=None, asset=None) -> list[Order]:
+        """Return only active (open) tracked orders for a strategy/asset.
+
+        This is intentionally faster than `get_tracked_orders()` because it only scans
+        the internal lists that can contain active orders (unprocessed/new/partially-filled
+        plus placeholders), avoiding the much larger filled/canceled/error histories.
+        """
+        # Allow filtering by Strategy instance or by name
+        if strategy is not None and not isinstance(strategy, str):
+            strategy_name = getattr(strategy, "name", getattr(strategy, "_name", None))
+        else:
+            strategy_name = strategy
+
+        active_candidates = (
+            self._unprocessed_orders.get_list()
+            + self._new_orders.get_list()
+            + self._partially_filled_orders.get_list()
+            + self._placeholder_orders.get_list()
+        )
+
+        result: list[Order] = []
+        for order in active_candidates:
+            if not order.is_active():
+                continue
+            if strategy_name is not None and order.strategy != strategy_name:
+                continue
+            if asset is not None and order.asset != asset:
+                continue
+            result.append(order)
         return result
 
     def get_all_orders(self) -> list[Order]:
@@ -1567,7 +1663,8 @@ class Broker(ABC):
         """notify relevant subscriber/strategy about
         new order event"""
 
-        self.logger.info(colored(f"New order was created: {order}", color="green"))
+        if self.logger.isEnabledFor(logging.INFO):
+            self.logger.info(colored(f"New order was created: {order}", color="green"))
 
         payload = dict(order=order)
         subscriber = self._get_subscriber(order.strategy)
@@ -1578,7 +1675,8 @@ class Broker(ABC):
         """notify relevant subscriber/strategy about
         canceled order event"""
 
-        self.logger.info(colored(f"Order was canceled: {order}", color="green"))
+        if self.logger.isEnabledFor(logging.INFO):
+            self.logger.info(colored(f"Order was canceled: {order}", color="green"))
 
         payload = dict(order=order)
         subscriber = self._get_subscriber(order.strategy)
@@ -1589,7 +1687,8 @@ class Broker(ABC):
         """notify relevant subscriber/strategy about
         partially filled order event"""
 
-        self.logger.info(colored(f"Order was partially filled: {order}", color="green"))
+        if self.logger.isEnabledFor(logging.INFO):
+            self.logger.info(colored(f"Order was partially filled: {order}", color="green"))
 
         payload = dict(
             position=position,
@@ -1608,7 +1707,8 @@ class Broker(ABC):
         """notify relevant subscriber/strategy about
         filled order event"""
 
-        self.logger.info(colored(f"Order was filled: {order}", color="green"))
+        if self.logger.isEnabledFor(logging.INFO):
+            self.logger.info(colored(f"Order was filled: {order}", color="green"))
 
         payload = dict(
             position=position,
@@ -1628,6 +1728,29 @@ class Broker(ABC):
     def _stream_established(self):
         self._is_stream_subscribed = True
 
+    @property
+    def _trade_event_log_df(self) -> pd.DataFrame:
+        """Trade event log as a DataFrame (materialized lazily for performance)."""
+        if not getattr(self, "_trade_event_log_enabled", True):
+            return getattr(self, "_trade_event_log_df_cache", pd.DataFrame())
+        cache = getattr(self, "_trade_event_log_df_cache", None)
+        if cache is None:
+            rows = getattr(self, "_trade_event_log_rows", [])
+            cache = pd.DataFrame(rows) if rows else pd.DataFrame()
+            self._trade_event_log_df_cache = cache
+        return cache
+
+    @_trade_event_log_df.setter
+    def _trade_event_log_df(self, value) -> None:
+        # Preserve legacy test behavior where callers set this to None to disable logging.
+        if value is None:
+            self._trade_event_log_enabled = False
+            self._trade_event_log_rows = []
+            self._trade_event_log_df_cache = pd.DataFrame()
+            return
+        self._trade_event_log_enabled = True
+        self._trade_event_log_df_cache = value
+
     def process_held_trades(self):
         """Processes any held trade notifications."""
         while len(self._held_trades) > 0:
@@ -1640,12 +1763,12 @@ class Broker(ABC):
             filled_quantity = th[3]
             multiplier = th[4]
 
-            # Log that the trade event was received
-            self.logger.info(
-                f"Processing held trade event. Trade event received for stored_order: {stored_order}, "
-                f"type_event: {type_event}, ID: {stored_order.identifier}, price: {price}, "
-                f"filled_quantity: {filled_quantity}, multiplier: {multiplier}"
-            )
+            if self.logger.isEnabledFor(logging.INFO):
+                self.logger.info(
+                    f"Processing held trade event. Trade event received for stored_order: {stored_order}, "
+                    f"type_event: {type_event}, ID: {stored_order.identifier}, price: {price}, "
+                    f"filled_quantity: {filled_quantity}, multiplier: {multiplier}"
+                )
 
             # Process the trade event
             self._process_trade_event(
@@ -1659,19 +1782,19 @@ class Broker(ABC):
     def _process_trade_event(self, stored_order, type_event, price=None, filled_quantity=None, multiplier=1, error=None): # Add error parameter
         """process an occurred trading event and update the
         corresponding order"""
-        # Log that the trade event was received
-        self.logger.info(
-            f"Processing trade event. Trade event received for {stored_order.strategy} strategy: {type_event} "
-            f"{stored_order.symbol} ID={stored_order.identifier}, processed by broker {self.name}"
-        )
+        if self.logger.isEnabledFor(logging.INFO):
+            self.logger.info(
+                f"Processing trade event. Trade event received for {stored_order.strategy} strategy: {type_event} "
+                f"{stored_order.symbol} ID={stored_order.identifier}, processed by broker {self.name}"
+            )
 
         if self._hold_trade_events and not self.IS_BACKTESTING_BROKER:
-            # Log that the trade event was held
-            self.logger.info(
-                f"Trade event held for {stored_order.strategy} strategy: {type_event} {stored_order.symbol} "
-                f"ID={stored_order.identifier}, processed by broker {self.name}. "
-                f"self._hold_trade_events is {self._hold_trade_events}"
-            )
+            if self.logger.isEnabledFor(logging.INFO):
+                self.logger.info(
+                    f"Trade event held for {stored_order.strategy} strategy: {type_event} {stored_order.symbol} "
+                    f"ID={stored_order.identifier}, processed by broker {self.name}. "
+                    f"self._hold_trade_events is {self._hold_trade_events}"
+                )
 
             # Hold the trade event
             self._held_trades.append(
@@ -1731,7 +1854,8 @@ class Broker(ABC):
                     subscriber.add_event(subscriber.ERROR_ORDER, payload)
         elif Order.is_equivalent_status(type_event, self.MODIFIED_ORDER):
             # TODO: Implement modification logic and notification if needed
-            self.logger.info(colored(f"Order was modified: {stored_order}", color="yellow"))
+            if self.logger.isEnabledFor(logging.INFO):
+                self.logger.info(colored(f"Order was modified: {stored_order}", color="yellow"))
             # Update raw data if modification response is available (might need adjustment)
             # stored_order.update_raw(modification_response_data)
             # self._on_modified_order(stored_order) # Need to implement _on_modified_order
@@ -1764,6 +1888,7 @@ class Broker(ABC):
             "filled_quantity": filled_quantity,
             "multiplier": multiplier,
             "trade_cost": stored_order.trade_cost,
+            "trade_slippage": getattr(stored_order, "trade_slippage", None),
             "time_in_force": stored_order.time_in_force,
             "asset.right": stored_order.asset.right if stored_order.asset is not None else None,
             "asset.strike": stored_order.asset.strike if stored_order.asset is not None else None,
@@ -1778,14 +1903,11 @@ class Broker(ABC):
                 delattr(stored_order, "_price_source")
             except AttributeError:
                 pass
-        # Create a DataFrame with the new row
-        new_row_df = pd.DataFrame(new_row, index=[0])
-
-        # Filter out empty or all-NA columns from new_row_df
-        new_row_df = new_row_df.dropna(axis=1, how="all")
-
-        # Concatenate the filtered new_row_df with the existing _trade_event_log_df
-        self._trade_event_log_df = pd.concat([self._trade_event_log_df, new_row_df], axis=0)
+        if getattr(self, "_trade_event_log_enabled", True):
+            # PERF: Avoid pandas concat per event; append to list and materialize once.
+            self._trade_event_log_rows.append(new_row)
+            # Invalidate cached DataFrame representation.
+            self._trade_event_log_df_cache = None
 
         return
 

--- a/lumibot/components/options_helper.py
+++ b/lumibot/components/options_helper.py
@@ -718,6 +718,33 @@ class OptionsHelper:
             source allows it).
         """
 
+        # PERF: Option strategies often evaluate the same contract multiple times within a single
+        # strategy datetime (MTM, liquidity checks, multi-leg pricing). In backtesting, quotes are
+        # immutable per bar, so cache evaluations for the current datetime.
+        current_dt = None
+        try:
+            current_dt = self.strategy.get_datetime()
+        except Exception:
+            current_dt = None
+
+        cache_dt = getattr(self, "_option_market_eval_cache_dt", None)
+        if cache_dt != current_dt:
+            self._option_market_eval_cache_dt = current_dt
+            self._option_market_eval_cache = {}
+
+        cache_key = (option_asset, max_spread_pct)
+        cache = getattr(self, "_option_market_eval_cache", {})
+        if cache_key in cache:
+            return cache[cache_key]
+
+        # PERF: `log_message()` respects BACKTESTING_QUIET_LOGS, but callers still pay the cost
+        # of building large f-strings. Gate string construction in this hot path.
+        should_log_info = False
+        try:
+            should_log_info = bool(getattr(self.strategy, "logger", None) and self.strategy.logger.isEnabledFor(logging.INFO))
+        except Exception:
+            should_log_info = False
+
         data_source = getattr(getattr(self.strategy, "broker", None), "data_source", None)
         allow_fallback = bool(getattr(data_source, "option_quote_fallback_allowed", False))
 
@@ -741,10 +768,11 @@ class OptionsHelper:
         try:
             quote = self.strategy.get_quote(option_asset)
         except Exception as exc:
-            self.strategy.log_message(
-                f"Error fetching quote for {option_asset}: {exc}",
-                color="red",
-            )
+            if should_log_info:
+                self.strategy.log_message(
+                    f"Error fetching quote for {option_asset}: {exc}",
+                    color="red",
+                )
 
         if quote is not None:
             if getattr(quote, "bid", None) is not None:
@@ -777,30 +805,41 @@ class OptionsHelper:
         # PERFORMANCE: Do not fetch trade-derived OHLC/last when bid/ask is already actionable.
         # ThetaData can provide NBBO without trades, and calling get_last_price() can trigger
         # expensive historical OHLC downloads (especially in backtests).
-        if allow_fallback and buy_price is None and sell_price is None:
-            try:
-                last_price = self.strategy.get_last_price(option_asset)
-            except Exception as exc:
-                self.strategy.log_message(
-                    f"Error fetching last price for {option_asset}: {exc}",
-                    color="red",
-                )
+        if buy_price is None and sell_price is None:
+            # First try to use the quote's price field. This is free (no extra downloader calls)
+            # and is often populated even when bid/ask is absent (e.g., daily OHLC-based quotes).
+            quote_price = None
+            if quote is not None:
+                quote_price = getattr(quote, "price", None)
+            if quote_price is not None:
+                last_price = self._coerce_price(quote_price, "quote_price", data_quality_flags, sanitization_notes)
+
+            # As a last resort, allow data-source-specific fallback to trade-only last price.
+            if last_price is None and allow_fallback:
+                try:
+                    last_price = self.strategy.get_last_price(option_asset)
+                except Exception as exc:
+                    if should_log_info:
+                        self.strategy.log_message(
+                            f"Error fetching last price for {option_asset}: {exc}",
+                            color="red",
+                        )
+
+                if last_price is not None:
+                    last_price = self._coerce_price(last_price, "last_price", data_quality_flags, sanitization_notes)
 
             if last_price is None:
                 missing_last_price = True
-            else:
-                last_price = self._coerce_price(last_price, "last_price", data_quality_flags, sanitization_notes)
-                if last_price is None:
-                    missing_last_price = True
 
-        if allow_fallback and last_price is not None and buy_price is None and sell_price is None:
+        if last_price is not None and buy_price is None and sell_price is None:
             buy_price = last_price
             sell_price = last_price
             used_last_price_fallback = True
-            self.strategy.log_message(
-                f"Using last-price fallback for {option_asset} due to missing bid/ask quotes.",
-                color="yellow",
-            )
+            if should_log_info:
+                self.strategy.log_message(
+                    f"Using last-price fallback for {option_asset} due to missing bid/ask quotes.",
+                    color="yellow",
+                )
         elif not has_bid_ask and allow_fallback and last_price is None:
             data_quality_flags.append("last_price_unusable")
 
@@ -810,32 +849,32 @@ class OptionsHelper:
             buy_price = None
             sell_price = None
 
-        # Compose log message
-        spread_str = f"{spread_pct:.2%}" if spread_pct is not None else "None"
-        max_spread_str = f"{max_spread_pct:.2%}" if max_spread_pct is not None else "None"
-        log_color = "red" if spread_too_wide else (
-            "yellow" if (missing_bid_ask or missing_last_price or used_last_price_fallback) else "blue"
-        )
-        if sanitization_notes:
-            note_summary = "; ".join(sanitization_notes)
-            self.strategy.log_message(
-                f"Option data sanitization for {option_asset}: {note_summary}",
-                color="yellow",
+        if should_log_info:
+            spread_str = f"{spread_pct:.2%}" if spread_pct is not None else "None"
+            max_spread_str = f"{max_spread_pct:.2%}" if max_spread_pct is not None else "None"
+            log_color = "red" if spread_too_wide else (
+                "yellow" if (missing_bid_ask or missing_last_price or used_last_price_fallback) else "blue"
             )
-        self.strategy.log_message(
-            (
-                f"Option market evaluation for {option_asset}: "
-                f"bid={bid}, ask={ask}, last={last_price}, spread={spread_str}, "
-                f"max_spread={max_spread_str}, missing_bid_ask={missing_bid_ask}, "
-                f"missing_last_price={missing_last_price}, spread_too_wide={spread_too_wide}, "
-                f"used_last_price_fallback={used_last_price_fallback}, "
-                f"buy_price={buy_price}, sell_price={sell_price}, "
-                f"data_quality_flags={data_quality_flags}"
-            ),
-            color=log_color,
-        )
+            if sanitization_notes:
+                note_summary = "; ".join(sanitization_notes)
+                self.strategy.log_message(
+                    f"Option data sanitization for {option_asset}: {note_summary}",
+                    color="yellow",
+                )
+            self.strategy.log_message(
+                (
+                    f"Option market evaluation for {option_asset}: "
+                    f"bid={bid}, ask={ask}, last={last_price}, spread={spread_str}, "
+                    f"max_spread={max_spread_str}, missing_bid_ask={missing_bid_ask}, "
+                    f"missing_last_price={missing_last_price}, spread_too_wide={spread_too_wide}, "
+                    f"used_last_price_fallback={used_last_price_fallback}, "
+                    f"buy_price={buy_price}, sell_price={sell_price}, "
+                    f"data_quality_flags={data_quality_flags}"
+                ),
+                color=log_color,
+            )
 
-        return OptionMarketEvaluation(
+        evaluation = OptionMarketEvaluation(
             bid=bid,
             ask=ask,
             last_price=last_price,
@@ -850,6 +889,13 @@ class OptionsHelper:
             max_spread_pct=max_spread_pct,
             data_quality_flags=data_quality_flags,
         )
+
+        try:
+            self._option_market_eval_cache[cache_key] = evaluation
+        except Exception:
+            pass
+
+        return evaluation
 
     def check_option_liquidity(self, option_asset: Asset, max_spread_pct: float) -> bool:
         """
@@ -1023,6 +1069,25 @@ class OptionsHelper:
         elif 'UnderlyingSymbol' in chains_map:
             underlying_symbol = chains_map['UnderlyingSymbol']
 
+        # PERF: Intraday strategies often request the "next valid expiration" on every bar, even
+        # though the answer is stable for the trading day. Cache per (underlying, date, side, chain
+        # fingerprint) so repeated calls avoid re-validating strikes/quotes.
+        cache_dt = getattr(self, "_expiration_cache_dt", None)
+        if cache_dt != dt:
+            self._expiration_cache_dt = dt
+            self._expiration_cache = {}
+
+        try:
+            chain_fingerprint = (len(specific_chain), min(specific_chain.keys()), max(specific_chain.keys()))
+        except Exception:
+            chain_fingerprint = (len(specific_chain) if isinstance(specific_chain, dict) else 0, None, None)
+
+        cache_underlying = underlying_symbol or getattr(underlying_asset, "symbol", None) or "<unknown>"
+        expiration_cache_key = (cache_underlying, dt, call_or_put_caps, bool(allow_prior), chain_fingerprint)
+        expiration_cache = getattr(self, "_expiration_cache", {})
+        if expiration_cache_key in expiration_cache:
+            return expiration_cache[expiration_cache_key]
+
         # Convert string expiries to dates for comparison
         expiration_dates: List[Tuple[str, date]] = _try_resolve_expiration(specific_chain)
         future_candidates = [(s, d) for s, d in expiration_dates if d >= dt]
@@ -1151,14 +1216,12 @@ class OptionsHelper:
                     # Fallback: Check for last traded price data
                     try:
                         mark_price, _, _ = self._get_option_mark_from_quote(test_option)
-                        if mark_price is None:
-                            price = self.strategy.get_last_price(test_option)
-                            if price is not None:
-                                self.strategy.log_message(
-                                    f"Found valid expiry {exp_date} with price data for {call_or_put_caps}",
-                                    color="blue",
-                                )
-                                return exp_date
+                        if mark_price is not None:
+                            self.strategy.log_message(
+                                f"Found valid expiry {exp_date} with quote-derived price data for {call_or_put_caps}",
+                                color="blue",
+                            )
+                            return exp_date
                     except Exception:
                         pass
                 else:
@@ -1174,6 +1237,10 @@ class OptionsHelper:
 
         resolved = _validate_candidates(future_candidates)
         if resolved is not None:
+            try:
+                self._expiration_cache[expiration_cache_key] = resolved
+            except Exception:
+                pass
             return resolved
 
         broker = getattr(self.strategy, "broker", None)
@@ -1192,10 +1259,18 @@ class OptionsHelper:
                     f"Falling back to prior valid expiry {resolved} (< {dt}) for {call_or_put_caps}.",
                     color="yellow",
                 )
+                try:
+                    self._expiration_cache[expiration_cache_key] = resolved
+                except Exception:
+                    pass
                 return resolved
 
         msg = f"No valid expirations on or after {dt} with tradeable data for {call_or_put_caps}; skipping."
         self.strategy.log_message(msg, color="yellow")
+        try:
+            self._expiration_cache[expiration_cache_key] = None
+        except Exception:
+            pass
         return None
 
     # ============================================================

--- a/lumibot/entities/__init__.py
+++ b/lumibot/entities/__init__.py
@@ -11,6 +11,8 @@ from .order import Order
 from .position import Position
 from .quote import Quote
 from .trading_fee import TradingFee
+from .trading_slippage import TradingSlippage
+from .smart_limit import SmartLimitConfig, SmartLimitPreset
 
 # Use base implementations directly
 Bars = _BarsBase
@@ -28,4 +30,7 @@ __all__ = [
     "Position",
     "Quote",
     "TradingFee",
+    "TradingSlippage",
+    "SmartLimitConfig",
+    "SmartLimitPreset",
 ]

--- a/lumibot/entities/asset.py
+++ b/lumibot/entities/asset.py
@@ -22,11 +22,13 @@ class StrEnum(str, Enum):
     3. Can be used in string comparisons without explicit conversion
     """
     def __str__(self):
-        return self.value
+        # Avoid Enum.value property lookups in hot paths; StrEnum members are already `str`.
+        return str.__str__(self)
 
     def __eq__(self, other):
         if isinstance(other, str):
-            return self.value == other
+            # Avoid Enum.value property lookups; compare as plain strings.
+            return str.__eq__(self, other)
         return super().__eq__(other)
 
     def __hash__(self):
@@ -259,6 +261,10 @@ class Asset:
 
         self.asset_type = self.asset_type_must_be_one_of(asset_type)
         self.right = self.right_must_be_one_of(right)
+        # Cache the hash: Asset objects are used heavily as dict keys during backtests (quotes, bars,
+        # chains, positions). Recomputing tuple hashes millions of times dominates CPU in option-heavy
+        # strategies; caching preserves correctness as long as identity fields remain unchanged.
+        self._cached_hash = hash((self.symbol, self.asset_type, self.expiration, self.strike, self.right))
 
     @classmethod
     def symbol2asset(cls, symbol: str):
@@ -297,10 +303,6 @@ class Asset:
             return Asset(symbol=symbol, asset_type="crypto")
         else:
             return Asset(symbol=None)
-
-    def __hash__(self):
-        # Original hash implementation - keep this unchanged
-        return hash((self.symbol, self.asset_type, self.expiration, self.strike, self.right))
 
     def __repr__(self):
         if self.asset_type == "future":
@@ -342,7 +344,7 @@ class Asset:
 
     def __hash__(self):
         """Make Asset hashable for use in sets and dicts."""
-        return hash((self.symbol, self.asset_type, self.expiration, self.strike, self.right))
+        return self._cached_hash
 
     def asset_type_must_be_one_of(self, v):
         # TODO: check if this works!

--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -210,6 +210,9 @@ class Data:
 
         self.df = self.set_date_format(self.df)
         self.df = self.df.sort_index()
+        # PERF: many hot paths (quotes/bars) assume the underlying index is unique. Cache this once.
+        # When the index is unique and we're not resampling, we can return bars without expensive resample/agg work.
+        self._index_is_unique = bool(getattr(self.df.index, "is_unique", False))
 
         self.trading_hours_start, self.trading_hours_end = self.set_times(trading_hours_start, trading_hours_end)
         self.date_start, self.date_end = self.set_dates(date_start, date_end)
@@ -852,6 +855,51 @@ class Data:
 
         if data is None:
             return None
+
+        # Fast-path: requesting native bars (1 minute or 1 day) from a Data object that is already in
+        # that native timestep can avoid a full resample/agg per call.
+        #
+        # This is critical for intraday strategies that call `get_historical_prices()` tens of thousands
+        # of times (e.g., RSI computations every bar). Resample is orders-of-magnitude slower than
+        # slicing when quantity==1 and the index is unique.
+        if (
+            quantity == 1
+            and self._index_is_unique
+            and (
+                (timestep == "minute" and self.timestep == "minute")
+                or (timestep == "day" and self.timestep == "day")
+            )
+        ):
+            dt_values = data.get("datetime")
+            if dt_values is None:
+                return None
+            # Only apply the fast-path when this is true OHLCV data. Quote-like data (bid/ask/etc)
+            # historically flows through different APIs and may not have the required OHLC columns.
+            if all(key in data for key in ("open", "high", "low", "close")):
+                df = pd.DataFrame({k: v for k, v in data.items() if k != "datetime"})
+                df.index = pd.to_datetime(dt_values)
+                df.index.name = "datetime"
+
+                # Match legacy resample behaviour: the resample/agg path only returns OHLCV
+                # (+ dividend when present) and does not drop rows just because some *other*
+                # column is NaN. Keep the output schema stable and avoid over-dropping.
+                cols = list(agg_column_map.keys())
+                if "dividend" in df.columns:
+                    cols.append("dividend")
+                cols = [c for c in cols if c in df.columns]
+                df = df[cols]
+
+                # In the resample path, `sum` turns NaN volume/dividend into 0. Mirror that
+                # so we don't accidentally drop valid bars (common for index bars).
+                if "volume" in df.columns:
+                    df["volume"] = df["volume"].fillna(0)
+                if "dividend" in df.columns:
+                    df["dividend"] = df["dividend"].fillna(0)
+
+                required = [c for c in ("open", "high", "low", "close") if c in df.columns]
+                if required:
+                    df = df.dropna(subset=required)
+                return df.tail(n=int(num_periods))
 
         df = pd.DataFrame(data).assign(datetime=lambda df: pd.to_datetime(df['datetime'])).set_index('datetime')
         if "dividend" in df.columns:

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from lumibot.entities.asset import Asset
 
 import lumibot.entities as entities
+from lumibot.entities.smart_limit import SmartLimitConfig
 
 # Set up module-specific logger
 from lumibot.tools.lumibot_logger import get_logger
@@ -94,6 +95,7 @@ class Order:
         STOP = "stop"
         STOP_LIMIT = "stop_limit"
         TRAIL = "trailing_stop"
+        SMART_LIMIT = "smart_limit"
 
     class OrderSide(StrEnum):
         BUY = "buy"
@@ -148,6 +150,7 @@ class Order:
         order_type: Union[OrderType, None] = None,
         order_class: Union[OrderClass, None] = OrderClass.SIMPLE,
         trade_cost: float = None,
+        trade_slippage: float = None,
         custom_params: dict = None,
         identifier: str = None,
         avg_fill_price: float = None,
@@ -155,6 +158,7 @@ class Order:
         child_orders: Union[list, None] = None,
         tag: str = "",
         status: OrderStatus = "unprocessed",
+        smart_limit: SmartLimitConfig = None,
     ):
         """Order class for managing individual orders.
 
@@ -270,9 +274,12 @@ class Order:
             The type of order. Possible values are: `market`, `limit`, `stop`, `stop_limit`, `trail`, `trail_limit`.
             (Deprecated, use 'order_type' instead)
         order_type : str or Order.OrderType
-            The type of order. Possible values are: `market`, `limit`, `stop`, `stop_limit`, `trail`, `trail_limit`.
+            The type of order. Possible values are: `market`, `limit`, `stop`, `stop_limit`, `trail`, `trail_limit`,
+            `smart_limit`.
         order_class : str
             The order class. Possible values are: `simple`, `bracket`, `oco`, `oto`, `multileg`.
+        smart_limit : SmartLimitConfig
+            Configuration for SMART_LIMIT orders. When set, the order type defaults to `smart_limit`.
         trade_cost : float
             The cost of this order in the quote currency.
         custom_params : dict
@@ -387,7 +394,9 @@ class Order:
         self.dependent_order = None
         self.dependent_order_filled = False
         self.order_type = order_type
+        self.smart_limit = smart_limit
         self.trade_cost = trade_cost
+        self.trade_slippage = 0.0 if trade_slippage is None else trade_slippage
         self.custom_params = custom_params
         self._trail_stop_price = None  # Used by backtesting broker to track desired trailing stop price so far
         self.tag = tag
@@ -494,6 +503,9 @@ class Order:
 
         # Check - Order Class values passed in the 'type' parameter is depricated. OTO/Bracket/etc should
         # This is done here so that the older depricated parameters are still accepted for backwards compatibility
+        if order_type in (self.OrderType.SMART_LIMIT, "smart_limit") and self.smart_limit is None:
+            self.smart_limit = SmartLimitConfig()
+
         try:
             self.order_type = order_type \
                 if isinstance(order_type, (self.OrderType, NONE_TYPE)) else self.OrderType(order_type)
@@ -688,6 +700,9 @@ class Order:
         position_filled,
     ):
         if self.order_type is None:
+            if self.smart_limit is not None:
+                self.order_type = self.OrderType.SMART_LIMIT
+                return
             # Check if this is a trailing stop order
             if trail_price is not None or trail_percent is not None:
                 self.order_type = self.OrderType.TRAIL
@@ -922,13 +937,9 @@ class Order:
         if not isinstance(other, Order):
             return False
 
-        # If the other object is an Order object, then compare the identifier.
-        return (
-            self.identifier == other.identifier
-            and self.asset == other.asset
-            and self.quantity == other.quantity
-            and self.side == other.side
-        )
+        # Orders are uniquely identified by their identifier; comparing deeper fields is expensive
+        # and can be inconsistent with `__hash__` which also hashes the identifier.
+        return self.identifier == other.identifier
 
     def __repr__(self):
         if self.asset is None:
@@ -1027,8 +1038,13 @@ class Order:
         bool
             True if the order is active, False otherwise.
         """
-        active_children = any([child for child in self.child_orders if child.is_active()])
-        return not self.is_filled() and not self.is_canceled() or active_children
+        # Fast-path: most orders are simple and active; avoid recursively scanning children
+        # unless the parent itself is no longer active.
+        if not self.is_filled() and not self.is_canceled():
+            return True
+        if not self.child_orders:
+            return False
+        return any(child.is_active() for child in self.child_orders)
 
     def is_canceled(self):
         """
@@ -1206,6 +1222,8 @@ class Order:
             result["limit"] = float(self.limit_price)
         if self.stop_price is not None:
             result["stop"] = float(self.stop_price)
+        if self.smart_limit is not None:
+            result["smart_limit"] = self.smart_limit.to_dict()
 
         return result
 
@@ -1298,6 +1316,9 @@ class Order:
                         setattr(obj, key, datetime.datetime.fromisoformat(value))
                     except ValueError:
                         setattr(obj, key, value)
+
+                elif key == "smart_limit":
+                    setattr(obj, key, SmartLimitConfig.from_dict(value))
 
                 # Recursively convert nested objects using from_dict (for objects like quote)
                 elif isinstance(value, dict) and hasattr(cls, key) and hasattr(getattr(cls, key), 'from_dict'):

--- a/lumibot/entities/smart_limit.py
+++ b/lumibot/entities/smart_limit.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Union
+
+from .trading_slippage import TradingSlippage
+
+
+class SmartLimitPreset(str, Enum):
+    FAST = "fast"
+    NORMAL = "normal"
+    PATIENT = "patient"
+
+
+_SMART_LIMIT_PRESET_CONFIG = {
+    SmartLimitPreset.FAST: {"steps": 3, "step_seconds": 5},
+    SmartLimitPreset.NORMAL: {"steps": 4, "step_seconds": 10},
+    SmartLimitPreset.PATIENT: {"steps": 5, "step_seconds": 20},
+}
+
+
+@dataclass
+class SmartLimitConfig:
+    """Configuration for SMART_LIMIT orders.
+
+    Parameters
+    ----------
+    preset : SmartLimitPreset
+        Execution pace (FAST, NORMAL, PATIENT).
+    final_price_pct : float
+        Percent of bid/ask spread allowed for the final price (1.0 = full spread).
+    slippage : TradingSlippage | float | None
+        Absolute slippage applied in backtests (mid ± slippage).
+    step_seconds : int | None
+        Optional override for seconds per step.
+    final_hold_seconds : int | None
+        Optional override for final hold time.
+    """
+
+    preset: SmartLimitPreset = SmartLimitPreset.NORMAL
+    final_price_pct: float = 1.0
+    slippage: Optional[Union[TradingSlippage, float]] = None
+    step_seconds: Optional[int] = None
+    final_hold_seconds: Optional[int] = None
+
+    def __post_init__(self):
+        if isinstance(self.preset, str):
+            self.preset = SmartLimitPreset(self.preset)
+        if self.slippage is not None and not isinstance(self.slippage, TradingSlippage):
+            self.slippage = TradingSlippage(amount=self.slippage)
+
+    def get_step_count(self) -> int:
+        return _SMART_LIMIT_PRESET_CONFIG[self.preset]["steps"]
+
+    def get_step_seconds(self) -> int:
+        if self.step_seconds is not None:
+            return int(self.step_seconds)
+        return _SMART_LIMIT_PRESET_CONFIG[self.preset]["step_seconds"]
+
+    def get_final_hold_seconds(self) -> int:
+        return int(self.final_hold_seconds) if self.final_hold_seconds is not None else 120
+
+    def get_slippage_amount(self) -> float:
+        if self.slippage is None:
+            return 0.0
+        return float(self.slippage.amount)
+
+    def to_dict(self) -> dict:
+        return {
+            "preset": self.preset.value,
+            "final_price_pct": float(self.final_price_pct),
+            "slippage": self.slippage.to_dict() if self.slippage else None,
+            "step_seconds": self.step_seconds,
+            "final_hold_seconds": self.final_hold_seconds,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Optional[dict]):
+        if data is None:
+            return None
+        slippage_data = data.get("slippage")
+        slippage = TradingSlippage.from_dict(slippage_data) if slippage_data else None
+        return cls(
+            preset=data.get("preset", SmartLimitPreset.NORMAL),
+            final_price_pct=data.get("final_price_pct", 1.0),
+            slippage=slippage,
+            step_seconds=data.get("step_seconds"),
+            final_hold_seconds=data.get("final_hold_seconds"),
+        )

--- a/lumibot/entities/trading_slippage.py
+++ b/lumibot/entities/trading_slippage.py
@@ -1,0 +1,28 @@
+from decimal import Decimal
+
+
+class TradingSlippage:
+    """TradingSlippage class. Defines a per-order slippage amount for backtesting fills."""
+
+    def __init__(self, amount=0.0):
+        """
+        Parameters
+        ----------
+        amount : Decimal, float, or None
+            Absolute slippage amount applied to the fill price (quote currency).
+
+        Example
+        --------
+        >>> from lumibot.entities import TradingSlippage
+        >>> slippage = TradingSlippage(amount=0.05)  # $0.05 slippage
+        """
+        self.amount = Decimal(amount)
+
+    def to_dict(self):
+        return {"amount": float(self.amount)}
+
+    @classmethod
+    def from_dict(cls, data):
+        if data is None:
+            return None
+        return cls(amount=data.get("amount", 0.0))

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -179,6 +179,8 @@ class _Strategy:
         parameters={},
         buy_trading_fees=[],
         sell_trading_fees=[],
+        buy_trading_slippages=[],
+        sell_trading_slippages=[],
         force_start_immediately=False,
         discord_webhook_url=None,
         account_history_db_connection_str=None,
@@ -244,6 +246,10 @@ class _Strategy:
             A list of TradingFee objects to use for buying assets. Defaults to an empty list.
         sell_trading_fees : list
             A list of TradingFee objects to use for selling assets. Defaults to an empty list.
+        buy_trading_slippages : list
+            A list of TradingSlippage objects to use for buy fills in backtesting. Defaults to empty list.
+        sell_trading_slippages : list
+            A list of TradingSlippage objects to use for sell fills in backtesting. Defaults to empty list.
         force_start_immidiately : bool
             If True, the strategy will start immediately. If False, the strategy will wait until the market opens
             to start. Defaults to True.
@@ -288,6 +294,8 @@ class _Strategy:
 
         self.buy_trading_fees = buy_trading_fees
         self.sell_trading_fees = sell_trading_fees
+        self.buy_trading_slippages = buy_trading_slippages
+        self.sell_trading_slippages = sell_trading_slippages
         self.save_logfile = save_logfile
         self.broker = broker
 
@@ -844,6 +852,32 @@ class _Strategy:
             and isinstance(source, ThetaDataBacktestingPandas)
         )
 
+        def _thetadata_quote_mark(quote_obj):
+            if quote_obj is None:
+                return None
+            bid = getattr(quote_obj, "bid", None)
+            ask = getattr(quote_obj, "ask", None)
+            price = getattr(quote_obj, "price", None)
+
+            def _coerce(val):
+                try:
+                    numeric = float(val)
+                except (TypeError, ValueError):
+                    return None
+                if math.isnan(numeric) or numeric <= 0:
+                    return None
+                return numeric
+
+            bid_val = _coerce(bid)
+            ask_val = _coerce(ask)
+            if bid_val is not None and ask_val is not None:
+                return (bid_val + ask_val) / 2
+            if bid_val is not None:
+                return bid_val
+            if ask_val is not None:
+                return ask_val
+            return _coerce(price)
+
         # Determine if this strategy is effectively daily cadence.
         try:
             cadence_seconds = self._get_sleeptime_seconds()
@@ -851,6 +885,27 @@ class _Strategy:
                 timestep_hint = "day"
         except Exception:
             timestep_hint = None
+
+        # ThetaData backtesting: for options, mark-to-market should be quote-driven (NBBO mark) and
+        # extremely fast. Calling `get_price_snapshot()` first causes an extra `_update_pandas_data()`
+        # pass per asset (and often still falls back to `get_quote()`), which is the dominant cost in
+        # long, option-heavy intraday backtests.
+        if is_thetadata_option_backtest:
+            try:
+                get_quote = getattr(source, "get_quote", None)
+                if callable(get_quote):
+                    quote_asset = getattr(self, "_quote_asset", None)
+                    if quote_asset is not None:
+                        quote = get_quote(base_asset, quote=quote_asset, timestep=timestep_hint or "minute")
+                    else:
+                        quote = get_quote(base_asset, timestep=timestep_hint or "minute")
+                    quote_mark = _thetadata_quote_mark(quote)
+                    if quote_mark is not None:
+                        return quote_mark
+            except Exception as e:
+                self.logger.debug("ThetaData quote-mark lookup failed for %s: %s", base_asset, e)
+            return None
+
         if hasattr(source, "get_price_snapshot"):
             try:
                 if timestep_hint:
@@ -873,51 +928,6 @@ class _Strategy:
 
         if snapshot_price is not None:
             return snapshot_price
-
-        def _thetadata_quote_mark(quote_obj):
-            if quote_obj is None:
-                return None
-            bid = getattr(quote_obj, "bid", None)
-            ask = getattr(quote_obj, "ask", None)
-            try:
-                bid_val = float(bid) if bid is not None else None
-                ask_val = float(ask) if ask is not None else None
-            except (TypeError, ValueError):
-                bid_val = None
-                ask_val = None
-            if bid_val is not None and bid_val <= 0:
-                bid_val = None
-            if ask_val is not None and ask_val <= 0:
-                ask_val = None
-            if bid_val is not None and ask_val is not None:
-                mid_val = (bid_val + ask_val) / 2
-                return mid_val if mid_val > 0 else None
-            if bid_val is not None:
-                return bid_val
-            if ask_val is not None:
-                return ask_val
-            return None
-
-        # ThetaData backtesting: for options, prefer quote-based mark pricing over stale last-trade.
-        # If we still can't price the option, return None so the strategy-level MTM forward-fill can apply.
-        if is_thetadata_option_backtest:
-            try:
-                get_quote = getattr(source, "get_quote", None)
-                if callable(get_quote):
-                    quote = get_quote(base_asset, timestep=timestep_hint or "minute")
-                    quote_mark = _thetadata_quote_mark(quote)
-                    if quote_mark is not None:
-                        self.logger.debug(
-                            "Using ThetaData quote mark %.4f for %s (bid=%s, ask=%s)",
-                            quote_mark,
-                            base_asset,
-                            getattr(quote, "bid", None) if quote else None,
-                            getattr(quote, "ask", None) if quote else None,
-                        )
-                        return quote_mark
-            except Exception as e:
-                self.logger.debug("ThetaData quote-mark lookup failed for %s: %s", base_asset, e)
-            return None
 
         get_last_price = getattr(source, "get_last_price", None)
         if callable(get_last_price):
@@ -1483,6 +1493,8 @@ class _Strategy:
         parameters = {},
         buy_trading_fees = [],
         sell_trading_fees = [],
+        buy_trading_slippages = [],
+        sell_trading_slippages = [],
         polygon_api_key = None,
         use_other_option_source = False,
         thetadata_username = None,
@@ -1562,6 +1574,10 @@ class _Strategy:
             A list of TradingFee objects to apply to the buy orders during backtests.
         sell_trading_fees : list of TradingFee objects
             A list of TradingFee objects to apply to the sell orders during backtests.
+        buy_trading_slippages : list of TradingSlippage objects
+            Slippage amounts to apply to buy SMART_LIMIT fills when no per-order slippage is provided.
+        sell_trading_slippages : list of TradingSlippage objects
+            Slippage amounts to apply to sell SMART_LIMIT fills when no per-order slippage is provided.
         polygon_api_key : str
             The polygon api key to use for polygon data. Only required if you are using PolygonDataBacktesting as
             the datasource_class.
@@ -1901,6 +1917,8 @@ class _Strategy:
             parameters=parameters,
             buy_trading_fees=buy_trading_fees,
             sell_trading_fees=sell_trading_fees,
+            buy_trading_slippages=buy_trading_slippages,
+            sell_trading_slippages=sell_trading_slippages,
             save_logfile=save_logfile,
             include_cash_positions=include_cash_positions,
             **kwargs,
@@ -2041,11 +2059,18 @@ class _Strategy:
                 f"{end_dt} and {start_dt}"
             )
 
-        # Check that backtesting_end is not in the future
+        # Check that backtesting_end is not in the future (allow opt-in override for testing)
         now = datetime.datetime.now(end_dt.tzinfo) if end_dt.tzinfo else datetime.datetime.now()
         if end_dt > now:
-            raise ValueError(
-                f"`backtesting_end` cannot be in the future. You passed in {end_dt}, now is {now}"
+            allow_future = os.environ.get("BACKTESTING_ALLOW_FUTURE_END", "").strip().lower() in {"1", "true", "yes"}
+            if not allow_future:
+                raise ValueError(
+                    f"`backtesting_end` cannot be in the future. You passed in {end_dt}, now is {now}"
+                )
+            get_logger(__name__).warning(
+                "`backtesting_end` is in the future (%s > %s). Proceeding because BACKTESTING_ALLOW_FUTURE_END=true.",
+                end_dt,
+                now,
             )
 
     def send_update_to_cloud(self):

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1448,6 +1448,36 @@ class _Strategy:
 
             strat_name = self._name if self._name is not None else "Strategy"
 
+            lumibot_version = None
+            backtesting_data_sources = None
+            backtest_time_seconds = None
+
+            try:
+                if self.is_backtesting:
+                    try:
+                        import lumibot as _lumibot
+
+                        lumibot_version = getattr(_lumibot, "__version__", None)
+                    except Exception:
+                        lumibot_version = None
+
+                    try:
+                        backtesting_data_sources = (
+                            os.environ.get("BACKTESTING_DATA_SOURCES")
+                            or os.environ.get("BACKTESTING_DATA_SOURCE")
+                            or type(self.broker.data_source).__name__
+                        )
+                    except Exception:
+                        backtesting_data_sources = os.environ.get("BACKTESTING_DATA_SOURCE")
+
+                    backtest_time_seconds = getattr(self, "_backtest_time_seconds", None)
+                    if backtest_time_seconds is None:
+                        start_ts = getattr(self, "_backtest_time_start_monotonic", None)
+                        if start_ts is not None:
+                            backtest_time_seconds = time.monotonic() - float(start_ts)
+            except Exception:
+                pass
+
             result = create_tearsheet(
                 self._strategy_returns_df,
                 strat_name,
@@ -1458,6 +1488,9 @@ class _Strategy:
                 save_tearsheet,
                 risk_free_rate=self.risk_free_rate,
                 strategy_parameters=strategy_parameters,
+                lumibot_version=lumibot_version,
+                backtesting_data_sources=backtesting_data_sources,
+                backtest_time_seconds=backtest_time_seconds,
             )
 
             return result
@@ -1926,6 +1959,10 @@ class _Strategy:
         self._trader.add_strategy(strategy)
 
         self.logger.info("Starting backtest...")
+        try:
+            strategy._backtest_time_start_monotonic = time.monotonic()
+        except Exception:
+            pass
         start = datetime.datetime.now()
 
         result = self._trader.run_all(
@@ -1989,6 +2026,14 @@ class _Strategy:
             indicators_file = f"{logdir}/{base_filename}_indicators.html"
         if not tearsheet_csv_file:
             tearsheet_csv_file = f"{logdir}/{base_filename}_tearsheet.csv"
+
+        try:
+            start_ts = getattr(self, "_backtest_time_start_monotonic", None)
+            if start_ts is not None:
+                self._backtest_time_seconds = time.monotonic() - float(start_ts)
+        except Exception:
+            # Never fail analysis due to timing metadata.
+            pass
 
         self.write_backtest_settings(settings_file)
 

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -3542,6 +3542,32 @@ class Strategy(_Strategy):
         """
         datasource = self.broker.data_source
         auto_adjust = datasource.auto_adjust if hasattr(datasource, "auto_adjust") else False
+
+        lumibot_version = None
+        backtesting_data_sources = None
+        backtest_time_seconds = None
+        try:
+            import lumibot as _lumibot
+
+            lumibot_version = getattr(_lumibot, "__version__", None)
+        except Exception:
+            pass
+        try:
+            backtesting_data_sources = (
+                os.environ.get("BACKTESTING_DATA_SOURCES")
+                or os.environ.get("BACKTESTING_DATA_SOURCE")
+                or type(datasource).__name__
+            )
+        except Exception:
+            backtesting_data_sources = os.environ.get("BACKTESTING_DATA_SOURCE")
+        try:
+            backtest_time_seconds = getattr(self, "_backtest_time_seconds", None)
+            if backtest_time_seconds is None:
+                start_ts = getattr(self, "_backtest_time_start_monotonic", None)
+                if start_ts is not None:
+                    backtest_time_seconds = time.monotonic() - float(start_ts)
+        except Exception:
+            pass
         settings = {
             "name": self.name,
             "backtesting_start": str(self.backtesting_start),
@@ -3555,7 +3581,10 @@ class Strategy(_Strategy):
             "quote_asset": self.quote_asset,
             "benchmark_asset": self._benchmark_asset,
             "starting_positions": self.starting_positions,
-            "parameters": {k: v for k, v in self.parameters.items() if k != 'pandas_data'}
+            "parameters": {k: v for k, v in self.parameters.items() if k != 'pandas_data'},
+            "lumibot_version": lumibot_version,
+            "backtesting_data_sources": backtesting_data_sources,
+            "backtest_time_seconds": backtest_time_seconds,
         }
         os.makedirs(os.path.dirname(settings_file), exist_ok=True)
         with open(settings_file, "w") as outfile:

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -18,8 +18,9 @@ from apscheduler.triggers.cron import CronTrigger
 from termcolor import colored, COLORS
 
 from ..data_sources import DataSource
-from ..entities import Asset, Data, Order, Position, Quote, TradingFee
+from ..entities import Asset, Data, Order, Position, Quote, TradingFee, TradingSlippage, SmartLimitConfig
 from ..tools import get_risk_free_rate
+from ..tools.smart_limit_utils import build_price_ladder, compute_final_price, compute_mid, infer_tick_size, round_to_tick
 from ..tools.polars_utils import PolarsResampleError, resample_polars_ohlc
 from ..traders import Trader
 from ..credentials import IS_BACKTESTING
@@ -423,6 +424,7 @@ class Strategy(_Strategy):
         order_type: Union[Order.OrderType, None] = None,
         order_class: Union[Order.OrderClass, None] = None,
         type: Union[Order.OrderType, None] = None,  # Deprecated, use 'order_type' instead
+        smart_limit: SmartLimitConfig = None,
         custom_params: dict = None,
     ):
         # noinspection PyShadowingNames,PyUnresolvedReferences
@@ -460,8 +462,10 @@ class Strategy(_Strategy):
             Whether the order is ``buy`` or ``sell``.
         order_type : Order.OrderType
             The type of order. Order types include: ``'market'``, ``'limit'``, ``'stop'``, ``'stop_limit'``,
-            ``trailing_stop``
+            ``trailing_stop``, ``smart_limit``
             We will try to determine the order type if you do not specify it.
+        smart_limit : SmartLimitConfig
+            Configuration for SMART_LIMIT orders. If provided, the order type defaults to ``smart_limit``.
         order_class: Order.OrderClass
             The class of the order. Order classes include: ``'simple'``, ``'bracket'``, ``'oco'``, ``'oto'``,
             ``'multileg'``
@@ -728,6 +732,9 @@ class Strategy(_Strategy):
             quote = self.quote_asset
 
         asset = self._sanitize_user_asset(asset)
+        if smart_limit is not None and order_type is None and type is None:
+            order_type = Order.OrderType.SMART_LIMIT
+
         order = Order(
             self.name,
             asset,
@@ -756,6 +763,7 @@ class Strategy(_Strategy):
             type=type,
             order_type=order_type,
             order_class=order_class,
+            smart_limit=smart_limit,
             custom_params=custom_params,
         )
 
@@ -1506,6 +1514,12 @@ class Strategy(_Strategy):
         >>> order = self.create_order("SPY", 100, "buy", limit_price=100.00, stop_price=100.00)
         >>> self.submit_order(order)
 
+        >>> # For a SMART_LIMIT order
+        >>> from lumibot.entities import SmartLimitConfig, SmartLimitPreset
+        >>> config = SmartLimitConfig(preset=SmartLimitPreset.NORMAL, slippage=0.05)
+        >>> order = self.create_order("SPY", 100, "buy", smart_limit=config)
+        >>> self.submit_order(order)
+
         >>> # For a market sell order
         >>> order = self.create_order("SPY", 100, "sell")
         >>> self.submit_order(order)
@@ -1585,7 +1599,114 @@ class Strategy(_Strategy):
             if not self._validate_order(order):
                 return
 
+            if order.order_type == Order.OrderType.SMART_LIMIT:
+                if self.broker.IS_BACKTESTING_BROKER:
+                    return self.broker.submit_order(order)
+
+                if order.smart_limit is None:
+                    order.smart_limit = SmartLimitConfig()
+
+                if order.order_class == Order.OrderClass.MULTILEG and order.child_orders:
+                    return self._submit_multileg_smart_limit(order)
+
+                quote = self.get_quote(order.asset, quote=order.quote, exchange=order.exchange)
+                bid = getattr(quote, "bid", None)
+                ask = getattr(quote, "ask", None)
+                if bid is None or ask is None or bid <= 0 or ask <= 0:
+                    self.log_message(
+                        f"[SMART_LIMIT] Missing bid/ask for {order.asset}; downgrading to market.",
+                        color="yellow",
+                    )
+                    order.smart_limit = None
+                    order.order_type = Order.OrderType.MARKET
+                    return self.broker.submit_order(order)
+
+                side = "buy" if order.is_buy_order() else "sell"
+                tick = infer_tick_size(bid, ask)
+                mid = compute_mid(bid, ask)
+                final_price = compute_final_price(bid, ask, side, order.smart_limit.final_price_pct)
+                ladder = build_price_ladder(mid, final_price, order.smart_limit.get_step_count())
+                initial_price = round_to_tick(ladder[0], tick, side=side)
+
+                order.limit_price = initial_price
+                order._smart_limit_state = {
+                    "created_at": time.monotonic(),
+                    "step_index": 0,
+                    "steps": order.smart_limit.get_step_count(),
+                    "step_seconds": order.smart_limit.get_step_seconds(),
+                    "final_hold_seconds": order.smart_limit.get_final_hold_seconds(),
+                }
+
+                original_type = order.order_type
+                order.order_type = Order.OrderType.LIMIT
+                try:
+                    submitted = self.broker.submit_order(order)
+                finally:
+                    order.order_type = original_type
+                return submitted
+
             return self.broker.submit_order(order)
+
+    def _submit_multileg_smart_limit(self, order: Order):
+        quote_data = []
+        for leg in order.child_orders:
+            quote = self.get_quote(leg.asset, quote=leg.quote, exchange=leg.exchange)
+            bid = getattr(quote, "bid", None)
+            ask = getattr(quote, "ask", None)
+            quote_data.append((leg, bid, ask))
+
+        if any(bid is None or ask is None or bid <= 0 or ask <= 0 for _, bid, ask in quote_data):
+            self.log_message(
+                f"[SMART_LIMIT] Missing bid/ask for multileg order; downgrading to market.",
+                color="yellow",
+            )
+            order.smart_limit = None
+            return self.broker.submit_orders(order.child_orders, is_multileg=True, order_type=Order.OrderType.MARKET)
+
+        net_bid = 0.0
+        net_ask = 0.0
+        side = "buy" if order.is_buy_order() else "sell"
+        for leg, bid, ask in quote_data:
+            if side == "buy":
+                if leg.is_buy_order():
+                    net_bid += bid
+                    net_ask += ask
+                else:
+                    net_bid -= ask
+                    net_ask -= bid
+            else:
+                if leg.is_buy_order():
+                    net_bid -= ask
+                    net_ask -= bid
+                else:
+                    net_bid += bid
+                    net_ask += ask
+        tick = infer_tick_size(net_bid, net_ask)
+        mid = compute_mid(net_bid, net_ask)
+        final_price = compute_final_price(net_bid, net_ask, side, order.smart_limit.final_price_pct)
+        ladder = build_price_ladder(mid, final_price, order.smart_limit.get_step_count())
+        initial_price = round_to_tick(ladder[0], tick, side=side)
+
+        order.limit_price = initial_price
+        order._smart_limit_state = {
+            "created_at": time.monotonic(),
+            "step_index": 0,
+            "steps": order.smart_limit.get_step_count(),
+            "step_seconds": order.smart_limit.get_step_seconds(),
+            "final_hold_seconds": order.smart_limit.get_final_hold_seconds(),
+        }
+
+        parent_order = self.broker.submit_orders(
+            order.child_orders,
+            is_multileg=True,
+            order_type=Order.OrderType.LIMIT,
+            price=initial_price,
+        )
+        if parent_order is not None:
+            parent_order.smart_limit = order.smart_limit
+            parent_order.order_type = Order.OrderType.SMART_LIMIT
+            parent_order._smart_limit_state = order._smart_limit_state
+        return parent_order
 
     def submit_orders(self, orders: List[Order], **kwargs):
         """[Deprecated] Submit a list of orders
@@ -4576,6 +4697,8 @@ class Strategy(_Strategy):
         parameters: dict = {},
         buy_trading_fees: List[TradingFee] = [],
         sell_trading_fees: List[TradingFee] = [],
+        buy_trading_slippages: List[TradingSlippage] = [],
+        sell_trading_slippages: List[TradingSlippage] = [],
         polygon_api_key: str = None,
         indicators_file: str = None,
         show_indicators: bool = True,
@@ -4653,6 +4776,10 @@ class Strategy(_Strategy):
             A list of TradingFee objects to apply to the buy orders during backtests.
         sell_trading_fees : list of TradingFee objects
             A list of TradingFee objects to apply to the sell orders during backtests.
+        buy_trading_slippages : list of TradingSlippage objects
+            Slippage amounts to apply to buy SMART_LIMIT fills when no per-order slippage is provided.
+        sell_trading_slippages : list of TradingSlippage objects
+            Slippage amounts to apply to sell SMART_LIMIT fills when no per-order slippage is provided.
         polygon_api_key : str
             The polygon api key to use for polygon data. Only required if you are using PolygonDataBacktesting as
             the datasource_class.
@@ -4738,6 +4865,8 @@ class Strategy(_Strategy):
             parameters=parameters,
             buy_trading_fees=buy_trading_fees,
             sell_trading_fees=sell_trading_fees,
+            buy_trading_slippages=buy_trading_slippages,
+            sell_trading_slippages=sell_trading_slippages,
             polygon_api_key=polygon_api_key,
             indicators_file=indicators_file,
             show_indicators=show_indicators,

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -1417,7 +1417,7 @@ class StrategyExecutor(Thread):
 
     def _is_pandas_daily_data_source(self):
         """Check if the broker has a pandas daily data source"""
-        has_data_source = hasattr(self.broker, "_data_source")
+        has_data_source = getattr(self.broker, "data_source", None) is not None
         return (
             has_data_source
             and self.broker.data_source.SOURCE == "PANDAS"
@@ -1636,7 +1636,7 @@ class StrategyExecutor(Thread):
         minutes, hours.
         """
 
-        has_data_source = hasattr(self.broker, "_data_source")
+        has_data_source = getattr(self.broker, "data_source", None) is not None
         market_name = getattr(self.broker, "market", None)
         is_continuous_market = market_name and self._is_continuous_market(market_name)
 

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -21,6 +21,7 @@ from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.entities import Asset, Order
 from lumibot.entities import Asset
 from lumibot.tools import append_locals, get_trading_days, staticdecorator
+from lumibot.tools.smart_limit_utils import build_price_ladder, compute_final_price, compute_mid, infer_tick_size, round_to_tick
 
 
 class StrategyExecutor(Thread):
@@ -179,6 +180,10 @@ class StrategyExecutor(Thread):
                 self.process_queue()
             except Empty:
                 pass
+            try:
+                self._process_smart_limit_orders()
+            except Exception as exc:
+                self.strategy.logger.error(f"SMART_LIMIT processing failed: {exc}")
             time.sleep(0.5)
 
     def safe_sleep(self, sleeptime):
@@ -187,17 +192,39 @@ class StrategyExecutor(Thread):
         if self.strategy.is_backtesting:
             self.process_queue()
 
-            # Get positions and serialize to minimal format for progress logging
-            # Use Position.to_minimal_dict() for proper asset info
-            positions = self.strategy.get_positions()
-            positions_minimal = [p.to_minimal_dict() for p in positions] if positions else None
+            # PERF: Serializing positions/orders every bar is expensive and becomes a major cost in
+            # long intraday backtests. The progress CSV is only written every ~2s (wall clock), so
+            # only materialize these payloads when we are likely to log a snapshot.
+            positions_minimal = None
+            orders_minimal = None
+            try:
+                data_source = getattr(self.broker, "data_source", None)
+                should_capture_progress_state = bool(getattr(data_source, "log_backtest_progress_to_file", False))
+                if should_capture_progress_state:
+                    last_logging_time = getattr(data_source, "_last_logging_time", None)
+                    # Mirror DataSourceBacktesting._update_datetime() throttling (~2s); use a small
+                    # cushion to avoid missing the boundary between two datetime.now() calls.
+                    now_wall = datetime.now()
+                    if last_logging_time is not None:
+                        should_capture_progress_state = (now_wall - last_logging_time).total_seconds() >= 1.9
+            except Exception:
+                should_capture_progress_state = True
 
-            # Get ACTIVE (open) orders only and serialize to minimal format
-            # Filter to is_active() to avoid serializing thousands of filled orders
-            # which can exceed CSV field size limits in high-frequency strategies
-            orders = self.broker.get_tracked_orders(strategy=self.strategy.name)
-            active_orders = [o for o in orders if o.is_active()] if orders else []
-            orders_minimal = [o.to_minimal_dict() for o in active_orders] if active_orders else None
+            if should_capture_progress_state:
+                positions = self.strategy.get_positions()
+                positions_minimal = [p.to_minimal_dict() for p in positions] if positions else None
+
+                active_orders = None
+                if hasattr(self.broker, "get_active_tracked_orders"):
+                    try:
+                        active_orders = self.broker.get_active_tracked_orders(strategy=self.strategy.name)
+                    except Exception:
+                        active_orders = None
+
+                if active_orders is None:
+                    orders = self.broker.get_tracked_orders(strategy=self.strategy.name)
+                    active_orders = [o for o in orders if o.is_active()] if orders else []
+                orders_minimal = [o.to_minimal_dict() for o in active_orders] if active_orders else None
 
             # Get initial budget for return calculation
             initial_budget = getattr(self.strategy, '_initial_budget', None)
@@ -473,25 +500,31 @@ class StrategyExecutor(Thread):
 
     def process_event(self, event, payload):
         # Log that we are processing an event.
-        self.strategy.logger.debug(f"Processing event: {event}, payload: {payload}")
+        if self.strategy.logger.isEnabledFor(logging.DEBUG):
+            self.strategy.logger.debug(f"Processing event: {event}, payload: {payload}")
 
         # If it's the first iteration, we don't want to process any events.
         # This is because in this case we are most likely processing events that occurred before the strategy started.
         if self.strategy._first_iteration or self.broker._first_iteration:
             # Reduce noise on startup: log at debug instead of info
-            self.strategy.logger.debug(f"Skipping event {event} because it is the first iteration. Payload: {payload}")
+            if self.strategy.logger.isEnabledFor(logging.DEBUG):
+                self.strategy.logger.debug(
+                    f"Skipping event {event} because it is the first iteration. Payload: {payload}"
+                )
 
             return
 
         if event == self.NEW_ORDER:
             # Log that we are processing a new order.
-            self.strategy.logger.info(f"Processing a new order, payload: {payload}")
+            if self.strategy.logger.isEnabledFor(logging.INFO):
+                self.strategy.logger.info(f"Processing a new order, payload: {payload}")
 
             self._on_new_order(**payload)
 
         elif event == self.CANCELED_ORDER:
             # Log that we are processing a canceled order.
-            self.strategy.logger.info(f"Processing a canceled order, payload: {payload}")
+            if self.strategy.logger.isEnabledFor(logging.INFO):
+                self.strategy.logger.info(f"Processing a canceled order, payload: {payload}")
 
             self._on_canceled_order(**payload)
 
@@ -579,6 +612,110 @@ class StrategyExecutor(Thread):
             event, payload = self.queue.get()
             self.process_event(event, payload)
 
+    def _process_smart_limit_orders(self):
+        if self.broker.IS_BACKTESTING_BROKER:
+            return
+
+        orders = self.broker.get_tracked_orders(self.strategy.name)
+        if not orders:
+            return
+
+        now = time.monotonic()
+        for order in orders:
+            if not order.is_active():
+                continue
+            smart_limit = getattr(order, "smart_limit", None)
+            if smart_limit is None or order.order_type != Order.OrderType.SMART_LIMIT:
+                continue
+
+            state = getattr(order, "_smart_limit_state", None)
+            if state is None:
+                state = {
+                    "created_at": now,
+                    "step_index": 0,
+                    "steps": smart_limit.get_step_count(),
+                    "step_seconds": smart_limit.get_step_seconds(),
+                    "final_hold_seconds": smart_limit.get_final_hold_seconds(),
+                }
+                order._smart_limit_state = state
+
+            elapsed = now - state["created_at"]
+            step_index = min(state["steps"] - 1, int(elapsed // state["step_seconds"]))
+            final_hold_start = state["step_seconds"] * (state["steps"] - 1)
+
+            if step_index == state["steps"] - 1 and elapsed >= final_hold_start + state["final_hold_seconds"]:
+                self.broker.cancel_order(order)
+                continue
+
+            if step_index == state["step_index"]:
+                continue
+
+            state["step_index"] = step_index
+
+            side = "buy" if order.is_buy_order() else "sell"
+            bid = ask = None
+            if order.order_class == Order.OrderClass.MULTILEG and order.child_orders:
+                net_bid = 0.0
+                net_ask = 0.0
+                for leg in order.child_orders:
+                    quote = self.strategy.get_quote(leg.asset, quote=leg.quote, exchange=leg.exchange)
+                    leg_bid = getattr(quote, "bid", None)
+                    leg_ask = getattr(quote, "ask", None)
+                    if leg_bid is None or leg_ask is None:
+                        net_bid = net_ask = None
+                        break
+                    if side == "buy":
+                        if leg.is_buy_order():
+                            net_bid += leg_bid
+                            net_ask += leg_ask
+                        else:
+                            net_bid -= leg_ask
+                            net_ask -= leg_bid
+                    else:
+                        if leg.is_buy_order():
+                            net_bid -= leg_ask
+                            net_ask -= leg_bid
+                        else:
+                            net_bid += leg_bid
+                            net_ask += leg_ask
+                bid = net_bid
+                ask = net_ask
+            else:
+                quote = self.strategy.get_quote(order.asset, quote=order.quote, exchange=order.exchange)
+                bid = getattr(quote, "bid", None)
+                ask = getattr(quote, "ask", None)
+
+            if bid is None or ask is None or bid <= 0 or ask <= 0:
+                if not getattr(order, "_smart_limit_missing_quote_logged", False):
+                    self.strategy.log_message(
+                        f"[SMART_LIMIT] Missing bid/ask for {order.asset}; keeping last limit.",
+                        color="yellow",
+                    )
+                    order._smart_limit_missing_quote_logged = True
+                continue
+
+            tick = infer_tick_size(bid, ask)
+            mid = compute_mid(bid, ask)
+            final_price = compute_final_price(bid, ask, side, smart_limit.final_price_pct)
+            ladder = build_price_ladder(mid, final_price, smart_limit.get_step_count())
+            target_price = round_to_tick(ladder[step_index], tick, side=side)
+
+            if order.limit_price is not None and abs(order.limit_price - target_price) < 1e-9:
+                continue
+
+            order.limit_price = target_price
+            try:
+                self.broker.modify_order(order, limit_price=target_price)
+            except Exception:
+                try:
+                    self.broker.cancel_order(order)
+                    original_type = order.order_type
+                    order.order_type = Order.OrderType.LIMIT
+                    self.broker.submit_order(order)
+                    order.order_type = original_type
+                except Exception as exc:
+                    self.strategy.logger.error(f"SMART_LIMIT reprice failed for {order.identifier}: {exc}")
+
     def stop(self):
         self.stop_event.set()
         self._on_abrupt_closing(KeyboardInterrupt())
@@ -625,7 +762,9 @@ class StrategyExecutor(Thread):
         @wraps(func_input)
         def func_output(self, *args, **kwargs):
             self.strategy._update_portfolio_value()
-            snapshot_before = self.strategy._copy_dict()
+            snapshot_before = {}
+            if getattr(self, "_capture_locals", False):
+                snapshot_before = self.strategy._copy_dict()
             result = func_input(self, *args, **kwargs)
             self._trace_stats(self._strategy_context, snapshot_before)
             return result
@@ -1219,6 +1358,13 @@ class StrategyExecutor(Thread):
             # For backtesting: market close means end of current trading day, not end of entire backtest
             # For live trading: market close means stop trading
             if self.strategy.is_backtesting:
+                # Backtesting must still process expired option contracts at end-of-day.
+                # The strategy's sleeptime is often much shorter than the remaining time-to-close,
+                # so the "oversleep to close" path below is not taken. Without settling here, 0DTE
+                # strategies accumulate expired contracts and can appear to "freeze" late in the
+                # backtest due to exploding open positions.
+                if hasattr(self.broker, "process_expired_option_contracts"):
+                    self.broker.process_expired_option_contracts(self.strategy)
                 # In backtesting, when market closes, we should advance to the next trading day
                 # The broker should handle advancing to the next day automatically
                 # Just return False to end this trading session, but the main loop should continue
@@ -1588,6 +1734,18 @@ class StrategyExecutor(Thread):
             self._before_market_closes()  # perhaps the user could set the time of day based on their data that the market closes?
 
         self.strategy.await_market_to_close(timedelta=0)
+
+        # Backtesting must cash-settle expired option/futures contracts at end-of-day.
+        #
+        # The intraday backtesting loop stops running iterations once we enter the
+        # `minutes_before_closing` window. That means we may never hit the
+        # `_strategy_sleep()` branch that previously handled settlement. Ensure we
+        # always settle after we advance the clock to the session close so 0DTE
+        # strategies don't accumulate expired contracts (which can look like a hang
+        # late in long backtests).
+        if self.strategy.is_backtesting and hasattr(self.broker, "process_expired_option_contracts"):
+            self.broker.process_expired_option_contracts(self.strategy)
+
         self._after_market_closes()
 
     def get_next_ap_scheduler_run_time(self):

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -1779,16 +1779,23 @@ class StrategyExecutor(Thread):
 
             # Initialize broker calendar and caches using trading days.
             #
-            # For Pandas backtests, derive the calendar from the data itself so the StrategyExecutor
-            # can run on the timestamps that exist in the supplied DataFrames (including daily bars
-            # where market_open == market_close).
+            # For *pure* PandasData backtests, derive the calendar from the data itself so the
+            # StrategyExecutor can run on timestamps that exist in the supplied DataFrames
+            # (including daily bars where market_open == market_close).
+            #
+            # IMPORTANT: do NOT apply this to PolygonDataBacktesting (or other providers that
+            # inherit from PandasData) because their _date_index is typically empty at startup.
+            # In that case, get_trading_days_pandas() returns a "full-day open" dummy calendar
+            # (00:00–23:59:59), which can skip lifecycle hooks like before_market_opens() and
+            # breaks legacy backtests (e.g. tests/backtest/test_polygon.py).
             data_source = getattr(self.broker, "data_source", None)
-            if (
+            is_pure_pandas_data_source = (
                 self.strategy.is_backtesting
                 and data_source is not None
-                and getattr(data_source, "SOURCE", None) == "PANDAS"
+                and type(data_source).__name__ in ("PandasData", "PandasDataBacktesting")
                 and hasattr(data_source, "get_trading_days_pandas")
-            ):
+            )
+            if is_pure_pandas_data_source:
                 self.broker.initialize_market_calendars(data_source.get_trading_days_pandas())
             else:
                 self.broker.initialize_market_calendars(get_trading_days(market))

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -1777,8 +1777,21 @@ class StrategyExecutor(Thread):
             # Get the trading days based on the market that the strategy is trading on
             market = self.broker.market
 
-            # Initialize broker calendar and caches using trading days
-            self.broker.initialize_market_calendars(get_trading_days(market))
+            # Initialize broker calendar and caches using trading days.
+            #
+            # For Pandas backtests, derive the calendar from the data itself so the StrategyExecutor
+            # can run on the timestamps that exist in the supplied DataFrames (including daily bars
+            # where market_open == market_close).
+            data_source = getattr(self.broker, "data_source", None)
+            if (
+                self.strategy.is_backtesting
+                and data_source is not None
+                and getattr(data_source, "SOURCE", None) == "PANDAS"
+                and hasattr(data_source, "get_trading_days_pandas")
+            ):
+                self.broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+            else:
+                self.broker.initialize_market_calendars(get_trading_days(market))
 
             #####
             # Main strategy execution loop
@@ -1807,6 +1820,12 @@ class StrategyExecutor(Thread):
                         raise e  # Re-raise original exception to preserve error message for tests
 
                 # Different logic for continuous vs non-continuous markets
+                if self._is_pandas_daily_data_source():
+                    # Pandas daily backtests advance via ``_process_pandas_daily_data`` (date-index driven),
+                    # so we must NOT also advance via the exchange trading calendar.
+                    if hasattr(self, "stop_event") and self.stop_event.is_set():
+                        break
+                    continue
                 if is_continuous_market:
                     # For continuous markets (24/7, futures), _run_trading_session handles the entire backtest
                     # No need to call _strategy_sleep or continue the loop - we're done

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -1416,13 +1416,26 @@ class StrategyExecutor(Thread):
     # ======Helper methods for _run_trading_session ====================
 
     def _is_pandas_daily_data_source(self):
-        """Check if the broker has a pandas daily data source"""
-        has_data_source = getattr(self.broker, "data_source", None) is not None
-        return (
-            has_data_source
-            and self.broker.data_source.SOURCE == "PANDAS"
-            and self.broker.data_source._timestep == "day"
-        )
+        """Return True only for *pure* Pandas daily backtests (not Polygon/ThetaData).
+
+        This route exists to support user-supplied `PandasDataBacktesting` runs where the
+        strategy should iterate over the provided DataFrame index (`_date_index`).
+
+        IMPORTANT: Do not apply this optimization to providers that *inherit* from
+        PandasData (e.g., PolygonDataBacktesting, ThetaDataBacktestingPandas). Those
+        providers manage their own market calendars and can switch `_timestep` to `"day"`
+        for daily-cadence strategies; treating them as "pure pandas daily" can cause the
+        backtest to terminate after a single bar.
+        """
+        data_source = getattr(self.broker, "data_source", None)
+        if not self.strategy.is_backtesting or data_source is None:
+            return False
+
+        # Strict class-name check to avoid matching derived providers.
+        if type(data_source).__name__ not in ("PandasData", "PandasDataBacktesting"):
+            return False
+
+        return getattr(data_source, "SOURCE", None) == "PANDAS" and getattr(data_source, "_timestep", None) == "day"
 
     def _process_pandas_daily_data(self):
         """Process pandas daily data and execute one trading iteration"""

--- a/lumibot/tools/backtest_cache.py
+++ b/lumibot/tools/backtest_cache.py
@@ -94,6 +94,12 @@ class BacktestCacheManager:
         self._client_factory = client_factory
         self._client = None
         self._client_lock = threading.Lock()
+        # When using the S3 backend we want "fresh per run" semantics (never trust an on-disk file that
+        # may have been produced by a previous cache version), but re-downloading the same object
+        # repeatedly within a single backtest is prohibitively slow. Track which remote keys have been
+        # downloaded in this process so we can safely reuse the local copy for the remainder of the run.
+        self._downloaded_remote_keys: set[str] = set()
+        self._downloaded_remote_keys_lock = threading.Lock()
 
     @property
     def enabled(self) -> bool:
@@ -117,21 +123,48 @@ class BacktestCacheManager:
         if not isinstance(local_path, Path):
             local_path = Path(local_path)
 
+        remote_key = self.remote_key_for(local_path, payload)
+        if remote_key is None:
+            return False
+
         if self._settings and self._settings.backend == "s3":
-            # S3 cache mode is exclusive: NEVER reuse a local file. We always delete any local copy
-            # and require a fresh download from S3. If the download fails, callers must fetch from
-            # the data source and re-upload—no local fallback is allowed when backend=s3.
+            marker_path = local_path.with_suffix(local_path.suffix + ".s3key")
+
+            # If the file was already downloaded (or produced) for this exact remote key, allow reuse
+            # across backtest runs. This preserves cache-version isolation because `remote_key`
+            # already includes `self._settings.version`.
+            if local_path.exists() and not force_download and marker_path.exists():
+                try:
+                    marker_value = marker_path.read_text(encoding="utf-8").strip()
+                except Exception:
+                    marker_value = ""
+
+                if marker_value == remote_key:
+                    with self._downloaded_remote_keys_lock:
+                        self._downloaded_remote_keys.add(remote_key)
+                    return False
+
+            with self._downloaded_remote_keys_lock:
+                already_downloaded = remote_key in self._downloaded_remote_keys
+
+            # S3 cache mode: ensure we download the object at least once per process (fresh run
+            # semantics), but then allow local reuse to avoid repeated downloads during the same
+            # backtest.
+            if local_path.exists() and already_downloaded and not force_download:
+                return False
+
             if local_path.exists():
                 try:
                     local_path.unlink()
                 except Exception:
                     pass
+            if marker_path.exists():
+                try:
+                    marker_path.unlink()
+                except Exception:
+                    pass
             force_download = True
         elif local_path.exists() and not force_download:
-            return False
-
-        remote_key = self.remote_key_for(local_path, payload)
-        if remote_key is None:
             return False
 
         client = self._get_client()
@@ -141,9 +174,21 @@ class BacktestCacheManager:
         try:
             client.download_file(self._settings.bucket, remote_key, str(tmp_path))
             os.replace(tmp_path, local_path)
+            # Persist a tiny marker so future runs can reuse the file without an extra S3 roundtrip,
+            # as long as the remote key (including cache version) matches.
+            try:
+                marker_path = local_path.with_suffix(local_path.suffix + ".s3key")
+                marker_tmp = marker_path.with_suffix(marker_path.suffix + ".tmp")
+                marker_path.parent.mkdir(parents=True, exist_ok=True)
+                marker_tmp.write_text(remote_key, encoding="utf-8")
+                os.replace(marker_tmp, marker_path)
+            except Exception:
+                pass
             logger.debug(
                 "[REMOTE_CACHE][DOWNLOAD] %s -> %s", remote_key, local_path.as_posix()
             )
+            with self._downloaded_remote_keys_lock:
+                self._downloaded_remote_keys.add(remote_key)
             return True
         except Exception as exc:  # pragma: no cover - narrow in helper
             if tmp_path.exists():
@@ -158,6 +203,12 @@ class BacktestCacheManager:
                         local_path.unlink()
                     except Exception:
                         pass
+                try:
+                    marker_path = local_path.with_suffix(local_path.suffix + ".s3key")
+                    if marker_path.exists():
+                        marker_path.unlink()
+                except Exception:
+                    pass
                 return False
             raise
 

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -80,6 +80,14 @@ def _build_trade_marker_tooltip(row: pd.Series):
     if trade_cost_dec is None:
         trade_cost_dec = amount_transacted_dec
 
+    slippage_value = row.get("trade_slippage")
+    slippage_dec = None
+    if not (pd.isna(slippage_value) or slippage_value == ""):
+        try:
+            slippage_dec = Decimal(str(slippage_value))
+        except (InvalidOperation, TypeError, ValueError):
+            slippage_dec = None
+
     if row.get("asset.asset_type") == "option":
         try:
             return (
@@ -118,6 +126,13 @@ def _build_trade_marker_tooltip(row: pd.Series):
                 + "Trade Cost: "
                 + str(trade_cost_dec.quantize(Decimal("0.01")).__format__(",f"))
                 + "<br>"
+                + "Slippage: "
+                + (
+                    str(slippage_dec.quantize(Decimal("0.01")).__format__(",f"))
+                    if slippage_dec is not None
+                    else "0.00"
+                )
+                + "<br>"
             )
         except (InvalidOperation, TypeError, ValueError):
             return None
@@ -130,6 +145,11 @@ def _build_trade_marker_tooltip(row: pd.Series):
         price_text = str(price_dec.quantize(Decimal("0.0001")).__format__(",f"))
         filled_qty_text = str(filled_quantity_dec.quantize(Decimal("0.01")).__format__(",f"))
         trade_cost_text = str(trade_cost_dec.quantize(Decimal("0.01")).__format__(",f"))
+        slippage_text = (
+            str(slippage_dec.quantize(Decimal("0.01")).__format__(",f"))
+            if slippage_dec is not None
+            else "0.00"
+        )
     except (InvalidOperation, TypeError, ValueError):
         return None
 
@@ -151,6 +171,9 @@ def _build_trade_marker_tooltip(row: pd.Series):
         + "<br>"
         + "Trade Cost: "
         + trade_cost_text
+        + "<br>"
+        + "Slippage: "
+        + slippage_text
         + "<br>"
     )
 
@@ -658,7 +681,7 @@ def plot_returns(
     standard_trade_columns = [
         "time", "side", "status", "filled_quantity", "symbol", "asset.asset_type",
         "asset.right", "asset.strike", "asset.expiration", "price", "type",
-        "asset.multiplier", "trade_cost"
+        "asset.multiplier", "trade_cost", "trade_slippage"
     ]
 
     if trades_df is None or trades_df.empty:

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -1038,6 +1038,10 @@ def create_tearsheet(
     save_tearsheet: bool,
     risk_free_rate: float,
     strategy_parameters: dict = None,
+    lumibot_version: str | None = None,
+    backtesting_data_source: str | None = None,
+    backtesting_data_sources: str | None = None,
+    backtest_time_seconds: float | None = None,
 ):
     # If show tearsheet is False, then we don't want to open the tearsheet in the browser
     # IMS create the tearsheet even if we are not showinbg it
@@ -1086,6 +1090,10 @@ def create_tearsheet(
             download_filename=tearsheet_file,  # Consider if you need a different name for clarity
             rf=risk_free_rate,
             parameters=strategy_parameters,
+            lumibot_version=lumibot_version,
+            backtesting_data_source=backtesting_data_source,
+            backtesting_data_sources=backtesting_data_sources,
+            backtest_time_seconds=backtest_time_seconds,
         )
 
     if show_tearsheet:

--- a/lumibot/tools/smart_limit_utils.py
+++ b/lumibot/tools/smart_limit_utils.py
@@ -1,0 +1,61 @@
+from decimal import Decimal, InvalidOperation, ROUND_CEILING, ROUND_FLOOR, ROUND_HALF_UP
+from typing import List, Optional
+
+
+def infer_tick_size(bid: Optional[float], ask: Optional[float]) -> Optional[float]:
+    if bid is None or ask is None:
+        return None
+    candidates = [0.01, 0.05, 0.1]
+    for tick in candidates:
+        if _is_multiple_of_tick(bid, tick) and _is_multiple_of_tick(ask, tick):
+            return tick
+    return 0.01
+
+
+def _is_multiple_of_tick(value: float, tick: float) -> bool:
+    try:
+        scaled = Decimal(str(value)) / Decimal(str(tick))
+    except (InvalidOperation, ZeroDivisionError):
+        return False
+    return abs(scaled - scaled.to_integral_value()) <= Decimal("0.000001")
+
+
+def round_to_tick(price: float, tick_size: Optional[float], side: Optional[str] = None) -> float:
+    if tick_size is None or tick_size <= 0:
+        return price
+    tick = Decimal(str(tick_size))
+    value = Decimal(str(price))
+    if side == "buy":
+        rounded = (value / tick).to_integral_value(rounding=ROUND_CEILING) * tick
+    elif side == "sell":
+        rounded = (value / tick).to_integral_value(rounding=ROUND_FLOOR) * tick
+    else:
+        rounded = (value / tick).to_integral_value(rounding=ROUND_HALF_UP) * tick
+    return float(rounded)
+
+
+def compute_mid(bid: float, ask: float) -> float:
+    return (bid + ask) / 2.0
+
+
+def compute_final_price(bid: float, ask: float, side: str, final_price_pct: float) -> float:
+    spread = ask - bid
+    if side == "buy":
+        return bid + spread * final_price_pct
+    return ask - spread * final_price_pct
+
+
+def build_price_ladder(mid: float, final_price: float, step_count: int) -> List[float]:
+    if step_count <= 1:
+        return [final_price]
+    ladder = []
+    step_delta = (final_price - mid) / float(step_count - 1)
+    for idx in range(step_count):
+        ladder.append(mid + step_delta * idx)
+    return ladder
+
+
+def expected_fill_price(mid: float, slippage: float, side: str) -> float:
+    if side == "buy":
+        return mid + slippage
+    return mid - slippage

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -1841,8 +1841,6 @@ def get_price_data(
     remote_payload = build_remote_cache_payload(asset, timespan, datastyle)
     cache_manager = get_backtest_cache()
 
-    sidecar_file = _cache_sidecar_path(cache_file)
-
     if cache_manager.enabled:
         try:
             fetched_remote = cache_manager.ensure_local_file(cache_file, payload=remote_payload)
@@ -1862,18 +1860,9 @@ def get_price_data(
                 exc,
             )
 
-        try:
-            # PERFORMANCE FIX (2025-12-07): Removed force_download=True for sidecar files.
-            # This was causing unnecessary S3 downloads on every backtest run.
-            # The sidecar will be downloaded if missing; if out-of-sync, validation will catch it.
-            cache_manager.ensure_local_file(sidecar_file, payload=remote_payload)
-        except Exception as exc:
-            logger.debug(
-                "[THETA][DEBUG][CACHE][REMOTE_SIDECAR_ERROR] asset=%s sidecar=%s error=%s",
-                asset,
-                sidecar_file,
-                exc,
-            )
+        # PERF: Sidecars are optional. Downloading them doubles S3 roundtrips for option-heavy
+        # strategies (parquet + sidecar per contract). If the sidecar is missing locally we fall
+        # back to computing metadata from the parquet itself.
 
     # DEBUG-LOG: Cache file check
     logger.debug(
@@ -1931,7 +1920,6 @@ def get_price_data(
     )
 
     sidecar_data = _load_cache_sidecar(cache_file)
-    cache_checksum = _hash_file(cache_file)
 
     def _validate_cache_frame(
         frame: Optional[pd.DataFrame],
@@ -1982,10 +1970,11 @@ def get_price_data(
         if sidecar_data:
             rows_match = sidecar_data.get("rows") in (None, total_rows) or int(sidecar_data.get("rows", 0)) == total_rows
             placeholders_match = sidecar_data.get("placeholders") in (None, placeholder_rows) or int(sidecar_data.get("placeholders", 0)) == placeholder_rows
-            checksum_match = (sidecar_data.get("checksum") is None) or (cache_checksum is None) or (sidecar_data.get("checksum") == cache_checksum)
             min_match = sidecar_data.get("min") is None or sidecar_data.get("min") == (min_ts.isoformat() if hasattr(min_ts, "isoformat") else None)
             max_match = sidecar_data.get("max") is None or sidecar_data.get("max") == (max_ts.isoformat() if hasattr(max_ts, "isoformat") else None)
-            if not all([rows_match, placeholders_match, checksum_match, min_match, max_match]):
+            # Checksum validation is intentionally skipped for performance. Parquet corruption is
+            # surfaced at read time; the remaining fields catch most logical mismatches cheaply.
+            if not all([rows_match, placeholders_match, min_match, max_match]):
                 return False, "sidecar_mismatch", True  # INTEGRITY FAILURE
 
         if span == "day":
@@ -2048,16 +2037,8 @@ def get_price_data(
         return True, "", False
 
     cache_ok, cache_reason, is_integrity_failure = _validate_cache_frame(df_all, requested_start, requested_end, timespan)
-    if cache_ok and df_all is not None and _load_cache_sidecar(cache_file) is None:
-        # Backfill a missing sidecar for a valid cache.
-        try:
-            checksum = _hash_file(cache_file)
-            _write_cache_sidecar(cache_file, df_all, checksum)
-        except Exception:
-            logger.debug(
-                "[THETA][DEBUG][CACHE][SIDECAR_BACKFILL_ERROR] cache_file=%s",
-                cache_file,
-            )
+    # Sidecar backfill intentionally skipped: sidecars are optional and should not add overhead for
+    # option-heavy backtests.
 
     if not cache_ok and df_all is not None:
         if is_integrity_failure:
@@ -2113,13 +2094,27 @@ def get_price_data(
         and str(getattr(asset, "asset_type", "stock")).lower() == "option"
         and not {"bid", "ask"}.issubset(df_all.columns)
     ):
-        cache_invalid = True
-        logger.info(
-            "[THETA][CACHE][SCHEMA_UPGRADE] asset=%s span=%s datastyle=%s missing_nbbo_cols=True; forcing refresh to include bid/ask",
-            asset,
-            timespan,
-            datastyle,
-        )
+        placeholder_only = False
+        try:
+            if "missing" in df_all.columns:
+                placeholder_only = bool(df_all["missing"].fillna(False).astype(bool).all())
+        except Exception:
+            placeholder_only = False
+        if placeholder_only:
+            logger.info(
+                "[THETA][CACHE][SCHEMA_UPGRADE] asset=%s span=%s datastyle=%s missing_nbbo_cols=True but cache is placeholder-only; skipping refresh",
+                asset,
+                timespan,
+                datastyle,
+            )
+        else:
+            cache_invalid = True
+            logger.info(
+                "[THETA][CACHE][SCHEMA_UPGRADE] asset=%s span=%s datastyle=%s missing_nbbo_cols=True; forcing refresh to include bid/ask",
+                asset,
+                timespan,
+                datastyle,
+            )
 
     # Check if we need to get more data
     logger.debug(
@@ -2313,8 +2308,15 @@ def get_price_data(
     # Initialize tqdm progress bar
     total_days = (fetch_end - fetch_start).days + 1
     total_queries = (total_days // MAX_DAYS) + 1
-    description = f"\nDownloading '{datastyle}' data for {asset} / {quote_asset} with '{timespan}' from ThetaData..."
-    logger.info(description)
+    quiet_logs = os.environ.get("BACKTESTING_QUIET_LOGS", "true").lower() == "true"
+    show_progress_bar = os.environ.get("BACKTESTING_SHOW_PROGRESS_BAR", "true").lower() == "true"
+    disable_progress = quiet_logs or not show_progress_bar
+
+    description = f"Downloading '{datastyle}' data for {asset} / {quote_asset} with '{timespan}' from ThetaData..."
+    if disable_progress:
+        logger.debug(description)
+    else:
+        logger.info(f"\n{description}")
 
     delta = timedelta(days=MAX_DAYS)
 
@@ -2576,12 +2578,24 @@ def get_price_data(
 
     total_queries = len(chunk_ranges)
     chunk_workers = max(1, min(MAX_PARALLEL_CHUNKS, total_queries))
-    logger.info(
-        "ThetaData downloader requesting %d chunk(s) with up to %d parallel workers.",
-        total_queries,
-        chunk_workers,
+    if disable_progress:
+        logger.debug(
+            "ThetaData downloader requesting %d chunk(s) with up to %d parallel workers.",
+            total_queries,
+            chunk_workers,
+        )
+    else:
+        logger.info(
+            "ThetaData downloader requesting %d chunk(s) with up to %d parallel workers.",
+            total_queries,
+            chunk_workers,
+        )
+    pbar = tqdm(
+        total=max(1, total_queries),
+        desc=f"\n{description}" if not disable_progress else description,
+        dynamic_ncols=True,
+        disable=disable_progress,
     )
-    pbar = tqdm(total=max(1, total_queries), desc=description, dynamic_ncols=True)
 
     # Track completed chunks for download status (thread-safe counter)
     completed_chunks = [0]  # Use list to allow mutation in nested scope
@@ -2863,6 +2877,17 @@ def get_missing_dates(df_all, asset, start, end):
         0 if df_all is None else len(df_all)
     )
 
+    asset_type_value = str(getattr(asset, "asset_type", "")).lower()
+    symbol_upper = str(getattr(asset, "symbol", "") or "").upper()
+    index_symbols = {
+        "SPX", "SPXW",
+        "RUT", "RUTW",
+        "VIX", "VIXW",
+        "NDX", "NDXP",
+        "XSP", "DJX", "OEX", "XEO",
+    }
+    is_index_asset = asset_type_value == "index" or symbol_upper in index_symbols
+
     trading_dates = get_trading_dates(asset, start, end)
 
     logger.debug(
@@ -2893,6 +2918,12 @@ def get_missing_dates(df_all, asset, start, end):
         df_working["missing"].astype(bool) if "missing" in df_working.columns else pd.Series(False, index=df_working.index)
     )
     placeholder_dates = set(dates_series[placeholder_mask].unique()) if hasattr(placeholder_mask, "__len__") else set()
+    if is_index_asset and hasattr(placeholder_mask, "__len__") and bool(placeholder_mask.all()):
+        logger.info(
+            "[THETA][CACHE][PLACEHOLDER_ONLY] asset=%s | placeholder-only cache detected; skipping refetch for index",
+            asset.symbol if hasattr(asset, 'symbol') else str(asset),
+        )
+        return []
     # Placeholder rows should be treated as missing coverage for past dates so we can refetch real data
     # (e.g. when caches were populated during an outage). We suppress future/expired-placeholder refetch
     # later when computing missing_dates.

--- a/lumibot/traders/trader.py
+++ b/lumibot/traders/trader.py
@@ -1,5 +1,6 @@
 import logging  # Needed for logging infrastructure setup
 import signal
+import warnings
 from pathlib import Path
 
 from lumibot.tools.lumibot_logger import get_logger
@@ -195,6 +196,16 @@ class Trader:
         else:
             # Live trades should always have full logging for both console and file
             set_log_level("INFO")
+
+        # PERFORMANCE: avoid spamming identical FutureWarnings thousands of times during backtests
+        # (e.g., pandas chained-assignment warnings inside strategy indicator code).
+        if self.is_backtest_broker:
+            warnings.simplefilter("once", FutureWarning)
+            warnings.filterwarnings(
+                "ignore",
+                category=FutureWarning,
+                message=r"A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.*",
+            )
 
         # Setting file logging if specified
         if self.logfile:

--- a/lumibot/trading_builtins/custom_stream.py
+++ b/lumibot/trading_builtins/custom_stream.py
@@ -16,17 +16,23 @@ class CustomStream:
         if self._stop_event.is_set():
             return
 
+        # Backtesting frequently requests synchronous dispatch to ensure broker state is updated
+        # before advancing the simulation clock. Processing inline avoids queue/join overhead and
+        # is safe because only the BacktestingBroker uses `wait_until_complete=True`.
+        if wait_until_complete:
+            try:
+                self._process_queue_event(event, payload)
+            except Exception as e:
+                logging.error(f"Error processing queue event: {e}")
+            return
+
         try:
             self._queue.put((event, payload), block=False)
         except queue.Full:
             logging.warning(f"Queue full, dropping event {event}")
             return
 
-        # Primarily used for backtesting. If wait_until_complete is True, the function will block until the queue is
-        # empty. This is useful for ensuring that all events have been processed before moving on to the next step.
-        if wait_until_complete:
-            # Wait for the queue to be processed
-            self._queue.join()
+        # If wait_until_complete is True, we handled the inline path above.
 
     def add_action(self, event_name):
         def add_event_action(f):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.17",
+    version="4.4.18",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,24 @@
+# Tests Agent Instructions (Legacy Test Policy)
+
+These rules apply to all files under `tests/`.
+
+## Legacy tests are high-authority
+
+- Treat any test whose **earliest commit date is before 2025-01-01** as **LEGACY**.
+- For LEGACY tests, **fix the code, not the test**.
+- Only change a LEGACY test when you can clearly justify that:
+  - the old expectation was incorrect, or
+  - behavior was intentionally changed for correctness (e.g., fixing lookahead bias),
+  and you document it in the test file.
+
+## Any test change must be explained
+
+- If you change any expected values or assertions, add a short note near the change
+  explaining **why** (what changed, and why the new expectation is correct).
+- Prefer making the test more robust (less brittle) over updating magic numbers.
+
+## CI guard for legacy edits
+
+- CI should block edits to LEGACY tests unless the PR is explicitly approved.
+  The recommended mechanism is a PR label + required write-up (see `.github/workflows/`).
+

--- a/tests/backtest/test_backtesting_broker_processing.py
+++ b/tests/backtest/test_backtesting_broker_processing.py
@@ -2,9 +2,11 @@ import pandas as pd
 import pytest
 from datetime import timedelta
 from decimal import Decimal
+from unittest.mock import MagicMock
 
 from lumibot.backtesting import BacktestingBroker, PandasDataBacktesting
-from lumibot.entities import Asset, Data, TradingFee
+from lumibot.entities import Asset, Data, SmartLimitConfig, SmartLimitPreset, TradingFee, TradingSlippage
+from lumibot.tools.smart_limit_utils import build_price_ladder, round_to_tick
 from lumibot.entities.order import Order
 from lumibot.strategies.strategy import Strategy
 
@@ -19,6 +21,8 @@ def make_ohlcv(
     freq: str = DEFAULT_FREQ,
     tz: str = "America/New_York",
     volume: int = 1_000,
+    bid: float | None = None,
+    ask: float | None = None,
 ):
     index = pd.date_range(start, periods=len(bars), freq=freq, tz=tz)
     opens, highs, lows, closes, volumes = [], [], [], [], []
@@ -43,7 +47,7 @@ def make_ohlcv(
         closes.append(close)
         volumes.append(vol)
 
-    return pd.DataFrame(
+    df = pd.DataFrame(
         {
             "open": opens,
             "high": highs,
@@ -53,6 +57,11 @@ def make_ohlcv(
         },
         index=index,
     )
+    if bid is not None:
+        df["bid"] = [bid for _ in range(len(bars))]
+    if ask is not None:
+        df["ask"] = [ask for _ in range(len(bars))]
+    return df
 
 
 class DummyStrategy(Strategy):
@@ -92,14 +101,53 @@ def build_data_source(asset: Asset, quote: Asset, df: pd.DataFrame) -> PandasDat
     return data_source
 
 
-def build_strategy(broker, buy_fee=None, sell_fee=None, budget=100000.0):
+def build_data_source_with_market(
+    asset: Asset,
+    quote: Asset,
+    df: pd.DataFrame,
+    *,
+    market: str,
+    datetime_end: pd.Timestamp | None = None,
+) -> PandasDataBacktesting:
+    dt_start = df.index[0]
+    dt_end = datetime_end if datetime_end is not None else (df.index[-1] + pd.Timedelta(minutes=1))
+
+    df_local = df.copy()
+    if df_local.index.tz is not None:
+        df_local = df_local.tz_convert("America/New_York").tz_localize(None)
+
+    data = Data(
+        asset=asset,
+        df=df_local,
+        quote=quote,
+        timestep="minute",
+        timezone="America/New_York",
+    )
+    pandas_data = {(asset, quote): data}
+    data_source = PandasDataBacktesting(
+        pandas_data=pandas_data,
+        datetime_start=dt_start,
+        datetime_end=dt_end,
+        show_progress_bar=False,
+        market=market,
+        auto_adjust=True,
+    )
+    data_source.load_data()
+    return data_source
+
+
+def build_strategy(broker, buy_fee=None, sell_fee=None, buy_slippage=None, sell_slippage=None, budget=100000.0):
     buy_fees = [buy_fee] if buy_fee else []
     sell_fees = [sell_fee] if sell_fee else []
+    buy_slippages = [buy_slippage] if buy_slippage else []
+    sell_slippages = [sell_slippage] if sell_slippage else []
     return DummyStrategy(
         broker=broker,
         budget=budget,
         buy_trading_fees=buy_fees,
         sell_trading_fees=sell_fees,
+        buy_trading_slippages=buy_slippages,
+        sell_trading_slippages=sell_slippages,
         analyze_backtest=False,
         parameters={},
     )
@@ -731,3 +779,486 @@ def test_missing_bar_falls_back_to_last_available_price():
     expected_cash = 100000.0 - (3 * 200.0)
     assert strategy.cash == pytest.approx(expected_cash, rel=1e-9)
     assert position_quantity(broker, strategy, asset) == pytest.approx(3.0)
+
+
+def test_smart_limit_fills_mid_plus_slippage_and_logs_slippage():
+    asset = Asset("SMART", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    df = make_ohlcv(
+        [(100.0, 101.0, 99.0, 100.0)],
+        bid=99.0,
+        ask=101.0,
+    )
+    data_source = build_data_source(asset, quote, df)
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = build_strategy(broker)
+    strategy._first_iteration = False
+
+    config = SmartLimitConfig(
+        preset=SmartLimitPreset.FAST,
+        slippage=TradingSlippage(amount=0.25),
+    )
+    order = strategy.create_order(
+        asset,
+        Decimal("2"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=config,
+    )
+    strategy.submit_order(order)
+    order._date_created = broker.datetime - timedelta(seconds=60)
+
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert order.is_filled()
+    assert order.get_fill_price() == pytest.approx(100.25)
+    assert order.trade_slippage == pytest.approx(0.5)  # 0.25 * 2
+
+    fills = broker._trade_event_log_df
+    fill_row = fills[fills["status"] == "fill"].iloc[0]
+    assert float(fill_row["trade_slippage"]) == pytest.approx(0.5)
+
+
+def test_smart_limit_downgrades_to_market_when_quotes_missing():
+    asset = Asset("NOBID", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    df = make_ohlcv(
+        [(50.0, 51.0, 49.0, 50.0)],
+        bid=None,
+        ask=None,
+    )
+    data_source = build_data_source(asset, quote, df)
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = build_strategy(broker)
+    strategy._first_iteration = False
+
+    config = SmartLimitConfig(preset=SmartLimitPreset.FAST, slippage=0.1)
+    order = strategy.create_order(
+        asset,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=config,
+    )
+    strategy.submit_order(order)
+    order._date_created = broker.datetime - timedelta(seconds=60)
+
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert order.is_filled()
+    assert order.get_fill_price() == pytest.approx(50.0)
+    assert order.trade_slippage == pytest.approx(0.0)
+
+
+def test_smart_limit_option_asset_fills_from_bid_ask():
+    asset = Asset(
+        "SPY",
+        asset_type=Asset.AssetType.OPTION,
+        expiration=pd.Timestamp("2025-02-21").date(),
+        strike=500,
+        right="CALL",
+        multiplier=100,
+    )
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    df = make_ohlcv(
+        [(4.0, 4.5, 3.5, 4.1)],
+        bid=3.9,
+        ask=4.3,
+    )
+    data_source = build_data_source(asset, quote, df)
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = build_strategy(broker)
+    strategy._first_iteration = False
+
+    config = SmartLimitConfig(
+        preset=SmartLimitPreset.FAST,
+        slippage=TradingSlippage(amount=0.1),
+    )
+    order = strategy.create_order(
+        asset,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=config,
+    )
+    strategy.submit_order(order)
+    order._date_created = broker.datetime - timedelta(seconds=60)
+
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert order.is_filled()
+    assert order.get_fill_price() == pytest.approx(4.2)  # mid 4.1 plus slippage 0.1
+
+
+def test_smart_limit_multileg_fills_children_atomically_and_sets_parent_price():
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    underlying = Asset("AAA", asset_type=Asset.AssetType.STOCK)
+    expiration = pd.Timestamp("2025-02-21").date()
+
+    long_call = Asset(
+        "AAA",
+        asset_type=Asset.AssetType.OPTION,
+        expiration=expiration,
+        strike=100,
+        right="CALL",
+        multiplier=100,
+    )
+    short_call = Asset(
+        "AAA",
+        asset_type=Asset.AssetType.OPTION,
+        expiration=expiration,
+        strike=105,
+        right="CALL",
+        multiplier=100,
+    )
+
+    df_underlying = make_ohlcv([(100.0, 101.0, 99.0, 100.0)])
+    df_long = make_ohlcv([(4.0, 4.5, 3.5, 4.1)], bid=4.0, ask=4.4)
+    df_short = make_ohlcv([(3.0, 3.3, 2.9, 3.1)], bid=3.0, ask=3.2)
+
+    pandas_data = {}
+    for asset, df in ((underlying, df_underlying), (long_call, df_long), (short_call, df_short)):
+        df_local = df.copy()
+        if df_local.index.tz is not None:
+            df_local = df_local.tz_convert("America/New_York").tz_localize(None)
+        pandas_data[(asset, quote)] = Data(
+            asset=asset,
+            df=df_local,
+            quote=quote,
+            timestep="minute",
+            timezone="America/New_York",
+        )
+
+    data_source = PandasDataBacktesting(
+        pandas_data=pandas_data,
+        datetime_start=df_long.index[0],
+        datetime_end=df_long.index[-1] + pd.Timedelta(minutes=1),
+        show_progress_bar=False,
+        market="24/7",
+        auto_adjust=True,
+    )
+    data_source.load_data()
+
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = build_strategy(broker)
+    strategy._first_iteration = False
+
+    config = SmartLimitConfig(
+        preset=SmartLimitPreset.FAST,
+        slippage=TradingSlippage(amount=0.09),
+    )
+    buy_long = strategy.create_order(
+        long_call,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=config,
+    )
+    sell_short = strategy.create_order(
+        short_call,
+        Decimal("1"),
+        Order.OrderSide.SELL,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=config,
+    )
+
+    submitted = strategy.submit_order([buy_long, sell_short])
+    assert isinstance(submitted, list)
+    assert len(submitted) == 1
+    parent = submitted[0]
+
+    # Force the parent into the final step so it becomes executable.
+    parent._date_created = broker.datetime - timedelta(seconds=60)
+
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert buy_long.is_filled()
+    assert sell_short.is_filled()
+    assert parent.is_filled()
+
+    assert buy_long.get_fill_price() == pytest.approx(4.26)
+    assert sell_short.get_fill_price() == pytest.approx(3.07)
+    assert float(parent.avg_fill_price) == pytest.approx(1.19)
+
+    assert buy_long.trade_slippage == pytest.approx(6.0)
+    assert sell_short.trade_slippage == pytest.approx(3.0)
+
+
+def test_smart_limit_sell_applies_slippage_below_mid():
+    asset = Asset("SMARTSELL", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    df = make_ohlcv(
+        [(200.0, 201.0, 199.0, 200.0)],
+        bid=199.0,
+        ask=201.0,
+    )
+    data_source = build_data_source(asset, quote, df)
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = build_strategy(broker)
+    strategy._first_iteration = False
+
+    config = SmartLimitConfig(
+        preset=SmartLimitPreset.FAST,
+        slippage=TradingSlippage(amount=0.4),
+    )
+    order = strategy.create_order(
+        asset,
+        Decimal("1"),
+        Order.OrderSide.SELL,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=config,
+    )
+    strategy.submit_order(order)
+    order._date_created = broker.datetime - timedelta(seconds=60)
+
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert order.is_filled()
+    assert order.get_fill_price() == pytest.approx(199.6)  # mid 200 minus slippage 0.4
+    assert order.trade_slippage == pytest.approx(0.4)
+
+
+def test_smart_limit_cancels_after_final_hold():
+    asset = Asset("CANCEL", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    df = make_ohlcv(
+        [(10.0, 11.0, 9.0, 10.0)],
+        bid=9.0,
+        ask=11.0,
+    )
+    data_source = build_data_source(asset, quote, df)
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = build_strategy(broker)
+    strategy._first_iteration = False
+
+    config = SmartLimitConfig(preset=SmartLimitPreset.FAST, slippage=0.1)
+    order = strategy.create_order(
+        asset,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=config,
+    )
+    strategy.submit_order(order)
+    order._date_created = broker.datetime - timedelta(seconds=200)
+
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert order.is_canceled()
+
+
+def test_smart_limit_respects_final_price_guard():
+    asset = Asset("GUARD", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    df = make_ohlcv(
+        [(100.0, 101.0, 99.0, 100.0)],
+        bid=99.0,
+        ask=101.0,
+    )
+    data_source = build_data_source(asset, quote, df)
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = build_strategy(broker)
+    strategy._first_iteration = False
+
+    config = SmartLimitConfig(
+        preset=SmartLimitPreset.FAST,
+        slippage=2.0,
+        final_price_pct=0.1,
+    )
+    order = strategy.create_order(
+        asset,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=config,
+    )
+    strategy.submit_order(order)
+    order._date_created = broker.datetime - timedelta(seconds=60)
+
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert not order.is_filled()
+
+
+def test_smart_limit_uses_strategy_slippage_when_config_missing():
+    asset = Asset("STRATSLIP", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    df = make_ohlcv(
+        [(100.0, 101.0, 99.0, 100.0)],
+        bid=99.0,
+        ask=101.0,
+    )
+    data_source = build_data_source(asset, quote, df)
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = build_strategy(broker, buy_slippage=TradingSlippage(amount=0.3))
+    strategy._first_iteration = False
+
+    config = SmartLimitConfig(preset=SmartLimitPreset.FAST)
+    order = strategy.create_order(
+        asset,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=config,
+    )
+    strategy.submit_order(order)
+    order._date_created = broker.datetime - timedelta(seconds=60)
+
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert order.is_filled()
+    assert order.get_fill_price() == pytest.approx(100.3)
+
+
+def test_market_order_prefers_quote_when_bid_ask_available():
+    asset = Asset("QUOTED", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    df = make_ohlcv(
+        [(100.0, 101.0, 99.0, 100.0)],
+        bid=99.0,
+        ask=101.0,
+    )
+    data_source = build_data_source(asset, quote, df)
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = build_strategy(broker)
+    strategy._first_iteration = False
+
+    order = strategy.create_order(
+        asset,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.MARKET,
+    )
+    submit_and_fill(strategy, broker, order)
+
+    assert order.is_filled()
+    assert order.get_fill_price() == pytest.approx(101.0)
+
+
+def test_market_order_falls_back_to_open_when_quotes_missing():
+    asset = Asset("NOQUOTE", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    df = make_ohlcv(
+        [(100.0, 101.0, 99.0, 100.0)],
+        bid=None,
+        ask=None,
+    )
+    data_source = build_data_source(asset, quote, df)
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = build_strategy(broker)
+    strategy._first_iteration = False
+
+    order = strategy.create_order(
+        asset,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.MARKET,
+    )
+    submit_and_fill(strategy, broker, order)
+
+    assert order.is_filled()
+    assert order.get_fill_price() == pytest.approx(100.0)
+
+
+def test_limit_order_uses_quote_when_ohlc_missing():
+    asset = Asset("MISSINGBAR", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    df = make_ohlcv(
+        [(100.0, 101.0, 99.0, 100.0)],
+        bid=99.0,
+        ask=101.0,
+    )
+    data_source = build_data_source(asset, quote, df)
+    data_source.get_historical_prices = MagicMock(return_value=None)
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = build_strategy(broker)
+    strategy._first_iteration = False
+
+    order = strategy.create_order(
+        asset,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=105.0,
+    )
+    submit_and_fill(strategy, broker, order)
+
+    assert order.is_filled()
+    assert order.get_fill_price() == pytest.approx(101.0)
+
+
+def test_smart_limit_ladder_and_rounding():
+    ladder = build_price_ladder(100.0, 102.0, 3)
+    assert ladder == pytest.approx([100.0, 101.0, 102.0])
+
+    assert round_to_tick(100.03, 0.05, side="buy") == pytest.approx(100.05)
+    assert round_to_tick(100.03, 0.05, side="sell") == pytest.approx(100.0)
+
+
+def test_future_end_date_stops_backtest_cleanly():
+    asset = Asset("AAPL", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    df = make_ohlcv(
+        bars=[(100.0, 101.0, 99.0, 100.0), (101.0, 102.0, 100.0, 101.0)],
+        start="2025-01-02 09:30",
+        freq="1min",
+    )
+    future_end = df.index[-1] + pd.Timedelta(days=10)
+    data_source = build_data_source_with_market(
+        asset,
+        quote,
+        df,
+        market="NYSE",
+        datetime_end=future_end,
+    )
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+
+    broker._update_datetime(df.index[-1] + pd.Timedelta(days=5))
+    strategy = build_strategy(broker)
+    broker._await_market_to_open(timedelta=0, strategy=strategy)
+
+    assert broker._end_of_trading_days_reached is True
+    assert broker.should_continue() is False
+    assert broker.data_source.datetime_end <= broker.datetime

--- a/tests/backtest/test_multileg_backtest.py
+++ b/tests/backtest/test_multileg_backtest.py
@@ -16,6 +16,7 @@ class _MultiLegStrategy(Strategy):
         self.long_asset = params["long_asset"]
         self.short_asset = params["short_asset"]
         self.quote = params["quote"]
+        self.parent_order_type = params.get("parent_order_type", Order.OrderType.MARKET)
         self.traded = False
         self.include_cash_positions = True
         self.sleeptime = "1D"
@@ -44,7 +45,7 @@ class _MultiLegStrategy(Strategy):
             asset=self.long_asset,
             quantity=Decimal("0"),
             side=Order.OrderSide.BUY,
-            order_type=Order.OrderType.MARKET,
+            order_type=self.parent_order_type,
             order_class=Order.OrderClass.MULTILEG,
             child_orders=[long_leg, short_leg],
         )
@@ -142,3 +143,82 @@ def test_multileg_spread_backtest_cash_and_parent_fill():
     assert len(actual_fills) == 2
     assert float(actual_fills.iloc[0]["filled_quantity"]) == pytest.approx(10.0)  # AAA buy
     assert float(actual_fills.iloc[1]["filled_quantity"]) == pytest.approx(5.0)   # BBB sell
+
+
+def test_multileg_parent_limit_order_fills_in_backtest():
+    price_map = {"AAA": [100.0, 101.0], "BBB": [50.0, 51.0]}
+    quote, data_source = _make_data_for_assets(price_map)
+
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+
+    long_asset = Asset("AAA", asset_type=Asset.AssetType.STOCK)
+    short_asset = Asset("BBB", asset_type=Asset.AssetType.STOCK)
+
+    strategy = _MultiLegStrategy(
+        broker=broker,
+        budget=100_000.0,
+        analyze_backtest=False,
+        parameters={
+            "long_asset": long_asset,
+            "short_asset": short_asset,
+            "quote": quote,
+            "parent_order_type": Order.OrderType.LIMIT,
+        },
+    )
+
+    trader = Trader(logfile="", backtest=True)
+    trader.add_strategy(strategy)
+    trader.run_all(show_plot=False, show_tearsheet=False, show_indicators=False, save_tearsheet=False)
+
+    parent_orders = [
+        order
+        for order in strategy.broker._filled_orders.get_list()
+        if getattr(order, "order_class", None) == Order.OrderClass.MULTILEG
+    ]
+    assert len(parent_orders) == 1
+    assert parent_orders[0].is_filled()
+
+
+class _SubmitOnlyStrategy(Strategy):
+    def initialize(self, parameters=None):
+        self.sleeptime = "1D"
+
+
+def test_submit_order_list_defaults_to_multileg_for_option_orders():
+    """Regression: submitting a list of option orders should not crash in BacktestingBroker._submit_orders."""
+    quote, data_source = _make_data_for_assets({"AAA": [100.0, 101.0]})
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+
+    strategy = _SubmitOnlyStrategy(
+        broker=broker,
+        budget=100_000.0,
+        analyze_backtest=False,
+    )
+
+    underlying = Asset("SPX", asset_type=Asset.AssetType.INDEX)
+    option_1 = Asset(
+        "SPX",
+        asset_type="option",
+        expiration="2025-01-02",
+        strike=100.0,
+        right="call",
+        underlying_asset=underlying,
+    )
+    option_2 = Asset(
+        "SPX",
+        asset_type="option",
+        expiration="2025-01-02",
+        strike=101.0,
+        right="call",
+        underlying_asset=underlying,
+    )
+
+    order_1 = strategy.create_order(option_1, Decimal("1"), Order.OrderSide.BUY, quote=quote)
+    order_2 = strategy.create_order(option_2, Decimal("1"), Order.OrderSide.SELL, quote=quote)
+
+    submitted = strategy.submit_order([order_1, order_2])
+    assert isinstance(submitted, list)
+    assert len(submitted) == 1
+    assert submitted[0].order_class == Order.OrderClass.MULTILEG

--- a/tests/backtest/test_quote_fill_fallback.py
+++ b/tests/backtest/test_quote_fill_fallback.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from lumibot.backtesting.backtesting_broker import BacktestingBroker
-from lumibot.entities import Asset, Order, Quote
+from lumibot.entities import Asset, Order, Quote, SmartLimitConfig, SmartLimitPreset, TradingSlippage
 from lumibot.tools.lumibot_logger import get_logger
 
 
@@ -38,7 +38,6 @@ def _build_broker(quote: Quote) -> BacktestingBroker:
     broker.data_source = object()
     broker._trade_event_log_df = None  # not used in these unit tests
     broker.get_quote = MagicMock(return_value=quote)
-    broker._is_thetadata_source = MagicMock(return_value=True)
     return broker
 
 
@@ -57,7 +56,7 @@ def test_try_fill_with_quote_returns_ask_for_buy_order():
 
     assert price == pytest.approx(45.0)
     assert getattr(order, "_price_source", None) == "quote"
-    assert any("ThetaData quote" in msg for msg, _ in strategy.messages)
+    assert any("quote" in msg for msg, _ in strategy.messages)
 
 
 def test_try_fill_with_quote_respects_limit_price():
@@ -76,8 +75,8 @@ def test_try_fill_with_quote_respects_limit_price():
     assert not hasattr(order, "_price_source")
 
 
-def test_thetadata_option_market_order_prefers_quote_fill_without_ohlc(monkeypatch):
-    """ThetaData option market orders should fill from NBBO without forcing OHLC downloads."""
+def test_market_order_prefers_quote_fill_without_ohlc():
+    """Market orders should fill from quotes when OHLC is missing."""
     quote = Quote(
         asset=Asset("SPXW", asset_type=Asset.AssetType.OPTION, expiration=None, strike=None, right="CALL"),
         bid=10.0,
@@ -109,7 +108,6 @@ def test_thetadata_option_market_order_prefers_quote_fill_without_ohlc(monkeypat
 
     broker.data_source = _DummyDataSource()
     broker.get_quote = MagicMock(return_value=quote)
-    broker._is_thetadata_source = MagicMock(return_value=True)
     broker._trade_event_log_df = None
     broker.process_expired_option_contracts = MagicMock()
 
@@ -135,3 +133,40 @@ def test_thetadata_option_market_order_prefers_quote_fill_without_ohlc(monkeypat
     broker._execute_filled_order.assert_called_once()
     fill_kwargs = broker._execute_filled_order.call_args.kwargs
     assert fill_kwargs["price"] == pytest.approx(10.0)
+
+
+def test_smart_limit_uses_quotes_with_polygon_source():
+    """SMART_LIMIT should use quotes regardless of data source when bid/ask are available."""
+    quote = Quote(
+        asset=Asset("SPY", asset_type=Asset.AssetType.STOCK),
+        bid=100.0,
+        ask=102.0,
+        timestamp=datetime.datetime.now(datetime.timezone.utc),
+    )
+    broker = BacktestingBroker.__new__(BacktestingBroker)
+    broker.logger = get_logger("polygon_quote_test")
+    now = datetime.datetime.now(datetime.timezone.utc)
+    broker.data_source = type(
+        "PolygonStub",
+        (),
+        {"SOURCE": "POLYGON", "get_datetime": lambda self: now},
+    )()
+    broker.get_quote = MagicMock(return_value=quote)
+
+    order = Order(
+        strategy="TestStrategy",
+        asset=quote.asset,
+        quantity=Decimal("1"),
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=SmartLimitConfig(
+            preset=SmartLimitPreset.FAST,
+            slippage=TradingSlippage(amount=0.2),
+        ),
+    )
+    order.quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    order._date_created = now - datetime.timedelta(seconds=30)
+
+    fill_price, _ = broker._smart_limit_backtest_price(order, strategy=None, open_=100.0, high_=102.0, low_=99.0)
+
+    assert fill_price == pytest.approx(101.2)

--- a/tests/test_alpaca_multileg_fix.py
+++ b/tests/test_alpaca_multileg_fix.py
@@ -7,10 +7,21 @@ due to incorrect order_class value and missing required fields.
 import pytest
 from unittest.mock import Mock, patch
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 
 from lumibot.entities.order import Order
 from lumibot.entities.asset import Asset
+from lumibot.entities.smart_limit import SmartLimitConfig, SmartLimitPreset
 from lumibot.brokers.alpaca import Alpaca
+from lumibot.strategies.strategy import Strategy
+
+
+class _StubStrategy(Strategy):
+    def initialize(self, parameters=None):
+        self.sleeptime = "1M"
+
+    def on_trading_iteration(self):
+        return
 
 
 class TestAlpacaMultiLegOrders:
@@ -211,6 +222,70 @@ class TestAlpacaMultiLegOrders:
         with pytest.raises(ValueError, match="limit price is required"):
             # This should raise an error because price is None for a limit order
             broker._submit_multileg_order(orders, order_type="limit", price=None)
+
+    @patch('lumibot.brokers.alpaca.TradingClient')
+    def test_smart_limit_submits_as_limit(self, mock_trading_client):
+        """Smart limit should downgrade to limit before broker submission."""
+        mock_trading_client.return_value = Mock()
+        broker = Alpaca(self.test_config, connect_stream=False)
+        broker._set_initial_positions = Mock()
+        captured = {}
+
+        def _capture_submit(order):
+            captured["order_type"] = order.order_type
+            return order
+
+        broker.submit_order = Mock(side_effect=_capture_submit)
+
+        with patch.object(Strategy, "update_broker_balances", return_value=None):
+            strategy = _StubStrategy(broker=broker, budget=100_000.0, analyze_backtest=False, parameters={})
+            strategy._first_iteration = False
+            strategy.get_quote = Mock(return_value=SimpleNamespace(bid=99.0, ask=101.0))
+
+            asset = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+            config = SmartLimitConfig(preset=SmartLimitPreset.NORMAL)
+            order = strategy.create_order(
+                asset,
+                1,
+                Order.OrderSide.BUY,
+                order_type=Order.OrderType.SMART_LIMIT,
+                smart_limit=config,
+            )
+            strategy.submit_order(order)
+
+        assert captured["order_type"] == Order.OrderType.LIMIT
+
+    @patch('lumibot.brokers.alpaca.TradingClient')
+    def test_smart_limit_downgrades_to_market_without_quotes(self, mock_trading_client):
+        """Smart limit should downgrade to market when bid/ask are missing."""
+        mock_trading_client.return_value = Mock()
+        broker = Alpaca(self.test_config, connect_stream=False)
+        broker._set_initial_positions = Mock()
+        captured = {}
+
+        def _capture_submit(order):
+            captured["order_type"] = order.order_type
+            return order
+
+        broker.submit_order = Mock(side_effect=_capture_submit)
+
+        with patch.object(Strategy, "update_broker_balances", return_value=None):
+            strategy = _StubStrategy(broker=broker, budget=100_000.0, analyze_backtest=False, parameters={})
+            strategy._first_iteration = False
+            strategy.get_quote = Mock(return_value=SimpleNamespace(bid=None, ask=None))
+
+            asset = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+            config = SmartLimitConfig(preset=SmartLimitPreset.NORMAL)
+            order = strategy.create_order(
+                asset,
+                1,
+                Order.OrderSide.BUY,
+                order_type=Order.OrderType.SMART_LIMIT,
+                smart_limit=config,
+            )
+            strategy.submit_order(order)
+
+        assert captured["order_type"] == Order.OrderType.MARKET
 
 
 if __name__ == "__main__":

--- a/tests/test_backtesting_broker.py
+++ b/tests/test_backtesting_broker.py
@@ -11,7 +11,7 @@ import pytz
 try:
     from lumibot.backtesting.backtesting_broker import BacktestingBroker
     from lumibot.data_sources import PandasData
-    from lumibot.entities import Asset, Order # Import Asset if needed by mocked methods
+    from lumibot.entities import Asset, Order, Quote # Import Asset if needed by mocked methods
 except ImportError:
     # Add path modification if running tests directly and lumibot is not installed
     import sys
@@ -19,7 +19,7 @@ except ImportError:
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
     from lumibot.backtesting.backtesting_broker import BacktestingBroker
     from lumibot.data_sources import PandasData
-    from lumibot.entities import Asset, Order
+    from lumibot.entities import Asset, Order, Quote
 
 
 class TestBacktestingBroker:
@@ -86,6 +86,59 @@ class TestBacktestingBroker:
         Order(asset=Asset("SPY"), quantity=10, side="buy", strategy='abc')
         broker.submit_order(Order(asset=Asset("SPY"), quantity=10, side="buy", strategy='abc'))
         broker._conform_order.assert_called_once()
+
+    def test_market_order_prefers_quote_when_missing_ohlc(self):
+        broker = BacktestingBroker.__new__(BacktestingBroker)
+        broker.logger = MagicMock()
+        broker.data_source = type("StubSource", (), {"_timestep": "minute"})()
+        broker.get_quote = MagicMock(
+            return_value=Quote(
+                asset=Asset("SPY"),
+                bid=99.0,
+                ask=101.0,
+            )
+        )
+
+        order = Order(
+            asset=Asset("SPY"),
+            quantity=10,
+            side="buy",
+            order_type=Order.OrderType.MARKET,
+            strategy="test",
+        )
+        order.quote = Asset("USD", asset_type="forex")
+
+        price = broker._try_fill_with_quote(order, strategy=None, open_=None, high_=None, low_=None)
+
+        assert price == 101.0
+
+    def test_get_next_trading_day_marks_end_of_trading_days(self):
+        """Regression: reaching end of trading calendar should stop backtest (no infinite loop)."""
+        broker = BacktestingBroker.__new__(BacktestingBroker)
+        broker.option_source = None
+        broker._end_of_trading_days_reached = False
+
+        tz = pytz.timezone("America/New_York")
+        now = tz.localize(dt(2025, 1, 3, 12, 0))
+
+        # Simulate a datasource whose configured end extends beyond available trading days.
+        broker.data_source = type(
+            "StubSource",
+            (),
+            {
+                "datetime_end": tz.localize(dt(2025, 2, 1)),
+                "get_datetime": lambda self: now,
+            },
+        )()
+
+        open_1 = tz.localize(dt(2025, 1, 2, 9, 30))
+        close_1 = tz.localize(dt(2025, 1, 2, 16, 0))
+        broker._trading_days = pd.DataFrame({"market_open": [open_1]}, index=[close_1])
+
+        assert broker._get_next_trading_day() is None
+        assert broker._end_of_trading_days_reached is True
+        assert broker.data_source.datetime_end == now
+        assert broker.should_continue() is False
 
 
 # New Test Class for Time Advancement Logic

--- a/tests/test_backtesting_datetime_normalization.py
+++ b/tests/test_backtesting_datetime_normalization.py
@@ -55,6 +55,27 @@ def test_verify_backtest_inputs_accepts_mixed_timezones():
     _Strategy.verify_backtest_inputs(naive_start, aware_end)
 
 
+def test_verify_backtest_inputs_rejects_future_end_by_default(monkeypatch):
+    """Guardrail: backtesting_end must not be in the future unless explicitly allowed."""
+    monkeypatch.delenv("BACKTESTING_ALLOW_FUTURE_END", raising=False)
+
+    start = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+    future_end = datetime.datetime(9999, 12, 31, tzinfo=datetime.timezone.utc)
+
+    with pytest.raises(ValueError, match="cannot be in the future"):
+        _Strategy.verify_backtest_inputs(start, future_end)
+
+
+def test_verify_backtest_inputs_allows_future_end_with_env(monkeypatch):
+    """Opt-in: allow future end dates for testing when BACKTESTING_ALLOW_FUTURE_END=true."""
+    monkeypatch.setenv("BACKTESTING_ALLOW_FUTURE_END", "true")
+
+    start = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+    future_end = datetime.datetime(9999, 12, 31, tzinfo=datetime.timezone.utc)
+
+    _Strategy.verify_backtest_inputs(start, future_end)
+
+
 def test_run_backtest_normalizes_mixed_timezones(disable_datasource_override):
     """Strategy.run_backtest should normalize naive/aware datetimes before validation."""
     naive_start = datetime.datetime(2025, 1, 1)

--- a/tests/test_backtesting_multileg_unit.py
+++ b/tests/test_backtesting_multileg_unit.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 from lumibot.backtesting import BacktestingBroker, PandasDataBacktesting
-from lumibot.entities import Asset, Data
+from lumibot.entities import Asset, Data, SmartLimitConfig, SmartLimitPreset
 from lumibot.entities.order import Order
 from lumibot.strategies.strategy import Strategy
 
@@ -186,3 +186,125 @@ def test_multileg_child_fills_adjust_cash_once_and_parent_is_cash_neutral():
     child_fills = fills[fills["status"] == "fill"]
     assert len(child_fills) == 2
     assert parent.trade_cost == pytest.approx(0.0, abs=1e-9)
+
+
+def test_multileg_parent_fill_price_uses_net_child_prices():
+    strategy, broker, asset, quote = _build_stock_strategy(price=50.0)
+
+    buy_child = _make_child_order(strategy, asset, quote, "10", Order.OrderSide.BUY)
+    sell_child = _make_child_order(strategy, asset, quote, "10", Order.OrderSide.SELL)
+
+    parent = Order(
+        strategy=strategy,
+        asset=asset,
+        quantity=Decimal("20"),
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.MARKET,
+        order_class=Order.OrderClass.MULTILEG,
+        child_orders=[buy_child, sell_child],
+    )
+
+    strategy.submit_order(parent)
+
+    broker._execute_filled_order(buy_child, price=50.0, filled_quantity=Decimal("10"), strategy=strategy)
+    strategy._executor.process_queue()
+
+    broker._execute_filled_order(sell_child, price=60.0, filled_quantity=Decimal("10"), strategy=strategy)
+    strategy._executor.process_queue()
+
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert parent.is_filled()
+    assert parent.avg_fill_price == pytest.approx(-10.0, abs=1e-9)
+    assert parent.trade_cost == pytest.approx(0.0, abs=1e-9)
+
+
+def test_multileg_parent_limit_order_still_fills_after_children():
+    strategy, broker, asset, quote = _build_stock_strategy(price=50.0)
+
+    buy_child = _make_child_order(strategy, asset, quote, "5", Order.OrderSide.BUY)
+    sell_child = _make_child_order(strategy, asset, quote, "5", Order.OrderSide.SELL)
+
+    parent = Order(
+        strategy=strategy,
+        asset=asset,
+        quantity=Decimal("10"),
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=49.0,
+        order_class=Order.OrderClass.MULTILEG,
+        child_orders=[buy_child, sell_child],
+    )
+
+    strategy.submit_order(parent)
+
+    broker._execute_filled_order(buy_child, price=50.0, filled_quantity=Decimal("5"), strategy=strategy)
+    strategy._executor.process_queue()
+
+    broker._execute_filled_order(sell_child, price=50.0, filled_quantity=Decimal("5"), strategy=strategy)
+    strategy._executor.process_queue()
+
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert parent.is_filled()
+    assert parent.trade_cost == pytest.approx(0.0, abs=1e-9)
+
+
+def test_multileg_smart_limit_net_fill_price():
+    asset_a = Asset("AAA", asset_type=Asset.AssetType.STOCK)
+    asset_b = Asset("BBB", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+    df_a = _make_df(price=100.0)
+    df_a["bid"] = [99.0 for _ in range(len(df_a))]
+    df_a["ask"] = [101.0 for _ in range(len(df_a))]
+    df_b = _make_df(price=20.0)
+    df_b["bid"] = [19.0 for _ in range(len(df_b))]
+    df_b["ask"] = [21.0 for _ in range(len(df_b))]
+
+    data_a = Data(asset=asset_a, df=df_a.tz_convert("America/New_York").tz_localize(None), quote=quote, timestep="minute", timezone="America/New_York")
+    data_b = Data(asset=asset_b, df=df_b.tz_convert("America/New_York").tz_localize(None), quote=quote, timestep="minute", timezone="America/New_York")
+    pandas_data = {(asset_a, quote): data_a, (asset_b, quote): data_b}
+
+    data_source = PandasDataBacktesting(
+        pandas_data=pandas_data,
+        datetime_start=df_a.index[0],
+        datetime_end=df_a.index[-1] + pd.Timedelta(minutes=1),
+        show_progress_bar=False,
+        market="24/7",
+        auto_adjust=True,
+    )
+    data_source.load_data()
+
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = _StubStrategy(broker=broker, budget=100_000.0, analyze_backtest=False, parameters={})
+    strategy._first_iteration = False
+
+    config = SmartLimitConfig(preset=SmartLimitPreset.FAST, slippage=0.1)
+    buy_leg = strategy.create_order(asset_a, Decimal("1"), "buy", order_type=Order.OrderType.MARKET)
+    sell_leg = strategy.create_order(asset_b, Decimal("1"), "sell", order_type=Order.OrderType.MARKET)
+
+    parent = Order(
+        strategy=strategy.name,
+        asset=asset_a,
+        quantity=Decimal("2"),
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        order_class=Order.OrderClass.MULTILEG,
+        child_orders=[buy_leg, sell_leg],
+        smart_limit=config,
+    )
+
+    strategy.submit_order(parent)
+    parent._date_created = broker.datetime - timedelta(seconds=60)
+
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert parent.is_filled()
+    assert parent.get_fill_price() == pytest.approx(80.1)

--- a/tests/test_backtesting_pandas_daily_routing.py
+++ b/tests/test_backtesting_pandas_daily_routing.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+from lumibot.strategies.strategy_executor import StrategyExecutor
+
+
+def _make_executor(data_source):
+    executor = StrategyExecutor.__new__(StrategyExecutor)
+    executor.strategy = SimpleNamespace(is_backtesting=True)
+    executor.broker = SimpleNamespace(data_source=data_source)
+    return executor
+
+
+def test_is_pandas_daily_data_source_only_matches_pure_pandas():
+    PandasDataBacktesting = type(
+        "PandasDataBacktesting",
+        (),
+        {"SOURCE": "PANDAS", "_timestep": "day"},
+    )
+    ThetaDataBacktestingPandas = type(
+        "ThetaDataBacktestingPandas",
+        (),
+        {"SOURCE": "PANDAS", "_timestep": "day"},
+    )
+
+    pandas_executor = _make_executor(PandasDataBacktesting())
+    assert pandas_executor._is_pandas_daily_data_source() is True
+
+    thetadata_executor = _make_executor(ThetaDataBacktestingPandas())
+    assert thetadata_executor._is_pandas_daily_data_source() is False
+

--- a/tests/test_broker_bitunix.py
+++ b/tests/test_broker_bitunix.py
@@ -1,9 +1,12 @@
 import unittest
 from unittest.mock import MagicMock, patch
 from decimal import Decimal
+from types import SimpleNamespace
 
 from lumibot.brokers.bitunix import Bitunix
-from lumibot.entities import Asset, Order, Position
+from lumibot.brokers.schwab import Schwab
+from lumibot.entities import Asset, Order, Position, SmartLimitConfig, SmartLimitPreset
+from lumibot.strategies.strategy import Strategy
 from lumibot.tools.bitunix_helpers import BitUnixClient
 from lumibot.brokers.broker import LumibotBrokerAPIError
 
@@ -117,6 +120,7 @@ class TestBitunixBroker(unittest.TestCase):
         self.assertEqual(broker._map_status_from_bitunix("PENDING_CANCEL"), Order.OrderStatus.CANCELED)
         self.assertEqual(broker._map_status_from_bitunix("UNKNOWN_STATUS"), Order.OrderStatus.ERROR) # Test default
 
+
     @patch("lumibot.brokers.bitunix.BitUnixClient")
     @patch("lumibot.brokers.bitunix.BitunixData")
     def test_parse_broker_order(self, MockBitunixData, MockBitUnixClientInstance):
@@ -175,6 +179,88 @@ class TestBitunixBroker(unittest.TestCase):
         self.assertEqual(broker._parse_source_timestep("1d"), "1d")
         # Test fallback/default
         self.assertEqual(broker._parse_source_timestep("unknown"), "1m")
+
+
+class _StubStrategy(Strategy):
+    def initialize(self, parameters=None):
+        self.sleeptime = "1M"
+
+    def on_trading_iteration(self):
+        return
+
+
+class TestSchwabSmartLimit(unittest.TestCase):
+    def test_smart_limit_submits_as_limit(self):
+        broker = Schwab.__new__(Schwab)
+        broker.IS_BACKTESTING_BROKER = False
+        broker.name = "Schwab"
+        broker.quote_assets = set()
+        broker.data_source = MagicMock()
+        broker._add_subscriber = MagicMock()
+        broker._set_initial_positions = MagicMock()
+        broker.get_quote = MagicMock(return_value=SimpleNamespace(bid=99.0, ask=101.0))
+
+        captured = {}
+
+        def _capture_submit(order):
+            captured["order_type"] = order.order_type
+            return order
+
+        broker.submit_order = MagicMock(side_effect=_capture_submit)
+
+        with patch.object(Strategy, "update_broker_balances", return_value=None):
+            strategy = _StubStrategy(broker=broker, budget=100_000.0, analyze_backtest=False, parameters={})
+            strategy._first_iteration = False
+            strategy.get_quote = MagicMock(return_value=SimpleNamespace(bid=99.0, ask=101.0))
+
+            asset = Asset("SPY")
+            config = SmartLimitConfig(preset=SmartLimitPreset.NORMAL)
+            order = strategy.create_order(
+                asset,
+                1,
+                Order.OrderSide.BUY,
+                order_type=Order.OrderType.SMART_LIMIT,
+                smart_limit=config,
+            )
+            strategy.submit_order(order)
+
+        self.assertEqual(captured["order_type"], Order.OrderType.LIMIT)
+
+    def test_smart_limit_downgrades_to_market_without_quotes(self):
+        broker = Schwab.__new__(Schwab)
+        broker.IS_BACKTESTING_BROKER = False
+        broker.name = "Schwab"
+        broker.quote_assets = set()
+        broker.data_source = MagicMock()
+        broker._add_subscriber = MagicMock()
+        broker._set_initial_positions = MagicMock()
+        broker.get_quote = MagicMock(return_value=SimpleNamespace(bid=None, ask=None))
+
+        captured = {}
+
+        def _capture_submit(order):
+            captured["order_type"] = order.order_type
+            return order
+
+        broker.submit_order = MagicMock(side_effect=_capture_submit)
+
+        with patch.object(Strategy, "update_broker_balances", return_value=None):
+            strategy = _StubStrategy(broker=broker, budget=100_000.0, analyze_backtest=False, parameters={})
+            strategy._first_iteration = False
+            strategy.get_quote = MagicMock(return_value=SimpleNamespace(bid=None, ask=None))
+
+            asset = Asset("SPY")
+            config = SmartLimitConfig(preset=SmartLimitPreset.NORMAL)
+            order = strategy.create_order(
+                asset,
+                1,
+                Order.OrderSide.BUY,
+                order_type=Order.OrderType.SMART_LIMIT,
+                smart_limit=config,
+            )
+            strategy.submit_order(order)
+
+        self.assertEqual(captured["order_type"], Order.OrderType.MARKET)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_data_polars_parity.py
+++ b/tests/test_data_polars_parity.py
@@ -155,6 +155,46 @@ def test_data_polars_timeshift_timedelta():
     assert len(df_pandas) == len(df_polars), "Row count mismatch with timedelta timeshift"
 
 
+def test_data_get_bars_fast_path_does_not_drop_on_nan_extra_columns():
+    """
+    Ensure the Data.get_bars() fast-path matches legacy resample semantics.
+
+    Historically, get_bars() resampled/aggregated OHLCV and therefore ignored unrelated columns
+    (e.g. bid/ask) when dropping NaNs. The fast-path must not drop rows just because an extra
+    column is NaN.
+    """
+    start = datetime(2024, 7, 18, 9, 30, tzinfo=timezone.utc)
+    mock_df = _create_mock_ohlc_data(start, periods=300)
+
+    # Add an "extra" column that is entirely NaN. The output should still include bars.
+    mock_df["bid"] = None
+
+    # Make volume NaN everywhere. The legacy resample path turns NaN volumes into 0 via `sum`,
+    # so the fast-path must do the same.
+    mock_df["volume"] = None
+
+    asset = Asset("HIMS", asset_type=Asset.AssetType.STOCK)
+    data_pandas = Data(
+        asset=asset,
+        df=mock_df.copy(),
+        timestep="minute",
+        quote=asset,
+    )
+
+    test_dt = datetime(2024, 7, 18, 10, 0, tzinfo=timezone.utc)
+    df_bars = data_pandas.get_bars(
+        dt=test_dt,
+        length=2,
+        timestep="minute",
+        timeshift=-2,
+    )
+
+    assert len(df_bars) == 2
+    assert "bid" not in df_bars.columns, "Extra columns should not be returned by get_bars()"
+    assert df_bars["volume"].isna().sum() == 0, "NaN volume should be normalized to 0 (resample parity)"
+    assert all(float(v) == 0.0 for v in df_bars["volume"]), "Expected filled volume to be 0.0 for NaN inputs"
+
+
 if __name__ == "__main__":
     # Run tests with verbose output
     pytest.main([__file__, "-v", "-s"])

--- a/tests/test_drift_rebalancer.py
+++ b/tests/test_drift_rebalancer.py
@@ -1805,12 +1805,12 @@ class TestDriftRebalancer:
         assert filled_orders.iloc[0]["type"] == "limit"
         assert filled_orders.iloc[0]["side"] == "buy"
         assert filled_orders.iloc[0]["symbol"] == "SPY"
-        assert filled_orders.iloc[0]["filled_quantity"] == 238.0
+        assert filled_orders.iloc[0]["filled_quantity"] == 244.0
 
         assert filled_orders.iloc[2]["type"] == "limit"
         assert filled_orders.iloc[2]["side"] == "sell"
         assert filled_orders.iloc[2]["symbol"] == "SPY"
-        assert filled_orders.iloc[2]["filled_quantity"] == 7.0
+        assert filled_orders.iloc[2]["filled_quantity"] == 9.0
 
     # @pytest.mark.skip()
     def test_classic_60_40_with_fractional(self, pandas_data_fixture):
@@ -1856,12 +1856,12 @@ class TestDriftRebalancer:
         assert filled_orders.iloc[0]["type"] == "limit"
         assert filled_orders.iloc[0]["side"] == "buy"
         assert filled_orders.iloc[0]["symbol"] == "SPY"
-        assert filled_orders.iloc[0]["filled_quantity"] == 238.635007755
+        assert filled_orders.iloc[0]["filled_quantity"] == 244.468891333
 
         assert filled_orders.iloc[2]["type"] == "limit"
         assert filled_orders.iloc[2]["side"] == "sell"
         assert filled_orders.iloc[2]["symbol"] == "SPY"
-        assert filled_orders.iloc[2]["filled_quantity"] == 8.347327921
+        assert filled_orders.iloc[2]["filled_quantity"] == 9.746995127
 
     @pytest.mark.xfail(reason="yahoo sucks")
     def test_crypto_50_50_with_yahoo(self):

--- a/tests/test_drift_rebalancer.py
+++ b/tests/test_drift_rebalancer.py
@@ -1802,6 +1802,11 @@ class TestDriftRebalancer:
         # Get all the filled limit orders
         filled_orders = trades_df[(trades_df["status"] == "fill")]
 
+        # NOTE (LEGACY REGRESSION):
+        # This test file predates 2025 and is treated as high-authority.
+        # These exact quantities are sensitive to daily-bar timestamp alignment and
+        # limit-fill semantics. They were updated when Pandas daily backtesting was
+        # corrected to avoid lookahead/stale-bar fills.
         assert filled_orders.iloc[0]["type"] == "limit"
         assert filled_orders.iloc[0]["side"] == "buy"
         assert filled_orders.iloc[0]["symbol"] == "SPY"
@@ -1853,6 +1858,11 @@ class TestDriftRebalancer:
         # Get all the filled limit orders
         filled_orders = trades_df[(trades_df["status"] == "fill")]
 
+        # NOTE (LEGACY REGRESSION):
+        # This test file predates 2025 and is treated as high-authority.
+        # These exact quantities are sensitive to daily-bar timestamp alignment and
+        # limit-fill semantics. They were updated when Pandas daily backtesting was
+        # corrected to avoid lookahead/stale-bar fills.
         assert filled_orders.iloc[0]["type"] == "limit"
         assert filled_orders.iloc[0]["side"] == "buy"
         assert filled_orders.iloc[0]["symbol"] == "SPY"

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -131,6 +131,17 @@ class TestOrderBasics:
         buy_order.avg_fill_price = 50.0
         assert buy_order.get_fill_price() == 50.0
 
+    def test_smart_limit_order_type_in_str(self):
+        asset = Asset("SPY")
+        order = Order(
+            strategy="abc",
+            asset=asset,
+            quantity=10,
+            side="buy",
+            order_type=Order.OrderType.SMART_LIMIT,
+        )
+        assert Order.OrderType.SMART_LIMIT in str(order).lower()
+
     def test_filled(self):
         asset = Asset("SPY")
         order = Order(strategy='abc', asset=asset, side="buy", quantity=100)
@@ -325,4 +336,3 @@ class TestOrderAdvanced:
 
     def test_is_equivalent_status(self):
         assert Order.is_equivalent_status("pending_new", Order.OrderStatus.NEW)
-

--- a/tests/test_order_serialization.py
+++ b/tests/test_order_serialization.py
@@ -4,7 +4,8 @@ that can cause DynamoDB 400KB limit errors.
 """
 import unittest
 from decimal import Decimal
-from lumibot.entities import Order, Asset
+
+from lumibot.entities import Asset, Order, SmartLimitConfig, SmartLimitPreset, TradingSlippage
 
 
 class TestOrderSerialization(unittest.TestCase):
@@ -84,6 +85,35 @@ class TestOrderSerialization(unittest.TestCase):
         self.assertNotIn("X" * 100, json_str, "Large _bars data should not be in output")
         self.assertNotIn("Y" * 100, json_str, "Large _raw data should not be in output")
         self.assertNotIn("transaction", json_str, "Transactions should not be in output")
+
+    def test_smart_limit_config_roundtrip(self):
+        """SmartLimitConfig should serialize cleanly for DynamoDB payloads."""
+        config = SmartLimitConfig(
+            preset=SmartLimitPreset.FAST,
+            slippage=TradingSlippage(amount=0.1),
+            final_price_pct=1.0,
+        )
+        payload = config.to_dict()
+        rebuilt = SmartLimitConfig.from_dict(payload)
+        self.assertEqual(rebuilt.preset, SmartLimitPreset.FAST)
+        self.assertAlmostEqual(rebuilt.get_slippage_amount(), 0.1)
+
+    def test_order_serialization_includes_smart_limit(self):
+        """Order serialization should preserve smart_limit config fields."""
+        config = SmartLimitConfig(preset=SmartLimitPreset.NORMAL, slippage=0.05)
+        order = Order(
+            strategy="test_strategy",
+            asset=self.asset,
+            quantity=1,
+            side="buy",
+            order_type=Order.OrderType.SMART_LIMIT,
+            smart_limit=config,
+        )
+        payload = order.to_dict()
+        self.assertIn("smart_limit", payload)
+        self.assertEqual(payload["smart_limit"]["preset"], "normal")
+        minimal = order.to_minimal_dict()
+        self.assertEqual(minimal["smart_limit"]["preset"], "normal")
 
 
 if __name__ == '__main__':

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import os
 from time import sleep
+from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
@@ -8,8 +9,17 @@ import pytest
 
 from lumibot.brokers.tradier import Tradier
 from lumibot.data_sources.tradier_data import TradierData
-from lumibot.entities import Asset, Order, Position
+from lumibot.entities import Asset, Order, Position, SmartLimitConfig, SmartLimitPreset
 from lumibot.credentials import TRADIER_TEST_CONFIG
+from lumibot.strategies.strategy import Strategy
+
+
+class _StubStrategy(Strategy):
+    def initialize(self, parameters=None):
+        self.sleeptime = "1M"
+
+    def on_trading_iteration(self):
+        return
 
 
 def pytest_collection_modifyitems(config, items):
@@ -154,6 +164,64 @@ class TestTradierBroker:
         mock_pull_positions.return_value = Position(strategy=strategy, asset=option_asset, quantity=0)
         option_order.side = "buy"
         assert broker._lumi_side2tradier(option_order) == "buy_to_open"
+
+    def test_smart_limit_submits_as_limit(self, mocker):
+        broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True, connect_stream=False)
+        broker._set_initial_positions = mocker.MagicMock()
+        mocker.patch.object(Strategy, "update_broker_balances", return_value=None)
+        captured = {}
+
+        def _capture_submit(order):
+            captured["order_type"] = order.order_type
+            return order
+
+        broker.submit_order = mocker.MagicMock(side_effect=_capture_submit)
+
+        strategy = _StubStrategy(broker=broker, budget=100_000.0, analyze_backtest=False, parameters={})
+        strategy._first_iteration = False
+        strategy.get_quote = mocker.MagicMock(return_value=SimpleNamespace(bid=99.0, ask=101.0))
+
+        asset = Asset("SPY")
+        config = SmartLimitConfig(preset=SmartLimitPreset.NORMAL)
+        order = strategy.create_order(
+            asset,
+            1,
+            Order.OrderSide.BUY,
+            order_type=Order.OrderType.SMART_LIMIT,
+            smart_limit=config,
+        )
+        strategy.submit_order(order)
+
+        assert captured["order_type"] == Order.OrderType.LIMIT
+
+    def test_smart_limit_downgrades_to_market_without_quotes(self, mocker):
+        broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True, connect_stream=False)
+        broker._set_initial_positions = mocker.MagicMock()
+        mocker.patch.object(Strategy, "update_broker_balances", return_value=None)
+        captured = {}
+
+        def _capture_submit(order):
+            captured["order_type"] = order.order_type
+            return order
+
+        broker.submit_order = mocker.MagicMock(side_effect=_capture_submit)
+
+        strategy = _StubStrategy(broker=broker, budget=100_000.0, analyze_backtest=False, parameters={})
+        strategy._first_iteration = False
+        strategy.get_quote = mocker.MagicMock(return_value=SimpleNamespace(bid=None, ask=None))
+
+        asset = Asset("SPY")
+        config = SmartLimitConfig(preset=SmartLimitPreset.NORMAL)
+        order = strategy.create_order(
+            asset,
+            1,
+            Order.OrderSide.BUY,
+            order_type=Order.OrderType.SMART_LIMIT,
+            smart_limit=config,
+        )
+        strategy.submit_order(order)
+
+        assert captured["order_type"] == Order.OrderType.MARKET
 
     def test_pull_broker_all_orders(self, mocker):
         """

--- a/tests/test_tradingfee.py
+++ b/tests/test_tradingfee.py
@@ -1,7 +1,11 @@
-from lumibot.entities import TradingFee
+from lumibot.entities import TradingFee, TradingSlippage
 
 
 class TestTradingFee:
     def test_init(self):
         fee = TradingFee(flat_fee=5.2)
         assert fee.flat_fee == 5.2
+
+    def test_slippage_init(self):
+        slippage = TradingSlippage(amount=0.15)
+        assert slippage.amount == 0.15


### PR DESCRIPTION
### Summary

Adds SMART_LIMIT (Option Alpha-style SmartPricing / walk-limit concept) with typed config + slippage support, plus backtesting reliability/perf fixes.

### Highlights
- SMART_LIMIT order type: presets (FAST/NORMAL/PATIENT) + SmartLimitConfig + TradingSlippage.
- Backtesting fills: SMART_LIMIT fills at mid ± slippage when bid/ask are available (atomic net pricing for multileg), downgrades to market when quotes missing (single warning).
- Reliability: backtests stop cleanly when end-of-data is reached (no infinite loop at end of trading-days data).
- Artifacts: tearsheets now include LumiBot version, backtesting data source(s), and Backtest time.

### Validation
- Local pytest: targeted unit tests + full `tests/backtest/` ran green.
- Manual acceptance backtests ran from Strategy Library using ThetaData windows per handoff.

---

LEGACY_TEST_CHANGE_REASON:

A legacy test file (`tests/test_drift_rebalancer.py`, first committed pre-2025) changed expected filled quantities because daily-cadence backtesting was corrected to use proper exchange calendars and avoid stale/incorrect daily-bar alignment. That changes which daily bar is used for the rebalance fills and therefore changes the computed share counts. The updated expectations match the broker trade log deterministically when the test runs with the intended datasource (`BACKTESTING_DATA_SOURCE=none`); earlier repro attempts were confounded by a `.env` overriding the datasource.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SMART_LIMIT order type with presets (FAST, NORMAL, PATIENT), multi‑leg support, and per‑order TradingSlippage.

* **Improvements**
  * Backtests favor NBBO/quote‑first mark pricing (midpoint ± slippage), allow inside‑spread fills, downgrade to market when quotes are missing, add end‑of‑data safeguards, and various caching/performance optimizations.

* **Documentation**
  * Comprehensive SMART_LIMIT and slippage docs, examples, and TOC updates.

* **Tests**
  * Expanded coverage for SMART_LIMIT, slippage, quote fallbacks, multileg flows, and backtest end behavior.

* **Chores**
  * Package version bump.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->