### PR TITLE
Fix SPX index coverage gap crash during option cash settlement (4.4.19)

### DIFF
--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -1094,33 +1094,64 @@ class BacktestingBroker(Broker):
 
         # Get the price of the underlying asset.
         #
-        # ThetaData index options (e.g., SPX) can arrive without an explicit underlying_asset,
+        # ThetaData index options (e.g., SPXW) can arrive without an explicit underlying_asset,
         # and legacy code defaulted to creating a stock Asset(symbol=SPX). That yields no data
-        # and can trigger the ThetaData "tail placeholder" coverage guard. If that happens,
-        # retry using an index asset type.
+        # and can trigger ThetaData coverage guards. If that happens, retry using an index asset type.
+        #
+        # Also, some ThetaData environments can lag on *minute* index coverage while still having
+        # official daily close (EOD) data. Cash settlement only needs the underlying level at
+        # expiration, so if minute last-price fails due to coverage gaps, fall back to daily close.
+        underlying_price = None
+        last_price_error = None
         try:
             underlying_price = self.get_last_price(underlying_asset)
-        except ValueError as exc:
+        except Exception as exc:
+            last_price_error = exc
             message = str(exc)
             if (
                 "[THETA][COVERAGE][TAIL_PLACEHOLDER]" in message
                 and getattr(underlying_asset, "asset_type", None) != "index"
             ):
-                underlying_asset_index = Asset(symbol=underlying_asset.symbol, asset_type="index")
-                underlying_price = self.get_last_price(underlying_asset_index)
-            else:
-                raise
+                underlying_asset = Asset(symbol=underlying_asset.symbol, asset_type="index")
+                try:
+                    underlying_price = self.get_last_price(underlying_asset)
+                    last_price_error = None
+                except Exception as exc2:
+                    last_price_error = exc2
 
         # If the underlying was mis-typed (e.g., SPX created as stock), some data sources
         # return None instead of raising. Retry as an index before settling.
         if underlying_price is None and getattr(underlying_asset, "asset_type", None) != "index":
-            underlying_asset_index = Asset(symbol=underlying_asset.symbol, asset_type="index")
-            underlying_price = self.get_last_price(underlying_asset_index)
+            underlying_asset = Asset(symbol=underlying_asset.symbol, asset_type="index")
+            try:
+                underlying_price = self.get_last_price(underlying_asset)
+                last_price_error = None
+            except Exception as exc:
+                last_price_error = exc
+
+        if underlying_price is None and last_price_error is not None:
+            # Common production failure mode: ThetaData returns placeholder-only minute bars for an
+            # index while daily close remains available. Use day-close as the settlement proxy.
+            message = str(last_price_error)
+            if "[THETA][COVERAGE]" in message:
+                try:
+                    bars = strategy.get_historical_prices(underlying_asset, length=1, timestep="day")
+                    df = getattr(bars, "df", None)
+                    if df is not None and not df.empty and "close" in df.columns:
+                        underlying_price = float(df["close"].iloc[-1])
+                        logger.warning(
+                            "[CASH_SETTLE][FALLBACK] get_last_price(%s) failed (%s); settling using daily close=%s",
+                            underlying_asset,
+                            message.splitlines()[0],
+                            underlying_price,
+                        )
+                except Exception:
+                    pass
 
         if underlying_price is None:
-            raise ValueError(
-                f"Unable to price underlying {underlying_asset} for cash settlement of {position.asset}"
-            )
+            if last_price_error is not None:
+                raise last_price_error
+            raise ValueError(f"Unable to price underlying {underlying_asset} for cash settlement of {position.asset}")
 
         # Calculate profit/loss per contract
         if position.asset.right == "CALL":

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ sqlalchemy
 bcrypt
 pytest
 scipy>=1.14.0
-quantstats-lumi>=1.0.1
+quantstats-lumi>=1.1.0
 python-dotenv  # Secret Storage
 ccxt>=4.4.80
 termcolor>=2.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.18",
+    version="4.4.19",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/tests/test_thetadata_spx_index_options.py
+++ b/tests/test_thetadata_spx_index_options.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date
 from types import SimpleNamespace
 
+import pandas as pd
 import pytest
 
 from lumibot.backtesting.backtesting_broker import BacktestingBroker
@@ -150,3 +151,52 @@ def test_cash_settle_index_option_retries_when_stock_price_is_none(monkeypatch):
 
     broker.cash_settle_options_contract(position, strategy)
     assert get_last_price_calls == ["stock", "index"]
+
+
+def test_cash_settle_index_option_falls_back_to_daily_close_on_coverage_gap(monkeypatch):
+    """If minute last-price cannot be fetched due to an index coverage gap, settle via daily close."""
+
+    option = Asset(
+        symbol="SPXW",
+        asset_type="option",
+        expiration=date(2025, 12, 22),
+        strike=6000.0,
+        right="CALL",
+    )
+    option.underlying_asset = Asset(symbol="SPX", asset_type="index")
+    option.multiplier = getattr(option, "multiplier", 100) or 100
+
+    position = SimpleNamespace(asset=option, quantity=1)
+
+    broker = BacktestingBroker.__new__(BacktestingBroker)
+    broker.IS_BACKTESTING_BROKER = True
+    broker.CASH_SETTLED = "CASH_SETTLED"
+
+    get_last_price_calls: list[str] = []
+
+    def fake_get_last_price(asset):
+        get_last_price_calls.append(asset.asset_type)
+        raise ValueError(
+            "[THETA][COVERAGE][GAP] asset=SPX/USD (minute) coverage_end=2025-12-16 16:00:00-05:00 "
+            "target_end=2025-12-22 16:00:00-05:00 rows=26 placeholders=26 days_behind=6; refusing to proceed"
+        )
+
+    broker.get_last_price = fake_get_last_price
+    broker.stream = SimpleNamespace(dispatch=lambda *args, **kwargs: None)
+
+    get_historical_prices_calls: list[tuple[str, int, str]] = []
+
+    def fake_get_historical_prices(asset, length, timestep="", **kwargs):
+        get_historical_prices_calls.append((asset.asset_type, length, timestep))
+        return SimpleNamespace(df=pd.DataFrame({"close": [6100.0]}))
+
+    strategy = SimpleNamespace(
+        get_cash=lambda: 0,
+        _set_cash_position=lambda value: None,
+        create_order=lambda *args, **kwargs: SimpleNamespace(child_orders=[]),
+        get_historical_prices=fake_get_historical_prices,
+    )
+
+    broker.cash_settle_options_contract(position, strategy)
+    assert get_last_price_calls == ["index"]
+    assert get_historical_prices_calls == [("index", 1, "day")]


### PR DESCRIPTION
Fixes prod backtests crashing with [THETA][COVERAGE][GAP] for SPX/USD minute during option cash-settlement (e.g. BackdoorButterfly0DTE around 2025-12-22).

- BacktestingBroker.cash_settle_options_contract: if ThetaData get_last_price fails with coverage errors, fall back to daily close (EOD) via strategy.get_historical_prices(timestep=day) for settlement.
- Regression test added in tests/test_thetadata_spx_index_options.py.
- Bump version to 4.4.19.
- Align requirements.txt to quantstats-lumi>=1.1.0 (PyPI already has 1.1.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced options settlement pricing with improved fallback mechanisms to handle data availability gaps, enabling graceful recovery when real-time pricing fails.

* **Chores**
  * Version bumped to 4.4.19.
  * Updated quantstats-lumi dependency to >=1.1.0.

* **Tests**
  * Added test coverage for options settlement fallback behavior under data constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->