### PR TITLE
Backtesting reliability + perf fixes (4.4.20)

### DIFF
--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -674,8 +674,9 @@ class ThetaDataBacktestingPandas(PandasData):
         # Get the start datetime and timestep unit.
         #
         # PERFORMANCE: For point-in-time option quote/price checks (length≈1–5 bars) a 5-day buffer is
-        # overkill and causes the downloader to fetch multiple prior trading days unnecessarily. Keep
-        # the larger buffer for broader historical pulls, daily cadence, and non-option assets.
+        # overkill and can force the downloader to include prior trading days. For intraday option
+        # quotes/prices we only need the current trading day for mark/greeks calculations; broader
+        # history pulls can still request a larger `length` (or provide an explicit start_dt).
         effective_start_buffer = START_BUFFER
         try:
             _, ts_unit_preview = self.convert_timestep_str_to_timedelta(timestep)
@@ -688,7 +689,7 @@ class ThetaDataBacktestingPandas(PandasData):
             and length <= 5
             and ts_unit_preview in {"minute", "hour"}
         ):
-            effective_start_buffer = timedelta(days=1)
+            effective_start_buffer = timedelta(0)
 
         start_datetime, ts_unit = self.get_start_datetime_and_ts_unit(
             length, timestep, start_dt, start_buffer=effective_start_buffer
@@ -2329,7 +2330,6 @@ class ThetaDataBacktestingPandas(PandasData):
         return AssetsMapping(result)
 
     def get_last_price(self, asset, timestep="minute", quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:
-        sample_length = 5
         dt = self.get_datetime()
         # In day mode, use day data for price lookups instead of defaulting to minute.
         # This prevents unnecessary minute data downloads at end of day-mode backtests.
@@ -2350,6 +2350,14 @@ class ThetaDataBacktestingPandas(PandasData):
                 "[THETA][DEBUG][TIMESTEP_ALIGN] get_last_price aligned from minute to day for asset=%s",
                 asset,
             )
+
+        # PERFORMANCE: `get_last_price()` is "last trade" semantics, not a historical-series API.
+        # For daily option last-price checks, fetching a 5-day window can cause unnecessary placeholder
+        # churn (Theta 472 / empty) during contract selection. Use a minimal window and rely on the
+        # existing progressive lookback (30/252 days) only when the current day has no trades.
+        sample_length = 5
+        if timestep == "day" and getattr(asset, "asset_type", None) == Asset.AssetType.OPTION:
+            sample_length = 1
 
         # PERF: cache last trade results within the same backtest datetime.
         # Backtest internals and user strategies may ask for the same asset's last price multiple

--- a/lumibot/components/options_helper.py
+++ b/lumibot/components/options_helper.py
@@ -62,7 +62,28 @@ class OptionsHelper:
         self.last_call_sell_strike: Optional[float] = None
         self.last_put_sell_strike: Optional[float] = None
         self._liquidity_deprecation_warned = False
+
+        # PERF: Option-heavy strategies often call quote/greeks helpers multiple times per bar.
+        # In backtesting, quotes are immutable within a bar, so cache derived values keyed by the
+        # current strategy datetime to avoid repeated get_quote()/get_greeks() work.
+        self._per_bar_cache_dt: Optional[datetime] = None
+        self._per_bar_option_mark_cache: Dict[Asset, Tuple[Optional[float], Optional[float], Optional[float]]] = {}
+        self._per_bar_delta_cache: Dict[Tuple[Asset, Optional[float]], Optional[float]] = {}
+        self._per_bar_greeks_cache: Dict[Tuple[Asset, Optional[float], Optional[float]], Optional[Dict[str, Any]]] = {}
         self.strategy.log_message("OptionsHelper initialized.", color="blue")
+
+    def _reset_per_bar_caches_if_needed(self) -> None:
+        """Reset per-bar caches when the strategy datetime advances."""
+        try:
+            current_dt = self.strategy.get_datetime()
+        except Exception:
+            return
+
+        if self._per_bar_cache_dt != current_dt:
+            self._per_bar_cache_dt = current_dt
+            self._per_bar_option_mark_cache = {}
+            self._per_bar_delta_cache = {}
+            self._per_bar_greeks_cache = {}
 
     @staticmethod
     def _coerce_price(value: Any, field_name: str, flags: List[str], notes: List[str]) -> Optional[float]:
@@ -127,6 +148,12 @@ class OptionsHelper:
         option_asset: Asset,
     ) -> Tuple[Optional[float], Optional[float], Optional[float]]:
         """Return (mark_price, bid, ask) derived from quotes; never calls get_last_price()."""
