### PR TITLE
Downgrade transient Alpaca/cloud network errors to warnings

### DIFF
--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -1320,8 +1320,18 @@ class Alpaca(Broker):
                 logger.error(error_msg)
                 raise ValueError(error_msg)
             else:
-                logger.error(f"OAuth Polling error: {e}")
-                logger.error(f"Full traceback: {traceback.format_exc()}")
+                is_rate_limited = (
+                    "rate limit" in error_message
+                    or "too many requests" in error_message
+                    or "42910000" in error_message
+                    or "status code: 429" in error_message
+                )
+                if is_rate_limited:
+                    logger.warning(f"OAuth Polling error (rate-limited): {e}")
+                    logger.debug(f"Full traceback: {traceback.format_exc()}")
+                else:
+                    logger.error(f"OAuth Polling error: {e}")
+                    logger.error(f"Full traceback: {traceback.format_exc()}")
         # No need to schedule next poll - PollingStream handles this automatically via timeout
 
     def _run_stream(self):

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -2233,16 +2233,16 @@ class _Strategy:
             self.logger.debug(f"Cloud response: Status={response.status_code}, Headers={dict(response.headers)}")
 
         except requests.exceptions.ConnectionError as e:
-            self.logger.error(f"Connection error when sending to cloud: {e}")
-            self.logger.error(traceback.format_exc())
+            self.logger.warning(f"Connection error when sending to cloud: {e}")
+            self.logger.debug(traceback.format_exc())
             return False
         except requests.exceptions.Timeout as e:
-            self.logger.error(f"Timeout error when sending to cloud: {e}")
-            self.logger.error(traceback.format_exc())
+            self.logger.warning(f"Timeout error when sending to cloud: {e}")
+            self.logger.debug(traceback.format_exc())
             return False
         except requests.exceptions.RequestException as e:
-            self.logger.error(f"Request error when sending to cloud: {e}")
-            self.logger.error(traceback.format_exc())
+            self.logger.warning(f"Request error when sending to cloud: {e}")
+            self.logger.debug(traceback.format_exc())
             return False
         except Exception as e:
             self.logger.error(f"Unexpected error when sending to cloud: {e}")

--- a/tests/test_alpaca_oauth.py
+++ b/tests/test_alpaca_oauth.py
@@ -214,6 +214,22 @@ class TestAlpacaOAuth(unittest.TestCase):
             self.assertIn("401 Unauthorized", str(context.exception))
 
     @patch('lumibot.brokers.alpaca.TradingClient')
+    def test_oauth_rate_limit_is_warning(self, mock_trading_client):
+        """Test that OAuth polling rate limits are logged as warnings and do not stop execution."""
+        mock_trading_client.return_value = Mock()
+
+        broker = Alpaca(self.oauth_config, connect_stream=False)
+
+        with patch.object(broker, 'sync_positions') as mock_sync:
+            mock_sync.side_effect = Exception('{"code":42910000,"message":"rate limit exceeded"}')
+
+            with self.assertLogs('lumibot.brokers.alpaca', level='WARNING') as cm:
+                broker.do_polling()
+
+            self.assertTrue(any("rate-limited" in msg.lower() for msg in cm.output))
+            self.assertFalse(any(msg.startswith("ERROR:") for msg in cm.output))
+
+    @patch('lumibot.brokers.alpaca.TradingClient')
     def test_strategy_none_handling(self, mock_trading_client):
         """Test that polling handles None strategy gracefully."""
         mock_trading_client.return_value = Mock()

--- a/tests/test_cloud_update_warning.py
+++ b/tests/test_cloud_update_warning.py
@@ -1,0 +1,71 @@
+import logging
+from types import SimpleNamespace
+
+import requests
+
+from lumibot.strategies._strategy import _Strategy
+
+
+def test_send_update_to_cloud_connection_error_logs_warning(monkeypatch, caplog):
+    dummy = SimpleNamespace(
+        is_backtesting=False,
+        lumiwealth_api_key="test_key_123",
+        _logged_missing_lumiwealth_api_key=False,
+        _name="DummyStrategy",
+        broker=SimpleNamespace(name="DummyBroker"),
+        logger=logging.getLogger("tests.cloud_update"),
+    )
+
+    dummy.get_portfolio_value = lambda: 100.0
+    dummy.get_cash = lambda: 100.0
+    dummy.get_positions = lambda: []
+    dummy.get_orders = lambda: []
+
+    def raise_connection_error(*_args, **_kwargs):
+        raise requests.exceptions.ConnectionError("Connection reset by peer")
+
+    monkeypatch.setattr(requests, "post", raise_connection_error)
+
+    caplog.set_level(logging.DEBUG)
+    result = _Strategy.send_update_to_cloud(dummy)
+
+    assert result is False
+    assert any(
+        record.levelno == logging.WARNING
+        and "Connection error when sending to cloud" in record.getMessage()
+        for record in caplog.records
+    )
+    assert all(record.levelno < logging.ERROR for record in caplog.records)
+
+
+def test_send_update_to_cloud_timeout_logs_warning(monkeypatch, caplog):
+    dummy = SimpleNamespace(
+        is_backtesting=False,
+        lumiwealth_api_key="test_key_123",
+        _logged_missing_lumiwealth_api_key=False,
+        _name="DummyStrategy",
+        broker=SimpleNamespace(name="DummyBroker"),
+        logger=logging.getLogger("tests.cloud_update"),
+    )
+
+    dummy.get_portfolio_value = lambda: 100.0
+    dummy.get_cash = lambda: 100.0
+    dummy.get_positions = lambda: []
+    dummy.get_orders = lambda: []
+
+    def raise_timeout(*_args, **_kwargs):
+        raise requests.exceptions.Timeout("timeout")
+
+    monkeypatch.setattr(requests, "post", raise_timeout)
+
+    caplog.set_level(logging.DEBUG)
+    result = _Strategy.send_update_to_cloud(dummy)
+
+    assert result is False
+    assert any(
+        record.levelno == logging.WARNING
+        and "Timeout error when sending to cloud" in record.getMessage()
+        for record in caplog.records
+    )
+    assert all(record.levelno < logging.ERROR for record in caplog.records)
+


### PR DESCRIPTION
Stops noisy BotSpot alert emails for transient Alpaca OAuth polling rate-limits and transient network failures when sending portfolio updates to the cloud by logging them as WARNING instead of ERROR. Adds unit tests to lock behavior.