### PR TITLE
v4.4.22: SmartLimit live + backtest parity work

### DIFF
--- a/docs/ACCEPTANCE_BACKTESTS.md
+++ b/docs/ACCEPTANCE_BACKTESTS.md
@@ -118,6 +118,7 @@ We keep two canonical windows:
 | `BackdoorButterfly0DTE_2025-12-25_18-29_KAD4Qk` | (unknown) | 2025-01-01 → 2025-11-30 | (n/a) | -26% | -28.55% | -32.51% | (unknown) | (unknown) |
 | `BackdoorButterfly0DTE_2025-12-31_15-43_TWzKau` | 4.4.20 | 2025-01-01 → 2025-11-30 | 79.8 | -22% | -24.00% | -30.13% | prod-like | macOS=26.1; CPU=Apple M3 Max; RAM=48GB; Python=3.11.8 |
 | `BackdoorButterfly0DTE_2026-01-02_10-29_HPNuUM` | 4.4.21 | 2025-01-01 → 2025-11-30 | 267.8 | -19% | -20.79% | -25.94% | prod-like | macOS=26.1; CPU=Apple M3 Max; RAM=48GB; Python=3.11.8 |
+| `BackdoorButterfly0DTE_2026-01-02_18-52_XdYcWQ` | 4.4.21 | 2025-01-01 → 2025-11-29 | 121.6 | -21% | -23.12% | -26.42% | prod-like | macOS=26.1; CPU=Apple M3 Max; RAM=48GB; Python=3.11.8 |
 
 ### 5) MELI Deep Drawdown Calls
 