+        self._reset_per_bar_caches_if_needed()
+
+        cached = self._per_bar_option_mark_cache.get(option_asset)
+        if cached is not None:
+            return cached
+
         try:
             quote = self.strategy.get_quote(option_asset)
         except Exception:
@@ -136,14 +163,22 @@ class OptionsHelper:
         ask = self._float_positive(getattr(quote, "ask", None))
 
         if bid is not None and ask is not None:
-            return (bid + ask) / 2.0, bid, ask
+            result = ((bid + ask) / 2.0, bid, ask)
+            self._per_bar_option_mark_cache[option_asset] = result
+            return result
         if bid is not None:
-            return bid, bid, None
+            result = (bid, bid, None)
+            self._per_bar_option_mark_cache[option_asset] = result
+            return result
         if ask is not None:
-            return ask, None, ask
+            result = (ask, None, ask)
+            self._per_bar_option_mark_cache[option_asset] = result
+            return result
 
         price = self._float_positive(getattr(quote, "price", None))
-        return price, bid, ask
+        result = (price, bid, ask)
+        self._per_bar_option_mark_cache[option_asset] = result
+        return result
 
     # ============================================================
     # Basic Utility Functions
@@ -431,7 +466,15 @@ class OptionsHelper:
                 continue
             delta = greeks.get("delta")
             strike_deltas[strike] = delta
-            self.strategy.log_message(f"Strike {strike}: delta = {delta}", color="blue")
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "[OptionsHelper] strike delta symbol=%s expiry=%s right=%s strike=%s delta=%s",
+                    getattr(underlying_asset, "symbol", None),
+                    expiry,
+                    right,
+                    strike,
+                    delta,
+                )
             if stop_greater_than is not None and delta is not None and delta >= stop_greater_than:
                 break
             if stop_less_than is not None and delta is not None and delta <= stop_less_than:
