### PR TITLE
Fix NVDA split-fetch thrash + SPX delta-scan slowness

### DIFF
--- a/lumibot/components/options_helper.py
+++ b/lumibot/components/options_helper.py
@@ -605,7 +605,154 @@ class OptionsHelper:
         """
         self.strategy.log_message(f"Computing strike deltas for {underlying_asset.symbol} at expiry {expiry}.", color="blue")
         strike_deltas: Dict[float, Optional[float]] = {}
+
         underlying_price = self.strategy.get_last_price(underlying_asset)
+        if underlying_price is None:
+            return strike_deltas
+
+        # ------------------------------------------------------------------
+        # PERF: Many AI-generated strategies pass hundreds of strikes into this
+        # method and then select the closest-to-target delta outside of LumiBot.
+        # Doing a quote snapshot + greeks solve per strike becomes thousands of
+        # remote calls in production (each with ~1s overhead).
+        #
+        # When the strategy exposes a target delta (common names: target_call_delta
+        # / target_put_delta) and the strike list is large, evaluate only O(log N)
+        # candidates using a bounded binary search over strikes.
+        # ------------------------------------------------------------------
+        target_delta: Optional[float] = None
+        if stop_greater_than is None and stop_less_than is None and len(strikes) >= 80:
+            right_norm = str(right).strip().lower()
+            if right_norm.startswith("c"):
+                var_name = "target_call_delta"
+            elif right_norm.startswith("p"):
+                var_name = "target_put_delta"
+            else:
+                var_name = ""
+
+            if var_name:
+                vars_obj = getattr(self.strategy, "vars", None)
+                if vars_obj is not None and hasattr(vars_obj, var_name):
+                    try:
+                        target_delta = float(getattr(vars_obj, var_name))
+                    except Exception:
+                        target_delta = None
+                if target_delta is None:
+                    params_obj = getattr(self.strategy, "parameters", None)
+                    if isinstance(params_obj, dict) and var_name in params_obj:
+                        try:
+                            target_delta = float(params_obj[var_name])
+                        except Exception:
+                            target_delta = None
+
+            if target_delta is not None and (not math.isfinite(target_delta) or abs(target_delta) > 1):
+                target_delta = None
+
+        if target_delta is not None:
+            strikes_sorted: List[float] = []
+            for value in strikes:
+                try:
+                    strikes_sorted.append(float(value))
+                except Exception:
+                    continue
+            strikes_sorted = sorted(set(strikes_sorted))
+
+            if len(strikes_sorted) >= 2:
+                self.strategy.log_message(
+                    f"Computing strike deltas fast-path: {len(strikes_sorted)} strikes -> binary search (target_delta={target_delta}).",
+                    color="blue",
+                )
+
+                lo = 0
+                hi = len(strikes_sorted) - 1
+                visited: set[int] = set()
+                max_iters = int(math.ceil(math.log2(len(strikes_sorted) + 1))) + 8
+
+                best_idx: Optional[int] = None
+                best_delta: Optional[float] = None
+
+                for _ in range(max_iters):
+                    if lo > hi:
+                        break
+
+                    mid = (lo + hi) // 2
+                    if mid in visited:
+                        break
+                    visited.add(mid)
+
+                    strike = strikes_sorted[mid]
+                    delta = self.get_delta_for_strike(
+                        underlying_asset,
+                        float(underlying_price),
+                        strike,
+                        expiry,
+                        right,
+                    )
+                    strike_deltas[strike] = delta
+
+                    if delta is None:
+                        # Try a few nearby strikes when the midpoint has no actionable prices.
+                        for offset in range(1, 6):
+                            resolved = False
+                            for idx in (mid - offset, mid + offset):
+                                if idx < lo or idx > hi or idx in visited:
+                                    continue
+                                visited.add(idx)
+                                strike_candidate = strikes_sorted[idx]
+                                delta_candidate = self.get_delta_for_strike(
+                                    underlying_asset,
+                                    float(underlying_price),
+                                    strike_candidate,
+                                    expiry,
+                                    right,
+                                )
+                                strike_deltas[strike_candidate] = delta_candidate
+                                if delta_candidate is None:
+                                    continue
+                                mid = idx
+                                strike = strike_candidate
+                                delta = delta_candidate
+                                resolved = True
+                                break
+                            if resolved:
+                                break
+
+                        if delta is None:
+                            break
+
+                    if delta is None:
+                        break
+
+                    if best_delta is None or abs(delta - target_delta) < abs(best_delta - target_delta):
+                        best_delta = delta
+                        best_idx = mid
+
+                    # Delta decreases as strike increases for both calls and puts.
+                    if delta > target_delta:
+                        lo = mid + 1
+                    elif delta < target_delta:
+                        hi = mid - 1
+                    else:
+                        break
+
+                # Add a small neighborhood around the best strike so callers that
+                # choose the closest delta externally still have tie-break context.
+                if best_idx is not None:
+                    for idx in range(max(0, best_idx - 2), min(len(strikes_sorted), best_idx + 3)):
+                        strike = strikes_sorted[idx]
+                        if strike in strike_deltas:
+                            continue
+                        strike_deltas[strike] = self.get_delta_for_strike(
+                            underlying_asset,
+                            float(underlying_price),
+                            strike,
+                            expiry,
+                            right,
+                        )
+
+                return strike_deltas
+
+        # Default: full scan (legacy behavior).
         for strike in strikes:
             option = Asset(
                 underlying_asset.symbol,
@@ -634,7 +781,7 @@ class OptionsHelper:
                 self.strategy.log_message(f"Could not calculate Greeks for {option.symbol} at strike {strike}", color="yellow")
                 continue
             delta = greeks.get("delta")
-            strike_deltas[strike] = delta
+            strike_deltas[float(strike)] = delta
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(
                     "[OptionsHelper] strike delta symbol=%s expiry=%s right=%s strike=%s delta=%s",

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -1057,6 +1057,27 @@ def create_tearsheet(
         logger.warning("No data to create tearsheet, skipping")
         return
 
+    def _write_placeholder_tearsheet(reason: str) -> None:
+        """Write a small HTML file explaining why QuantStats was skipped/failed."""
+        try:
+            placeholder = f"""<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>{strat_name} tearsheet unavailable</title>
+  </head>
+  <body>
+    <h1>{strat_name}</h1>
+    <p><strong>Tearsheet not generated.</strong></p>
+    <p>{reason}</p>
+  </body>
+</html>
+"""
+            with open(str(tearsheet_file), "w", encoding="utf-8") as f:
+                f.write(placeholder)
+        except Exception as exc:  # pragma: no cover
+            logger.warning("Failed to write placeholder tearsheet to %s: %s", tearsheet_file, exc)
+
     # Uncomment for debugging
     # _df1.to_csv(f"df1.csv")
     # _df2.to_csv(f"df2.csv")
@@ -1065,7 +1086,21 @@ def create_tearsheet(
 
     bm_text = f"Compared to {benchmark_asset}" if benchmark_asset else ""
     title = f"{strat_name} {bm_text}"
-    
+
+    # QuantStats (via seaborn/scipy) can raise (e.g., LinAlgError) when the return series is
+    # degenerate, such as no trades and a flat portfolio value. In these cases we must not
+    # crash the backtest; write a placeholder tearsheet instead.
+    strategy_returns = df_final["strategy"].dropna()
+    benchmark_returns = df_final["benchmark"].dropna()
+    if strategy_returns.empty or benchmark_returns.empty or strategy_returns.nunique() <= 1 or benchmark_returns.nunique() <= 1:
+        logger.warning(
+            "Not enough return variation to generate QuantStats tearsheet (strategy unique=%d, benchmark unique=%d); writing placeholder.",
+            int(strategy_returns.nunique()) if not strategy_returns.empty else 0,
+            int(benchmark_returns.nunique()) if not benchmark_returns.empty else 0,
+        )
+        _write_placeholder_tearsheet("Return series is flat/degenerate (often caused by zero trades).")
+        return
+
     '''
     # Check if all the values are equal to 0
     if df_final["benchmark"].sum() == 0:
@@ -1081,20 +1116,25 @@ def create_tearsheet(
     df_final["benchmark"].name = str(benchmark_asset)
 
     # Run quantstats reports surpressing any logs because it can be noisy for no reason
-    with open(os.devnull, "w") as f, contextlib.redirect_stdout(f), contextlib.redirect_stderr(f):
-        result = qs.reports.html(
-            df_final["strategy"],
-            df_final["benchmark"],
-            title=title,
-            output=tearsheet_file,
-            download_filename=tearsheet_file,  # Consider if you need a different name for clarity
-            rf=risk_free_rate,
-            parameters=strategy_parameters,
-            lumibot_version=lumibot_version,
-            backtesting_data_source=backtesting_data_source,
-            backtesting_data_sources=backtesting_data_sources,
-            backtest_time_seconds=backtest_time_seconds,
-        )
+    try:
+        with open(os.devnull, "w") as f, contextlib.redirect_stdout(f), contextlib.redirect_stderr(f):
+            result = qs.reports.html(
+                df_final["strategy"],
+                df_final["benchmark"],
+                title=title,
+                output=tearsheet_file,
+                download_filename=tearsheet_file,  # Consider if you need a different name for clarity
+                rf=risk_free_rate,
+                parameters=strategy_parameters,
+                lumibot_version=lumibot_version,
+                backtesting_data_source=backtesting_data_source,
+                backtesting_data_sources=backtesting_data_sources,
+                backtest_time_seconds=backtest_time_seconds,
+            )
+    except Exception as exc:
+        logger.warning("QuantStats tearsheet generation failed: %s", exc)
+        _write_placeholder_tearsheet(f"QuantStats error: {exc}")
+        return
 
     if show_tearsheet:
         url = "file://" + os.path.abspath(str(tearsheet_file))

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -1253,6 +1253,121 @@ def _ensure_event_cache(
     return cache_df.loc[mask].copy()
 
 
+# ==============================================================================
+# In-memory corporate actions cache (per-process / per-backtest)
+# ==============================================================================
+#
+# Corporate actions (splits/dividends) are used in multiple hot paths:
+# - option strike reverse-split adjustments (_get_option_query_strike)
+# - OHLC corporate action normalization (_apply_corporate_actions_to_frame)
+#
+# In production backtests, the strategy code may trigger these helpers many times
+# per simulated bar. The on-disk cache prevents repeated network downloads, but
+# repeatedly loading/merging/filtering the disk cache can still be expensive and
+# creates noisy logs (e.g. "[THETA][SPLITS] Got 1 splits..." on every call).
+#
+# This in-memory cache ensures we only execute the expensive cache load/refresh
+# once per symbol/event_type/range per process (a backtest container runs one
+# strategy), and it also rate-limits repeated retries after transient failures.
+# ==============================================================================
+
+_event_cache_memory: Dict[Tuple[str, str], Dict[str, Any]] = {}
+
+
+def _event_cache_failure_ttl_s() -> float:
+    """How long to suppress repeated event-cache refresh attempts after a failure."""
+    try:
+        ttl_s = float(os.environ.get("THETADATA_EVENT_CACHE_FAILURE_TTL_S", "60"))
+        return max(ttl_s, 0.0)
+    except Exception:
+        return 60.0
+
+
+def _get_theta_events_cached(
+    asset: Asset,
+    event_type: str,
+    start_date: date,
+    end_date: date,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+) -> pd.DataFrame:
+    """Return Theta corporate actions using an in-memory memoization layer."""
+    if not asset.symbol:
+        return pd.DataFrame()
+
+    normalized_event_type = str(event_type).lower().strip()
+    if normalized_event_type not in {"dividends", "splits"}:
+        return pd.DataFrame()
+
+    range_start = min(start_date, end_date)
+    range_end = max(start_date, end_date)
+    symbol_key = str(asset.symbol).upper()
+    cache_key = (normalized_event_type, symbol_key)
+
+    entry = _event_cache_memory.get(cache_key)
+    if entry is not None:
+        entry_start = entry.get("range_start")
+        entry_end = entry.get("range_end")
+        cached_df = entry.get("df")
+        if (
+            isinstance(entry_start, date)
+            and isinstance(entry_end, date)
+            and isinstance(cached_df, pd.DataFrame)
+            and entry_start <= range_start
+            and entry_end >= range_end
+        ):
+            if cached_df.empty:
+                return pd.DataFrame()
+            date_series = cached_df["event_date"].dt.date
+            mask = (date_series >= range_start) & (date_series <= range_end)
+            return cached_df.loc[mask].copy()
+
+        last_error_ts = entry.get("last_error_ts")
+        if isinstance(last_error_ts, (int, float)):
+            ttl_s = _event_cache_failure_ttl_s()
+            if ttl_s > 0 and (time.time() - float(last_error_ts)) < ttl_s:
+                return pd.DataFrame()
+
+    try:
+        events = _ensure_event_cache(asset, normalized_event_type, range_start, range_end, username, password)
+    except Exception as exc:
+        now = time.time()
+        prev_ts = entry.get("last_error_ts") if isinstance(entry, dict) else None
+        ttl_s = _event_cache_failure_ttl_s()
+        if not isinstance(prev_ts, (int, float)) or ttl_s <= 0 or (now - float(prev_ts)) >= ttl_s:
+            logger.warning(
+                "[THETA][%s] ThetaData %s fetch failed for %s: %s",
+                normalized_event_type.upper(),
+                normalized_event_type,
+                asset.symbol,
+                exc,
+            )
+        _event_cache_memory[cache_key] = {
+            "range_start": entry.get("range_start") if isinstance(entry, dict) else None,
+            "range_end": entry.get("range_end") if isinstance(entry, dict) else None,
+            "df": entry.get("df") if isinstance(entry, dict) else pd.DataFrame(),
+            "last_error_ts": now,
+            "last_error": str(exc),
+        }
+        return pd.DataFrame()
+
+    # Cache the fetched window in-memory (even when empty).
+    _event_cache_memory[cache_key] = {
+        "range_start": range_start,
+        "range_end": range_end,
+        "df": events if isinstance(events, pd.DataFrame) else pd.DataFrame(),
+        "last_error_ts": None,
+        "last_error": None,
+    }
+
+    if events is None or events.empty:
+        return pd.DataFrame()
+
+    date_series = events["event_date"].dt.date
+    mask = (date_series >= range_start) & (date_series <= range_end)
+    return events.loc[mask].copy()
+
+
 def _get_theta_dividends(
     asset: Asset,
     start_date: date,
@@ -1262,7 +1377,11 @@ def _get_theta_dividends(
 ) -> pd.DataFrame:
     if str(getattr(asset, "asset_type", "stock")).lower() != "stock":
         return pd.DataFrame()
-    return _ensure_event_cache(asset, "dividends", start_date, end_date, username, password)
+    events = _get_theta_events_cached(asset, "dividends", start_date, end_date, username, password)
+    if events is not None and not events.empty:
+        logger.debug("[THETA][DIVIDENDS] Loaded %d dividend events for %s", len(events), asset.symbol)
+        return events
+    return pd.DataFrame()
 
 
 def _get_theta_splits(
@@ -1272,21 +1391,22 @@ def _get_theta_splits(
     username: Optional[str] = None,
     password: Optional[str] = None,
 ) -> pd.DataFrame:
-    """Fetch split data from ThetaData only. No fallback to other data sources."""
+    """Fetch split data from ThetaData only. No fallback to other data sources.
+
+    Note: this function is called from several hot paths (including option strike
+    reverse-split adjustments). It uses an in-memory memoization layer to avoid
+    repeatedly loading/refreshing the on-disk cache and to suppress retry storms
+    after transient downloader/Theta failures.
+    """
     if str(getattr(asset, "asset_type", "stock")).lower() != "stock":
         return pd.DataFrame()
 
-    try:
-        splits = _ensure_event_cache(asset, "splits", start_date, end_date, username, password)
-        if splits is not None and not splits.empty:
-            logger.info("[THETA][SPLITS] Got %d splits from ThetaData for %s", len(splits), asset.symbol)
-            return splits
-        else:
-            logger.debug("[THETA][SPLITS] No splits found in ThetaData for %s", asset.symbol)
-            return pd.DataFrame()
-    except Exception as e:
-        logger.warning("[THETA][SPLITS] ThetaData split fetch failed for %s: %s", asset.symbol, e)
-        return pd.DataFrame()
+    splits = _get_theta_events_cached(asset, "splits", start_date, end_date, username, password)
+    if splits is not None and not splits.empty:
+        # Avoid log spam in tight loops: emit this at DEBUG level.
+        logger.debug("[THETA][SPLITS] Loaded %d split events for %s", len(splits), asset.symbol)
+        return splits
+    return pd.DataFrame()
 
 
 def _get_option_query_strike(option_asset: Asset, sim_datetime: datetime = None) -> float:

--- a/tests/test_options_helper_strike_deltas_fastpath.py
+++ b/tests/test_options_helper_strike_deltas_fastpath.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from lumibot.components.options_helper import OptionsHelper
+from lumibot.entities import Asset
+
+
+class _Vars:
+    pass
+
+
+class _StrategyStub:
+    def __init__(self, *, target_call_delta: float | None = None, target_put_delta: float | None = None):
+        self.vars = _Vars()
+        if target_call_delta is not None:
+            self.vars.target_call_delta = target_call_delta
+        if target_put_delta is not None:
+            self.vars.target_put_delta = target_put_delta
+
+    def log_message(self, *_args, **_kwargs):
+        return None
+
+    def get_datetime(self):
+        return datetime(2025, 1, 1, 9, 30)
+
+    def get_last_price(self, _asset):
+        return 100.0
+
+
+def _closest_strike(mapping: dict[float, float | None], target: float) -> float:
+    best_strike = None
+    best_diff = None
+    for strike, delta in mapping.items():
+        if delta is None:
+            continue
+        diff = abs(delta - target)
+        if best_diff is None or diff < best_diff:
+            best_diff = diff
+            best_strike = strike
+    assert best_strike is not None
+    return best_strike
+
+
+def test_get_strike_deltas_fast_path_uses_few_calls_for_calls():
+    strategy = _StrategyStub(target_call_delta=0.4)
+    helper = OptionsHelper(strategy)
+
+    call_count = 0
+
+    def fake_get_delta_for_strike(_underlying_asset, _underlying_price, strike, _expiry, right):
+        nonlocal call_count
+        call_count += 1
+        assert str(right).lower().startswith("c")
+        # Linear monotonic delta: strike 50 -> 1.0, strike 150 -> 0.0
+        return 1.0 - ((float(strike) - 50.0) / 100.0)
+
+    helper.get_delta_for_strike = fake_get_delta_for_strike  # type: ignore[assignment]
+
+    underlying = Asset("SPX", asset_type="stock")
+    strikes = list(range(50, 151))  # 101 strikes (>= 80 triggers fast-path)
+
+    deltas = helper.get_strike_deltas(underlying, date(2025, 1, 17), strikes, "call")
+
+    # The fast-path should not evaluate every strike.
+    assert call_count < 40
+    chosen = _closest_strike(deltas, 0.4)
+    # For the linear mapping, strike=110 yields delta=0.4
+    assert abs(chosen - 110.0) <= 2.0
+
+
+def test_get_strike_deltas_fast_path_uses_few_calls_for_puts():
+    strategy = _StrategyStub(target_put_delta=-0.4)
+    helper = OptionsHelper(strategy)
+
+    call_count = 0
+
+    def fake_get_delta_for_strike(_underlying_asset, _underlying_price, strike, _expiry, right):
+        nonlocal call_count
+        call_count += 1
+        assert str(right).lower().startswith("p")
+        # Linear monotonic delta: strike 50 -> 0.0, strike 150 -> -1.0
+        return -((float(strike) - 50.0) / 100.0)
+
+    helper.get_delta_for_strike = fake_get_delta_for_strike  # type: ignore[assignment]
+
+    underlying = Asset("SPX", asset_type="stock")
+    strikes = list(range(50, 151))  # 101 strikes (>= 80 triggers fast-path)
+
+    deltas = helper.get_strike_deltas(underlying, date(2025, 1, 17), strikes, "put")
+
+    assert call_count < 40
+    chosen = _closest_strike(deltas, -0.4)
+    # For the linear mapping, strike=90 yields delta=-0.4
+    assert abs(chosen - 90.0) <= 2.0
+

--- a/tests/test_tearsheet_flat_returns.py
+++ b/tests/test_tearsheet_flat_returns.py
@@ -1,0 +1,31 @@
+import pandas as pd
+
+from lumibot.tools.indicators import create_tearsheet
+
+
+def test_create_tearsheet_does_not_crash_on_flat_returns(tmp_path):
+    # Flat portfolio value + flat benchmark => degenerate returns series.
+    idx = pd.to_datetime(["2025-01-02", "2025-01-03"])
+    strategy_df = pd.DataFrame({"portfolio_value": [100000.0, 100000.0]}, index=idx)
+    benchmark_df = pd.DataFrame({"symbol_cumprod": [1.0, 1.0]}, index=idx)
+
+    out = tmp_path / "tearsheet.html"
+    create_tearsheet(
+        strategy_df=strategy_df,
+        strat_name="FlatStrategy",
+        tearsheet_file=str(out),
+        benchmark_df=benchmark_df,
+        benchmark_asset="SPY",
+        show_tearsheet=False,
+        save_tearsheet=True,
+        risk_free_rate=0.0,
+        strategy_parameters={},
+        lumibot_version="test",
+        backtesting_data_source="thetadata",
+        backtesting_data_sources="thetadata",
+        backtest_time_seconds=1.0,
+    )
+
+    assert out.exists()
+    assert "Tearsheet not generated" in out.read_text(encoding="utf-8", errors="ignore")
+

--- a/tests/test_thetadata_helper_event_memoization.py
+++ b/tests/test_thetadata_helper_event_memoization.py
@@ -1,0 +1,59 @@
+from datetime import date
+
+import pandas as pd
+
+from lumibot.entities import Asset
+from lumibot.tools import thetadata_helper
+
+
+def test_get_theta_splits_memoizes_in_memory(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_ensure_event_cache(asset, event_type, start_date, end_date, username=None, password=None):
+        calls["count"] += 1
+        assert event_type == "splits"
+        assert asset.symbol == "NVDA"
+        assert start_date <= end_date
+        return pd.DataFrame(
+            {
+                "event_date": [pd.Timestamp("2024-06-07")],
+                "ratio": [10.0],
+            }
+        )
+
+    monkeypatch.setattr(thetadata_helper, "_ensure_event_cache", fake_ensure_event_cache)
+    thetadata_helper._event_cache_memory.clear()
+
+    asset = Asset("NVDA", asset_type="stock")
+
+    # First call populates the in-memory cache.
+    df1 = thetadata_helper._get_theta_splits(asset, date(2013, 1, 1), date(2026, 1, 1))
+    assert not df1.empty
+
+    # Second call is fully covered by the cached window and must not call _ensure_event_cache again.
+    df2 = thetadata_helper._get_theta_splits(asset, date(2014, 1, 1), date(2025, 1, 1))
+    assert not df2.empty
+
+    assert calls["count"] == 1
+
+
+def test_get_theta_splits_failure_ttl_suppresses_retry_storm(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_ensure_event_cache(asset, event_type, start_date, end_date, username=None, password=None):
+        calls["count"] += 1
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(thetadata_helper, "_ensure_event_cache", fake_ensure_event_cache)
+    thetadata_helper._event_cache_memory.clear()
+    monkeypatch.setenv("THETADATA_EVENT_CACHE_FAILURE_TTL_S", "60")
+
+    asset = Asset("NVDA", asset_type="stock")
+
+    df1 = thetadata_helper._get_theta_splits(asset, date(2020, 1, 1), date(2020, 1, 2))
+    df2 = thetadata_helper._get_theta_splits(asset, date(2020, 1, 1), date(2020, 1, 2))
+
+    assert df1.empty
+    assert df2.empty
+    assert calls["count"] == 1
+


### PR DESCRIPTION
Addresses three production backtest pain points:

1) SPX (copy2/copy3) extreme slowness
- Root cause: delta strike scanning triggered hundreds/thousands of per-strike quote requests (Submitted to queue spam).
- Fix: OptionsHelper.get_strike_deltas() fast-path uses bounded binary search when a target delta is provided (reduces O(N) requests to ~O(log N)).

2) NVDA drawdown strategy slowness / split-fetch timeouts
- Observed repeated [THETA][SPLITS] calls and occasional queue timeouts (Async timeout) during split fetch.
- Fix: in-memory memoization for Theta corporate actions (splits/dividends) with a short failure TTL to suppress retry storms; avoids per-call INFO spam by logging split/dividend loads at DEBUG.

3) Backtests with zero trades failing at the end (QuantStats)
- Root cause: QuantStats/Seaborn histogram (gaussian_kde) can raise (e.g., LinAlgError) when the return series is degenerate (flat PV / zero trades).
- Fix: detect degenerate return series and write a placeholder tearsheet HTML instead of crashing the backtest; also catch/report QuantStats exceptions.

Tests:
- tests/test_options_helper_strike_deltas_fastpath.py
- tests/test_thetadata_helper_event_memoization.py
- tests/test_tearsheet_flat_returns.py

Prod references (for investigation):
- SPX slow runs: c7c6bbd9-41f7-48c9-8754-3231e354f83b, 6be31002-44ec-4ae7-857a-db5e01323e7c
- NVDA run (flat PV so far): 334e2c98-7134-4f38-860c-b6b11879a51b


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Faster strike-delta lookup for large option chains with reduced evaluations and more consistent results
  * In-memory caching for ThetaData corporate actions with failure TTL to reduce redundant work

* **New Features**
  * Generates a friendly placeholder tearsheet when reports cannot be produced (avoids crashes)

* **Tests**
  * Added tests for strike-delta optimization, ThetaData memoization/failure suppression, and flat-return tearsheet handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->