### PR TITLE
Hotfix: prevent one-sided option quote crash (4.4.24)

### DIFF
--- a/docs/remote_cache.md
+++ b/docs/remote_cache.md
@@ -60,7 +60,9 @@ prod/cache/v1/thetadata/stock/minute/ohlc/stock_SPY_minute_ohlc.parquet
 This format aligns with the intended IAM policy layout (provider → asset class →
 timespan → datastyle) and keeps migration straightforward for other data sources
 such as Polygon or DataBento. Option-chain caches now live at
-`thetadata/option/option_chains/<symbol>_<date>.parquet`.
+`thetadata/<asset-folder>/option_chains/<symbol>_<date>.parquet`, where
+`<asset-folder>` matches `thetadata_helper._resolve_asset_folder(...)` (for
+example `stock` or `index`).
 
 ## Implementation Overview
 
@@ -72,6 +74,9 @@ such as Polygon or DataBento. Option-chain caches now live at
 * `thetadata_helper.get_price_data` calls the manager before attempting to read
   from disk, and again after successful cache updates. Payload metadata captures
   provider, symbol, asset type, and option attributes for future auditing.
+* `thetadata_helper.get_chains_cached` also hydrates/uploads option-chain parquet
+  files so production backtest containers can reuse warm chains from S3 instead
+  of rebuilding them from ThetaData on every run.
 * Remote uploads run only in `s3_readwrite` mode. The read-only path returns
   early, leaving a TODO hook (`BacktestCacheManager.on_local_update`) for the
   Lambda-triggered workflow.

--- a/lumibot/components/options_helper.py
+++ b/lumibot/components/options_helper.py
@@ -122,20 +122,32 @@ class OptionsHelper:
 
     @staticmethod
     def has_actionable_price(evaluation: Optional["OptionMarketEvaluation"]) -> bool:
-        """Return True when the evaluation contains a usable buy price."""
+        """Return True when the evaluation contains usable buy and sell prices.
+
+        A quote can be "one-sided" (ask-only or bid-only). In that case we cannot
+        safely execute both buy and sell actions, so treat it as non-actionable.
+        """
         if evaluation is None:
             return False
 
-        price = evaluation.buy_price
-        if price is None:
+        buy_price = evaluation.buy_price
+        sell_price = evaluation.sell_price
+        if buy_price is None or sell_price is None:
             return False
 
         try:
-            price = float(price)
+            buy_price = float(buy_price)
+            sell_price = float(sell_price)
         except (TypeError, ValueError):
             return False
 