@@ -461,7 +504,8 @@ class OptionsHelper:
         Optional[float]
             The computed delta or None if unavailable.
         """
-        self.strategy.log_message(f"Getting delta for {underlying_asset.symbol} at strike {strike}, expiry {expiry}", color="blue")
+        self._reset_per_bar_caches_if_needed()
+
         option = Asset(
             underlying_asset.symbol,
             asset_type="option",
@@ -470,6 +514,16 @@ class OptionsHelper:
             right=right,
             underlying_asset=underlying_asset,
         )
+
+        cache_underlying: Optional[float]
+        try:
+            cache_underlying = float(underlying_price) if underlying_price is not None else None
+        except Exception:
+            cache_underlying = None
+
+        delta_cache_key = (option, cache_underlying)
+        if delta_cache_key in self._per_bar_delta_cache:
+            return self._per_bar_delta_cache[delta_cache_key]
 
         def _coerce_price(value: Any) -> Optional[float]:
             try:
@@ -488,23 +542,48 @@ class OptionsHelper:
                 option_price = None
 
         if option_price is None:
-            self.strategy.log_message(f"No price for option {option.symbol} at strike {strike}", color="yellow")
+            self._per_bar_delta_cache[delta_cache_key] = None
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "[OptionsHelper] delta unavailable (missing price) option=%s expiry=%s strike=%s right=%s",
+                    option.symbol,
+                    option.expiration,
+                    option.strike,
+                    option.right,
+                )
             return None
 
-        try:
-            greeks = self.strategy.get_greeks(option, underlying_price=underlying_price, asset_price=option_price)
-        except TypeError:
-            # Some unit tests (and custom strategy stubs) mock get_greeks without the asset_price kwarg.
-            greeks = self.strategy.get_greeks(option, underlying_price=underlying_price)
+        greeks_cache_key = (option, cache_underlying, option_price)
+        greeks = self._per_bar_greeks_cache.get(greeks_cache_key)
+        if greeks is None and greeks_cache_key not in self._per_bar_greeks_cache:
+            try:
+                greeks = self.strategy.get_greeks(option, underlying_price=underlying_price, asset_price=option_price)
+            except TypeError:
+                # Some unit tests (and custom strategy stubs) mock get_greeks without the asset_price kwarg.
+                greeks = self.strategy.get_greeks(option, underlying_price=underlying_price)
+            self._per_bar_greeks_cache[greeks_cache_key] = greeks
         # Handle None from get_greeks - can happen when option price or underlying price unavailable
         if greeks is None:
+            self._per_bar_delta_cache[delta_cache_key] = None
             self.strategy.log_message(
                 f"Could not calculate Greeks for {option.symbol} at strike {strike} (greeks returned None)",
-                color="yellow"
+                color="yellow",
             )
             return None
         delta = greeks.get("delta")
-        self.strategy.log_message(f"Delta for strike {strike} is {delta}", color="blue")
+        self._per_bar_delta_cache[delta_cache_key] = delta
+
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "[OptionsHelper] delta option=%s expiry=%s strike=%s right=%s underlying_price=%s option_price=%s delta=%s",
+                option.symbol,
+                option.expiration,
+                option.strike,
+                option.right,
+                underlying_price,
+                option_price,
+                delta,
+            )
         return delta
 
     def find_strike_for_delta(self, underlying_asset: Asset, underlying_price: float,
@@ -606,22 +685,76 @@ class OptionsHelper:
             color="blue",
         )
 
-        closest_strike: Optional[float] = None
-        closest_delta: Optional[float] = None
+        # Delta is monotonic in strike:
+        # - Calls: delta decreases as strike increases.
+        # - Puts: delta increases (toward 0) as strike increases.
+        is_call = option_type == "CALL"
 
-        for strike in candidate_strikes:
+        best_strike: Optional[float] = None
+        best_delta: Optional[float] = None
+
+        lo = 0
+        hi = len(candidate_strikes) - 1
+        max_iters = int(math.ceil(math.log2(len(candidate_strikes) + 1))) + 8
+        visited: set[int] = set()
+
+        for _ in range(max_iters):
+            if lo > hi:
+                break
+
+            mid = (lo + hi) // 2
+            if mid in visited:
+                break
+            visited.add(mid)
+
+            strike = candidate_strikes[mid]
             self.strategy.log_message(
-                f"🔎 Trying strike {strike:g} (range: {strike_min:.2f}-{strike_max:.2f})",
+                f"🔍 Trying strike {strike:g} (range: {strike_min:.2f}-{strike_max:.2f})",
                 color="blue",
             )
             mid_delta = self.get_delta_for_strike(underlying_asset, underlying_price, strike, expiry, right)
-            if mid_delta is None:
-                continue
 
-            self.strategy.log_message(
-                f"📈 Strike {strike:g} has delta {mid_delta:.4f} (target: {target_delta})",
-                color="blue",
-            )
+            if mid_delta is None:
+                # Try nearby strikes when the midpoint has no actionable prices.
+                resolved = False
+                for offset in range(1, 6):
+                    for idx in (mid - offset, mid + offset):
+                        if idx < lo or idx > hi or idx in visited:
+                            continue
+                        visited.add(idx)
+                        strike_candidate = candidate_strikes[idx]
+                        delta_candidate = self.get_delta_for_strike(
+                            underlying_asset, underlying_price, strike_candidate, expiry, right
+                        )
+                        if delta_candidate is None:
+                            continue
+                        strike = strike_candidate
+                        mid_delta = delta_candidate
+                        mid = idx
+                        resolved = True
+                        break
+                    if resolved:
+                        break
+
+                if mid_delta is None:
+                    break
+
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "[OptionsHelper] strike search step symbol=%s right=%s expiry=%s strike=%s delta=%s target=%s lo=%s hi=%s",
+                    getattr(underlying_asset, "symbol", None),
+                    option_type,
+                    expiry,
+                    strike,
+                    mid_delta,
+                    target_delta,
+                    lo,
+                    hi,
+                )
+
+            if best_delta is None or abs(mid_delta - target_delta) < abs(best_delta - target_delta):
+                best_delta = mid_delta
+                best_strike = float(strike)
 
             if abs(mid_delta - target_delta) < 0.001:
                 self.strategy.log_message(
@@ -630,26 +763,35 @@ class OptionsHelper:
                 )
                 return float(strike)
 
-            if closest_delta is None or abs(mid_delta - target_delta) < abs(closest_delta - target_delta):
-                closest_delta = mid_delta
-                closest_strike = float(strike)
+            if is_call:
+                # Call delta decreases with strike.
+                if mid_delta > target_delta:
+                    lo = mid + 1
+                else:
+                    hi = mid - 1
+            else:
+                # Put delta increases with strike.
+                if mid_delta < target_delta:
+                    lo = mid + 1
+                else:
+                    hi = mid - 1
 
-        if closest_strike is None:
+        if best_strike is None:
             self.strategy.log_message(f"❌ No valid strike found for target delta {target_delta}", color="red")
             return None
 
         self.strategy.log_message(
-            f"✅ RESULT: Closest strike {closest_strike:g} with delta {closest_delta:.4f} (target was {target_delta})",
+            f"✅ RESULT: Closest strike {best_strike:g} with delta {best_delta:.4f} (target was {target_delta})",
             color="green",
         )
-        if underlying_price > 50 and closest_strike < 10:
+        if underlying_price > 50 and best_strike < 10:
             self.strategy.log_message(
-                f"⚠️  WARNING: Strike {closest_strike:g} seems too low for underlying price ${underlying_price}. "
+                f"⚠️  WARNING: Strike {best_strike:g} seems too low for underlying price ${underlying_price}. "
                 f"This might indicate a data issue.",
                 color="red",
             )
 
-        return closest_strike
+        return best_strike
 
     def calculate_multileg_limit_price(self, orders: List[Order], limit_type: str) -> Optional[float]:
         """