@@ -133,6 +134,7 @@ This strategy is **under investigation** for baseline mismatch (do not rebaselin
 |---|---:|---|---:|---:|---:|---:|---|---|
 | `MeliDeepDrawdownCalls_2025-12-25_20-38_33bGtY` | (unknown) | 2013-01-01 → 2025-12-17 | (n/a) | 131% | 7.26% | -97.78% | expected (historical anchor) | (unknown) |
 | `MeliDeepDrawdownCalls_2026-01-02_10-09_7yisFp` | 4.4.21 | 2013-01-01 → 2025-12-17 | 856.3 | -91% | -18.22% | -99.73% | under investigation | macOS=26.1; CPU=Apple M3 Max; RAM=48GB; Python=3.11.8 |
+| `MeliDeepDrawdownCalls_2026-01-02_19-24_kZELl5` | 4.4.21 | 2013-01-01 → 2025-12-17 | 350.4 | 14% | 1.08% | -98.26% | under investigation (daily snapshot NBBO override) | macOS=26.1; CPU=Apple M3 Max; RAM=48GB; Python=3.11.8 |
 
 See: `docs/investigations/ACCURACY_AUDIT_2026-01-02.md` for the divergence notes and first-diff audit plan.
 
@@ -148,6 +150,7 @@ See: `docs/investigations/ACCURACY_AUDIT_2026-01-02.md` for the divergence notes
 | run_id | lumibot | window | wall_time_s | total_return | cagr | max_dd | flags | machine |
 |---|---:|---|---:|---:|---:|---:|---|---|
 | `BackdoorButterfly0DTESmartLimit_2026-01-02_10-34_UTFoHq` | 4.4.21 | 2025-01-01 → 2025-11-30 | 283.0 | -3% | -2.96% | -13.58% | prod-like | macOS=26.1; CPU=Apple M3 Max; RAM=48GB; Python=3.11.8 |
+| `BackdoorButterfly0DTESmartLimit_2026-01-02_19-49_QXkWuB` | 4.4.21 | 2025-01-01 → 2025-11-29 | 107.1 | -6% | -6.2% | -13.39% | prod-like | macOS=26.1; CPU=Apple M3 Max; RAM=48GB; Python=3.11.8 |
 
 ### 7) SPX Short Straddle Intraday (production stall repro)
 
@@ -164,6 +167,7 @@ We keep two canonical windows:
 |---|---:|---|---:|---:|---:|---:|---|---|
 | `SPXShortStraddle_2025-12-31_17-16_Ff79Hy` | 4.4.20 | 2025-01-01 → 2025-11-30 | 104.8 | -17% | -18.99% | -28.34% | speed baseline (historical) | macOS=26.1; CPU=Apple M3 Max; RAM=48GB; Python=3.11.8 |
 | `SPXShortStraddle_2026-01-02_10-39_XtAwjW` | 4.4.21 | 2025-01-06 → 2025-12-25 | 516.8 | -17% | -17.81% | -33.51% | stall repro window | macOS=26.1; CPU=Apple M3 Max; RAM=48GB; Python=3.11.8 |
+| `SPXShortStraddle_2026-01-02_18-51_1JvQro` | 4.4.21 | 2025-01-06 → 2025-12-24 | 63.8 | -17% | -17.5% | -33.51% | stall repro window (perf fix) | macOS=26.1; CPU=Apple M3 Max; RAM=48GB; Python=3.11.8 |
 
 ## Optional: Profiling artifact (opt-in)
 

--- a/docs/ACCEPTANCE_SMOKES.md
+++ b/docs/ACCEPTANCE_SMOKES.md
@@ -1,0 +1,41 @@
+# Acceptance Smoke Tests (ThetaData)
+
+This repo contains a small set of **short-window, end-to-end ThetaData backtests** that serve as a
+release smoke gate.
+
+These are intentionally **not** the full Strategy Library acceptance suite (those are manual and
+long-window). The smokes exist to catch obvious regressions in:
+- ThetaData downloader connectivity + queue behavior
+- Index options + minute quotes
+- Daily cadence data plumbing
+- Strategy runner/backtest engine stability
+
+## What runs
+
+- `tests/backtest/test_theta_strategies_integration.py` (marked `acceptance_smoke`)
+
+These tests are written to **skip** cleanly when required secrets are not present.
+
+## How to run locally
+
+```bash
+cd "/Users/robertgrzesik/Documents/Development/lumivest_bot_server/strategies/lumibot"
+
+/Users/robertgrzesik/bin/safe-timeout 1800s env \\
+  BACKTESTING_DATA_SOURCE=ThetaData \\
+  DATADOWNLOADER_BASE_URL="http://data-downloader.lumiwealth.com:8080" \\
+  DATADOWNLOADER_API_KEY="***" \\
+  python3 -m pytest -q -m acceptance_smoke tests/backtest/test_theta_strategies_integration.py
+```
+
+## CI (trusted only)
+
+To run these in GitHub Actions you must provide:
+- `DATADOWNLOADER_API_KEY` (secret)
+- `DATADOWNLOADER_BASE_URL` (env, usually `http://data-downloader.lumiwealth.com:8080`)
+
+Recommended pattern:
+- run on `workflow_dispatch` (manual “release gate”)
+- optionally add a scheduled nightly run
+
+Keep the smoke windows short (days/weeks), and avoid full-year runs in PR CI.

--- a/docs/investigations/ACCURACY_AUDIT_2026-01-02.md
+++ b/docs/investigations/ACCURACY_AUDIT_2026-01-02.md
@@ -52,12 +52,23 @@ Yahoo (parity check):
 - Fill sanity:
   - Option marks/quotes appear bid/ask-driven; no mid-price “cheating” observed for market fills.
 
+Perf regression follow-up:
+- Run id: `BackdoorButterfly0DTE_2026-01-02_18-52_XdYcWQ`
+- Strategy CAGR ≈ `-23.12%` (same “regular fill punishment” story).
+- Runtime: ~2m (regression fixed; prior 4.4.21 run was ~4m+ on the same window).
+
 ## Backdoor Butterfly 0DTE (SmartLimit)
 
 - Run id: `BackdoorButterfly0DTESmartLimit_2026-01-02_10-34_UTFoHq`
 - Strategy CAGR ≈ `-2.96%` (SmartLimit improves results vs regular fills, as expected).
 - Fill sanity:
   - SmartLimit behavior appears to use quote-derived mid + slippage (net multi-leg), not bid/ask worst-case.
+
+Perf regression follow-up:
+- Run id: `BackdoorButterfly0DTESmartLimit_2026-01-02_19-49_QXkWuB`
+- Strategy CAGR ≈ `-6.2%` (still materially better than regular fills; exact value can vary run-to-run).
+- Runtime: ~1m50 (regression fixed vs the earlier ~4m+ SmartLimit run).
+- Notable: late-window SPX minute bars around the Thanksgiving/half-day period can be missing; the strategy logs “no SPX data available” for signal computation, but completes and produces artifacts.
 
 ## MELI Deep Drawdown Calls
 
@@ -72,7 +83,14 @@ Yahoo (parity check):
   - Prior “known-good” artifact `MeliDeepDrawdownCalls_2025-12-25_20-38_33bGtY_tearsheet.csv` reports Strategy CAGR ≈ `+7.26%`.
   - This run reports Strategy CAGR ≈ `-18.22%`.
   - Trade list diverges materially starting in 2021 (expiration selection differs for some entries).
-  - Hypothesis: expiration validation now prefers actionable intraday NBBO snapshots, changing which expirations are considered tradeable at historical dates. This should improve realism, but it changes results and should be explicitly re-baselined if accepted.
+- Hypothesis: expiration validation now prefers actionable intraday NBBO snapshots, changing which expirations are considered tradeable at historical dates. This should improve realism, but it changes results and should be explicitly re-baselined if accepted.
+
+Daily-cadence pricing realism follow-up:
+- Run id: `MeliDeepDrawdownCalls_2026-01-02_19-24_kZELl5`
+- Strategy CAGR ≈ `+1.08%` (improved vs the “bad” run; still below the historical anchor).
+- Runtime: ~6m
+- Key finding: the historical anchor enters a ~3-month call (e.g., `2021-06-18`) even though the strategy targets ~270-day expirations; the newer behavior selects longer-dated expirations (e.g., `2022-01-21`), which is more consistent with the strategy’s intent.
+- This is treated as **under investigation** until we decide whether to rebaseline MELI metrics.
 
 ## SPX Short Straddle Intraday
 
@@ -81,3 +99,7 @@ Yahoo (parity check):
 - Stall sanity:
   - No “silent” wedges observed locally.
   - Queue client emits submit/result logs continuously; in production, the same codepath emits heartbeat logs during longer waits (to avoid silent stalls).
+
+Perf regression follow-up:
+- Run id: `SPXShortStraddle_2026-01-02_18-51_1JvQro`
+- Runtime: ~1m04 on the stall repro window (speed parity restored locally).

--- a/docs/investigations/PROD_SPEED_PARITY_YAPPI_2026-01-03.md
+++ b/docs/investigations/PROD_SPEED_PARITY_YAPPI_2026-01-03.md
@@ -1,0 +1,63 @@
+# Production Speed Parity — YAPPI Findings (2026-01-03)
+
+Goal: explain the **production vs local speed gap** with profiler evidence (not guesses).
+
+This doc records one profiled production run and a comparable profiled local run.
+
+## Production run (profile enabled)
+
+- Bot Manager `bot_id`: `codexspx3280b3dee4b7410fba`
+- Strategy code: `Demos/SPX Short Straddle Intraday (Copy).py` (used as portable `main.py` in Bot Manager; local `sys.path` preamble removed)
+- Window: `2025-01-06 → 2025-12-24`
+- Flags (prod-like + profiling):
+  - `BACKTESTING_DATA_SOURCE=thetadata`
+  - `DATADOWNLOADER_BASE_URL=http://data-downloader.lumiwealth.com:8080`
+  - `SHOW_PLOT=True`, `SHOW_INDICATORS=True`, `SHOW_TEARSHEET=True`
+  - `BACKTESTING_QUIET_LOGS=false`, `BACKTESTING_SHOW_PROGRESS_BAR=true`
+  - `BACKTESTING_PROFILE=yappi`
+- Observed runtime (Bot Manager status `elapsed`): **~32 minutes**
+- Artifacts (Bot Manager status): `profile_yappi_csv=true` (confirmed downloadable)
+
+Downloaded artifacts (local paths; not committed):
+- `Strategy Library/logs/prod_profiles/codexspx3280b3dee4b7410fba_profile_yappi_raw.csv`
+- `Strategy Library/logs/prod_profiles/codexspx3280b3dee4b7410fba_stats_csv`
+- `Strategy Library/logs/prod_profiles/codexspx3280b3dee4b7410fba_trades_csv`
+
+### Top YAPPI hotspots (production)
+
+From `codexspx3280b3dee4b7410fba_profile_yappi_raw.csv`:
+- `/usr/local/lib/python3.12/threading.py Condition.wait` (`ttot_s ≈ 6003`)
+- `/usr/local/lib/python3.12/threading.py Event.wait` (`ttot_s ≈ 4005`)
+- `/usr/local/lib/python3.12/queue.py Queue.get` (`ttot_s ≈ 1999`)
+- `lumibot.tools.thetadata_queue_client.QueueClient.execute_request / wait_for_result` (`ttot_s ≈ 1048 / 1029`)
+- `lumibot.tools.thetadata_helper.get_request / get_historical_data` (`ttot_s ≈ 1050 / 1289`)
+- `lumibot.backtesting.thetadata_backtesting_pandas.ThetaDataBacktestingPandas.get_quote` (`ttot_s ≈ 1289`)
+
+Interpretation:
+- The run is **dominated by waiting** (threading/queue waits + downloader queue polling), not CPU compute.
+- This is consistent with “too many downloader requests” (high `ncall` counts for quote/historical fetch paths).
+- It is **not** consistent with a single “silent hang” socket wedge (requests return; the backtest progresses).
+
+## Local run (profile enabled)
+
+- Run id: `SPXShortStraddle_2026-01-02_20-36_dst4Kh`
+- Window: `2025-01-06 → 2025-12-24`
+- Flags: same as production (prod-like + `BACKTESTING_PROFILE=yappi`)
+- Observed runtime (local log): **~2m18s**
+- Profile artifact: `Strategy Library/logs/SPXShortStraddle_2026-01-02_20-36_dst4Kh_profile_yappi.csv`
+
+Key difference observed in logs:
+- Local run uses the **index fast-path** (“closest strike without quote probe”), which reduces quote-validation probing and cuts request volume.
+
+## Action items (next)
+
+1. **Deploy v4.4.22** (includes the index fast-path perf fix) to production.
+2. Re-run the same profiled production backtest and compare:
+   - wall time
+   - `ncall` for `thetadata_queue_client.queue_request`, `thetadata_backtesting_pandas.get_quote`
+   - share of time in `threading/queue` waits vs non-waiting work
+3. If production is still materially slower after request-count reduction:
+   - investigate downloader throughput / queue contention
+   - investigate ECS CPU/memory sizing
+   - consider additional caching/negative-caching tweaks (only with accuracy preserved)
+

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -654,8 +654,10 @@ class Alpaca(Broker):
         - The sign of the limit price (positive/negative) is not used by Alpaca to distinguish credit/debit.
         - Alpaca requires that the leg ratio quantities are relatively prime (GCD == 1).
         """
+        requested_multileg_type = order_type if order_type in ("credit", "debit", "even") else None
+
         # Convert Tradier-specific order types to Alpaca-supported types
-        if order_type in ("credit", "debit", "even"):
+        if requested_multileg_type is not None:
             order_type = "limit"
         # All legs must have the same underlying symbol
         symbol = orders[0].asset.symbol
@@ -671,30 +673,33 @@ class Alpaca(Broker):
                 option_symbol = f"{order.asset.symbol}{date}{order.asset.right[0]}{strike_formatted}"
             else:
                 option_symbol = order.asset.symbol
-            # Determine position_intent (buy_to_open, sell_to_open, etc.)
+            # Determine leg side + position intent for Alpaca's mleg payload.
+            # - leg.side must be "buy" or "sell"
+            # - leg.position_intent must be one of: buy_to_open, buy_to_close, sell_to_open, sell_to_close
             position_intent = getattr(order, "position_intent", None)
-            if not position_intent:
-                # Check if we have an open position in this option
-                pos = self.get_tracked_position(order.strategy, order.asset)
-                if pos is not None and pos.quantity != 0:
-                    # Closing position
-                    if order.side == "buy":
-                        position_intent = "buy_to_close"
-                    elif order.side == "sell":
-                        position_intent = "sell_to_close"
-                else:
-                    # Opening position
-                    if order.side == "buy":
-                        position_intent = "buy_to_open"
-                    elif order.side == "sell":
-                        position_intent = "sell_to_open"
+            raw_side = order.side
+            if raw_side in ("buy_to_open", "buy_to_close"):
+                leg_side = "buy"
+                position_intent = position_intent or raw_side
+            elif raw_side in ("sell_to_open", "sell_to_close"):
+                leg_side = "sell"
+                position_intent = position_intent or raw_side
+            else:
+                leg_side = "buy" if order.is_buy_order() else "sell"
+                if not position_intent:
+                    # Fall back to position-based intent inference when the side doesn't encode open/close.
+                    pos = self.get_tracked_position(order.strategy, order.asset)
+                    if pos is not None and pos.quantity != 0:
+                        position_intent = "buy_to_close" if leg_side == "buy" else "sell_to_close"
+                    else:
+                        position_intent = "buy_to_open" if leg_side == "buy" else "sell_to_open"
             # Collect leg quantities for GCD check
             leg_qty = int(abs(order.quantity))
             leg_quantities.append(leg_qty)
             legs.append({
                 "symbol": option_symbol,
                 "ratio_qty": str(order.quantity),
-                "side": order.side,
+                "side": leg_side,
                 "position_intent": position_intent
             })
         # Ensure leg ratio quantities are relatively prime (GCD == 1)
@@ -712,12 +717,19 @@ class Alpaca(Broker):
         # For multi-leg orders, we need to set the primary asset info from the first leg
         first_order = orders[0]
         
-        # Map extended side values to simple buy/sell for Alpaca API
-        side = first_order.side
-        if side in ("buy_to_open", "buy_to_close"):
+        # Determine top-level side for Alpaca.
+        # Alpaca mleg orders require a primary side; for debit/credit packages, this should
+        # reflect the net debit/credit rather than the first leg ordering.
+        if requested_multileg_type == "debit":
             side = "buy"
-        elif side in ("sell_to_open", "sell_to_close"):
+        elif requested_multileg_type == "credit":
             side = "sell"
+        else:
+            side = first_order.side
+            if side in ("buy_to_open", "buy_to_close"):
+                side = "buy"
+            elif side in ("sell_to_open", "sell_to_close"):
+                side = "sell"
         
         # multileg is not a valid order_class for Alpaca. It is mleg now, and cannot be combined with a symbol.
 
@@ -1038,10 +1050,24 @@ class Alpaca(Broker):
 
             # Try to replace the order on Alpaca, handle APIError for accepted status
             try:
-                self.api.replace_order_by_id(
+                replaced = self.api.replace_order_by_id(
                     order_id=order.identifier,
                     order_data=replace_req,
                 )
+                # Alpaca can return a *new* order id when replacing. Keep LumiBot's order object
+                # aligned so SMART_LIMIT can continue repricing/canceling reliably.
+                new_id = getattr(replaced, "id", None)
+                if new_id:
+                    order.identifier = new_id
+                    try:
+                        for child in getattr(order, "child_orders", []) or []:
+                            child.parent_identifier = new_id
+                    except Exception:
+                        pass
+                    try:
+                        order.update_raw(replaced)
+                    except Exception:
+                        pass
             except Exception as e:
                 # If error is "cannot replace order in accepted status", just log and skip
                 if hasattr(e, "args") and e.args and "cannot replace order in accepted status" in str(e.args[0]):

--- a/lumibot/components/options_helper.py
+++ b/lumibot/components/options_helper.py
@@ -362,6 +362,40 @@ class OptionsHelper:
                 )
                 continue
 
+            # PERF (intraday index strategies):
+            # For liquid index underlyings, the nearest strike is almost always tradeable. Doing
+            # snapshot-only quote probes for every candidate strike adds per-day remote requests
+            # (dominating runtime in long-window backtests). Keep the strict quote validation for
+            # non-index underlyings and for far-OTM index selections where liquidity is less certain.
+            if (
+                is_theta_backtest
+                and not is_daily_cadence
+                and self._is_index_like_underlying(underlying_asset, getattr(underlying_asset, "symbol", None))
+            ):
+                try:
+                    underlying_price = None
+                    price_value = self.strategy.get_last_price(underlying_asset)
+                    if price_value is not None:
+                        underlying_price = float(price_value)
+                    if underlying_price and math.isfinite(underlying_price) and underlying_price > 0:
+                        distance = abs(float(rounded_underlying_price) - underlying_price) / underlying_price
+                        if distance <= 0.05:
+                            closest_strike = strikes_sorted[0]
+                            self.strategy.log_message(
+                                f"Target strike {rounded_underlying_price} -> Using closest strike without quote probe (index fast-path): {closest_strike}",
+                                color="green",
+                            )
+                            return Asset(
+                                underlying_asset.symbol,
+                                asset_type="option",
+                                expiration=exp_date,
+                                strike=closest_strike,
+                                right=put_or_call,
+                                underlying_asset=underlying_asset,
+                            )
+                except Exception:
+                    pass
+
             if is_theta_backtest:
                 # ThetaData backtests: validate the option has *some* price signal at the current
                 # strategy datetime so strategies don't get stuck selecting contracts with no history
@@ -1284,6 +1318,45 @@ class OptionsHelper:
 
         return _ChainHintContext(data_source, min_expiration_date)
 
+    @staticmethod
+    def _is_index_like_underlying(underlying_asset: Optional[Asset], symbol: Optional[str]) -> bool:
+        """Return True when the underlying behaves like an index for option-liquidity heuristics.
+
+        Some strategies represent indices as plain stock Assets (asset_type="stock"). We treat a
+        small allowlist of known index symbols as "index-like" so intraday backtests can avoid
+        excessively expensive validation probes that are unnecessary for highly liquid index options.
+        """
+
+        try:
+            if underlying_asset is not None and getattr(underlying_asset, "asset_type", None) == Asset.AssetType.INDEX:
+                return True
+        except Exception:
+            pass
+
+        symbol_upper = None
+        try:
+            symbol_upper = (symbol or getattr(underlying_asset, "symbol", None) or "").upper()
+        except Exception:
+            symbol_upper = None
+
+        if not symbol_upper:
+            return False
+
+        return symbol_upper in {
+            "SPX",
+            "SPXW",
+            "NDX",
+            "NDXP",
+            "RUT",
+            "RUTW",
+            "VIX",
+            "VIXW",
+            "XSP",
+            "DJX",
+            "OEX",
+            "XEO",
+        }
+
     def get_expiration_on_or_after_date(
         self,
         dt: Union[date, datetime],
@@ -1480,6 +1553,25 @@ class OptionsHelper:
         # Convert string expiries to dates for comparison
         expiration_dates: List[Tuple[str, date]] = _try_resolve_expiration(specific_chain)
         future_candidates = [(s, d) for s, d in expiration_dates if d >= dt]
+
+        # PERF (intraday 0DTE index strategies):
+        # For highly liquid index options (SPX/SPXW/etc), validating the *expiration itself* via
+        # per-day snapshot quote probes adds a guaranteed remote round-trip (and dominates runtime
+        # in long-window backtests) while rarely changing the outcome. The strike-selection step
+        # still validates actionable NBBO for the actual contracts we intend to trade.
+        if (
+            is_backtesting
+            and as_of_date is not None
+            and dt == as_of_date
+            and self._is_index_like_underlying(underlying_asset, underlying_symbol)
+        ):
+            for _exp_str, exp_date in expiration_dates:
+                if exp_date == dt:
+                    try:
+                        self._expiration_cache[expiration_cache_key] = exp_date
+                    except Exception:
+                        pass
+                    return exp_date
 
         # Log chain search (DEBUG level for details)
         logger.debug("[OptionsHelper] Finding expiration >= %s: %d candidates from %d total expirations",

--- a/lumibot/components/options_helper.py
+++ b/lumibot/components/options_helper.py
@@ -1079,7 +1079,7 @@ class OptionsHelper:
             if getattr(quote, "ask", None) is not None:
                 ask = self._coerce_price(getattr(quote, "ask", None), "ask", data_quality_flags, sanitization_notes)
 
-        if (bid is None or ask is None) and getattr(option_asset, "asset_type", None) == Asset.AssetType.OPTION:
+        if getattr(option_asset, "asset_type", None) == Asset.AssetType.OPTION:
             broker = getattr(self.strategy, "broker", None)
             data_source = getattr(broker, "data_source", None) if broker is not None else None
             is_theta_backtest = (
@@ -1092,10 +1092,38 @@ class OptionsHelper:
                 and data_source.__class__.__name__ == "ThetaDataBacktestingPandas"
             )
 
-            # Prefer actionable NBBO from a point-in-time snapshot when bar-aligned quotes omit
-            # bid/ask (common in historical option backtests). Only fall back to `quote.price`
-            # or last-trade pricing when NBBO is unavailable.
+            is_daily_cadence = False
             if is_theta_backtest:
+                # Daily-cadence backtests can have a mismatch between:
+                # - bar-aligned "day" quotes (which can effectively reflect a prior close), and
+                # - intraday option NBBO (which is what execution/fill logic should anchor to).
+                #
+                # Prefer a point-in-time NBBO snapshot for ThetaData options when running daily
+                # cadence, but keep the existing behavior for intraday strategies (and for cases
+                # where snapshot quotes are genuinely missing).
+                try:
+                    sleeptime = getattr(self.strategy, "sleeptime", None)
+                    if isinstance(sleeptime, str) and sleeptime.strip().upper().endswith("D"):
+                        is_daily_cadence = True
+                except Exception:
+                    pass
+                try:
+                    if getattr(data_source, "_timestep", None) == "day":
+                        is_daily_cadence = True
+                except Exception:
+                    pass
+
+            if is_theta_backtest and is_daily_cadence:
+                _, snap_bid, snap_ask = self._get_option_mark_from_quote(option_asset, snapshot=True)
+                if snap_bid is not None and snap_ask is not None:
+                    if bid != snap_bid or ask != snap_ask:
+                        data_quality_flags.append("snapshot_nbbo_override")
+                    bid = snap_bid
+                    ask = snap_ask
+            elif (bid is None or ask is None) and is_theta_backtest:
+                # Prefer actionable NBBO from a point-in-time snapshot when bar-aligned quotes omit
+                # bid/ask (common in historical option backtests). Only fall back to `quote.price`
+                # or last-trade pricing when NBBO is unavailable.
                 _, snap_bid, snap_ask = self._get_option_mark_from_quote(option_asset, snapshot=True)
                 if snap_bid is not None and snap_ask is not None:
                     bid = snap_bid

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -20,7 +20,14 @@ from termcolor import colored, COLORS
 from ..data_sources import DataSource
 from ..entities import Asset, Data, Order, Position, Quote, TradingFee, TradingSlippage, SmartLimitConfig
 from ..tools import get_risk_free_rate
-from ..tools.smart_limit_utils import build_price_ladder, compute_final_price, compute_mid, infer_tick_size, round_to_tick
+from ..tools.smart_limit_utils import (
+    build_price_ladder,
+    compute_final_price,
+    compute_final_price_from_mid,
+    compute_mid,
+    infer_tick_size,
+    round_to_tick,
+)
 from ..tools.polars_utils import PolarsResampleError, resample_polars_ohlc
 from ..traders import Trader
 from ..credentials import IS_BACKTESTING
@@ -1592,6 +1599,88 @@ class Strategy(_Strategy):
             if 'is_multileg' not in kwargs:
                 kwargs['is_multileg'] = default_multileg
 
+            is_multileg = bool(kwargs.get("is_multileg"))
+            wants_smart_limit = any(
+                o.order_type == Order.OrderType.SMART_LIMIT or getattr(o, "smart_limit", None) is not None for o in order
+            )
+            if wants_smart_limit:
+                cfg = next((getattr(o, "smart_limit", None) for o in order if getattr(o, "smart_limit", None) is not None), None)
+                if cfg is None:
+                    cfg = SmartLimitConfig()
+
+                if any(getattr(o, "smart_limit", None) not in (None, cfg) for o in order):
+                    self.log_message(
+                        "[SMART_LIMIT] Multi-leg SMART_LIMIT requires a single SmartLimitConfig; using the first config for all legs.",
+                        color="yellow",
+                    )
+
+                for o in order:
+                    o.order_type = Order.OrderType.SMART_LIMIT
+                    o.smart_limit = cfg
+
+                if is_multileg:
+                    if self.broker.IS_BACKTESTING_BROKER:
+                        return self.broker.submit_orders(order, **kwargs)
+                    return self._submit_multileg_smart_limit_orders(order, cfg, **kwargs)
+
+                # Multiple independent SMART_LIMIT orders.
+                submitted_orders = []
+                for o in order:
+                    submitted_orders.append(self.submit_order(o))
+                return submitted_orders
+
+            # Broker-agnostic multi-leg LIMIT UX:
+            # If the caller requests a package LIMIT (`order_type='limit'`) on a broker that uses
+            # debit/credit/even semantics (Tradier) or needs net-side hints (Alpaca mleg),
+            # infer the net sign from quotes and map internally so strategies remain portable.
+            if (
+                is_multileg
+                and not self.broker.IS_BACKTESTING_BROKER
+                and str(kwargs.get("order_type", "")).lower() == str(Order.OrderType.LIMIT)
+                and str(getattr(self.broker, "name", "")).lower() in {"tradier", "alpaca"}
+            ):
+                inferred = self._infer_multileg_type_and_mid(order)
+                if inferred is not None:
+                    inferred_type, inferred_mid_abs = inferred
+                else:
+                    inferred_type, inferred_mid_abs = None, None
+
+                raw_price = kwargs.get("price")
+                price_abs = None
+                if raw_price is not None:
+                    try:
+                        price_abs = abs(float(raw_price))
+                    except Exception:
+                        price_abs = None
+
+                if inferred_type is None:
+                    # Fall back to interpreting a signed price (negative=credit) if quotes are missing.
+                    if raw_price is not None:
+                        try:
+                            signed = float(raw_price)
+                            inferred_type = "even" if abs(signed) < 1e-9 else ("debit" if signed > 0 else "credit")
+                            if price_abs is None:
+                                price_abs = abs(signed)
+                            self.log_message(
+                                "[MULTILEG][LIMIT] Missing quotes; inferring debit/credit from price sign. "
+                                "For net credits, pass a negative price or explicit order_type='credit'.",
+                                color="yellow",
+                            )
+                        except Exception:
+                            inferred_type = None
+
+                if inferred_type is not None:
+                    kwargs["order_type"] = inferred_type
+                    if price_abs is None and inferred_mid_abs is not None:
+                        price_abs = float(inferred_mid_abs)
+
+                    broker_name = str(getattr(self.broker, "name", "")).lower()
+                    if inferred_type == "even" and broker_name == "tradier":
+                        kwargs["price"] = None
+                    else:
+                        # Alpaca requires a limit_price for mleg orders; treat even as 0.0 and let the broker decide.
+                        kwargs["price"] = 0.0 if price_abs is None else float(price_abs)
+
             return self.broker.submit_orders(order, **kwargs)
 
         else:
@@ -1612,7 +1701,7 @@ class Strategy(_Strategy):
                 quote = self.get_quote(order.asset, quote=order.quote, exchange=order.exchange)
                 bid = getattr(quote, "bid", None)
                 ask = getattr(quote, "ask", None)
-                if bid is None or ask is None or bid <= 0 or ask <= 0:
+                if bid is None or ask is None or bid < 0 or ask <= 0:
                     self.log_message(
                         f"[SMART_LIMIT] Missing bid/ask for {order.asset}; downgrading to market.",
                         color="yellow",
@@ -1648,65 +1737,128 @@ class Strategy(_Strategy):
             return self.broker.submit_order(order)
 
     def _submit_multileg_smart_limit(self, order: Order):
-        quote_data = []
-        for leg in order.child_orders:
+        return self._submit_multileg_smart_limit_orders(order.child_orders, order.smart_limit)
+
+    def _compute_multileg_net_best_fastest(self, child_orders: List[Order]) -> tuple[float, float] | None:
+        """Compute signed net best/fastest prices for a multi-leg options package.
+
+        Convention (matches OptionsHelper and SMART_LIMIT logic):
+        - For buy legs: best=bid, fastest=ask (positive contribution)
+        - For sell legs: best=-ask, fastest=-bid (negative contribution)
+        """
+
+        quote_data: list[tuple[Order, float | None, float | None]] = []
+        for leg in child_orders:
             quote = self.get_quote(leg.asset, quote=leg.quote, exchange=leg.exchange)
             bid = getattr(quote, "bid", None)
             ask = getattr(quote, "ask", None)
             quote_data.append((leg, bid, ask))
 
-        if any(bid is None or ask is None or bid <= 0 or ask <= 0 for _, bid, ask in quote_data):
+        if any(bid is None or ask is None or bid < 0 or ask <= 0 for _, bid, ask in quote_data):
+            return None
+
+        net_best = 0.0
+        net_fastest = 0.0
+        for leg, bid, ask in quote_data:
+            if leg.is_buy_order():
+                net_best += float(bid)
+                net_fastest += float(ask)
+            else:
+                net_best -= float(ask)
+                net_fastest -= float(bid)
+
+        return net_best, net_fastest
+
+    def _infer_multileg_type_and_mid(self, child_orders: List[Order]) -> tuple[str, float] | None:
+        """Infer package type (debit/credit/even) and return abs(net_mid)."""
+
+        computed = self._compute_multileg_net_best_fastest(child_orders)
+        if computed is None:
+            return None
+
+        net_best, net_fastest = computed
+        mid_signed = compute_mid(net_best, net_fastest)
+        if abs(mid_signed) < 1e-9:
+            return "even", 0.0
+        if mid_signed > 0:
+            return "debit", float(abs(mid_signed))
+        return "credit", float(abs(mid_signed))
+
+    def _submit_multileg_smart_limit_orders(self, child_orders: List[Order], smart_limit: SmartLimitConfig, **kwargs):
+        if self.broker.IS_BACKTESTING_BROKER:
+            kwargs.setdefault("is_multileg", True)
+            return self.broker.submit_orders(child_orders, **kwargs)
+
+        if smart_limit is None:
+            smart_limit = SmartLimitConfig()
+
+        computed = self._compute_multileg_net_best_fastest(child_orders)
+        if computed is None:
             self.log_message(
-                f"[SMART_LIMIT] Missing bid/ask for multileg order; downgrading to market.",
+                "[SMART_LIMIT] Missing bid/ask for multileg order; downgrading to market.",
                 color="yellow",
             )
-            order.smart_limit = None
-            return self.broker.submit_orders(order.child_orders, is_multileg=True, order_type=Order.OrderType.MARKET)
+            return self.broker.submit_orders(child_orders, is_multileg=True, order_type=Order.OrderType.MARKET)
+        net_best, net_fastest = computed
 
-        net_bid = 0.0
-        net_ask = 0.0
-        side = "buy" if order.is_buy_order() else "sell"
-        for leg, bid, ask in quote_data:
-            if side == "buy":
-                if leg.is_buy_order():
-                    net_bid += bid
-                    net_ask += ask
-                else:
-                    net_bid -= ask
-                    net_ask -= bid
-            else:
-                if leg.is_buy_order():
-                    net_bid -= ask
-                    net_ask -= bid
-                else:
-                    net_bid += bid
-                    net_ask += ask
-        tick = infer_tick_size(net_bid, net_ask)
-        mid = compute_mid(net_bid, net_ask)
-        final_price = compute_final_price(net_bid, net_ask, side, order.smart_limit.final_price_pct)
-        ladder = build_price_ladder(mid, final_price, order.smart_limit.get_step_count())
-        initial_price = round_to_tick(ladder[0], tick, side=side)
+        tick = infer_tick_size(net_best, net_fastest)
+        mid = compute_mid(net_best, net_fastest)
+        final_signed = compute_final_price_from_mid(mid, net_fastest, smart_limit.final_price_pct)
+        ladder = build_price_ladder(mid, final_signed, smart_limit.get_step_count())
+        initial_signed = round_to_tick(ladder[0], tick, side="buy")
 
-        order.limit_price = initial_price
-        order._smart_limit_state = {
+        initial_type = "even" if abs(initial_signed) < 1e-9 else ("debit" if initial_signed > 0 else "credit")
+        initial_price: float | None = abs(initial_signed) if initial_type != "even" else 0.0
+        broker_name = str(getattr(self.broker, "name", "")).lower()
+        if initial_type == "even" and broker_name == "tradier":
+            initial_price = None
+
+        duration = kwargs.get("duration") or kwargs.get("time_in_force")
+        if not duration:
+            duration = "day" if all(o.asset.asset_type == "option" for o in child_orders) else (
+                getattr(child_orders[0], "time_in_force", None) or "day"
+            )
+
+        state = {
             "created_at": time.monotonic(),
             "step_index": 0,
-            "steps": order.smart_limit.get_step_count(),
-            "step_seconds": order.smart_limit.get_step_seconds(),
-            "final_hold_seconds": order.smart_limit.get_final_hold_seconds(),
+            "steps": smart_limit.get_step_count(),
+            "step_seconds": smart_limit.get_step_seconds(),
+            "final_hold_seconds": smart_limit.get_final_hold_seconds(),
+            "multileg_order_type": initial_type,
         }
 
-        parent_order = self.broker.submit_orders(
-            order.child_orders,
-            is_multileg=True,
-            order_type=Order.OrderType.LIMIT,
-            price=initial_price,
-        )
+        submit_price = 0.0 if initial_price is None else float(initial_price)
+        submit_price_or_none = None if (initial_type == "even" and broker_name == "tradier") else submit_price
+
+        try:
+            submitted = self.broker.submit_orders(
+                child_orders,
+                is_multileg=True,
+                order_type=initial_type,
+                duration=duration,
+                price=submit_price_or_none,
+            )
+        except Exception as exc:
+            self.log_message(
+                f"[SMART_LIMIT] Multi-leg submit failed for type={initial_type} ({exc}); retrying as limit.",
+                color="yellow",
+            )
+            submitted = self.broker.submit_orders(
+                child_orders,
+                is_multileg=True,
+                order_type=Order.OrderType.LIMIT,
+                duration=duration,
+                price=submit_price,
+            )
+
+        parent_order = submitted[0] if isinstance(submitted, list) and submitted else submitted
         if parent_order is not None:
-            parent_order.smart_limit = order.smart_limit
+            parent_order.smart_limit = smart_limit
             parent_order.order_type = Order.OrderType.SMART_LIMIT
-            parent_order._smart_limit_state = order._smart_limit_state
-        return parent_order
+            parent_order._smart_limit_state = state
+            parent_order.limit_price = 0.0 if initial_price is None else float(initial_price)
+        return submitted
 
     def submit_orders(self, orders: List[Order], **kwargs):
         """[Deprecated] Submit a list of orders

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -21,7 +21,14 @@ from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.entities import Asset, Order
 from lumibot.entities import Asset
 from lumibot.tools import append_locals, get_trading_days, staticdecorator
-from lumibot.tools.smart_limit_utils import build_price_ladder, compute_final_price, compute_mid, infer_tick_size, round_to_tick
+from lumibot.tools.smart_limit_utils import (
+    build_price_ladder,
+    compute_final_price,
+    compute_final_price_from_mid,
+    compute_mid,
+    infer_tick_size,
+    round_to_tick,
+)
 
 
 class StrategyExecutor(Thread):
@@ -644,7 +651,10 @@ class StrategyExecutor(Thread):
             final_hold_start = state["step_seconds"] * (state["steps"] - 1)
 
             if step_index == state["steps"] - 1 and elapsed >= final_hold_start + state["final_hold_seconds"]:
-                self.broker.cancel_order(order)
+                try:
+                    self.broker.cancel_order(order)
+                except Exception as exc:
+                    self.strategy.logger.error(f"SMART_LIMIT cancel failed for {order.identifier}: {exc}")
                 continue
 
             if step_index == state["step_index"]:
@@ -652,40 +662,94 @@ class StrategyExecutor(Thread):
 
             state["step_index"] = step_index
 
-            side = "buy" if order.is_buy_order() else "sell"
-            bid = ask = None
             if order.order_class == Order.OrderClass.MULTILEG and order.child_orders:
-                net_bid = 0.0
-                net_ask = 0.0
+                quote_data: list[tuple[Order, float | None, float | None]] = []
                 for leg in order.child_orders:
                     quote = self.strategy.get_quote(leg.asset, quote=leg.quote, exchange=leg.exchange)
                     leg_bid = getattr(quote, "bid", None)
                     leg_ask = getattr(quote, "ask", None)
-                    if leg_bid is None or leg_ask is None:
-                        net_bid = net_ask = None
-                        break
-                    if side == "buy":
-                        if leg.is_buy_order():
-                            net_bid += leg_bid
-                            net_ask += leg_ask
-                        else:
-                            net_bid -= leg_ask
-                            net_ask -= leg_bid
-                    else:
-                        if leg.is_buy_order():
-                            net_bid -= leg_ask
-                            net_ask -= leg_bid
-                        else:
-                            net_bid += leg_bid
-                            net_ask += leg_ask
-                bid = net_bid
-                ask = net_ask
-            else:
-                quote = self.strategy.get_quote(order.asset, quote=order.quote, exchange=order.exchange)
-                bid = getattr(quote, "bid", None)
-                ask = getattr(quote, "ask", None)
+                    quote_data.append((leg, leg_bid, leg_ask))
 
-            if bid is None or ask is None or bid <= 0 or ask <= 0:
+                if any(b is None or a is None or b < 0 or a <= 0 for _, b, a in quote_data):
+                    if not getattr(order, "_smart_limit_missing_quote_logged", False):
+                        self.strategy.log_message(
+                            f"[SMART_LIMIT] Missing bid/ask for {order.asset}; keeping last limit.",
+                            color="yellow",
+                        )
+                        order._smart_limit_missing_quote_logged = True
+                    continue
+
+                net_best = 0.0
+                net_fastest = 0.0
+                for leg, leg_bid, leg_ask in quote_data:
+                    if leg.is_buy_order():
+                        net_best += float(leg_bid)
+                        net_fastest += float(leg_ask)
+                    else:
+                        net_best -= float(leg_ask)
+                        net_fastest -= float(leg_bid)
+
+                tick = infer_tick_size(net_best, net_fastest)
+                mid = compute_mid(net_best, net_fastest)
+                final_signed = compute_final_price_from_mid(mid, net_fastest, smart_limit.final_price_pct)
+                ladder = build_price_ladder(mid, final_signed, smart_limit.get_step_count())
+                target_signed = round_to_tick(ladder[step_index], tick, side="buy")
+
+                target_type = "even" if abs(target_signed) < 1e-9 else ("debit" if target_signed > 0 else "credit")
+                target_price = abs(target_signed) if target_type != "even" else 0.0
+                if target_type == "even" and getattr(self.broker, "name", "").lower() == "tradier":
+                    target_price = None
+
+                current_type = state.get("multileg_order_type")
+                if current_type is None:
+                    current_type = target_type
+                    state["multileg_order_type"] = current_type
+
+                if current_type == target_type and target_price is not None and order.limit_price is not None:
+                    if abs(float(order.limit_price) - float(target_price)) < 1e-9:
+                        continue
+                if current_type == target_type and target_type == "even":
+                    continue
+
+                should_replace = current_type != target_type
+                if not should_replace:
+                    try:
+                        if target_price is None:
+                            should_replace = True
+                        else:
+                            self.broker.modify_order(order, limit_price=float(target_price))
+                            order.limit_price = float(target_price)
+                            continue
+                    except Exception:
+                        should_replace = True
+
+                if should_replace:
+                    try:
+                        self.broker.cancel_order(order)
+                        submitted = self.broker.submit_orders(
+                            order.child_orders,
+                            is_multileg=True,
+                            order_type=target_type,
+                            price=target_price,
+                        )
+                        new_parent = submitted[0] if isinstance(submitted, list) and submitted else submitted
+                        if new_parent is not None:
+                            new_parent.smart_limit = smart_limit
+                            new_parent.order_type = Order.OrderType.SMART_LIMIT
+                            new_parent._smart_limit_state = state
+                            state["multileg_order_type"] = target_type
+                            new_parent.limit_price = 0.0 if target_price is None else float(target_price)
+                    except Exception as exc:
+                        self.strategy.logger.error(f"SMART_LIMIT reprice failed for {order.identifier}: {exc}")
+
+                continue
+
+            side = "buy" if order.is_buy_order() else "sell"
+            quote = self.strategy.get_quote(order.asset, quote=order.quote, exchange=order.exchange)
+            bid = getattr(quote, "bid", None)
+            ask = getattr(quote, "ask", None)
+
+            if bid is None or ask is None or bid < 0 or ask <= 0:
                 if not getattr(order, "_smart_limit_missing_quote_logged", False):
                     self.strategy.log_message(
                         f"[SMART_LIMIT] Missing bid/ask for {order.asset}; keeping last limit.",

--- a/lumibot/tools/smart_limit_utils.py
+++ b/lumibot/tools/smart_limit_utils.py
@@ -39,10 +39,36 @@ def compute_mid(bid: float, ask: float) -> float:
 
 
 def compute_final_price(bid: float, ask: float, side: str, final_price_pct: float) -> float:
-    spread = ask - bid
+    """Compute the SMART_LIMIT final price.
+
+    `final_price_pct` is interpreted as the fraction of the bid/ask spread (from the midpoint
+    toward the aggressive edge) we're willing to traverse.
+
+    - pct=0.0 -> final stays at the midpoint (least aggressive).
+    - pct=1.0 -> final reaches the aggressive edge (buy: ask, sell: bid).
+    """
+
+    pct = float(final_price_pct)
+    if pct < 0:
+        pct = 0.0
+    elif pct > 1:
+        pct = 1.0
+
+    mid = compute_mid(bid, ask)
     if side == "buy":
-        return bid + spread * final_price_pct
-    return ask - spread * final_price_pct
+        return mid + (ask - mid) * pct
+    return mid + (bid - mid) * pct
+
+
+def compute_final_price_from_mid(mid: float, aggressive_price: float, final_price_pct: float) -> float:
+    """Final price from a midpoint toward an 'aggressive' edge price."""
+
+    pct = float(final_price_pct)
+    if pct < 0:
+        pct = 0.0
+    elif pct > 1:
+        pct = 1.0
+    return mid + (aggressive_price - mid) * pct
 
 
 def build_price_ladder(mid: float, final_price: float, step_count: int) -> List[float]:

--- a/scripts/after_hours_stock_smart_limit.py
+++ b/scripts/after_hours_stock_smart_limit.py
@@ -1,0 +1,182 @@
+"""After-hours SMART_LIMIT experiment for stocks (paper).
+
+This is an ops script: it places real paper orders and logs repricing + fills.
+Use this to sanity-check after-hours behavior (e.g. Tradier `time_in_force='post'`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from lumibot.brokers.alpaca import Alpaca
+from lumibot.brokers.tradier import Tradier
+from lumibot.credentials import ALPACA_TEST_CONFIG, TRADIER_TEST_CONFIG
+from lumibot.entities import Asset, Order, SmartLimitConfig, SmartLimitPreset
+from lumibot.strategies.strategy import Strategy
+
+
+class _Harness(Strategy):
+    def initialize(self, parameters=None):
+        self.sleeptime = "1S"
+
+    def on_trading_iteration(self):
+        return
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    ts: float
+    status: str
+    limit_price: Optional[float]
+    avg_fill_price: Optional[float]
+
+
+def _make_broker(name: str):
+    name = name.lower().strip()
+    if name == "tradier":
+        if not TRADIER_TEST_CONFIG.get("ACCOUNT_NUMBER") or not TRADIER_TEST_CONFIG.get("ACCESS_TOKEN"):
+            raise RuntimeError("Missing TRADIER_TEST_ACCOUNT_NUMBER / TRADIER_TEST_ACCESS_TOKEN in .env")
+        return Tradier(
+            account_number=TRADIER_TEST_CONFIG["ACCOUNT_NUMBER"],
+            access_token=TRADIER_TEST_CONFIG["ACCESS_TOKEN"],
+            paper=True,
+            connect_stream=True,
+        )
+    if name == "alpaca":
+        return Alpaca(ALPACA_TEST_CONFIG, connect_stream=False)
+    raise ValueError(f"Unsupported broker: {name}")
+
+
+def _poll(broker, order: Order) -> _Snapshot:
+    now = time.time()
+    broker_name = str(getattr(broker, "name", "")).lower()
+
+    if broker_name == "tradier":
+        record = broker._pull_broker_order(order.identifier)  # noqa: SLF001 (ops script)
+        status = str(record.get("status", "")).lower()
+        limit_price = record.get("price")
+        avg_fill = record.get("avg_fill_price")
+        return _Snapshot(
+            ts=now,
+            status=status,
+            limit_price=float(limit_price) if limit_price is not None else None,
+            avg_fill_price=float(avg_fill) if avg_fill is not None else None,
+        )
+
+    if broker_name == "alpaca":
+        raw = broker.api.get_order_by_id(order.identifier)
+        raw_status = getattr(raw, "status", "")
+        if hasattr(raw_status, "value"):
+            raw_status = raw_status.value
+        status = str(raw_status).lower()
+        limit_price = getattr(raw, "limit_price", None)
+        avg_fill = getattr(raw, "filled_avg_price", None) or getattr(raw, "avg_fill_price", None)
+        return _Snapshot(
+            ts=now,
+            status=status,
+            limit_price=float(limit_price) if limit_price is not None else None,
+            avg_fill_price=float(avg_fill) if avg_fill is not None else None,
+        )
+
+    raise ValueError(f"Unsupported broker for polling: {broker_name}")
+
+
+def _drive_until_done(strategy: _Harness, order: Order, *, timeout_seconds: int) -> tuple[bool, list[_Snapshot]]:
+    start = time.time()
+    snapshots: list[_Snapshot] = []
+    last_limit = None
+
+    while time.time() - start < timeout_seconds:
+        snap = _poll(strategy.broker, order)
+        snapshots.append(snap)
+
+        order.status = snap.status
+        if snap.limit_price is not None:
+            order.limit_price = float(snap.limit_price)
+
+        if last_limit is None and snap.limit_price is not None:
+            last_limit = snap.limit_price
+        elif last_limit is not None and snap.limit_price is not None and abs(snap.limit_price - last_limit) > 1e-9:
+            print(f"{datetime.now().isoformat()} limit moved: {last_limit} -> {snap.limit_price}")
+            last_limit = snap.limit_price
+
+        if snap.status in {"filled", "fill"}:
+            return True, snapshots
+        if snap.status in {"canceled", "cancelled", "rejected", "expired", "error"}:
+            return False, snapshots
+
+        try:
+            strategy._executor._process_smart_limit_orders()  # noqa: SLF001 (ops script)
+        except Exception as exc:
+            print(f"{datetime.now().isoformat()} SMART_LIMIT tick error: {exc}")
+
+        time.sleep(1.0)
+
+    return False, snapshots
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--broker", choices=["tradier", "alpaca"], required=True)
+    parser.add_argument("--symbol", default="SPY")
+    parser.add_argument("--timeout-seconds", type=int, default=180)
+    parser.add_argument("--tif", default="post", help="Tradier duration (post/pre/day/gtc). Alpaca ignores this.")
+    args = parser.parse_args()
+
+    broker = _make_broker(args.broker)
+    strategy = _Harness(broker=broker)
+    try:
+        strategy.initialize()
+    except TypeError:
+        strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=30)
+    asset = Asset(args.symbol.upper(), asset_type=Asset.AssetType.STOCK)
+
+    print(f"{datetime.now().isoformat()} submitting BUY SMART_LIMIT {asset.symbol} after-hours tif={args.tif}")
+    buy = strategy.create_order(
+        asset,
+        1,
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+        time_in_force=args.tif,
+    )
+    submitted_buy = strategy.submit_order(buy)
+    ok_buy, buy_snaps = _drive_until_done(strategy, submitted_buy, timeout_seconds=args.timeout_seconds)
+    buy_fill = next((s.avg_fill_price for s in reversed(buy_snaps) if s.avg_fill_price is not None), None)
+    print(f"{datetime.now().isoformat()} BUY done ok={ok_buy} fill={buy_fill}")
+
+    if not ok_buy:
+        return 2
+
+    print(f"{datetime.now().isoformat()} submitting SELL SMART_LIMIT {asset.symbol} after-hours tif={args.tif}")
+    sell = strategy.create_order(
+        asset,
+        1,
+        Order.OrderSide.SELL,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+        time_in_force=args.tif,
+    )
+    submitted_sell = strategy.submit_order(sell)
+    ok_sell, sell_snaps = _drive_until_done(strategy, submitted_sell, timeout_seconds=args.timeout_seconds)
+    sell_fill = next((s.avg_fill_price for s in reversed(sell_snaps) if s.avg_fill_price is not None), None)
+    print(f"{datetime.now().isoformat()} SELL done ok={ok_sell} fill={sell_fill}")
+
+    return 0 if ok_sell else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/scripts/after_hours_stock_smart_limit.py
+++ b/scripts/after_hours_stock_smart_limit.py
@@ -122,6 +122,11 @@ def _drive_until_done(strategy: _Harness, order: Order, *, timeout_seconds: int)
 
         time.sleep(1.0)
 
+    # Timeout: cancel the order so we don't leave a dangling after-hours paper order behind.
+    try:
+        strategy.broker.cancel_order(order)
+    except Exception:
+        pass
     return False, snapshots
 
 
@@ -143,40 +148,52 @@ def main() -> int:
     cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=30)
     asset = Asset(args.symbol.upper(), asset_type=Asset.AssetType.STOCK)
 
-    print(f"{datetime.now().isoformat()} submitting BUY SMART_LIMIT {asset.symbol} after-hours tif={args.tif}")
-    buy = strategy.create_order(
-        asset,
-        1,
-        Order.OrderSide.BUY,
-        order_type=Order.OrderType.SMART_LIMIT,
-        smart_limit=cfg,
-        time_in_force=args.tif,
-    )
-    submitted_buy = strategy.submit_order(buy)
-    ok_buy, buy_snaps = _drive_until_done(strategy, submitted_buy, timeout_seconds=args.timeout_seconds)
-    buy_fill = next((s.avg_fill_price for s in reversed(buy_snaps) if s.avg_fill_price is not None), None)
-    print(f"{datetime.now().isoformat()} BUY done ok={ok_buy} fill={buy_fill}")
+    try:
+        # Best-effort: clear any previously-open orders for this strategy before we start.
+        try:
+            strategy.cancel_open_orders()
+        except Exception:
+            pass
 
-    if not ok_buy:
-        return 2
+        print(f"{datetime.now().isoformat()} submitting BUY SMART_LIMIT {asset.symbol} after-hours tif={args.tif}")
+        buy = strategy.create_order(
+            asset,
+            1,
+            Order.OrderSide.BUY,
+            order_type=Order.OrderType.SMART_LIMIT,
+            smart_limit=cfg,
+            time_in_force=args.tif,
+        )
+        submitted_buy = strategy.submit_order(buy)
+        ok_buy, buy_snaps = _drive_until_done(strategy, submitted_buy, timeout_seconds=args.timeout_seconds)
+        buy_fill = next((s.avg_fill_price for s in reversed(buy_snaps) if s.avg_fill_price is not None), None)
+        print(f"{datetime.now().isoformat()} BUY done ok={ok_buy} fill={buy_fill}")
 
-    print(f"{datetime.now().isoformat()} submitting SELL SMART_LIMIT {asset.symbol} after-hours tif={args.tif}")
-    sell = strategy.create_order(
-        asset,
-        1,
-        Order.OrderSide.SELL,
-        order_type=Order.OrderType.SMART_LIMIT,
-        smart_limit=cfg,
-        time_in_force=args.tif,
-    )
-    submitted_sell = strategy.submit_order(sell)
-    ok_sell, sell_snaps = _drive_until_done(strategy, submitted_sell, timeout_seconds=args.timeout_seconds)
-    sell_fill = next((s.avg_fill_price for s in reversed(sell_snaps) if s.avg_fill_price is not None), None)
-    print(f"{datetime.now().isoformat()} SELL done ok={ok_sell} fill={sell_fill}")
+        if not ok_buy:
+            return 2
 
-    return 0 if ok_sell else 3
+        print(f"{datetime.now().isoformat()} submitting SELL SMART_LIMIT {asset.symbol} after-hours tif={args.tif}")
+        sell = strategy.create_order(
+            asset,
+            1,
+            Order.OrderSide.SELL,
+            order_type=Order.OrderType.SMART_LIMIT,
+            smart_limit=cfg,
+            time_in_force=args.tif,
+        )
+        submitted_sell = strategy.submit_order(sell)
+        ok_sell, sell_snaps = _drive_until_done(strategy, submitted_sell, timeout_seconds=args.timeout_seconds)
+        sell_fill = next((s.avg_fill_price for s in reversed(sell_snaps) if s.avg_fill_price is not None), None)
+        print(f"{datetime.now().isoformat()} SELL done ok={ok_sell} fill={sell_fill}")
+
+        return 0 if ok_sell else 3
+    finally:
+        # Best-effort cleanup so we don't leave paper orders hanging around.
+        try:
+            strategy.cancel_open_orders()
+        except Exception:
+            pass
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/scripts/bench_smart_limit_vs_market.py
+++ b/scripts/bench_smart_limit_vs_market.py
@@ -1,0 +1,457 @@
+"""Benchmark SMART_LIMIT vs MARKET fills (paper trading).
+
+This script is intentionally operational (not a unit test). It places *real* paper trades and compares:
+- Market order fills
+- SMART_LIMIT fills (with repricing)
+
+It is designed to be run manually during market hours.
+"""
+
+from __future__ import annotations
+
+import sys
+import argparse
+import csv
+import random
+import time
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Optional
+
+# Ensure the repo root is importable when running as a script (sys.path[0] == scripts/).
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from lumibot.brokers.alpaca import Alpaca
+from lumibot.brokers.tradier import Tradier
+from lumibot.components.options_helper import OptionsHelper
+from lumibot.credentials import ALPACA_TEST_CONFIG, TRADIER_TEST_CONFIG
+from lumibot.entities import Asset, Order, SmartLimitConfig, SmartLimitPreset
+from lumibot.strategies.strategy import Strategy
+
+
+def _is_finite_positive(value: Any) -> bool:
+    try:
+        return value is not None and float(value) > 0 and float(value) == float(value)
+    except Exception:
+        return False
+
+
+class _BenchStrategy(Strategy):
+    def initialize(self, parameters=None):
+        self.sleeptime = "1S"
+        self.options_helper = OptionsHelper(self)
+
+    def on_trading_iteration(self):
+        return
+
+
+@dataclass(frozen=True)
+class _FillSnapshot:
+    ts: float
+    status: str
+    limit_price: Optional[float]
+    avg_fill_price: Optional[float]
+    filled_qty: Optional[float]
+
+
+def _make_broker(name: str):
+    name = name.lower().strip()
+    if name == "alpaca":
+        return Alpaca(ALPACA_TEST_CONFIG, connect_stream=False)
+    if name == "tradier":
+        if not TRADIER_TEST_CONFIG.get("ACCOUNT_NUMBER") or not TRADIER_TEST_CONFIG.get("ACCESS_TOKEN"):
+            raise RuntimeError("Missing TRADIER_TEST_ACCOUNT_NUMBER / TRADIER_TEST_ACCESS_TOKEN in .env")
+        return Tradier(
+            account_number=TRADIER_TEST_CONFIG["ACCOUNT_NUMBER"],
+            access_token=TRADIER_TEST_CONFIG["ACCESS_TOKEN"],
+            paper=True,
+            connect_stream=True,
+        )
+    raise ValueError(f"Unsupported broker: {name}")
+
+
+def _poll_order(broker, order: Order) -> _FillSnapshot:
+    now = time.time()
+    broker_name = getattr(broker, "name", "").lower()
+
+    if broker_name == "alpaca":
+        raw = broker.api.get_order_by_id(order.identifier)
+        raw_status = getattr(raw, "status", "")
+        if hasattr(raw_status, "value"):
+            raw_status = raw_status.value
+        status = str(raw_status).lower()
+        limit_price = getattr(raw, "limit_price", None)
+        avg_fill = getattr(raw, "filled_avg_price", None) or getattr(raw, "avg_fill_price", None)
+        filled_qty = getattr(raw, "filled_qty", None) or getattr(raw, "qty", None)
+        return _FillSnapshot(
+            ts=now,
+            status=status,
+            limit_price=float(limit_price) if limit_price is not None else None,
+            avg_fill_price=float(avg_fill) if avg_fill is not None else None,
+            filled_qty=float(filled_qty) if filled_qty is not None else None,
+        )
+
+    if broker_name == "tradier":
+        record = broker._pull_broker_order(order.identifier)  # noqa: SLF001 (ops script)
+        status = str(record.get("status", "")).lower()
+        limit_price = record.get("price")
+        avg_fill = record.get("avg_fill_price")
+        filled_qty = record.get("exec_quantity") or record.get("filled_quantity")
+        return _FillSnapshot(
+            ts=now,
+            status=status,
+            limit_price=float(limit_price) if limit_price is not None else None,
+            avg_fill_price=float(avg_fill) if avg_fill is not None else None,
+            filled_qty=float(filled_qty) if filled_qty is not None else None,
+        )
+
+    raise ValueError(f"Unsupported broker: {broker_name}")
+
+
+def _wait_for_fill(
+    strategy: _BenchStrategy,
+    order: Order,
+    *,
+    timeout_seconds: int,
+    drive_smart_limit: bool,
+) -> tuple[bool, list[_FillSnapshot]]:
+    snapshots: list[_FillSnapshot] = []
+    start = time.time()
+    last_limit: Optional[float] = None
+
+    while time.time() - start < timeout_seconds:
+        snap = _poll_order(strategy.broker, order)
+        snapshots.append(snap)
+
+        # Keep the LumiBot order object roughly in sync so SMART_LIMIT repricing stops once filled/canceled.
+        try:
+            order.status = snap.status
+            if snap.limit_price is not None:
+                order.limit_price = float(snap.limit_price)
+        except Exception:
+            pass
+
+        if snap.limit_price is not None and last_limit is None:
+            last_limit = snap.limit_price
+        elif snap.limit_price is not None and last_limit is not None and abs(snap.limit_price - last_limit) > 1e-9:
+            last_limit = snap.limit_price
+
+        if snap.status in {"filled", "fill"}:
+            return True, snapshots
+        if snap.status in {"canceled", "cancelled", "rejected", "expired", "error"}:
+            return False, snapshots
+
+        if drive_smart_limit:
+            try:
+                strategy._executor._process_smart_limit_orders()  # noqa: SLF001 (ops script)
+            except Exception as exc:
+                strategy.log_message(f"[bench] SMART_LIMIT tick error: {exc}", color="red")
+
+        time.sleep(1.0)
+
+    return False, snapshots
+
+
+def _pick_underlying(symbol: str) -> Asset:
+    symbol = symbol.upper().strip()
+    if symbol in {"SPX", "SPXW", "NDX", "RUT", "VIX"}:
+        return Asset(symbol, asset_type=Asset.AssetType.INDEX)
+    return Asset(symbol, asset_type=Asset.AssetType.STOCK)
+
+
+def _pick_expiry(strategy: _BenchStrategy, underlying: Asset, days_out: int) -> date:
+    chains = strategy.get_chains(underlying)
+    if not chains and underlying.symbol.upper() == "SPX":
+        chains = strategy.get_chains(Asset("SPXW", asset_type=Asset.AssetType.INDEX))
+    if not chains and underlying.symbol.upper() == "SPXW":
+        chains = strategy.get_chains(Asset("SPX", asset_type=Asset.AssetType.INDEX))
+    if not chains:
+        raise RuntimeError(f"No option chains for {underlying.symbol}")
+
+    target_date = datetime.now().astimezone().date() + timedelta(days=days_out)
+    expiry = strategy.options_helper.get_expiration_on_or_after_date(
+        target_date,
+        chains,
+        "call",
+        underlying_asset=underlying,
+    )
+    if expiry is None:
+        raise RuntimeError(f"Could not find expiry for {underlying.symbol} on/after {target_date}")
+    return expiry
+
+
+def _pick_atm_strike(strategy: _BenchStrategy, underlying: Asset, expiry: date) -> float:
+    """Pick an approximate ATM strike.
+
+    Some brokers/data sources don't provide a reliable index last price (e.g. Tradier + SPX),
+    but still provide option chains + strikes. Fall back to the chain median strike.
+    """
+
+    price = strategy.get_last_price(underlying)
+    if _is_finite_positive(price):
+        return float(price)
+
+    chains = strategy.get_chains(underlying)
+    if not chains and underlying.symbol.upper() == "SPX":
+        chains = strategy.get_chains(Asset("SPXW", asset_type=Asset.AssetType.INDEX))
+    if not chains and underlying.symbol.upper() == "SPXW":
+        chains = strategy.get_chains(Asset("SPX", asset_type=Asset.AssetType.INDEX))
+    if not chains:
+        raise RuntimeError(f"Underlying price unavailable and no chains for {underlying.symbol}")
+
+    strikes_raw = chains.strikes(expiry, "CALL") or []
+    strikes = sorted(float(s) for s in strikes_raw if s is not None)
+    if not strikes:
+        raise RuntimeError(f"No strikes found for {underlying.symbol} expiry={expiry}")
+    return float(strikes[len(strikes) // 2])
+
+
+def _strike_step(symbol: str) -> float:
+    symbol = symbol.upper().strip()
+    if symbol in {"SPX", "SPXW", "RUT", "NDX"}:
+        return 5.0
+    if symbol in {"TSLA"}:
+        return 5.0
+    return 1.0
+
+
+def _build_single_call(
+    strategy: _BenchStrategy,
+    underlying_symbol: str,
+    *,
+    days_out: int,
+    otm_points: float,
+    order_type: str,
+    smart_limit: Optional[SmartLimitConfig],
+) -> tuple[Order, Order]:
+    underlying = _pick_underlying(underlying_symbol)
+    expiry = _pick_expiry(strategy, underlying, days_out)
+    atm = _pick_atm_strike(strategy, underlying, expiry)
+    step = _strike_step(underlying.symbol)
+    atm_rounded = round(atm / step) * step
+    strike = atm_rounded + otm_points
+
+    call_asset = strategy.options_helper.find_next_valid_option(underlying, strike, expiry, put_or_call="call")
+    if call_asset is None:
+        raise RuntimeError("Could not find a valid call option asset")
+
+    open_order = strategy.create_order(
+        call_asset,
+        1,
+        Order.OrderSide.BUY_TO_OPEN,
+        order_type=order_type,
+        smart_limit=smart_limit,
+    )
+    close_order = strategy.create_order(
+        call_asset,
+        1,
+        Order.OrderSide.SELL_TO_CLOSE,
+        order_type=order_type,
+        smart_limit=smart_limit,
+    )
+    return open_order, close_order
+
+
+def _build_iron_condor(
+    strategy: _BenchStrategy,
+    underlying_symbol: str,
+    *,
+    days_out: int,
+    short_distance: float,
+    wing_width: float,
+    order_type: str,
+    smart_limit: Optional[SmartLimitConfig],
+) -> tuple[list[Order], list[Order]]:
+    underlying = _pick_underlying(underlying_symbol)
+    expiry = _pick_expiry(strategy, underlying, days_out)
+    atm = _pick_atm_strike(strategy, underlying, expiry)
+    step = _strike_step(underlying.symbol)
+    atm_rounded = round(atm / step) * step
+
+    put_short = atm_rounded - short_distance
+    put_long = put_short - wing_width
+    call_short = atm_rounded + short_distance
+    call_long = call_short + wing_width
+
+    put_short_asset = strategy.options_helper.find_next_valid_option(underlying, put_short, expiry, put_or_call="put")
+    put_long_asset = strategy.options_helper.find_next_valid_option(underlying, put_long, expiry, put_or_call="put")
+    call_short_asset = strategy.options_helper.find_next_valid_option(underlying, call_short, expiry, put_or_call="call")
+    call_long_asset = strategy.options_helper.find_next_valid_option(underlying, call_long, expiry, put_or_call="call")
+
+    if not all([put_short_asset, put_long_asset, call_short_asset, call_long_asset]):
+        raise RuntimeError("Failed to resolve all iron condor legs")
+
+    open_legs = [
+        strategy.create_order(put_long_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(put_short_asset, 1, Order.OrderSide.SELL_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(call_short_asset, 1, Order.OrderSide.SELL_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(call_long_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+    ]
+
+    close_legs = [
+        strategy.create_order(put_long_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(put_short_asset, 1, Order.OrderSide.BUY_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(call_short_asset, 1, Order.OrderSide.BUY_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(call_long_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+    ]
+
+    return open_legs, close_legs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--broker", required=True, choices=["alpaca", "tradier"])
+    parser.add_argument("--symbol", required=True, help="Underlying (e.g. SPY, TSLA, SPX, SPXW)")
+    parser.add_argument("--structure", required=True, choices=["single_call", "iron_condor"])
+    parser.add_argument("--days-out", type=int, default=7)
+    parser.add_argument("--trials", type=int, default=3)
+    parser.add_argument("--preset", choices=["fast", "normal", "patient"], default="fast")
+    parser.add_argument("--final-price-pct", type=float, default=1.0)
+    parser.add_argument("--final-hold-seconds", type=int, default=120)
+    parser.add_argument("--timeout-seconds", type=int, default=240)
+    parser.add_argument("--output", default="logs/bench_smart_limit_vs_market.csv")
+    parser.add_argument("--market-first", action="store_true")
+    args = parser.parse_args()
+
+    broker = _make_broker(args.broker)
+    strategy = _BenchStrategy(broker=broker)
+    # In live mode, Strategy.initialize() is normally invoked by the Trader/Executor.
+    # This script drives the strategy manually, so call initialize explicitly.
+    try:
+        strategy.initialize()
+    except TypeError:
+        # Legacy initialize signatures may accept parameters; ignore for this ops script.
+        strategy.initialize(parameters=None)
+
+    preset = SmartLimitPreset(args.preset)
+    smart_cfg = SmartLimitConfig(
+        preset=preset,
+        final_price_pct=float(args.final_price_pct),
+        final_hold_seconds=int(args.final_hold_seconds),
+    )
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    headers = [
+        "trial",
+        "broker",
+        "symbol",
+        "structure",
+        "mode",
+        "open_status",
+        "open_fill_price",
+        "close_status",
+        "close_fill_price",
+        "open_reprices",
+        "close_reprices",
+        "open_seconds",
+        "close_seconds",
+        "timestamp",
+    ]
+
+    write_header = not output_path.exists()
+    with output_path.open("a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=headers)
+        if write_header:
+            writer.writeheader()
+
+        modes = ["market", "smart"]
+        for trial in range(1, args.trials + 1):
+            if args.market_first:
+                run_order = modes
+            else:
+                run_order = modes[:]
+                random.shuffle(run_order)
+
+            for mode in run_order:
+                if mode == "market":
+                    order_type = Order.OrderType.MARKET
+                    smart_limit = None
+                    drive = False
+                else:
+                    order_type = Order.OrderType.SMART_LIMIT
+                    smart_limit = smart_cfg
+                    drive = True
+
+                if args.structure == "single_call":
+                    open_order, close_order = _build_single_call(
+                        strategy,
+                        args.symbol,
+                        days_out=args.days_out,
+                        otm_points=_strike_step(args.symbol),
+                        order_type=order_type,
+                        smart_limit=smart_limit,
+                    )
+
+                    submitted = strategy.submit_order(open_order)
+                    open_parent = submitted
+                    ok_open, open_snaps = _wait_for_fill(strategy, open_parent, timeout_seconds=args.timeout_seconds, drive_smart_limit=drive)
+
+                    submitted_close = strategy.submit_order(close_order)
+                    close_parent = submitted_close
+                    ok_close, close_snaps = _wait_for_fill(strategy, close_parent, timeout_seconds=args.timeout_seconds, drive_smart_limit=drive)
+
+                else:
+                    open_legs, close_legs = _build_iron_condor(
+                        strategy,
+                        args.symbol,
+                        days_out=args.days_out,
+                        short_distance=_strike_step(args.symbol) * 10,
+                        wing_width=_strike_step(args.symbol) * 5,
+                        order_type=order_type,
+                        smart_limit=smart_limit,
+                    )
+
+                    submit_kwargs = {}
+                    if mode == "market" and args.broker == "alpaca":
+                        submit_kwargs = {"is_multileg": True, "order_type": "market"}
+
+                    submitted = strategy.submit_order(open_legs, **submit_kwargs)
+                    open_parent = submitted[0] if isinstance(submitted, list) else submitted
+                    ok_open, open_snaps = _wait_for_fill(strategy, open_parent, timeout_seconds=args.timeout_seconds, drive_smart_limit=drive)
+
+                    submitted_close = strategy.submit_order(close_legs, **submit_kwargs)
+                    close_parent = submitted_close[0] if isinstance(submitted_close, list) else submitted_close
+                    ok_close, close_snaps = _wait_for_fill(strategy, close_parent, timeout_seconds=args.timeout_seconds, drive_smart_limit=drive)
+
+                def _count_reprices(snaps: list[_FillSnapshot]) -> int:
+                    prices = [s.limit_price for s in snaps if s.limit_price is not None]
+                    uniq = []
+                    for p in prices:
+                        if not uniq or abs(p - uniq[-1]) > 1e-9:
+                            uniq.append(p)
+                    return max(0, len(uniq) - 1)
+
+                open_fill = next((s.avg_fill_price for s in reversed(open_snaps) if s.avg_fill_price is not None), None)
+                close_fill = next((s.avg_fill_price for s in reversed(close_snaps) if s.avg_fill_price is not None), None)
+
+                writer.writerow(
+                    {
+                        "trial": trial,
+                        "broker": args.broker,
+                        "symbol": args.symbol,
+                        "structure": args.structure,
+                        "mode": mode,
+                        "open_status": ok_open,
+                        "open_fill_price": open_fill,
+                        "close_status": ok_close,
+                        "close_fill_price": close_fill,
+                        "open_reprices": _count_reprices(open_snaps),
+                        "close_reprices": _count_reprices(close_snaps),
+                        "open_seconds": round(open_snaps[-1].ts - open_snaps[0].ts, 2) if open_snaps else None,
+                        "close_seconds": round(close_snaps[-1].ts - close_snaps[0].ts, 2) if close_snaps else None,
+                        "timestamp": datetime.now().isoformat(),
+                    }
+                )
+                f.flush()
+
+    print(f"Wrote results to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_smart_limit_vs_market.py
+++ b/scripts/bench_smart_limit_vs_market.py
@@ -39,6 +39,56 @@ def _is_finite_positive(value: Any) -> bool:
         return False
 
 
+def _quote_snapshot(strategy: Strategy, asset: Asset, *, quote: Asset | None = None, exchange: str | None = None):
+    q = strategy.get_quote(asset, quote=quote, exchange=exchange)
+    bid = getattr(q, "bid", None)
+    ask = getattr(q, "ask", None)
+    try:
+        bid_f = float(bid) if bid is not None else None
+    except Exception:
+        bid_f = None
+    try:
+        ask_f = float(ask) if ask is not None else None
+    except Exception:
+        ask_f = None
+    mid_f = None
+    if bid_f is not None and ask_f is not None and ask_f > 0 and bid_f >= 0:
+        mid_f = (bid_f + ask_f) / 2.0
+    return bid_f, ask_f, mid_f
+
+
+def _multileg_net_snapshot(strategy: Strategy, legs: list[Order]):
+    quote_data: list[tuple[Order, float | None, float | None]] = []
+    for leg in legs:
+        q = strategy.get_quote(leg.asset, quote=leg.quote, exchange=leg.exchange)
+        bid = getattr(q, "bid", None)
+        ask = getattr(q, "ask", None)
+        try:
+            bid_f = float(bid) if bid is not None else None
+        except Exception:
+            bid_f = None
+        try:
+            ask_f = float(ask) if ask is not None else None
+        except Exception:
+            ask_f = None
+        quote_data.append((leg, bid_f, ask_f))
+
+    if any(b is None or a is None or b < 0 or a <= 0 for _, b, a in quote_data):
+        return None, None, None
+
+    net_best = 0.0
+    net_fastest = 0.0
+    for leg, bid_f, ask_f in quote_data:
+        if leg.is_buy_order():
+            net_best += float(bid_f)
+            net_fastest += float(ask_f)
+        else:
+            net_best -= float(ask_f)
+            net_fastest -= float(bid_f)
+
+    return net_best, net_fastest, (net_best + net_fastest) / 2.0
+
+
 class _BenchStrategy(Strategy):
     def initialize(self, parameters=None):
         self.sleeptime = "1S"
@@ -152,6 +202,10 @@ def _wait_for_fill(
 
         time.sleep(1.0)
 
+    try:
+        strategy.broker.cancel_order(order)
+    except Exception:
+        pass
     return False, snapshots
 
 
@@ -312,7 +366,7 @@ def main() -> int:
     parser.add_argument("--final-price-pct", type=float, default=1.0)
     parser.add_argument("--final-hold-seconds", type=int, default=120)
     parser.add_argument("--timeout-seconds", type=int, default=240)
-    parser.add_argument("--output", default="logs/bench_smart_limit_vs_market.csv")
+    parser.add_argument("--output", default="logs/bench_smart_limit_vs_market_v2.csv")
     parser.add_argument("--market-first", action="store_true")
     args = parser.parse_args()
 
@@ -342,8 +396,20 @@ def main() -> int:
         "symbol",
         "structure",
         "mode",
+        "open_submit_bid",
+        "open_submit_ask",
+        "open_submit_mid",
+        "open_net_best",
+        "open_net_fastest",
+        "open_net_mid",
         "open_status",
         "open_fill_price",
+        "close_submit_bid",
+        "close_submit_ask",
+        "close_submit_mid",
+        "close_net_best",
+        "close_net_fastest",
+        "close_net_mid",
         "close_status",
         "close_fill_price",
         "open_reprices",
@@ -377,6 +443,11 @@ def main() -> int:
                     smart_limit = smart_cfg
                     drive = True
 
+                open_submit_bid = open_submit_ask = open_submit_mid = None
+                close_submit_bid = close_submit_ask = close_submit_mid = None
+                open_net_best = open_net_fastest = open_net_mid = None
+                close_net_best = close_net_fastest = close_net_mid = None
+
                 if args.structure == "single_call":
                     open_order, close_order = _build_single_call(
                         strategy,
@@ -387,13 +458,34 @@ def main() -> int:
                         smart_limit=smart_limit,
                     )
 
+                    open_submit_bid, open_submit_ask, open_submit_mid = _quote_snapshot(
+                        strategy, open_order.asset, quote=open_order.quote, exchange=open_order.exchange
+                    )
                     submitted = strategy.submit_order(open_order)
                     open_parent = submitted
                     ok_open, open_snaps = _wait_for_fill(strategy, open_parent, timeout_seconds=args.timeout_seconds, drive_smart_limit=drive)
 
-                    submitted_close = strategy.submit_order(close_order)
-                    close_parent = submitted_close
-                    ok_close, close_snaps = _wait_for_fill(strategy, close_parent, timeout_seconds=args.timeout_seconds, drive_smart_limit=drive)
+                    ok_close = False
+                    close_snaps: list[_FillSnapshot] = []
+                    if ok_open:
+                        close_submit_bid, close_submit_ask, close_submit_mid = _quote_snapshot(
+                            strategy, close_order.asset, quote=close_order.quote, exchange=close_order.exchange
+                        )
+                        submitted_close = strategy.submit_order(close_order)
+                        close_parent = submitted_close
+                        ok_close, close_snaps = _wait_for_fill(strategy, close_parent, timeout_seconds=args.timeout_seconds, drive_smart_limit=drive)
+                        if not ok_close:
+                            # Best-effort flatten to avoid leaving positions behind.
+                            mkt_close = strategy.create_order(
+                                close_order.asset,
+                                close_order.quantity,
+                                close_order.side,
+                                order_type=Order.OrderType.MARKET,
+                                quote=close_order.quote,
+                                exchange=close_order.exchange,
+                            )
+                            submitted_mkt = strategy.submit_order(mkt_close)
+                            _wait_for_fill(strategy, submitted_mkt, timeout_seconds=60, drive_smart_limit=False)
 
                 else:
                     open_legs, close_legs = _build_iron_condor(
@@ -410,13 +502,30 @@ def main() -> int:
                     if mode == "market" and args.broker == "alpaca":
                         submit_kwargs = {"is_multileg": True, "order_type": "market"}
 
+                    open_net_best, open_net_fastest, open_net_mid = _multileg_net_snapshot(strategy, open_legs)
                     submitted = strategy.submit_order(open_legs, **submit_kwargs)
                     open_parent = submitted[0] if isinstance(submitted, list) else submitted
                     ok_open, open_snaps = _wait_for_fill(strategy, open_parent, timeout_seconds=args.timeout_seconds, drive_smart_limit=drive)
 
-                    submitted_close = strategy.submit_order(close_legs, **submit_kwargs)
-                    close_parent = submitted_close[0] if isinstance(submitted_close, list) else submitted_close
-                    ok_close, close_snaps = _wait_for_fill(strategy, close_parent, timeout_seconds=args.timeout_seconds, drive_smart_limit=drive)
+                    ok_close = False
+                    close_snaps = []
+                    if ok_open:
+                        close_net_best, close_net_fastest, close_net_mid = _multileg_net_snapshot(strategy, close_legs)
+                        submitted_close = strategy.submit_order(close_legs, **submit_kwargs)
+                        close_parent = submitted_close[0] if isinstance(submitted_close, list) else submitted_close
+                        ok_close, close_snaps = _wait_for_fill(strategy, close_parent, timeout_seconds=args.timeout_seconds, drive_smart_limit=drive)
+                        if not ok_close:
+                            # Best-effort flatten: market close legs as a package.
+                            close_mkt_legs = [
+                                strategy.create_order(leg.asset, leg.quantity, leg.side, order_type=Order.OrderType.MARKET, smart_limit=None)
+                                for leg in close_legs
+                            ]
+                            mkt_kwargs = {}
+                            if args.broker == "alpaca":
+                                mkt_kwargs = {"is_multileg": True, "order_type": "market"}
+                            submitted_mkt = strategy.submit_order(close_mkt_legs, **mkt_kwargs)
+                            mkt_parent = submitted_mkt[0] if isinstance(submitted_mkt, list) else submitted_mkt
+                            _wait_for_fill(strategy, mkt_parent, timeout_seconds=60, drive_smart_limit=False)
 
                 def _count_reprices(snaps: list[_FillSnapshot]) -> int:
                     prices = [s.limit_price for s in snaps if s.limit_price is not None]
@@ -436,8 +545,20 @@ def main() -> int:
                         "symbol": args.symbol,
                         "structure": args.structure,
                         "mode": mode,
+                        "open_submit_bid": open_submit_bid,
+                        "open_submit_ask": open_submit_ask,
+                        "open_submit_mid": open_submit_mid,
+                        "open_net_best": open_net_best,
+                        "open_net_fastest": open_net_fastest,
+                        "open_net_mid": open_net_mid,
                         "open_status": ok_open,
                         "open_fill_price": open_fill,
+                        "close_submit_bid": close_submit_bid,
+                        "close_submit_ask": close_submit_ask,
+                        "close_submit_mid": close_submit_mid,
+                        "close_net_best": close_net_best,
+                        "close_net_fastest": close_net_fastest,
+                        "close_net_mid": close_net_mid,
                         "close_status": ok_close,
                         "close_fill_price": close_fill,
                         "open_reprices": _count_reprices(open_snaps),
@@ -448,6 +569,11 @@ def main() -> int:
                     }
                 )
                 f.flush()
+
+                try:
+                    strategy.cancel_open_orders()
+                except Exception:
+                    pass
 
     print(f"Wrote results to {output_path}")
     return 0

--- a/scripts/bench_smart_limit_vs_market_crypto.py
+++ b/scripts/bench_smart_limit_vs_market_crypto.py
@@ -1,0 +1,351 @@
+"""Benchmark SMART_LIMIT vs MARKET fills for Alpaca crypto (paper).
+
+Crypto is 24/7, so this script is useful on weekends/after-hours to validate SMART_LIMIT behavior
+without waiting for the equity/options session.
+
+This is an ops script: it places real paper orders.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import random
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from lumibot.brokers.alpaca import Alpaca
+from lumibot.credentials import ALPACA_TEST_CONFIG
+from lumibot.entities import Asset, Order, SmartLimitConfig, SmartLimitPreset
+from lumibot.strategies.strategy import Strategy
+
+
+class _BenchStrategy(Strategy):
+    def initialize(self, parameters=None):
+        self.sleeptime = "1S"
+
+    def on_trading_iteration(self):
+        return
+
+
+@dataclass(frozen=True)
+class _FillResult:
+    ok: bool
+    seconds: float
+    reprices: int
+    submit_bid: Optional[float]
+    submit_ask: Optional[float]
+    submit_mid: Optional[float]
+    fill_price: Optional[float]
+
+
+def _alpaca() -> Alpaca:
+    api_key = ALPACA_TEST_CONFIG.get("API_KEY")
+    api_secret = ALPACA_TEST_CONFIG.get("API_SECRET")
+    if not api_key or not api_secret or api_key == "<your key here>" or api_secret == "<your key here>":
+        raise RuntimeError("Missing ALPACA_TEST_API_KEY / ALPACA_TEST_API_SECRET in .env")
+    return Alpaca(ALPACA_TEST_CONFIG, connect_stream=False)
+
+
+def _poll_alpaca_order(broker: Alpaca, order: Order):
+    return broker.api.get_order_by_id(order.identifier)
+
+
+def _cancel_alpaca_open_orders_for_symbol(broker: Alpaca, symbol: str) -> None:
+    """Best-effort cleanup to avoid Alpaca crypto wash-trade rejections in paper."""
+    try:
+        from alpaca.trading.enums import QueryOrderStatus
+        from alpaca.trading.requests import GetOrdersRequest
+    except Exception:
+        return
+
+    target = str(symbol).upper().replace("/", "")
+    try:
+        request = GetOrdersRequest(status=QueryOrderStatus.OPEN, limit=500)
+        open_orders = broker.api.get_orders(filter=request) or []
+    except Exception:
+        return
+
+    for raw in open_orders:
+        raw_symbol = getattr(raw, "symbol", None)
+        if raw_symbol is None and hasattr(raw, "_raw") and isinstance(raw._raw, dict):
+            raw_symbol = raw._raw.get("symbol")
+        if not raw_symbol:
+            continue
+        raw_norm = str(raw_symbol).upper().replace("/", "")
+        if raw_norm != target:
+            continue
+        try:
+            broker.api.cancel_order_by_id(getattr(raw, "id", None) or raw._raw.get("id"))  # noqa: SLF001
+        except Exception:
+            pass
+
+
+def _get_crypto_position_qty(broker: Alpaca, base_symbol: str) -> float:
+    base_symbol = str(base_symbol).upper()
+    try:
+        positions = broker.api.get_all_positions() or []
+    except Exception:
+        return 0.0
+    for p in positions:
+        sym = str(getattr(p, "symbol", "")).upper().replace("/", "")
+        if sym.startswith(base_symbol):
+            try:
+                return float(getattr(p, "qty", 0.0))
+            except Exception:
+                return 0.0
+    return 0.0
+
+
+def _quote_snapshot(strategy: _BenchStrategy, base: Asset, quote: Asset) -> tuple[Optional[float], Optional[float], Optional[float]]:
+    q = strategy.get_quote(base, quote=quote)
+    bid = getattr(q, "bid", None)
+    ask = getattr(q, "ask", None)
+    try:
+        bid_f = float(bid) if bid is not None else None
+    except Exception:
+        bid_f = None
+    try:
+        ask_f = float(ask) if ask is not None else None
+    except Exception:
+        ask_f = None
+    mid_f = None
+    if bid_f is not None and ask_f is not None and ask_f > 0 and bid_f >= 0:
+        mid_f = (bid_f + ask_f) / 2.0
+    return bid_f, ask_f, mid_f
+
+
+def _wait_fill(
+    strategy: _BenchStrategy,
+    order: Order,
+    *,
+    timeout_seconds: int,
+    drive_smart_limit: bool,
+) -> tuple[bool, int, float, Optional[float]]:
+    start = time.time()
+    last_limit = None
+    reprices = 0
+
+    while time.time() - start < timeout_seconds:
+        if drive_smart_limit:
+            try:
+                strategy._executor._process_smart_limit_orders()  # noqa: SLF001 (ops script)
+            except Exception:
+                pass
+
+        try:
+            raw = _poll_alpaca_order(strategy.broker, order)
+        except Exception:
+            # If submission failed, the order identifier might be a local UUID that the broker doesn't know about.
+            return False, reprices, time.time() - start, None
+        raw_status = getattr(raw, "status", "")
+        if hasattr(raw_status, "value"):
+            raw_status = raw_status.value
+        status = str(raw_status).lower()
+
+        limit_price = getattr(raw, "limit_price", None)
+        if limit_price is not None:
+            try:
+                limit_f = float(limit_price)
+                if last_limit is None:
+                    last_limit = limit_f
+                elif abs(limit_f - last_limit) > 1e-9:
+                    reprices += 1
+                    last_limit = limit_f
+            except Exception:
+                pass
+
+        if status in {"filled", "fill"}:
+            avg_fill = getattr(raw, "filled_avg_price", None) or getattr(raw, "avg_fill_price", None)
+            fill_price = float(avg_fill) if avg_fill is not None else None
+            return True, reprices, time.time() - start, fill_price
+        if status in {"canceled", "cancelled", "rejected", "expired", "error"}:
+            avg_fill = getattr(raw, "filled_avg_price", None) or getattr(raw, "avg_fill_price", None)
+            fill_price = float(avg_fill) if avg_fill is not None else None
+            return False, reprices, time.time() - start, fill_price
+
+        time.sleep(1.0)
+
+    try:
+        strategy.broker.cancel_order(order)
+    except Exception:
+        pass
+    return False, reprices, time.time() - start, None
+
+
+def _slippage_vs_mid(side: str, fill_price: Optional[float], mid: Optional[float]) -> Optional[float]:
+    if fill_price is None or mid is None:
+        return None
+    side = side.lower()
+    if side == "buy":
+        return float(fill_price) - float(mid)
+    return float(mid) - float(fill_price)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--symbol", default="BTC", help="Crypto base (e.g. BTC, ETH)")
+    parser.add_argument("--quote", default="USD", help="Quote currency (default USD)")
+    parser.add_argument("--qty", type=float, default=0.001)
+    parser.add_argument("--trials", type=int, default=5)
+    parser.add_argument("--preset", choices=["fast", "normal", "patient"], default="fast")
+    parser.add_argument("--final-price-pct", type=float, default=1.0)
+    parser.add_argument("--step-seconds", type=int, default=1)
+    parser.add_argument("--final-hold-seconds", type=int, default=30)
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    parser.add_argument("--output", default="logs/bench_smart_limit_vs_market_crypto.csv")
+    parser.add_argument("--market-first", action="store_true")
+    args = parser.parse_args()
+
+    broker = _alpaca()
+    strategy = _BenchStrategy(broker=broker)
+    try:
+        strategy.initialize()
+    except TypeError:
+        strategy.initialize(parameters=None)
+
+    preset = SmartLimitPreset(args.preset)
+    smart_cfg = SmartLimitConfig(
+        preset=preset,
+        final_price_pct=float(args.final_price_pct),
+        step_seconds=int(args.step_seconds),
+        final_hold_seconds=int(args.final_hold_seconds),
+    )
+
+    base = Asset(args.symbol.upper(), asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset(args.quote.upper(), asset_type=Asset.AssetType.FOREX)
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    headers = [
+        "trial",
+        "mode",
+        "side",
+        "symbol",
+        "qty",
+        "submit_bid",
+        "submit_ask",
+        "submit_mid",
+        "fill_price",
+        "slippage_vs_mid",
+        "reprices",
+        "seconds",
+        "timestamp",
+    ]
+
+    write_header = not out_path.exists()
+    with out_path.open("a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=headers)
+        if write_header:
+            writer.writeheader()
+
+        for trial in range(1, args.trials + 1):
+            _cancel_alpaca_open_orders_for_symbol(broker, f"{base.symbol}/{quote.symbol}")
+
+            # Best-effort flatten (paper can charge fees/rounding; keep it simple and sell any existing base qty).
+            existing_qty = _get_crypto_position_qty(broker, base.symbol)
+            if existing_qty > 0:
+                flatten = strategy.create_order(
+                    base,
+                    existing_qty,
+                    Order.OrderSide.SELL,
+                    order_type=Order.OrderType.MARKET,
+                    quote=quote,
+                )
+                submitted_flatten = strategy.submit_order(flatten)
+                _wait_fill(strategy, submitted_flatten, timeout_seconds=30, drive_smart_limit=False)
+
+            modes = ["market", "smart"]
+            if not args.market_first:
+                random.shuffle(modes)
+
+            for mode in modes:
+                if mode == "market":
+                    order_type = Order.OrderType.MARKET
+                    smart_limit = None
+                    drive = False
+                else:
+                    order_type = Order.OrderType.SMART_LIMIT
+                    smart_limit = smart_cfg
+                    drive = True
+
+                # Round-trip: buy then sell. Sell size must reflect what we actually received after fees/rounding.
+                for side in ("buy", "sell"):
+                    bid, ask, mid = _quote_snapshot(strategy, base, quote)
+                    order_side = Order.OrderSide.BUY if side == "buy" else Order.OrderSide.SELL
+                    qty = float(args.qty)
+                    if side == "sell":
+                        # After the buy, Alpaca can apply crypto fees/rounding such that base qty is slightly less
+                        # than requested. Sell the available position size to avoid "insufficient balance".
+                        for _ in range(10):
+                            qty = _get_crypto_position_qty(broker, base.symbol)
+                            if qty > 0:
+                                break
+                            time.sleep(0.5)
+                        if qty <= 0:
+                            break
+                    order = strategy.create_order(
+                        base,
+                        qty,
+                        order_side,
+                        order_type=order_type,
+                        smart_limit=smart_limit,
+                        quote=quote,
+                    )
+
+                    submitted = strategy.submit_order(order)
+                    ok, reprices, seconds, fill_price = _wait_fill(
+                        strategy,
+                        submitted,
+                        timeout_seconds=int(args.timeout_seconds),
+                        drive_smart_limit=drive,
+                    )
+
+                    writer.writerow(
+                        {
+                            "trial": trial,
+                            "mode": mode,
+                            "side": side,
+                            "symbol": f"{base.symbol}/{quote.symbol}",
+                            "qty": float(args.qty),
+                            "submit_bid": bid,
+                            "submit_ask": ask,
+                            "submit_mid": mid,
+                            "fill_price": fill_price,
+                            "slippage_vs_mid": _slippage_vs_mid(side, fill_price, mid),
+                            "reprices": reprices,
+                            "seconds": round(seconds, 2),
+                            "timestamp": datetime.now().isoformat(),
+                        }
+                    )
+                    f.flush()
+
+                    if not ok:
+                        try:
+                            strategy.cancel_open_orders()
+                        except Exception:
+                            pass
+                        # If the buy succeeded but sell failed, the next iteration will attempt sell again.
+                        break
+
+            # Best-effort cleanup between trials.
+            try:
+                strategy.cancel_open_orders()
+            except Exception:
+                pass
+
+    print(f"Wrote results to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ known-third-party=lumibot
 markers =
     apitest: marks tests as API tests (deselect with '-m "not apitest"')
     downloader: marks tests that require the shared Theta downloader service
+    acceptance_smoke: short-window end-to-end backtest smokes (trusted secrets required)
 
 # Exclude the warnings issued by underlying library that we can't fix
 filterwarnings =

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.21",
+    version="4.4.22",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/tests/backtest/test_theta_strategies_integration.py
+++ b/tests/backtest/test_theta_strategies_integration.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from dotenv import load_dotenv
 
-pytestmark = []
+pytestmark = [pytest.mark.acceptance_smoke]
 
 
 DEFAULT_ENV_PATH = Path.home() / "Documents/Development/Strategy Library/Demos/.env"

--- a/tests/test_options_helper_evaluate_option_market_daily_snapshot_override.py
+++ b/tests/test_options_helper_evaluate_option_market_daily_snapshot_override.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from lumibot.components.options_helper import OptionsHelper
+from lumibot.entities import Asset, Quote
+
+
+class _DummyBroker:
+    def __init__(self, *, timestep: str):
+        class ThetaDataBacktestingPandas:  # noqa: N801 - intentional for __name__ match
+            def __init__(self, timestep: str):
+                self._timestep = timestep
+
+        self.IS_BACKTESTING_BROKER = True
+        self.data_source = ThetaDataBacktestingPandas(timestep)
+        self.option_source = None
+
+
+class _Strategy:
+    def __init__(self, *, now: datetime, sleeptime: str, timestep: str, bid: float, ask: float):
+        self.is_backtesting = True
+        self.broker = _DummyBroker(timestep=timestep)
+        self._now = now
+        self.sleeptime = sleeptime
+        self._bid = bid
+        self._ask = ask
+
+    def get_datetime(self):
+        return self._now
+
+    def get_quote(self, asset):
+        return Quote(asset=asset, bid=self._bid, ask=self._ask, price=None, timestamp=self._now)
+
+    def log_message(self, *args, **kwargs):
+        return None
+
+
+def test_evaluate_option_market_overrides_day_quotes_with_snapshot_nbbo_in_daily_cadence():
+    now = datetime(2025, 1, 6, 9, 30, 0)
+    strategy = _Strategy(now=now, sleeptime="1D", timestep="day", bid=1.0, ask=2.0)
+    helper = OptionsHelper(strategy)
+
+    option = Asset("SPY", asset_type="option", expiration=now.date(), strike=500.0, right="call")
+
+    def _mock_mark(asset, *, snapshot: bool):
+        if snapshot:
+            return 11.0, 10.0, 12.0
+        return None, None, None
+
+    helper._get_option_mark_from_quote = _mock_mark  # type: ignore[method-assign]
+
+    evaluation = helper.evaluate_option_market(option, max_spread_pct=0.5)
+    assert evaluation.bid == 10.0
+    assert evaluation.ask == 12.0
+    assert evaluation.buy_price == 12.0
+    assert evaluation.sell_price == 10.0
+    assert "snapshot_nbbo_override" in evaluation.data_quality_flags
+
+
+def test_evaluate_option_market_keeps_existing_bid_ask_in_intraday_cadence():
+    now = datetime(2025, 1, 6, 9, 30, 0)
+    strategy = _Strategy(now=now, sleeptime="1M", timestep="minute", bid=1.0, ask=2.0)
+    helper = OptionsHelper(strategy)
+
+    option = Asset("SPY", asset_type="option", expiration=now.date(), strike=500.0, right="call")
+
+    def _mock_mark(asset, *, snapshot: bool):  # pragma: no cover - should not affect intraday override
+        if snapshot:
+            return 11.0, 10.0, 12.0
+        return None, None, None
+
+    helper._get_option_mark_from_quote = _mock_mark  # type: ignore[method-assign]
+
+    evaluation = helper.evaluate_option_market(option, max_spread_pct=0.5)
+    assert evaluation.bid == 1.0
+    assert evaluation.ask == 2.0
+    assert "snapshot_nbbo_override" not in evaluation.data_quality_flags

--- a/tests/test_options_helper_index_fast_paths.py
+++ b/tests/test_options_helper_index_fast_paths.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from lumibot.components.options_helper import OptionsHelper
+from lumibot.entities import Asset
+
+
+class _DummyBroker:
+    def __init__(self):
+        class ThetaDataBacktestingPandas:  # noqa: N801 - intentional for __name__ match
+            pass
+
+        self.IS_BACKTESTING_BROKER = True
+        self.data_source = ThetaDataBacktestingPandas()
+
+
+class _ChainsWithStrikes:
+    def __init__(self, *, expiry: date, strikes: list[float]):
+        self._expiry = expiry
+        self._strikes = strikes
+        self._chains = {
+            "Chains": {
+                "CALL": {expiry.strftime("%Y-%m-%d"): strikes},
+                "PUT": {expiry.strftime("%Y-%m-%d"): strikes},
+            }
+        }
+
+    def get(self, key, default=None):
+        return self._chains.get(key, default)
+
+    def strikes(self, expiry, right):
+        if expiry != self._expiry:
+            return []
+        right_key = str(right).upper()
+        return list(self._chains["Chains"].get(right_key, {}).get(self._expiry.strftime("%Y-%m-%d"), []))
+
+
+class _Strategy:
+    def __init__(self, *, now: datetime, chains):
+        self.is_backtesting = True
+        self.broker = _DummyBroker()
+        self._now = now
+        self._chains = chains
+        self.sleeptime = "1M"
+        self.parameters = {}
+
+    def get_datetime(self):
+        return self._now
+
+    def get_last_price(self, asset):
+        # Used by the index fast-path distance check.
+        if getattr(asset, "symbol", None) == "SPXW":
+            return 6010.0
+        return None
+
+    def get_chains(self, underlying_asset):
+        return self._chains
+
+    def log_message(self, *args, **kwargs):
+        return None
+
+
+def test_get_expiration_on_or_after_date_skips_quote_validation_for_0dte_index():
+    now = datetime(2025, 1, 6, 10, 15, 0)
+    helper = OptionsHelper(_Strategy(now=now, chains=None))
+
+    chains = {"Chains": {"CALL": {"2025-01-06": [6000.0, 6010.0]}}}
+    underlying = Asset("SPXW", asset_type=Asset.AssetType.INDEX)
+
+    def _boom(*args, **kwargs):  # pragma: no cover - should never run
+        raise AssertionError("_get_option_mark_from_quote should not be called for 0DTE index expiry fast-path")
+
+    helper._get_option_mark_from_quote = _boom  # type: ignore[method-assign]
+
+    expiry = helper.get_expiration_on_or_after_date(
+        dt=now.date(),
+        chains=chains,
+        call_or_put="call",
+        underlying_asset=underlying,
+    )
+
+    assert expiry == now.date()
+
+
+def test_find_next_valid_option_skips_snapshot_quote_scans_for_atm_index():
+    now = datetime(2025, 1, 6, 10, 15, 0)
+    expiry = now.date()
+    chains = _ChainsWithStrikes(expiry=expiry, strikes=[6000.0, 6010.0, 6020.0])
+    strategy = _Strategy(now=now, chains=chains)
+    helper = OptionsHelper(strategy)
+
+    def _boom(*args, **kwargs):  # pragma: no cover - should never run
+        raise AssertionError("_get_option_mark_from_quote should not be called for ATM index fast-path")
+
+    helper._get_option_mark_from_quote = _boom  # type: ignore[method-assign]
+
+    underlying = Asset("SPXW", asset_type=Asset.AssetType.INDEX)
+    option = helper.find_next_valid_option(
+        underlying_asset=underlying,
+        rounded_underlying_price=6010.0,
+        expiry=expiry,
+        put_or_call="call",
+    )
+
+    assert option is not None
+    assert option.strike == 6010.0

--- a/tests/test_smart_limit_live_alpaca.py
+++ b/tests/test_smart_limit_live_alpaca.py
@@ -33,6 +33,35 @@ def _alpaca() -> Alpaca:
 def _poll_alpaca_order(broker: Alpaca, order: Order):
     return broker.api.get_order_by_id(order.identifier)
 
+def _cancel_alpaca_open_orders_for_symbol(broker: Alpaca, symbol: str) -> None:
+    """Best-effort cleanup for Alpaca to avoid crypto wash-trade rejections in paper."""
+    try:
+        from alpaca.trading.enums import QueryOrderStatus
+        from alpaca.trading.requests import GetOrdersRequest
+    except Exception:
+        return
+
+    target = str(symbol).upper().replace("/", "")
+    try:
+        request = GetOrdersRequest(status=QueryOrderStatus.OPEN, limit=500)
+        open_orders = broker.api.get_orders(filter=request) or []
+    except Exception:
+        return
+
+    for raw in open_orders:
+        raw_symbol = getattr(raw, "symbol", None)
+        if raw_symbol is None and hasattr(raw, "_raw") and isinstance(raw._raw, dict):
+            raw_symbol = raw._raw.get("symbol")
+        if not raw_symbol:
+            continue
+        raw_norm = str(raw_symbol).upper().replace("/", "")
+        if raw_norm != target:
+            continue
+        try:
+            broker.api.cancel_order_by_id(getattr(raw, "id", None) or raw._raw.get("id"))  # noqa: SLF001
+        except Exception:
+            pass
+
 
 def _wait_fill(strategy: _HarnessStrategy, order: Order, *, timeout: int, drive_smart_limit: bool) -> tuple[bool, int, float]:
     start = time.time()
@@ -242,3 +271,77 @@ def test_alpaca_spy_stock_smart_limit_fills():
     submitted_close = strategy.submit_order(close_order)
     ok_close, _, close_elapsed = _wait_fill(strategy, submitted_close, timeout=120, drive_smart_limit=True)
     assert ok_close, f"Stock sell did not fill (elapsed={close_elapsed:.1f}s)"
+
+
+def test_alpaca_crypto_btcusd_smart_limit_fills_24_7():
+    broker = _alpaca()
+
+    strategy = _HarnessStrategy(broker=broker)
+    try:
+        strategy.initialize()
+    except TypeError:
+        strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, step_seconds=1, final_hold_seconds=180)
+    base = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    qty = 0.001
+
+    try:
+        _cancel_alpaca_open_orders_for_symbol(broker, "BTC/USD")
+
+        open_order = strategy.create_order(
+            base,
+            qty,
+            Order.OrderSide.BUY,
+            order_type=Order.OrderType.SMART_LIMIT,
+            smart_limit=cfg,
+            quote=quote,
+        )
+        submitted_open = strategy.submit_order(open_order)
+        assert submitted_open is not None
+        ok_open, reprices_open, open_elapsed = _wait_fill(strategy, submitted_open, timeout=240, drive_smart_limit=True)
+        assert ok_open, f"BTCUSD buy did not fill (reprices={reprices_open}, elapsed={open_elapsed:.1f}s)"
+
+        # Alpaca crypto can apply fees/rounding such that the filled base quantity is slightly less than requested.
+        # Close whatever we actually have available to avoid "insufficient balance" errors.
+        close_qty = qty
+        try:
+            positions = broker.api.get_all_positions() or []
+            for p in positions:
+                sym = str(getattr(p, "symbol", "")).upper().replace("/", "")
+                if sym.startswith(base.symbol.upper()):
+                    close_qty = float(getattr(p, "qty", close_qty))
+                    break
+        except Exception:
+            pass
+        if close_qty <= 0:
+            close_qty = qty
+
+        close_order = strategy.create_order(
+            base,
+            close_qty,
+            Order.OrderSide.SELL,
+            order_type=Order.OrderType.SMART_LIMIT,
+            smart_limit=cfg,
+            quote=quote,
+        )
+        submitted_close = strategy.submit_order(close_order)
+        ok_close, reprices_close, close_elapsed = _wait_fill(strategy, submitted_close, timeout=240, drive_smart_limit=True)
+        if not ok_close:
+            market_close = strategy.create_order(base, qty, Order.OrderSide.SELL, order_type=Order.OrderType.MARKET, quote=quote)
+            submitted_market = strategy.submit_order(market_close)
+            ok_mkt, _, _ = _wait_fill(strategy, submitted_market, timeout=60, drive_smart_limit=False)
+            assert ok_mkt, "BTCUSD market close fallback did not fill"
+            pytest.fail(f"BTCUSD smart close did not fill (reprices={reprices_close}, elapsed={close_elapsed:.1f}s)")
+
+        if open_elapsed > cfg.get_step_seconds():
+            assert reprices_open >= 1
+        if close_elapsed > cfg.get_step_seconds():
+            assert reprices_close >= 1
+    finally:
+        # Best-effort cleanup to avoid leaving open orders behind if the test fails mid-way.
+        try:
+            strategy.cancel_open_orders()
+        except Exception:
+            pass

--- a/tests/test_smart_limit_live_alpaca.py
+++ b/tests/test_smart_limit_live_alpaca.py
@@ -1,0 +1,244 @@
+import time
+from datetime import datetime, timedelta
+
+import pytest
+
+from lumibot.brokers.alpaca import Alpaca
+from lumibot.components.options_helper import OptionsHelper
+from lumibot.credentials import ALPACA_TEST_CONFIG
+from lumibot.entities import Asset, Order, SmartLimitConfig, SmartLimitPreset
+from lumibot.strategies.strategy import Strategy
+
+
+pytestmark = pytest.mark.apitest
+
+
+class _HarnessStrategy(Strategy):
+    def initialize(self, parameters=None):
+        self.sleeptime = "1S"
+        self.options_helper = OptionsHelper(self)
+
+    def on_trading_iteration(self):
+        return
+
+
+def _alpaca() -> Alpaca:
+    api_key = ALPACA_TEST_CONFIG.get("API_KEY")
+    api_secret = ALPACA_TEST_CONFIG.get("API_SECRET")
+    if not api_key or not api_secret or api_key == "<your key here>" or api_secret == "<your key here>":
+        pytest.skip("Missing ALPACA_TEST_API_KEY / ALPACA_TEST_API_SECRET in .env")
+    return Alpaca(ALPACA_TEST_CONFIG, connect_stream=False)
+
+
+def _poll_alpaca_order(broker: Alpaca, order: Order):
+    return broker.api.get_order_by_id(order.identifier)
+
+
+def _wait_fill(strategy: _HarnessStrategy, order: Order, *, timeout: int, drive_smart_limit: bool) -> tuple[bool, int, float]:
+    start = time.time()
+    last_price = None
+    reprices = 0
+    while time.time() - start < timeout:
+        if drive_smart_limit:
+            strategy._executor._process_smart_limit_orders()
+
+        raw = _poll_alpaca_order(strategy.broker, order)
+        raw_status = getattr(raw, "status", "")
+        if hasattr(raw_status, "value"):
+            raw_status = raw_status.value
+        status = str(raw_status).lower()
+        order.status = status
+
+        price = getattr(raw, "limit_price", None)
+        if price is not None:
+            try:
+                price = float(price)
+                order.limit_price = price
+                if last_price is None:
+                    last_price = price
+                elif abs(price - last_price) > 1e-9:
+                    reprices += 1
+                    last_price = price
+            except Exception:
+                pass
+
+        if status in {"filled", "fill"}:
+            elapsed = time.time() - start
+            return True, reprices, elapsed
+        if status in {"canceled", "cancelled", "rejected", "expired", "error"}:
+            elapsed = time.time() - start
+            return False, reprices, elapsed
+
+        time.sleep(1.0)
+
+    return False, reprices, time.time() - start
+
+
+def _strike_step(symbol: str) -> float:
+    return 1.0 if symbol.upper() == "SPY" else 5.0
+
+
+def _pick_expiry(strategy: _HarnessStrategy, underlying: Asset, days_out: int):
+    chains = strategy.get_chains(underlying)
+    if not chains:
+        raise RuntimeError(f"No chains for {underlying.symbol}")
+    target_date = datetime.now().astimezone().date() + timedelta(days=days_out)
+    expiry = strategy.options_helper.get_expiration_on_or_after_date(target_date, chains, "call", underlying_asset=underlying)
+    if expiry is None:
+        raise RuntimeError("No expiry found")
+    return expiry
+
+
+def _pick_atm(strategy: _HarnessStrategy, underlying: Asset) -> float:
+    price = strategy.get_last_price(underlying)
+    if price and float(price) > 0:
+        return float(price)
+    raise RuntimeError("Underlying price unavailable")
+
+
+def _build_spy_iron_condor(strategy: _HarnessStrategy, *, days_out: int, short_distance: float, wing_width: float, cfg: SmartLimitConfig):
+    underlying = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    expiry = _pick_expiry(strategy, underlying, days_out)
+    atm = _pick_atm(strategy, underlying)
+    step = _strike_step("SPY")
+    atm_rounded = round(atm / step) * step
+
+    put_short = atm_rounded - short_distance
+    put_long = put_short - wing_width
+    call_short = atm_rounded + short_distance
+    call_long = call_short + wing_width
+
+    put_short_asset = strategy.options_helper.find_next_valid_option(underlying, put_short, expiry, put_or_call="put")
+    put_long_asset = strategy.options_helper.find_next_valid_option(underlying, put_long, expiry, put_or_call="put")
+    call_short_asset = strategy.options_helper.find_next_valid_option(underlying, call_short, expiry, put_or_call="call")
+    call_long_asset = strategy.options_helper.find_next_valid_option(underlying, call_long, expiry, put_or_call="call")
+
+    assert put_short_asset and put_long_asset and call_short_asset and call_long_asset
+
+    open_legs = [
+        strategy.create_order(put_long_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+        strategy.create_order(put_short_asset, 1, Order.OrderSide.SELL_TO_OPEN, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+        strategy.create_order(call_short_asset, 1, Order.OrderSide.SELL_TO_OPEN, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+        strategy.create_order(call_long_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+    ]
+    close_legs = [
+        strategy.create_order(put_long_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+        strategy.create_order(put_short_asset, 1, Order.OrderSide.BUY_TO_CLOSE, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+        strategy.create_order(call_short_asset, 1, Order.OrderSide.BUY_TO_CLOSE, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+        strategy.create_order(call_long_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+    ]
+    return open_legs, close_legs
+
+
+def test_alpaca_spy_multileg_smart_limit_fills_and_reprices():
+    broker = _alpaca()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    try:
+        strategy.initialize()
+    except TypeError:
+        strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=30)
+    open_legs, close_legs = _build_spy_iron_condor(strategy, days_out=7, short_distance=5.0, wing_width=5.0, cfg=cfg)
+
+    submitted = strategy.submit_order(open_legs)
+    parent = submitted[0] if isinstance(submitted, list) else submitted
+    assert parent is not None
+
+    ok_open, reprices_open, open_elapsed = _wait_fill(strategy, parent, timeout=240, drive_smart_limit=True)
+    assert ok_open, f"Open did not fill (reprices={reprices_open}, elapsed={open_elapsed:.1f}s)"
+
+    submitted_close = strategy.submit_order(close_legs)
+    parent_close = submitted_close[0] if isinstance(submitted_close, list) else submitted_close
+    ok_close, reprices_close, close_elapsed = _wait_fill(strategy, parent_close, timeout=240, drive_smart_limit=True)
+    assert ok_close, f"Close did not fill (reprices={reprices_close}, elapsed={close_elapsed:.1f}s)"
+
+    if open_elapsed > cfg.get_step_seconds():
+        assert reprices_open >= 1
+
+
+def test_alpaca_spy_single_leg_smart_limit_fills():
+    broker = _alpaca()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    try:
+        strategy.initialize()
+    except TypeError:
+        strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=30)
+    underlying = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    expiry = _pick_expiry(strategy, underlying, days_out=30)
+    atm = _pick_atm(strategy, underlying)
+    step = _strike_step("SPY")
+    atm_rounded = round(atm / step) * step
+    strike = atm_rounded + (10 * step)
+
+    call_asset = strategy.options_helper.find_next_valid_option(underlying, strike, expiry, put_or_call="call")
+    assert call_asset is not None
+
+    open_order = strategy.create_order(
+        call_asset,
+        1,
+        Order.OrderSide.BUY_TO_OPEN,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+    )
+    submitted_open = strategy.submit_order(open_order)
+    assert submitted_open is not None
+    ok_open, reprices_open, open_elapsed = _wait_fill(strategy, submitted_open, timeout=180, drive_smart_limit=True)
+    assert ok_open, f"Single-leg open did not fill (reprices={reprices_open}, elapsed={open_elapsed:.1f}s)"
+
+    close_order = strategy.create_order(
+        call_asset,
+        1,
+        Order.OrderSide.SELL_TO_CLOSE,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+    )
+    submitted_close = strategy.submit_order(close_order)
+    ok_close, reprices_close, close_elapsed = _wait_fill(strategy, submitted_close, timeout=180, drive_smart_limit=True)
+    assert ok_close, f"Single-leg close did not fill (reprices={reprices_close}, elapsed={close_elapsed:.1f}s)"
+
+
+def test_alpaca_spy_stock_smart_limit_fills():
+    broker = _alpaca()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    try:
+        strategy.initialize()
+    except TypeError:
+        strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=30)
+    asset = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+
+    open_order = strategy.create_order(
+        asset,
+        1,
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+    )
+    submitted_open = strategy.submit_order(open_order)
+    assert submitted_open is not None
+    ok_open, _, open_elapsed = _wait_fill(strategy, submitted_open, timeout=120, drive_smart_limit=True)
+    assert ok_open, f"Stock buy did not fill (elapsed={open_elapsed:.1f}s)"
+
+    close_order = strategy.create_order(
+        asset,
+        1,
+        Order.OrderSide.SELL,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+    )
+    submitted_close = strategy.submit_order(close_order)
+    ok_close, _, close_elapsed = _wait_fill(strategy, submitted_close, timeout=120, drive_smart_limit=True)
+    assert ok_close, f"Stock sell did not fill (elapsed={close_elapsed:.1f}s)"

--- a/tests/test_smart_limit_live_tradier.py
+++ b/tests/test_smart_limit_live_tradier.py
@@ -1,0 +1,264 @@
+import time
+from datetime import datetime, timedelta
+
+import pytest
+
+from lumibot.brokers.tradier import Tradier
+from lumibot.components.options_helper import OptionsHelper
+from lumibot.credentials import TRADIER_TEST_CONFIG
+from lumibot.entities import Asset, Order, SmartLimitConfig, SmartLimitPreset
+from lumibot.strategies.strategy import Strategy
+
+
+pytestmark = pytest.mark.apitest
+
+
+class _HarnessStrategy(Strategy):
+    def initialize(self, parameters=None):
+        self.sleeptime = "1S"
+        self.options_helper = OptionsHelper(self)
+
+    def on_trading_iteration(self):
+        return
+
+
+def _tradier() -> Tradier:
+    if not TRADIER_TEST_CONFIG.get("ACCOUNT_NUMBER") or not TRADIER_TEST_CONFIG.get("ACCESS_TOKEN"):
+        pytest.skip("Missing TRADIER_TEST_ACCOUNT_NUMBER / TRADIER_TEST_ACCESS_TOKEN in .env")
+    return Tradier(
+        account_number=TRADIER_TEST_CONFIG["ACCOUNT_NUMBER"],
+        access_token=TRADIER_TEST_CONFIG["ACCESS_TOKEN"],
+        paper=True,
+        connect_stream=True,
+    )
+
+
+def _poll_tradier_order(broker: Tradier, order: Order) -> dict:
+    # Internal helper is fine for apitests; this is not production code.
+    return broker._pull_broker_order(order.identifier)
+
+
+def _wait_fill(strategy: _HarnessStrategy, order: Order, *, timeout: int, drive_smart_limit: bool) -> tuple[bool, int, float]:
+    start = time.time()
+    last_price = None
+    reprices = 0
+    while time.time() - start < timeout:
+        if drive_smart_limit:
+            strategy._executor._process_smart_limit_orders()
+
+        record = _poll_tradier_order(strategy.broker, order)
+        status = str(record.get("status", "")).lower()
+        order.status = status
+
+        price = record.get("price")
+        if price is not None:
+            try:
+                price = float(price)
+                order.limit_price = price
+                if last_price is None:
+                    last_price = price
+                elif abs(price - last_price) > 1e-9:
+                    reprices += 1
+                    last_price = price
+            except Exception:
+                pass
+
+        if status == "filled":
+            elapsed = time.time() - start
+            return True, reprices, elapsed
+        if status in {"canceled", "cancelled", "rejected", "expired", "error"}:
+            elapsed = time.time() - start
+            return False, reprices, elapsed
+
+        time.sleep(1.0)
+
+    return False, reprices, time.time() - start
+
+
+def _strike_step(symbol: str) -> float:
+    return 5.0 if symbol.upper() in {"SPX", "SPXW", "NDX", "RUT"} else 1.0
+
+
+def _pick_expiry(strategy: _HarnessStrategy, underlying: Asset, days_out: int):
+    chains = strategy.get_chains(underlying)
+    if not chains and underlying.symbol.upper() == "SPX":
+        chains = strategy.get_chains(Asset("SPXW", asset_type=Asset.AssetType.INDEX))
+    if not chains and underlying.symbol.upper() == "SPXW":
+        chains = strategy.get_chains(Asset("SPX", asset_type=Asset.AssetType.INDEX))
+    if not chains:
+        raise RuntimeError(f"No chains for {underlying.symbol}")
+
+    target_date = datetime.now().astimezone().date() + timedelta(days=days_out)
+    expiry = strategy.options_helper.get_expiration_on_or_after_date(target_date, chains, "call", underlying_asset=underlying)
+    if expiry is None:
+        raise RuntimeError("No expiry found")
+    return expiry
+
+
+def _pick_atm_strike(strategy: _HarnessStrategy, underlying: Asset, expiry) -> float:
+    price = strategy.get_last_price(underlying)
+    if price and float(price) > 0:
+        return float(price)
+
+    chains = strategy.get_chains(underlying)
+    if not chains and underlying.symbol.upper() == "SPX":
+        chains = strategy.get_chains(Asset("SPXW", asset_type=Asset.AssetType.INDEX))
+    if not chains and underlying.symbol.upper() == "SPXW":
+        chains = strategy.get_chains(Asset("SPX", asset_type=Asset.AssetType.INDEX))
+    if not chains:
+        raise RuntimeError("No chains available to infer ATM strike")
+
+    strikes_raw = chains.strikes(expiry, "CALL") or []
+    strikes = sorted(float(s) for s in strikes_raw if s is not None)
+    if not strikes:
+        raise RuntimeError("No strikes available to infer ATM strike")
+    return float(strikes[len(strikes) // 2])
+
+
+def _build_spx_iron_condor(strategy: _HarnessStrategy, *, days_out: int, short_distance: float, wing_width: float, cfg: SmartLimitConfig):
+    underlying = Asset("SPX", asset_type=Asset.AssetType.INDEX)
+    expiry = _pick_expiry(strategy, underlying, days_out)
+    atm = _pick_atm_strike(strategy, underlying, expiry)
+    step = _strike_step("SPX")
+    atm_rounded = round(atm / step) * step
+
+    put_short = atm_rounded - short_distance
+    put_long = put_short - wing_width
+    call_short = atm_rounded + short_distance
+    call_long = call_short + wing_width
+
+    put_short_asset = strategy.options_helper.find_next_valid_option(underlying, put_short, expiry, put_or_call="put")
+    put_long_asset = strategy.options_helper.find_next_valid_option(underlying, put_long, expiry, put_or_call="put")
+    call_short_asset = strategy.options_helper.find_next_valid_option(underlying, call_short, expiry, put_or_call="call")
+    call_long_asset = strategy.options_helper.find_next_valid_option(underlying, call_long, expiry, put_or_call="call")
+
+    assert put_short_asset and put_long_asset and call_short_asset and call_long_asset
+
+    open_legs = [
+        strategy.create_order(put_long_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+        strategy.create_order(put_short_asset, 1, Order.OrderSide.SELL_TO_OPEN, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+        strategy.create_order(call_short_asset, 1, Order.OrderSide.SELL_TO_OPEN, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+        strategy.create_order(call_long_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+    ]
+    close_legs = [
+        strategy.create_order(put_long_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+        strategy.create_order(put_short_asset, 1, Order.OrderSide.BUY_TO_CLOSE, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+        strategy.create_order(call_short_asset, 1, Order.OrderSide.BUY_TO_CLOSE, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+        strategy.create_order(call_long_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg),
+    ]
+    return open_legs, close_legs
+
+
+def test_tradier_spx_multileg_smart_limit_fills_and_reprices():
+    broker = _tradier()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    try:
+        strategy.initialize()
+    except TypeError:
+        strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=30)
+    open_legs, close_legs = _build_spx_iron_condor(strategy, days_out=7, short_distance=50.0, wing_width=50.0, cfg=cfg)
+
+    submitted = strategy.submit_order(open_legs)
+    parent = submitted[0] if isinstance(submitted, list) else submitted
+    assert parent is not None
+
+    ok_open, reprices_open, open_elapsed = _wait_fill(strategy, parent, timeout=240, drive_smart_limit=True)
+    assert ok_open, f"Open did not fill (reprices={reprices_open}, elapsed={open_elapsed:.1f}s)"
+
+    submitted_close = strategy.submit_order(close_legs)
+    parent_close = submitted_close[0] if isinstance(submitted_close, list) else submitted_close
+    ok_close, reprices_close, close_elapsed = _wait_fill(strategy, parent_close, timeout=240, drive_smart_limit=True)
+    assert ok_close, f"Close did not fill (reprices={reprices_close}, elapsed={close_elapsed:.1f}s)"
+
+    # If it filled instantly, reprices can be 0; otherwise we expect at least one reprice step.
+    if open_elapsed > cfg.get_step_seconds():
+        assert reprices_open >= 1
+
+
+def test_tradier_spy_single_leg_smart_limit_fills():
+    broker = _tradier()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    try:
+        strategy.initialize()
+    except TypeError:
+        strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=30)
+    underlying = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    expiry = _pick_expiry(strategy, underlying, days_out=30)
+    atm = _pick_atm_strike(strategy, underlying, expiry)
+    step = _strike_step("SPY")
+    atm_rounded = round(atm / step) * step
+    strike = atm_rounded + (10 * step)
+
+    call_asset = strategy.options_helper.find_next_valid_option(underlying, strike, expiry, put_or_call="call")
+    assert call_asset is not None
+
+    open_order = strategy.create_order(
+        call_asset,
+        1,
+        Order.OrderSide.BUY_TO_OPEN,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+    )
+    submitted_open = strategy.submit_order(open_order)
+    assert submitted_open is not None
+    ok_open, reprices_open, open_elapsed = _wait_fill(strategy, submitted_open, timeout=180, drive_smart_limit=True)
+    assert ok_open, f"Single-leg open did not fill (reprices={reprices_open}, elapsed={open_elapsed:.1f}s)"
+
+    close_order = strategy.create_order(
+        call_asset,
+        1,
+        Order.OrderSide.SELL_TO_CLOSE,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+    )
+    submitted_close = strategy.submit_order(close_order)
+    ok_close, reprices_close, close_elapsed = _wait_fill(strategy, submitted_close, timeout=180, drive_smart_limit=True)
+    assert ok_close, f"Single-leg close did not fill (reprices={reprices_close}, elapsed={close_elapsed:.1f}s)"
+
+
+def test_tradier_spy_stock_smart_limit_fills():
+    broker = _tradier()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    try:
+        strategy.initialize()
+    except TypeError:
+        strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=30)
+    asset = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+
+    open_order = strategy.create_order(
+        asset,
+        1,
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+    )
+    submitted_open = strategy.submit_order(open_order)
+    assert submitted_open is not None
+    ok_open, _, open_elapsed = _wait_fill(strategy, submitted_open, timeout=120, drive_smart_limit=True)
+    assert ok_open, f"Stock buy did not fill (elapsed={open_elapsed:.1f}s)"
+
+    close_order = strategy.create_order(
+        asset,
+        1,
+        Order.OrderSide.SELL,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+    )
+    submitted_close = strategy.submit_order(close_order)
+    ok_close, _, close_elapsed = _wait_fill(strategy, submitted_close, timeout=120, drive_smart_limit=True)
+    assert ok_close, f"Stock sell did not fill (elapsed={close_elapsed:.1f}s)"

--- a/tests/test_smart_limit_multileg_unit.py
+++ b/tests/test_smart_limit_multileg_unit.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+
+from lumibot.brokers.alpaca import Alpaca
+from lumibot.entities import Asset, Order, SmartLimitConfig, SmartLimitPreset
+from lumibot.strategies.strategy import Strategy
+from lumibot.strategies.strategy_executor import StrategyExecutor
+
+
+@dataclass(frozen=True)
+class _Quote:
+    bid: float
+    ask: float
+
+
+class _BrokerStub:
+    IS_BACKTESTING_BROKER = False
+
+    def __init__(self, *, name: str):
+        self.name = name
+        self.submit_orders = None
+        self.submit_order = None
+        self.modify_order = None
+        self.cancel_order = None
+        self.get_tracked_orders = None
+
+
+class _MinimalStrategy(Strategy):
+    """Strategy stub that avoids Strategy.__init__ (no broker side effects)."""
+
+    def __init__(self, broker):
+        self.broker = broker
+        self._name = "unit"
+
+    def log_message(self, *_args, **_kwargs):
+        return
+
+    def _validate_order(self, _order):  # noqa: SLF001 - intentional override for unit tests
+        return True
+
+    def on_trading_iteration(self):
+        return
+
+
+def _option(symbol: str, strike: float) -> Asset:
+    return Asset(
+        symbol,
+        asset_type=Asset.AssetType.OPTION,
+        expiration=date(2026, 1, 16),
+        strike=float(strike),
+        right="call",
+    )
+
+
+def _leg(strategy_name: str, asset: Asset, side: Order.OrderSide) -> Order:
+    return Order(strategy_name, asset=asset, quantity=1, side=side, order_type=Order.OrderType.MARKET)
+
+
+def test_multileg_limit_maps_to_debit_tradier(mocker):
+    broker = _BrokerStub(name="tradier")
+    broker.submit_orders = mocker.Mock(return_value="ok")
+    strategy = _MinimalStrategy(broker)
+
+    long_leg = _leg("unit", _option("SPY", 500), Order.OrderSide.BUY_TO_OPEN)
+    short_leg = _leg("unit", _option("SPY", 505), Order.OrderSide.SELL_TO_OPEN)
+
+    def _get_quote(asset, **_kwargs):
+        if asset == long_leg.asset:
+            return _Quote(bid=1.00, ask=1.20)
+        return _Quote(bid=0.50, ask=0.60)
+
+    mocker.patch.object(strategy, "get_quote", side_effect=_get_quote)
+
+    strategy.submit_order([long_leg, short_leg], is_multileg=True, order_type=Order.OrderType.LIMIT, price=0.50)
+
+    _, kwargs = broker.submit_orders.call_args
+    assert kwargs["order_type"] == "debit"
+    assert kwargs["price"] == 0.50
+
+
+def test_multileg_limit_maps_to_credit_tradier(mocker):
+    broker = _BrokerStub(name="tradier")
+    broker.submit_orders = mocker.Mock(return_value="ok")
+    strategy = _MinimalStrategy(broker)
+
+    long_leg = _leg("unit", _option("SPY", 500), Order.OrderSide.BUY_TO_OPEN)
+    short_leg = _leg("unit", _option("SPY", 505), Order.OrderSide.SELL_TO_OPEN)
+
+    def _get_quote(asset, **_kwargs):
+        if asset == long_leg.asset:
+            return _Quote(bid=0.50, ask=0.60)
+        return _Quote(bid=1.00, ask=1.20)
+
+    mocker.patch.object(strategy, "get_quote", side_effect=_get_quote)
+
+    strategy.submit_order([long_leg, short_leg], is_multileg=True, order_type=Order.OrderType.LIMIT, price=0.30)
+
+    _, kwargs = broker.submit_orders.call_args
+    assert kwargs["order_type"] == "credit"
+    assert kwargs["price"] == 0.30
+
+
+def test_multileg_limit_maps_to_even_tradier_price_none(mocker):
+    broker = _BrokerStub(name="tradier")
+    broker.submit_orders = mocker.Mock(return_value="ok")
+    strategy = _MinimalStrategy(broker)
+
+    leg1 = _leg("unit", _option("SPY", 500), Order.OrderSide.BUY_TO_OPEN)
+    leg2 = _leg("unit", _option("SPY", 505), Order.OrderSide.SELL_TO_OPEN)
+
+    def _get_quote(_asset, **_kwargs):
+        return _Quote(bid=1.00, ask=1.00)
+
+    mocker.patch.object(strategy, "get_quote", side_effect=_get_quote)
+
+    # Omit price; inferred "even" should map to Tradier type=even with no price.
+    strategy.submit_order([leg1, leg2], is_multileg=True, order_type=Order.OrderType.LIMIT)
+
+    _, kwargs = broker.submit_orders.call_args
+    assert kwargs["order_type"] == "even"
+    assert kwargs["price"] is None
+
+
+def test_multileg_limit_even_alpaca_uses_zero_price(mocker):
+    broker = _BrokerStub(name="alpaca")
+    broker.submit_orders = mocker.Mock(return_value="ok")
+    strategy = _MinimalStrategy(broker)
+
+    leg1 = _leg("unit", _option("SPY", 500), Order.OrderSide.BUY_TO_OPEN)
+    leg2 = _leg("unit", _option("SPY", 505), Order.OrderSide.SELL_TO_OPEN)
+
+    def _get_quote(_asset, **_kwargs):
+        return _Quote(bid=1.00, ask=1.00)
+
+    mocker.patch.object(strategy, "get_quote", side_effect=_get_quote)
+
+    strategy.submit_order([leg1, leg2], is_multileg=True, order_type=Order.OrderType.LIMIT)
+
+    _, kwargs = broker.submit_orders.call_args
+    assert kwargs["order_type"] == "even"
+    assert kwargs["price"] == 0.0
+
+
+def test_multileg_inference_allows_zero_bid(mocker):
+    broker = _BrokerStub(name="tradier")
+    broker.submit_orders = mocker.Mock(return_value="ok")
+    strategy = _MinimalStrategy(broker)
+
+    leg1 = _leg("unit", _option("SPY", 500), Order.OrderSide.BUY_TO_OPEN)
+    leg2 = _leg("unit", _option("SPY", 505), Order.OrderSide.SELL_TO_OPEN)
+
+    # Bid=0 is valid for illiquid options; ask must still be >0.
+    def _get_quote(asset, **_kwargs):
+        if asset == leg1.asset:
+            return _Quote(bid=0.00, ask=0.10)
+        return _Quote(bid=0.05, ask=0.10)
+
+    mocker.patch.object(strategy, "get_quote", side_effect=_get_quote)
+
+    strategy.submit_order([leg1, leg2], is_multileg=True, order_type=Order.OrderType.LIMIT, price=0.01)
+
+    assert broker.submit_orders.called
+
+
+def test_smart_limit_multileg_reprice_uses_submit_orders_on_modify_failure(mocker):
+    broker = _BrokerStub(name="tradier")
+    broker.IS_BACKTESTING_BROKER = False
+
+    # Track one active multi-leg SMART_LIMIT parent order.
+    tracked_orders: list[Order] = []
+    broker.get_tracked_orders = mocker.Mock(side_effect=lambda _name: tracked_orders)
+    broker.cancel_order = mocker.Mock()
+    broker.submit_orders = mocker.Mock(return_value=[Order("unit", asset=Asset("SPY"), quantity=1, side=Order.OrderSide.BUY)])
+    broker.modify_order = mocker.Mock(side_effect=RuntimeError("modify not supported"))
+    broker.submit_order = mocker.Mock()
+
+    strategy = _MinimalStrategy(broker)
+    strategy.logger = SimpleNamespace(error=lambda *_a, **_k: None)
+
+    executor = StrategyExecutor(strategy=strategy)
+    strategy._executor = executor  # noqa: SLF001 - test wiring
+
+    # Build a parent multileg order with 2 legs (enough to exercise the path).
+    leg_buy = _leg("unit", _option("SPY", 500), Order.OrderSide.BUY_TO_OPEN)
+    leg_sell = _leg("unit", _option("SPY", 505), Order.OrderSide.SELL_TO_OPEN)
+    parent = Order(
+        "unit",
+        asset=Asset("SPY"),
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        order_class=Order.OrderClass.MULTILEG,
+        child_orders=[leg_buy, leg_sell],
+        status=Order.OrderStatus.OPEN,
+        smart_limit=SmartLimitConfig(preset=SmartLimitPreset.FAST, step_seconds=1, final_hold_seconds=999),
+        identifier="parent-id",
+    )
+    parent.limit_price = 0.30
+    parent._smart_limit_state = {  # noqa: SLF001 - direct state injection
+        "created_at": 0.0,
+        "step_index": 0,
+        "steps": parent.smart_limit.get_step_count(),
+        "step_seconds": parent.smart_limit.get_step_seconds(),
+        "final_hold_seconds": parent.smart_limit.get_final_hold_seconds(),
+        "multileg_order_type": "debit",
+    }
+    tracked_orders.append(parent)
+
+    def _get_quote(asset, **_kwargs):
+        # Ensure target price differs from current limit_price so a reprice is attempted.
+        if asset == leg_buy.asset:
+            return _Quote(bid=0.50, ask=0.60)
+        return _Quote(bid=0.20, ask=0.30)
+
+    mocker.patch.object(strategy, "get_quote", side_effect=_get_quote)
+    mocker.patch("lumibot.strategies.strategy_executor.time.monotonic", return_value=1.0)
+
+    executor._process_smart_limit_orders()
+
+    assert broker.modify_order.called
+    assert broker.cancel_order.called
+    assert broker.submit_orders.called
+    assert not broker.submit_order.called
+
+
+def test_alpaca_modify_order_updates_identifier_and_child_parent(mocker):
+    alpaca = Alpaca.__new__(Alpaca)  # Avoid Alpaca.__init__ (no network / credentials required).
+
+    old_id = "old"
+    new_id = "new"
+
+    class _Api:
+        def get_order_by_id(self, order_id):
+            assert order_id == old_id
+            return SimpleNamespace(status="new")
+
+        def replace_order_by_id(self, order_id, order_data):
+            assert order_id == old_id
+            assert hasattr(order_data, "limit_price")
+            return SimpleNamespace(id=new_id, status="accepted", limit_price=getattr(order_data, "limit_price", None))
+
+    alpaca.api = _Api()
+
+    child = Order("unit", asset=Asset("SPY"), quantity=1, side=Order.OrderSide.BUY)
+    child.parent_identifier = old_id
+    parent = Order("unit", asset=Asset("SPY"), quantity=1, side=Order.OrderSide.BUY, identifier=old_id, child_orders=[child])
+
+    alpaca._modify_order(parent, limit_price=1.23)
+
+    assert parent.identifier == new_id
+    assert child.parent_identifier == new_id


### PR DESCRIPTION
This PR is the consolidated v4.4.22 workstream (includes SmartLimit-live changes + backtest parity fixes).

Highlights
- Version: bump to 4.4.22.
- Perf (SPX + Backdoor): add index intraday fast-paths in OptionsHelper to avoid expensive quote-validation probing for liquid index underlyings.
- Correctness (MELI daily): prefer snapshot NBBO for daily-cadence option market evaluation when available (reduces stale EOD bid/ask usage at 09:30 ET).
- Smokes: mark ThetaData integration backtests as `acceptance_smoke` and document how to run them.
- Docs: keep the manual acceptance gate up to date (metrics + wall times + run_ids) and capture production profiling findings.

Key files
- lumibot/components/options_helper.py
- tests/test_options_helper_index_fast_paths.py
- tests/test_options_helper_evaluate_option_market_daily_snapshot_override.py
- tests/backtest/test_theta_strategies_integration.py
- docs/ACCEPTANCE_BACKTESTS.md
- docs/ACCEPTANCE_SMOKES.md
- docs/investigations/ACCURACY_AUDIT_2026-01-02.md
- docs/investigations/PROD_SPEED_PARITY_YAPPI_2026-01-03.md

Local acceptance evidence (Strategy Library/logs)
- SPX Short Straddle (stall repro window):
  - Slow (pre-fix): SPXShortStraddle_2026-01-02_10-39_XtAwjW wall_time_s=516.8
  - Fast (post-fix): SPXShortStraddle_2026-01-02_18-51_1JvQro wall_time_s=63.8
- Backdoor Butterfly (baseline window):
  - Slow (pre-fix): BackdoorButterfly0DTE_2026-01-02_10-29_HPNuUM wall_time_s=267.8
  - Fast (post-fix): BackdoorButterfly0DTE_2026-01-02_18-52_XdYcWQ wall_time_s=121.6
- Backdoor Butterfly SmartLimit:
  - Slow (pre-fix): BackdoorButterfly0DTESmartLimit_2026-01-02_10-34_UTFoHq wall_time_s=283.0
  - Fast (post-fix): BackdoorButterfly0DTESmartLimit_2026-01-02_19-49_QXkWuB wall_time_s=107.1
- MELI (daily option pricing):
  - Bad mismatch: MeliDeepDrawdownCalls_2026-01-02_10-09_7yisFp
  - Improved: MeliDeepDrawdownCalls_2026-01-02_19-24_kZELl5

Production speed parity profiling (evidence)
- Ran a profiled production backtest via Bot Manager:
  - bot_id=codexspx3280b3dee4b7410fba
  - window=2025-01-06 -> 2025-12-24
  - observed elapsed ~32m (v4.4.21 deployed)
  - downloaded YAPPI artifact successfully (profile_yappi_csv=true)
- Findings: time dominated by threading/queue waits + thetadata_queue_client polling (i.e., request volume / I/O wait), not pure CPU compute.
  - Full write-up: docs/investigations/PROD_SPEED_PARITY_YAPPI_2026-01-03.md

Notes / limitations
- Strategy Library demos are not modified.
- CI workflow for acceptance smokes was not added in this PR because the current git token does not have `workflow` scope for pushing `.github/workflows/*`.
  - The smoke tests + marker + docs are included; a maintainer can add the workflow file via GitHub UI or via a token with workflow scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced multi-leg smart limit orders with improved pricing and repricing logic across brokers
  * Optimized option chain lookups for index-based strategies through intelligent fast-path routing

* **Improvements**
  * Refined smart limit order handling for single and multi-leg positions
  * Enhanced data quality validation in backtesting scenarios

* **Documentation**
  * Added acceptance smoke test suite documentation
  * Added production performance profiling analysis and accuracy audit records

* **Testing**
  * Expanded live trading test coverage for multiple broker integrations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->