-        return math.isfinite(price) and price > 0 and not evaluation.spread_too_wide
+        return (
+            math.isfinite(buy_price)
+            and buy_price > 0
+            and math.isfinite(sell_price)
+            and sell_price > 0
+            and not evaluation.spread_too_wide
+        )
 
     @staticmethod
     def _float_positive(value: Any) -> Optional[float]:

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -5132,6 +5132,29 @@ def get_chains_cached(
     # 2) Build cache folder path
     chain_folder = Path(LUMIBOT_CACHE_FOLDER) / "thetadata" / _resolve_asset_folder(asset) / "option_chains"
     chain_folder.mkdir(parents=True, exist_ok=True)
+    cache_file = chain_folder / f"{asset.symbol}_{current_date.isoformat()}.parquet"
+
+    # If the S3 remote cache is enabled, opportunistically hydrate the chain cache file for this
+    # exact date. Production backtest containers start with empty disks; without this step every
+    # run rebuilds chains from ThetaData even when S3 is warm, which keeps hitting the downloader
+    # and makes prod much slower than local warm-cache runs.
+    #
+    # We intentionally only attempt the exact-date file here:
+    # - It is deterministic and keeps the S3 key stable.
+    # - Reuse across days is still handled by the local folder scan (tolerance window) once at
+    #   least one file exists on disk during the current run.
+    try:
+        from lumibot.tools.backtest_cache import get_backtest_cache
+
+        if not cache_file.exists():
+            get_backtest_cache().ensure_local_file(cache_file)
+    except Exception:
+        logger.debug(
+            "[THETA][CHAIN_CACHE] Remote cache hydrate failed for %s on %s",
+            asset.symbol,
+            current_date,
+            exc_info=True,
+        )
 
     constraints = chain_constraints or {}
     hint_present = any(
@@ -5244,9 +5267,19 @@ def get_chains_cached(
         }
 
     # 5) Save to cache file for future reuse
-    cache_file = chain_folder / f"{asset.symbol}_{current_date.isoformat()}.parquet"
     df_to_cache = pd.DataFrame({"data": [chains_dict]})
     df_to_cache.to_parquet(cache_file, compression='snappy', engine='pyarrow')
     logger.debug(f"Saved chain cache: {cache_file}")
+    try:
+        from lumibot.tools.backtest_cache import get_backtest_cache
+
+        get_backtest_cache().on_local_update(cache_file)
+    except Exception:
+        logger.debug(
+            "[THETA][CHAIN_CACHE] Remote cache upload failed for %s on %s",
+            asset.symbol,
+            current_date,
+            exc_info=True,
+        )
 
     return chains_dict

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.22",
+    version="4.4.23",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.23",
+    version="4.4.24",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/tests/test_options_helper.py
+++ b/tests/test_options_helper.py
@@ -747,6 +747,46 @@ class TestOptionsHelper(unittest.TestCase):
         self.assertTrue(evaluation.missing_bid_ask)
         self.assertFalse(OptionsHelper.has_actionable_price(evaluation))
 
+    def test_has_actionable_price_requires_sell_price(self):
+        """Ask-only quotes should be treated as non-actionable to prevent crashes."""
+        option_asset = Asset(
+            "TEST",
+            asset_type=Asset.AssetType.OPTION,
+            expiration=date.today() + timedelta(days=7),
+            strike=200,
+            right="call",
+            underlying_asset=Asset("TEST", asset_type=Asset.AssetType.STOCK),
+        )
+
+        self.mock_strategy.get_quote.return_value = Mock(bid=None, ask=0.05)
+        self.mock_strategy.broker.data_source.option_quote_fallback_allowed = False
+
+        evaluation = self.options_helper.evaluate_option_market(option_asset, max_spread_pct=0.25)
+
+        self.assertEqual(evaluation.buy_price, 0.05)
+        self.assertIsNone(evaluation.sell_price)
+        self.assertFalse(OptionsHelper.has_actionable_price(evaluation))
+
+    def test_has_actionable_price_requires_buy_price(self):
+        """Bid-only quotes should be treated as non-actionable to prevent crashes."""
+        option_asset = Asset(
+            "TEST",
+            asset_type=Asset.AssetType.OPTION,
+            expiration=date.today() + timedelta(days=7),
+            strike=200,
+            right="call",
+            underlying_asset=Asset("TEST", asset_type=Asset.AssetType.STOCK),
+        )
+
+        self.mock_strategy.get_quote.return_value = Mock(bid=0.05, ask=None)
+        self.mock_strategy.broker.data_source.option_quote_fallback_allowed = False
+
+        evaluation = self.options_helper.evaluate_option_market(option_asset, max_spread_pct=0.25)
+
+        self.assertIsNone(evaluation.buy_price)
+        self.assertEqual(evaluation.sell_price, 0.05)
+        self.assertFalse(OptionsHelper.has_actionable_price(evaluation))
+
     def test_has_actionable_price_requires_positive_finite_value(self):
         """has_actionable_price returns False for zero or negative values."""
         evaluation = OptionMarketEvaluation(


### PR DESCRIPTION
This PR now targets 4.4.24 (hotfix) and includes:

- Crash fix: OptionsHelper.has_actionable_price() now requires both buy_price and sell_price to be present/finite/positive. One-sided quotes (ask-only/bid-only) are treated as non-actionable to prevent float(None) crashes in option strategies.
- Regression tests: adds unit tests for ask-only and bid-only quotes.
- Prod speed parity: persists ThetaData option-chain parquet caches into the S3 backtest cache (so fresh prod containers can hydrate chains instead of rebuilding via downloader).

Local verification:
- pytest -q tests/test_options_helper.py
- pytest -q tests/test_strategy_price_guard.py
- Manual SPX Short Straddle backtest no longer crashes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote S3-backed caching for option-chain data so backtests can reuse cached chains across runs.

* **Behavior Changes**
  * Options price validation tightened: quotes now require both buy and sell sides to be actionable.

* **Documentation**
  * Updated docs describing cache hydration and remote storage behavior.

* **Tests**
  * Added tests to assert non-actionable behavior when only one side of a quote is present.

* **Chores**
  * Version bumped to 4.4.24.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->