--- a/lumibot/tools/helpers.py
+++ b/lumibot/tools/helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import os
 import re
 import sys
+import time
 from decimal import Decimal, ROUND_HALF_EVEN
 
 import pytz
@@ -20,6 +21,11 @@ from ..constants import LUMIBOT_DEFAULT_PYTZ, LUMIBOT_DEFAULT_TIMEZONE
 # Trading calendar cache: saves ~0.8s on repeated calendar.schedule() calls
 # Key: (market, start_date_str, end_date_str, tz_str)
 _TRADING_CALENDAR_CACHE = {}
+
+# Progress bar throttling: when BACKTESTING_QUIET_LOGS=false we print progress as newline-separated
+# lines. For fast simulations this can spam thousands of lines in a single second and drown out
+# strategy logs. Throttle to at most ~1 line/second per (output, prefix) when not in quiet mode.
+_PROGRESS_LAST_PRINT: dict[tuple[int, str], tuple[float, str]] = {}
 
 
 def get_chunks(l, chunk_size):
@@ -368,6 +374,23 @@ def print_progress_bar(
     percent_str = ("  {:.%df}" % decimals).format(percent)
     percent_str = percent_str[-decimals - 4 :]
 
+    # Check if quiet logs mode is enabled.
+    # When quiet_logs=true: no newline, progress bar overwrites itself in place
+    # When quiet_logs=false: add newline so log messages appear on their own lines
+    quiet_logs = os.environ.get("BACKTESTING_QUIET_LOGS", "true").lower() == "true"
+
+    if not quiet_logs:
+        key = (id(file), str(prefix))
+        now_mono = time.monotonic()
+        last = _PROGRESS_LAST_PRINT.get(key)
+        if last is not None:
+            last_time, _ = last
+            # In newline-progress mode, cap output to ~1 line/sec regardless of how fast the
+            # simulation advances. Always allow the final 100% line through.
+            if (now_mono - last_time) < 1.0 and percent < 100:
+                return
+        _PROGRESS_LAST_PRINT[key] = (now_mono, percent_str)
+
     now = dt.datetime.now()
     elapsed = now - backtesting_started
 
@@ -408,10 +431,6 @@ def print_progress_bar(
     # Clear rest of line with ANSI escape code
     line += "\033[K"
 
-    # Check if quiet logs mode is enabled
-    # When quiet_logs=true: no newline, progress bar overwrites itself in place
-    # When quiet_logs=false: add newline so log messages appear on their own lines
-    quiet_logs = os.environ.get("BACKTESTING_QUIET_LOGS", "true").lower() == "true"
     if not quiet_logs:
         line += "\n"
 
@@ -582,5 +601,3 @@ def get_timezone_from_datetime(dtm: dt.datetime) -> pytz.timezone:
         return pytz.timezone(timezone_name)
     except (AttributeError, pytz.exceptions.UnknownTimeZoneError):
         return LUMIBOT_DEFAULT_PYTZ
-
-

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -299,7 +299,7 @@ OPTION_LIST_ENDPOINTS = {
 
 # Bump this to invalidate old chain cache files when the chain schema/normalization changes.
 # v3 (2025-12-21): SPX index options need SPXW expirations for 0DTE strategies.
-THETADATA_CHAIN_CACHE_VERSION = 3
+THETADATA_CHAIN_CACHE_VERSION = 4
 
 DEFAULT_SESSION_HOURS = {
     True: ("04:00:00", "20:00:00"),   # include extended hours
@@ -4863,7 +4863,7 @@ def build_historical_chain(
                     for option_type in ["CALL", "PUT"]:
                         for expiry_date, strikes in chains[option_type].items():
                             normalized = {
-                                round(_select_normalized_strike(float(strike)), 2)
+                                round(_select_normalized_strike(float(strike)), 5)
                                 for strike in strikes
                                 if strike is not None
                             }

--- a/lumibot/tools/thetadata_queue_client.py
+++ b/lumibot/tools/thetadata_queue_client.py
@@ -34,8 +34,14 @@ logger = logging.getLogger(__name__)
 
 # Configuration from environment
 # Queue mode is ALWAYS enabled - it's the only way to connect to ThetaData
-QUEUE_POLL_INTERVAL = float(os.environ.get("THETADATA_QUEUE_POLL_INTERVAL", "0.01"))  # 10ms default - fast polling
-QUEUE_TIMEOUT = float(os.environ.get("THETADATA_QUEUE_TIMEOUT", "0"))  # 0 = wait forever (never fail)
+# NOTE: Extremely fast polling can overwhelm the downloader (and CloudWatch) when many requests
+# are in flight. A 200ms default keeps progress responsive without creating a status-poll storm.
+QUEUE_POLL_INTERVAL = float(os.environ.get("THETADATA_QUEUE_POLL_INTERVAL", "0.2"))
+
+# NOTE: Never timing out can cause production backtests to appear "stuck forever" when a single
+# downloader request is lost or wedged. Default to a bounded wait; callers can override per-call
+# or via env var if they truly want infinite waits.
+QUEUE_TIMEOUT = float(os.environ.get("THETADATA_QUEUE_TIMEOUT", "600"))
 MAX_CONCURRENT_REQUESTS = int(os.environ.get("THETADATA_MAX_CONCURRENT", "8"))  # Max requests in flight
 QUEUE_SUBMIT_HTTP_TIMEOUT = float(os.environ.get("THETADATA_QUEUE_SUBMIT_HTTP_TIMEOUT", "120"))
 QUEUE_STATUS_HTTP_TIMEOUT = float(os.environ.get("THETADATA_QUEUE_STATUS_HTTP_TIMEOUT", "10"))
@@ -552,13 +558,37 @@ class QueueClient:
         start_time = time.time()
         last_log_time = 0
         last_position = None
+        last_status = None
 
         while True:
             elapsed = time.time() - start_time
 
             # Check timeout (0 = wait forever)
             if timeout > 0 and elapsed > timeout:
-                raise TimeoutError(f"Timed out waiting for {request_id} after {elapsed:.1f}s")
+                info = self._refresh_status(request_id)
+                if info:
+                    last_status = info.status
+                    last_position = info.queue_position
+                    last_error = info.error
+                    last_attempts = info.attempts
+                    last_estimated_wait = info.estimated_wait
+                else:
+                    last_error = None
+                    last_attempts = None
+                    last_estimated_wait = None
+
+                raise TimeoutError(
+                    "Timed out waiting for %s after %.1fs (status=%s position=%s attempts=%s est_wait=%s error=%s)"
+                    % (
+                        request_id,
+                        elapsed,
+                        last_status,
+                        last_position,
+                        last_attempts,
+                        last_estimated_wait,
+                        last_error,
+                    )
+                )
 
             # Refresh status
             info = self._refresh_status(request_id)
@@ -566,6 +596,7 @@ class QueueClient:
             if info:
                 status = info.status
                 position = info.queue_position
+                last_status = status
 
                 # Log position changes or periodic updates
                 if position != last_position or time.time() - last_log_time > 10:

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.19",
+    version="4.4.20",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/tests/test_thetadata_queue_client.py
+++ b/tests/test_thetadata_queue_client.py
@@ -24,6 +24,7 @@ os.environ["DATADOWNLOADER_API_KEY"] = "test-api-key"
 
 from lumibot.tools.thetadata_queue_client import (
     QUEUE_POLL_INTERVAL,
+    QUEUE_TIMEOUT,
     QueueClient,
     QueuedRequestInfo,
     get_queue_client,
@@ -45,7 +46,7 @@ class TestQueueClientInit:
         assert client.api_key == "test-key"
         assert client.api_key_header == "X-Downloader-Key"
         assert client.poll_interval == QUEUE_POLL_INTERVAL
-        assert client.timeout == 0  # 0 = wait forever
+        assert client.timeout == QUEUE_TIMEOUT
 
     def test_init_with_custom_values(self):
         """Test client initializes with custom values."""


### PR DESCRIPTION
Changes:\n- ThetaData queue client: default 10m timeout + 200ms polling, richer timeout errors\n- OptionsHelper: per-bar caches + true binary-search delta strike selection (reduces per-strike work/log spam)\n- ThetaData: reduce daily option last-price window + higher-precision chain strike normalization (cuts 472 placeholder churn)\n- Backtesting: throttle progress output when BACKTESTING_QUIET_LOGS=false\n- Bump version to 4.4.20\n\nValidation (local):\n- pytest: tests/test_thetadata_queue_client.py, tests/test_options_helper.py, tests/test_thetadata_get_last_price_trade_only.py, tests/test_portfolio_valuation_fallbacks.py, tests/test_tearsheet.py, tests/test_thetadata_option_mtm_prefers_quote_mark.py, tests/test_data_repair_times_and_fill_daily_quotes.py\n- Acceptance backtests (ThetaData): Backdoor Butterfly 0DTE (2025), MELI (2013-2025), TQQQ SMA200 (2013-2025), Leaps Alpha Picks (2025-10-01→2025-10-15), AAPL Deep Dip Calls (2020-2025)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progress output throttling for quieter backtesting feedback.
  * Enhanced queue client configuration with tunable timeout and backoff parameters.

* **Bug Fixes**
  * Optimized option data fetching and pricing calculations.
  * Improved per-bar caching for option quotes and greeks.

* **Chores**
  * Version bump to 4.4.20.
  * Option chain cache invalidation for precision updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->