### PR TITLE
ThetaData: per-asset download progress for EOD + contract-specific matching

### DIFF
--- a/docs/BACKTESTING_ARCHITECTURE.md
+++ b/docs/BACKTESTING_ARCHITECTURE.md
@@ -495,7 +495,7 @@ ThetaData downloads can occur at any point during a backtest when data is needed
 **Functions:**
 - `get_download_status()` - Get current download state
 - `set_download_status(asset, quote_asset, data_type, timespan, current, total)` - Update status
-- `clear_download_status()` - Clear status after download completes
+- `finalize_download_status()` / `clear_download_status()` - Mark inactive (finalize keeps the last `current/total` visible for UI polling)
 
 **Download Status Format:**
 ```python
@@ -506,10 +506,15 @@ ThetaData downloads can occur at any point during a backtest when data is needed
     "data_type": "ohlc",      # Data type (ohlc, trades, quotes)
     "timespan": "minute",     # Timespan (minute, day, etc.)
     "progress": 50,           # Progress percentage (0-100)
-    "current": 5,             # Current chunk number
-    "total": 10               # Total chunks
+    "current": 5,             # Completed request "pieces" for THIS asset operation
+    "total": 10               # Total request "pieces" for THIS asset operation
 }
 ```
+
+**Semantics (important):**
+- `current/total` are **not** “percent of the whole backtest downloaded”.
+- They represent progress for the **single asset currently being hydrated** (e.g., one stock, or one option contract identified by symbol + strike + expiration + right).
+- A “piece” is whatever deterministic request plan the data source uses for that asset (e.g., per-trading-day requests for intraday history, or per-date-window requests for EOD history).
 
 **Extending to Other Data Sources:**
 

--- a/docs/SMART_LIMIT_LIVE_TESTING.md
+++ b/docs/SMART_LIMIT_LIVE_TESTING.md
@@ -1,0 +1,51 @@
+## SMART_LIMIT live testing (paper)
+
+This repo has two layers of coverage:
+
+- **Unit tests** (deterministic): validate SMART_LIMIT math + state machine behavior without broker APIs.
+- **API tests** (`pytest -m apitest`): place real paper orders to validate submission + repricing + fills.
+
+### 1) One-time setup
+
+- Put broker creds in `.env` (repo root). The tests load it automatically.
+
+### 2) Run unit tests (any time)
+
+```bash
+/Users/robertgrzesik/bin/safe-timeout 1200s python3 -m pytest -q \
+  tests/test_smart_limit_utils_unit.py \
+  tests/test_smart_limit_single_leg_unit.py \
+  tests/test_smart_limit_multileg_unit.py \
+  tests/test_tradier_stream_optional_unit.py
+```
+
+### 3) Run live paper smoke (market hours)
+
+These are “fast confidence” tests (stocks + single-leg options + 4-leg options) and should complete quickly.
+
+```bash
+/Users/robertgrzesik/bin/safe-timeout 2400s python3 -m pytest -q -m "apitest and not smartlimit_matrix" \
+  tests/test_smart_limit_live_alpaca.py \
+  tests/test_smart_limit_live_tradier.py
+```
+
+### 4) Run live matrix (market hours)
+
+These are heavier tests that add:
+
+- debit + credit multi-leg packages (condor + butterfly)
+- puts + long-dated options (wider spreads)
+- short options (skips if broker rejects)
+- non-SMART multi-leg LIMIT UX parity (no debit/credit/even in strategy code)
+
+```bash
+/Users/robertgrzesik/bin/safe-timeout 7200s python3 -m pytest -q -m smartlimit_matrix \
+  tests/test_smart_limit_live_matrix_alpaca.py \
+  tests/test_smart_limit_live_matrix_tradier.py
+```
+
+### 5) Benchmarks (market hours; not a pytest)
+
+Benchmarks are in `scripts/` and write CSVs to `logs/`. These are used for price-improvement statistics and are not
+treated as strict pass/fail (paper fills can be unrealistic).
+

--- a/docs/investigations/2026-01-08_BACKTESTING_PROD_BENCHMARKS_ENDPOINT_BREAKDOWN.md
+++ b/docs/investigations/2026-01-08_BACKTESTING_PROD_BENCHMARKS_ENDPOINT_BREAKDOWN.md
@@ -1,0 +1,43 @@
+# Production Backtest Benchmarks: Endpoint Breakdown (Sanitized)
+
+Date: 2026-01-08
+
+This investigation records a **sanitized** snapshot of which downloader endpoint families dominate two “must-fix” production backtests. Raw IDs/URLs and log queries are intentionally kept out of this committed document (those belong in `docs/handoffs/`).
+
+## Benchmarks (must-fix)
+
+1) **SPX Short Straddle Intraday (Full year)**
+- Dominant family: `option/history/quote`
+- Secondary: `index/history/price`
+- Takeaway: runtime is primarily **hydration/fanout-bound**, not compute-bound.
+
+2) **Alpha Picks Options (≈1 month)**
+- Dominant family: `option/list/strikes`
+- Secondary: `option/history/quote`, `option/history/eod`
+- Takeaway: runtime is primarily **chain/strike discovery + quote/eod hydration**, not compute-bound.
+
+## Observed endpoint family counts (order-of-magnitude)
+
+These are representative counts observed from production log aggregation for the above benchmarks.
+
+### SPX Short Straddle Intraday (slow run)
+- `option/history/quote`: ~2.3k
+- `index/history/price`: ~0.2k
+
+### Alpha Picks Options (slow run)
+- `option/list/strikes`: ~0.6k
+- `option/history/quote`: ~0.5k
+- `option/history/eod`: ~0.2k
+
+### Alpha Picks Options (fast/warm run)
+- `option/history/quote`: O(10–100)
+
+## Implications
+
+- Fixing “hours-long” option backtests requires reducing request **fanout** and improving cache **coverage** for the dominant families, especially `option/history/quote` and (for some strategies) `option/list/strikes`.
+- CPU sizing helps only after hydration request volume is brought under control.
+
+## Next steps (implementation work is tracked elsewhere)
+
+- Ensure `download_status` propagates end-to-end (BotManager must not overwrite it).
+- Ensure `download_status` progress reflects **a single asset download operation** (one option contract or one stock time series broken into N request “pieces”), not whole-backtest progress.

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -108,6 +108,21 @@ class Tradier(Broker):
         # Override default market setting for Tradier to be NYSE, but still respect config/env if set
         self.market = (config.get("MARKET") if config else None) or os.environ.get("MARKET") or "NYSE"
 
+    def _safe_stream_dispatch(self, event, **kwargs):
+        """Dispatch an event to the stream if it exists.
+
+        Tradier can run in polling mode and/or with `connect_stream=False`. Order submission and polling must not
+        crash purely because a stream is unavailable.
+        """
+
+        stream = getattr(self, "stream", None)
+        if stream is None:
+            return
+        try:
+            stream.dispatch(event, **kwargs)
+        except Exception:
+            return
+
     def cancel_order(self, order: Order):
         """Cancels an order at the broker. Nothing will be done for orders that are already cancelled or filled."""
         # Check if the order is already cancelled or filled
@@ -285,7 +300,7 @@ class Tradier(Broker):
         parent_order.child_orders = orders
         parent_order.update_raw(order_response)  # This marks order as 'transmitted'
         self._unprocessed_orders.append(parent_order)
-        self.stream.dispatch(self.NEW_ORDER, order=parent_order)
+        self._safe_stream_dispatch(self.NEW_ORDER, order=parent_order)
         return parent_order
 
     def _submit_order(self, order: Order):
@@ -375,7 +390,7 @@ class Tradier(Broker):
                     )
                 except TradierApiError as e:
                     msg = colored(f"Error submitting order {order}: {e}", color="red")
-                    self.stream.dispatch(self.ERROR_ORDER, order=order, error_msg=msg)
+                    self._safe_stream_dispatch(self.ERROR_ORDER, order=order, error_msg=msg)
                     return None
 
             elif order.asset is not None and order.asset.asset_type == Asset.AssetType.STOCK:
@@ -425,11 +440,11 @@ class Tradier(Broker):
             order.status = Order.OrderStatus.SUBMITTED
             order.update_raw(order_response)  # This marks order as 'transmitted'
             self._unprocessed_orders.append(order)
-            self.stream.dispatch(self.NEW_ORDER, order=order)
+            self._safe_stream_dispatch(self.NEW_ORDER, order=order)
 
         except TradierApiError as e:
             msg = colored(f"Error submitting order {order}: {e}", color="red")
-            self.stream.dispatch(self.ERROR_ORDER, order=order, error_msg=msg)
+            self._safe_stream_dispatch(self.ERROR_ORDER, order=order, error_msg=msg)
 
         return order
 
@@ -875,7 +890,7 @@ class Tradier(Broker):
                     if not order.equivalent_status(stored_order):
                         match order.status.lower():
                             case "submitted" | "open":
-                                self.stream.dispatch(self.NEW_ORDER, order=stored_order)
+                                self._safe_stream_dispatch(self.NEW_ORDER, order=stored_order)
                             case "partial_filled":
                                 # Not handled for polling, only dispatch completely filled orders
                                 pass
@@ -905,16 +920,18 @@ class Tradier(Broker):
                                 # values will be filled in by Tradier, so do not trigger a 'filled' event until
                                 # all the needed data has been populated.
                                 if fill_price is not None and fill_qty is not None:
-                                    self.stream.dispatch(
-                                        self.FILLED_ORDER, order=stored_order, price=fill_price,
-                                        filled_quantity=fill_qty
+                                    self._safe_stream_dispatch(
+                                        self.FILLED_ORDER,
+                                        order=stored_order,
+                                        price=fill_price,
+                                        filled_quantity=fill_qty,
                                     )
                             case "canceled":
-                                self.stream.dispatch(self.CANCELED_ORDER, order=stored_order)
+                                self._safe_stream_dispatch(self.CANCELED_ORDER, order=stored_order)
                             case "error":
                                 default_msg = f"{self.name} encountered an error with order {order.identifier} | {order}"
                                 msg = order_row["reason_description"] if "reason_description" in order_row else default_msg
-                                self.stream.dispatch(self.ERROR_ORDER, order=stored_order, error_msg=msg)
+                                self._safe_stream_dispatch(self.ERROR_ORDER, order=stored_order, error_msg=msg)
                             case "cash_settled":
                                 # Don't know how to detect this case in Tradier.
                                 # Reference: https://documentation.tradier.com/brokerage-api/reference/response/orders
@@ -941,7 +958,7 @@ class Tradier(Broker):
                 # stopped tracking them. This is particularly true with Paper Trading where orders are not tracked
                 # overnight.
                 if order.is_active():
-                    self.stream.dispatch(self.CANCELED_ORDER, order=order)
+                    self._safe_stream_dispatch(self.CANCELED_ORDER, order=order)
 
     def _get_broker_id_from_raw_orders(self, raw_orders):
         ids = []

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -1698,7 +1698,16 @@ class Strategy(_Strategy):
                 if order.order_class == Order.OrderClass.MULTILEG and order.child_orders:
                     return self._submit_multileg_smart_limit(order)
 
-                quote = self.get_quote(order.asset, quote=order.quote, exchange=order.exchange)
+                try:
+                    quote = self.get_quote(order.asset, quote=order.quote, exchange=order.exchange)
+                except Exception as exc:
+                    self.log_message(
+                        f"[SMART_LIMIT] Quote fetch failed for {order.asset} ({exc}); downgrading to market.",
+                        color="yellow",
+                    )
+                    order.smart_limit = None
+                    order.order_type = Order.OrderType.MARKET
+                    return self.broker.submit_order(order)
                 bid = getattr(quote, "bid", None)
                 ask = getattr(quote, "ask", None)
                 if bid is None or ask is None or bid < 0 or ask <= 0:
@@ -1721,8 +1730,8 @@ class Strategy(_Strategy):
                 order._smart_limit_state = {
                     "created_at": time.monotonic(),
                     "step_index": 0,
-                    "steps": order.smart_limit.get_step_count(),
-                    "step_seconds": order.smart_limit.get_step_seconds(),
+                    "steps": max(1, order.smart_limit.get_step_count()),
+                    "step_seconds": max(1, order.smart_limit.get_step_seconds()),
                     "final_hold_seconds": order.smart_limit.get_final_hold_seconds(),
                 }
 
@@ -1749,9 +1758,13 @@ class Strategy(_Strategy):
 
         quote_data: list[tuple[Order, float | None, float | None]] = []
         for leg in child_orders:
-            quote = self.get_quote(leg.asset, quote=leg.quote, exchange=leg.exchange)
-            bid = getattr(quote, "bid", None)
-            ask = getattr(quote, "ask", None)
+            try:
+                quote = self.get_quote(leg.asset, quote=leg.quote, exchange=leg.exchange)
+                bid = getattr(quote, "bid", None)
+                ask = getattr(quote, "ask", None)
+            except Exception:
+                bid = None
+                ask = None
             quote_data.append((leg, bid, ask))
 
         if any(bid is None or ask is None or bid < 0 or ask <= 0 for _, bid, ask in quote_data):
@@ -1822,8 +1835,8 @@ class Strategy(_Strategy):
         state = {
             "created_at": time.monotonic(),
             "step_index": 0,
-            "steps": smart_limit.get_step_count(),
-            "step_seconds": smart_limit.get_step_seconds(),
+            "steps": max(1, smart_limit.get_step_count()),
+            "step_seconds": max(1, smart_limit.get_step_seconds()),
             "final_hold_seconds": smart_limit.get_final_hold_seconds(),
             "multileg_order_type": initial_type,
         }

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -640,11 +640,21 @@ class StrategyExecutor(Thread):
                 state = {
                     "created_at": now,
                     "step_index": 0,
-                    "steps": smart_limit.get_step_count(),
-                    "step_seconds": smart_limit.get_step_seconds(),
+                    "steps": max(1, smart_limit.get_step_count()),
+                    "step_seconds": max(1, smart_limit.get_step_seconds()),
                     "final_hold_seconds": smart_limit.get_final_hold_seconds(),
                 }
                 order._smart_limit_state = state
+            else:
+                # Defensive: older/corrupt state should not crash the executor.
+                try:
+                    if int(state.get("steps", 0)) <= 0:
+                        state["steps"] = max(1, smart_limit.get_step_count())
+                    if int(state.get("step_seconds", 0)) <= 0:
+                        state["step_seconds"] = max(1, smart_limit.get_step_seconds())
+                except Exception:
+                    state["steps"] = max(1, smart_limit.get_step_count())
+                    state["step_seconds"] = max(1, smart_limit.get_step_seconds())
 
             elapsed = now - state["created_at"]
             step_index = min(state["steps"] - 1, int(elapsed // state["step_seconds"]))
@@ -665,9 +675,13 @@ class StrategyExecutor(Thread):
             if order.order_class == Order.OrderClass.MULTILEG and order.child_orders:
                 quote_data: list[tuple[Order, float | None, float | None]] = []
                 for leg in order.child_orders:
-                    quote = self.strategy.get_quote(leg.asset, quote=leg.quote, exchange=leg.exchange)
-                    leg_bid = getattr(quote, "bid", None)
-                    leg_ask = getattr(quote, "ask", None)
+                    try:
+                        quote = self.strategy.get_quote(leg.asset, quote=leg.quote, exchange=leg.exchange)
+                        leg_bid = getattr(quote, "bid", None)
+                        leg_ask = getattr(quote, "ask", None)
+                    except Exception:
+                        leg_bid = None
+                        leg_ask = None
                     quote_data.append((leg, leg_bid, leg_ask))
 
                 if any(b is None or a is None or b < 0 or a <= 0 for _, b, a in quote_data):
@@ -745,7 +759,10 @@ class StrategyExecutor(Thread):
                 continue
 
             side = "buy" if order.is_buy_order() else "sell"
-            quote = self.strategy.get_quote(order.asset, quote=order.quote, exchange=order.exchange)
+            try:
+                quote = self.strategy.get_quote(order.asset, quote=order.quote, exchange=order.exchange)
+            except Exception:
+                quote = None
             bid = getattr(quote, "bid", None)
             ask = getattr(quote, "ask", None)
 

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -182,12 +182,38 @@ def advance_download_status_progress(
 
         if asset is not None:
             try:
-                status_symbol = (_download_status.get("asset") or {}).get("symbol")
+                status_asset = _download_status.get("asset") or {}
+                status_symbol = status_asset.get("symbol")
                 asset_symbol = getattr(asset, "symbol", None)
                 if status_symbol is not None and asset_symbol is not None and str(status_symbol) != str(asset_symbol):
                     return
+
+                # Options share the same underlying symbol across many contracts; only treat a
+                # progress update as applicable if the contract identity matches.
+                status_type = str(status_asset.get("type") or "").lower()
+                if status_type == "option" or str(getattr(asset, "asset_type", "")).lower() == "option":
+                    status_exp = status_asset.get("exp")
+                    status_strike = status_asset.get("strike")
+                    status_right = status_asset.get("right")
+
+                    asset_exp = getattr(asset, "expiration", None)
+                    asset_exp_str = asset_exp.isoformat() if hasattr(asset_exp, "isoformat") else (str(asset_exp) if asset_exp else None)
+                    asset_strike = getattr(asset, "strike", None)
+                    asset_right = getattr(asset, "right", None)
+
+                    if status_exp is not None and asset_exp_str is not None and str(status_exp) != str(asset_exp_str):
+                        return
+                    if status_right is not None and asset_right is not None and str(status_right).upper() != str(asset_right).upper():
+                        return
+                    if status_strike is not None and asset_strike is not None:
+                        try:
+                            if float(status_strike) != float(asset_strike):
+                                return
+                        except Exception:
+                            if str(status_strike) != str(asset_strike):
+                                return
             except Exception:
-                pass
+                return
 
         total = _download_status.get("total") or 0
         try:
@@ -4948,6 +4974,10 @@ def get_historical_eod_data(
     header_format: Optional[List[str]] = None
     windows = list(_chunk_windows())
 
+    # Track progress for this single-asset EOD download operation.
+    # Each outer window is one "piece" (even if a window needs to be split due to server errors).
+    set_download_status(asset, "USD", datastyle, "day", 0, max(1, len(windows)))
+
     # DEBUG-LOG: EOD data request (overall)
     logger.debug(
         "[THETA][DEBUG][EOD][REQUEST] asset=%s start=%s end=%s datastyle=%s chunks=%d",
@@ -4958,59 +4988,65 @@ def get_historical_eod_data(
         len(windows)
     )
 
-    for idx, (window_start, window_end) in enumerate(windows, start=1):
-        logger.debug(
-            "[THETA][DEBUG][EOD][REQUEST][CHUNK] asset=%s chunk=%d/%d start=%s end=%s",
-            asset,
-            idx,
-            len(windows),
-            window_start,
-            window_end,
-        )
-
-        try:
-            chunk_payloads = _collect_chunk_payloads(window_start, window_end)
-        except ThetaRequestError as exc:
-            logger.error(
-                "[THETA][ERROR][EOD][CHUNK] asset=%s chunk=%d/%d start=%s end=%s status=%s detail=%s",
-                asset,
-                idx,
-                len(windows),
-                window_start,
-                window_end,
-                exc.status_code,
-                exc.body,
-            )
-            raise
-        except ValueError as exc:
-            logger.error(
-                "[THETA][ERROR][EOD][CHUNK] asset=%s chunk=%d/%d start=%s end=%s error=%s",
-                asset,
-                idx,
-                len(windows),
-                window_start,
-                window_end,
-                exc,
-            )
-            raise
-
-        for json_resp in chunk_payloads:
-            if not json_resp:
-                continue
-
-            response_rows = json_resp.get("response") or []
-            if response_rows:
-                aggregated_rows.extend(response_rows)
-            if not header_format and json_resp.get("header", {}).get("format"):
-                header_format = json_resp["header"]["format"]
-
+    try:
+        for idx, (window_start, window_end) in enumerate(windows, start=1):
             logger.debug(
-                "[THETA][DEBUG][EOD][RESPONSE][CHUNK] asset=%s chunk=%d/%d rows=%d",
+                "[THETA][DEBUG][EOD][REQUEST][CHUNK] asset=%s chunk=%d/%d start=%s end=%s",
                 asset,
                 idx,
                 len(windows),
-                len(response_rows),
+                window_start,
+                window_end,
             )
+
+            try:
+                chunk_payloads = _collect_chunk_payloads(window_start, window_end)
+            except ThetaRequestError as exc:
+                logger.error(
+                    "[THETA][ERROR][EOD][CHUNK] asset=%s chunk=%d/%d start=%s end=%s status=%s detail=%s",
+                    asset,
+                    idx,
+                    len(windows),
+                    window_start,
+                    window_end,
+                    exc.status_code,
+                    exc.body,
+                )
+                raise
+            except ValueError as exc:
+                logger.error(
+                    "[THETA][ERROR][EOD][CHUNK] asset=%s chunk=%d/%d start=%s end=%s error=%s",
+                    asset,
+                    idx,
+                    len(windows),
+                    window_start,
+                    window_end,
+                    exc,
+                )
+                raise
+
+            for json_resp in chunk_payloads:
+                if not json_resp:
+                    continue
+
+                response_rows = json_resp.get("response") or []
+                if response_rows:
+                    aggregated_rows.extend(response_rows)
+                if not header_format and json_resp.get("header", {}).get("format"):
+                    header_format = json_resp["header"]["format"]
+
+                logger.debug(
+                    "[THETA][DEBUG][EOD][RESPONSE][CHUNK] asset=%s chunk=%d/%d rows=%d",
+                    asset,
+                    idx,
+                    len(windows),
+                    len(response_rows),
+                )
+
+            # Mark one outer window complete.
+            advance_download_status_progress(asset=asset, data_type=datastyle, timespan="day", step=1)
+    finally:
+        finalize_download_status()
 
     if not aggregated_rows or not header_format:
         logger.debug(

--- a/scripts/run_smart_limit_matrix_apitests.sh
+++ b/scripts/run_smart_limit_matrix_apitests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+/Users/robertgrzesik/bin/safe-timeout 7200s python3 -m pytest -q -m smartlimit_matrix \
+  tests/test_smart_limit_live_matrix_alpaca.py \
+  tests/test_smart_limit_live_matrix_tradier.py
+

--- a/scripts/run_smart_limit_smoke_apitests.sh
+++ b/scripts/run_smart_limit_smoke_apitests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+/Users/robertgrzesik/bin/safe-timeout 2400s python3 -m pytest -q -m "apitest and not smartlimit_matrix" \
+  tests/test_smart_limit_live_alpaca.py \
+  tests/test_smart_limit_live_tradier.py
+

--- a/scripts/run_smart_limit_unit_tests.sh
+++ b/scripts/run_smart_limit_unit_tests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+/Users/robertgrzesik/bin/safe-timeout 1200s python3 -m pytest -q \
+  tests/test_smart_limit_utils_unit.py \
+  tests/test_smart_limit_single_leg_unit.py \
+  tests/test_smart_limit_multileg_unit.py \
+  tests/test_tradier_stream_optional_unit.py
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ known-third-party=lumibot
 [tool:pytest]
 markers =
     apitest: marks tests as API tests (deselect with '-m "not apitest"')
+    smartlimit_matrix: larger SMART_LIMIT live matrix tests (run with '-m smartlimit_matrix')
     downloader: marks tests that require the shared Theta downloader service
     acceptance_backtest: full Strategy Library acceptance backtests (ThetaData, prod-like flags)
 

--- a/tests/test_smart_limit_live_matrix_alpaca.py
+++ b/tests/test_smart_limit_live_matrix_alpaca.py
@@ -1,0 +1,386 @@
+import time
+from datetime import datetime, timedelta
+
+import pytest
+
+from lumibot.brokers.alpaca import Alpaca
+from lumibot.components.options_helper import OptionsHelper
+from lumibot.credentials import ALPACA_TEST_CONFIG
+from lumibot.entities import Asset, Order, SmartLimitConfig, SmartLimitPreset
+from lumibot.strategies.strategy import Strategy
+
+
+pytestmark = [pytest.mark.apitest, pytest.mark.smartlimit_matrix]
+
+
+class _HarnessStrategy(Strategy):
+    def initialize(self, parameters=None):
+        self.sleeptime = "1S"
+        self.options_helper = OptionsHelper(self)
+
+    def on_trading_iteration(self):
+        return
+
+
+def _alpaca() -> Alpaca:
+    api_key = ALPACA_TEST_CONFIG.get("API_KEY")
+    api_secret = ALPACA_TEST_CONFIG.get("API_SECRET")
+    if not api_key or not api_secret or api_key == "<your key here>" or api_secret == "<your key here>":
+        pytest.skip("Missing ALPACA_TEST_API_KEY / ALPACA_TEST_API_SECRET in .env")
+    return Alpaca(ALPACA_TEST_CONFIG, connect_stream=False)
+
+
+def _poll_alpaca_order(broker: Alpaca, order: Order):
+    return broker.api.get_order_by_id(order.identifier)
+
+
+def _wait_fill(strategy: _HarnessStrategy, order: Order, *, timeout: int, drive_smart_limit: bool) -> tuple[bool, int, float]:
+    start = time.time()
+    last_price = None
+    reprices = 0
+    while time.time() - start < timeout:
+        if drive_smart_limit:
+            strategy._executor._process_smart_limit_orders()
+
+        raw = _poll_alpaca_order(strategy.broker, order)
+        raw_status = getattr(raw, "status", "")
+        if hasattr(raw_status, "value"):
+            raw_status = raw_status.value
+        status = str(raw_status).lower()
+        order.status = status
+
+        price = getattr(raw, "limit_price", None)
+        if price is not None:
+            try:
+                price = float(price)
+                order.limit_price = price
+                if last_price is None:
+                    last_price = price
+                elif abs(price - last_price) > 1e-9:
+                    reprices += 1
+                    last_price = price
+            except Exception:
+                pass
+
+        if status in {"filled", "fill"}:
+            elapsed = time.time() - start
+            return True, reprices, elapsed
+        if status in {"canceled", "cancelled", "rejected", "expired", "error"}:
+            elapsed = time.time() - start
+            return False, reprices, elapsed
+
+        time.sleep(1.0)
+
+    try:
+        strategy.broker.cancel_order(order)
+    except Exception:
+        pass
+    return False, reprices, time.time() - start
+
+
+def _strike_step(symbol: str) -> float:
+    return 1.0 if symbol.upper() == "SPY" else 5.0
+
+
+def _pick_expiry(strategy: _HarnessStrategy, underlying: Asset, days_out: int):
+    chains = strategy.get_chains(underlying)
+    if not chains:
+        raise RuntimeError(f"No chains for {underlying.symbol}")
+    target_date = datetime.now().astimezone().date() + timedelta(days=days_out)
+    expiry = strategy.options_helper.get_expiration_on_or_after_date(target_date, chains, "call", underlying_asset=underlying)
+    if expiry is None:
+        raise RuntimeError("No expiry found")
+    return expiry
+
+
+def _pick_atm(strategy: _HarnessStrategy, underlying: Asset) -> float:
+    price = strategy.get_last_price(underlying)
+    if price and float(price) > 0:
+        return float(price)
+    raise RuntimeError("Underlying price unavailable")
+
+
+def _pick_wide_spread_stock(strategy: _HarnessStrategy, candidates: list[str], *, min_spread_pct: float) -> Asset | None:
+    for sym in candidates:
+        asset = Asset(sym, asset_type=Asset.AssetType.STOCK)
+        try:
+            q = strategy.get_quote(asset)
+        except Exception:
+            continue
+        bid = getattr(q, "bid", None)
+        ask = getattr(q, "ask", None)
+        try:
+            bid_f = float(bid)
+            ask_f = float(ask)
+        except Exception:
+            continue
+        if ask_f <= 0 or bid_f < 0:
+            continue
+        mid = (bid_f + ask_f) / 2.0
+        if mid <= 0:
+            continue
+        spread_pct = (ask_f - bid_f) / mid
+        if spread_pct >= float(min_spread_pct):
+            return asset
+    return None
+
+
+def _find_option(
+    strategy: _HarnessStrategy,
+    underlying: Asset,
+    *,
+    expiry,
+    put_or_call: str,
+    strike: float,
+    max_spread_pct: float | None,
+):
+    step = _strike_step(underlying.symbol)
+    for offset in range(0, 11):
+        candidate_strike = strike + offset * step
+        asset = strategy.options_helper.find_next_valid_option(underlying, candidate_strike, expiry, put_or_call=put_or_call)
+        if asset is None:
+            continue
+        evaluation = strategy.options_helper.evaluate_option_market(asset, max_spread_pct=max_spread_pct)
+        if evaluation.has_bid_ask and evaluation.buy_price and evaluation.sell_price:
+            return asset
+    return None
+
+
+def _build_spy_iron_condor(strategy: _HarnessStrategy, *, days_out: int, short_distance: float, wing_width: float, order_type, smart_limit):
+    underlying = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    expiry = _pick_expiry(strategy, underlying, days_out)
+    atm = _pick_atm(strategy, underlying)
+    step = _strike_step("SPY")
+    atm_rounded = round(atm / step) * step
+
+    put_short = atm_rounded - short_distance
+    put_long = put_short - wing_width
+    call_short = atm_rounded + short_distance
+    call_long = call_short + wing_width
+
+    put_short_asset = strategy.options_helper.find_next_valid_option(underlying, put_short, expiry, put_or_call="put")
+    put_long_asset = strategy.options_helper.find_next_valid_option(underlying, put_long, expiry, put_or_call="put")
+    call_short_asset = strategy.options_helper.find_next_valid_option(underlying, call_short, expiry, put_or_call="call")
+    call_long_asset = strategy.options_helper.find_next_valid_option(underlying, call_long, expiry, put_or_call="call")
+    assert put_short_asset and put_long_asset and call_short_asset and call_long_asset
+
+    open_legs = [
+        strategy.create_order(put_long_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(put_short_asset, 1, Order.OrderSide.SELL_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(call_short_asset, 1, Order.OrderSide.SELL_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(call_long_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+    ]
+    close_legs = [
+        strategy.create_order(put_long_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(put_short_asset, 1, Order.OrderSide.BUY_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(call_short_asset, 1, Order.OrderSide.BUY_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(call_long_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+    ]
+    return open_legs, close_legs
+
+
+def _build_spy_call_butterfly(strategy: _HarnessStrategy, *, days_out: int, width: float, order_type, smart_limit):
+    underlying = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    expiry = _pick_expiry(strategy, underlying, days_out)
+    atm = _pick_atm(strategy, underlying)
+    step = _strike_step("SPY")
+    mid_strike = round(atm / step) * step
+    low = mid_strike - width
+    high = mid_strike + width
+
+    low_asset = strategy.options_helper.find_next_valid_option(underlying, low, expiry, put_or_call="call")
+    mid_asset = strategy.options_helper.find_next_valid_option(underlying, mid_strike, expiry, put_or_call="call")
+    high_asset = strategy.options_helper.find_next_valid_option(underlying, high, expiry, put_or_call="call")
+    assert low_asset and mid_asset and high_asset
+
+    open_legs = [
+        strategy.create_order(low_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(mid_asset, 2, Order.OrderSide.SELL_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(high_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+    ]
+    close_legs = [
+        strategy.create_order(low_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(mid_asset, 2, Order.OrderSide.BUY_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(high_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+    ]
+    return open_legs, close_legs
+
+
+def _assert_open_close_fill(
+    strategy: _HarnessStrategy,
+    open_order,
+    close_order,
+    *,
+    drive_smart_limit: bool,
+    timeout_open: int,
+    timeout_close: int,
+    require_reprices: bool = False,
+):
+    submitted_open = strategy.submit_order(open_order)
+    open_parent = submitted_open[0] if isinstance(submitted_open, list) else submitted_open
+    ok_open, reprices_open, open_elapsed = _wait_fill(strategy, open_parent, timeout=timeout_open, drive_smart_limit=drive_smart_limit)
+    assert ok_open, f"Open did not fill (reprices={reprices_open}, elapsed={open_elapsed:.1f}s)"
+
+    submitted_close = strategy.submit_order(close_order)
+    close_parent = submitted_close[0] if isinstance(submitted_close, list) else submitted_close
+    ok_close, reprices_close, close_elapsed = _wait_fill(
+        strategy, close_parent, timeout=timeout_close, drive_smart_limit=drive_smart_limit
+    )
+    if not ok_close:
+        # Best-effort flatten: market close (single leg).
+        if isinstance(close_order, list):
+            close_mkt_legs = [strategy.create_order(leg.asset, leg.quantity, leg.side, order_type=Order.OrderType.MARKET) for leg in close_order]
+            submitted_mkt = strategy.submit_order(close_mkt_legs, is_multileg=True, order_type="market")
+            mkt_parent = submitted_mkt[0] if isinstance(submitted_mkt, list) else submitted_mkt
+            _wait_fill(strategy, mkt_parent, timeout=60, drive_smart_limit=False)
+        else:
+            mkt_close = strategy.create_order(close_order.asset, close_order.quantity, close_order.side, order_type=Order.OrderType.MARKET)
+            submitted_mkt = strategy.submit_order(mkt_close)
+            _wait_fill(strategy, submitted_mkt, timeout=60, drive_smart_limit=False)
+        pytest.fail(f"Close did not fill (reprices={reprices_close}, elapsed={close_elapsed:.1f}s)")
+
+    if require_reprices and open_elapsed > 5:
+        assert reprices_open >= 1
+
+
+def test_alpaca_matrix_stock_liquid_and_wide_spread():
+    broker = _alpaca()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=60)
+    liquid = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    wide = _pick_wide_spread_stock(strategy, ["GME", "AMC", "PLTR", "SOFI", "F", "T"], min_spread_pct=0.002)
+    if wide is None:
+        pytest.skip("No wide-spread stock found in candidate list")
+
+    for asset in (liquid, wide):
+        buy = strategy.create_order(asset, 1, Order.OrderSide.BUY, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg)
+        sell = strategy.create_order(asset, 1, Order.OrderSide.SELL, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg)
+        _assert_open_close_fill(strategy, buy, sell, drive_smart_limit=True, timeout_open=180, timeout_close=180)
+
+
+def test_alpaca_matrix_single_leg_call_and_put_liquid_and_wide_spread():
+    broker = _alpaca()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=60)
+    underlying = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    atm = _pick_atm(strategy, underlying)
+    expiry_liquid = _pick_expiry(strategy, underlying, 7)
+    expiry_wide = _pick_expiry(strategy, underlying, 180)
+    step = _strike_step("SPY")
+    atm_rounded = round(atm / step) * step
+
+    call_liquid = _find_option(strategy, underlying, expiry=expiry_liquid, put_or_call="call", strike=atm_rounded, max_spread_pct=0.5)
+    put_liquid = _find_option(strategy, underlying, expiry=expiry_liquid, put_or_call="put", strike=atm_rounded, max_spread_pct=0.5)
+    call_wide = _find_option(strategy, underlying, expiry=expiry_wide, put_or_call="call", strike=atm_rounded + (20 * step), max_spread_pct=None)
+
+    if call_liquid is None or put_liquid is None or call_wide is None:
+        pytest.skip("Could not find suitable option contracts for matrix test")
+
+    for opt in (call_liquid, put_liquid, call_wide):
+        open_order = strategy.create_order(opt, 1, Order.OrderSide.BUY_TO_OPEN, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg)
+        close_order = strategy.create_order(opt, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg)
+        _assert_open_close_fill(strategy, open_order, close_order, drive_smart_limit=True, timeout_open=240, timeout_close=240)
+
+
+def test_alpaca_matrix_short_option_single_leg_smart_limit_or_skip():
+    broker = _alpaca()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=60)
+    underlying = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    expiry = _pick_expiry(strategy, underlying, 7)
+    atm = _pick_atm(strategy, underlying)
+    step = _strike_step("SPY")
+    strike = round(atm / step) * step
+    call_asset = _find_option(strategy, underlying, expiry=expiry, put_or_call="call", strike=strike, max_spread_pct=0.75)
+    if call_asset is None:
+        pytest.skip("No suitable shortable option found")
+
+    open_order = strategy.create_order(call_asset, 1, Order.OrderSide.SELL_TO_OPEN, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg)
+    submitted_open = strategy.submit_order(open_order)
+    ok_open, _, _ = _wait_fill(strategy, submitted_open, timeout=120, drive_smart_limit=True)
+    if not ok_open and str(getattr(submitted_open, "status", "")).lower() in {"rejected", "error"}:
+        pytest.skip("Broker rejected short option open (insufficient permissions/margin in paper)")
+    assert ok_open, "Short option open did not fill"
+
+    close_order = strategy.create_order(call_asset, 1, Order.OrderSide.BUY_TO_CLOSE, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg)
+    submitted_close = strategy.submit_order(close_order)
+    ok_close, _, _ = _wait_fill(strategy, submitted_close, timeout=180, drive_smart_limit=True)
+    assert ok_close, "Short option close did not fill"
+
+
+def test_alpaca_matrix_multileg_credit_condor_and_debit_butterfly_smart_limit():
+    broker = _alpaca()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=60)
+
+    open_legs, close_legs = _build_spy_iron_condor(
+        strategy,
+        days_out=7,
+        short_distance=5.0,
+        wing_width=5.0,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+    )
+    _assert_open_close_fill(strategy, open_legs, close_legs, drive_smart_limit=True, timeout_open=300, timeout_close=300)
+
+    open_bfly, close_bfly = _build_spy_call_butterfly(
+        strategy,
+        days_out=7,
+        width=5.0,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+    )
+    _assert_open_close_fill(strategy, open_bfly, close_bfly, drive_smart_limit=True, timeout_open=300, timeout_close=300)
+
+
+def test_alpaca_matrix_multileg_limit_parity_without_debit_credit():
+    broker = _alpaca()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    strategy.initialize(parameters=None)
+
+    open_legs, close_legs = _build_spy_iron_condor(
+        strategy,
+        days_out=7,
+        short_distance=5.0,
+        wing_width=5.0,
+        order_type=Order.OrderType.LIMIT,
+        smart_limit=None,
+    )
+
+    submitted_open = strategy.submit_order(open_legs, is_multileg=True, order_type=Order.OrderType.LIMIT)
+    open_parent = submitted_open[0] if isinstance(submitted_open, list) else submitted_open
+    ok_open, _, _ = _wait_fill(strategy, open_parent, timeout=240, drive_smart_limit=False)
+    assert ok_open, "Package LIMIT open did not fill"
+
+    submitted_close = strategy.submit_order(close_legs, is_multileg=True, order_type=Order.OrderType.LIMIT)
+    close_parent = submitted_close[0] if isinstance(submitted_close, list) else submitted_close
+    ok_close, _, _ = _wait_fill(strategy, close_parent, timeout=240, drive_smart_limit=False)
+    if not ok_close:
+        submitted_mkt = strategy.submit_order(close_legs, is_multileg=True, order_type="market")
+        mkt_parent = submitted_mkt[0] if isinstance(submitted_mkt, list) else submitted_mkt
+        _wait_fill(strategy, mkt_parent, timeout=60, drive_smart_limit=False)
+        pytest.fail("Package LIMIT close did not fill")
+

--- a/tests/test_smart_limit_live_matrix_tradier.py
+++ b/tests/test_smart_limit_live_matrix_tradier.py
@@ -1,0 +1,400 @@
+import time
+from datetime import datetime, timedelta
+
+import pytest
+
+from lumibot.brokers.tradier import Tradier
+from lumibot.components.options_helper import OptionsHelper
+from lumibot.credentials import TRADIER_TEST_CONFIG
+from lumibot.entities import Asset, Order, SmartLimitConfig, SmartLimitPreset
+from lumibot.strategies.strategy import Strategy
+
+
+pytestmark = [pytest.mark.apitest, pytest.mark.smartlimit_matrix]
+
+
+class _HarnessStrategy(Strategy):
+    def initialize(self, parameters=None):
+        self.sleeptime = "1S"
+        self.options_helper = OptionsHelper(self)
+
+    def on_trading_iteration(self):
+        return
+
+
+def _tradier() -> Tradier:
+    if not TRADIER_TEST_CONFIG.get("ACCOUNT_NUMBER") or not TRADIER_TEST_CONFIG.get("ACCESS_TOKEN"):
+        pytest.skip("Missing TRADIER_TEST_ACCOUNT_NUMBER / TRADIER_TEST_ACCESS_TOKEN in .env")
+    return Tradier(
+        account_number=TRADIER_TEST_CONFIG["ACCOUNT_NUMBER"],
+        access_token=TRADIER_TEST_CONFIG["ACCESS_TOKEN"],
+        paper=True,
+        connect_stream=True,
+    )
+
+
+def _poll_tradier_order(broker: Tradier, order: Order) -> dict:
+    return broker._pull_broker_order(order.identifier)  # noqa: SLF001
+
+
+def _wait_fill(strategy: _HarnessStrategy, order: Order, *, timeout: int, drive_smart_limit: bool) -> tuple[bool, int, float]:
+    start = time.time()
+    last_price = None
+    reprices = 0
+    while time.time() - start < timeout:
+        if drive_smart_limit:
+            strategy._executor._process_smart_limit_orders()
+
+        record = _poll_tradier_order(strategy.broker, order)
+        status = str(record.get("status", "")).lower()
+        order.status = status
+
+        price = record.get("price")
+        if price is not None:
+            try:
+                price = float(price)
+                order.limit_price = price
+                if last_price is None:
+                    last_price = price
+                elif abs(price - last_price) > 1e-9:
+                    reprices += 1
+                    last_price = price
+            except Exception:
+                pass
+
+        if status == "filled":
+            elapsed = time.time() - start
+            return True, reprices, elapsed
+        if status in {"canceled", "cancelled", "rejected", "expired", "error"}:
+            elapsed = time.time() - start
+            return False, reprices, elapsed
+
+        time.sleep(1.0)
+
+    try:
+        strategy.broker.cancel_order(order)
+    except Exception:
+        pass
+    return False, reprices, time.time() - start
+
+
+def _strike_step(symbol: str) -> float:
+    return 5.0 if symbol.upper() in {"SPX", "SPXW", "NDX", "RUT"} else 1.0
+
+
+def _pick_expiry(strategy: _HarnessStrategy, underlying: Asset, days_out: int):
+    chains = strategy.get_chains(underlying)
+    if not chains and underlying.symbol.upper() == "SPX":
+        chains = strategy.get_chains(Asset("SPXW", asset_type=Asset.AssetType.INDEX))
+    if not chains and underlying.symbol.upper() == "SPXW":
+        chains = strategy.get_chains(Asset("SPX", asset_type=Asset.AssetType.INDEX))
+    if not chains:
+        raise RuntimeError(f"No chains for {underlying.symbol}")
+
+    target_date = datetime.now().astimezone().date() + timedelta(days=days_out)
+    expiry = strategy.options_helper.get_expiration_on_or_after_date(target_date, chains, "call", underlying_asset=underlying)
+    if expiry is None:
+        raise RuntimeError("No expiry found")
+    return expiry
+
+
+def _pick_atm_strike(strategy: _HarnessStrategy, underlying: Asset, expiry) -> float:
+    price = strategy.get_last_price(underlying)
+    if price and float(price) > 0:
+        return float(price)
+
+    chains = strategy.get_chains(underlying)
+    if not chains and underlying.symbol.upper() == "SPX":
+        chains = strategy.get_chains(Asset("SPXW", asset_type=Asset.AssetType.INDEX))
+    if not chains and underlying.symbol.upper() == "SPXW":
+        chains = strategy.get_chains(Asset("SPX", asset_type=Asset.AssetType.INDEX))
+    if not chains:
+        raise RuntimeError("No chains available to infer ATM strike")
+
+    strikes_raw = chains.strikes(expiry, "CALL") or []
+    strikes = sorted(float(s) for s in strikes_raw if s is not None)
+    if not strikes:
+        raise RuntimeError("No strikes available to infer ATM strike")
+    return float(strikes[len(strikes) // 2])
+
+
+def _pick_wide_spread_stock(strategy: _HarnessStrategy, candidates: list[str], *, min_spread_pct: float) -> Asset | None:
+    for sym in candidates:
+        asset = Asset(sym, asset_type=Asset.AssetType.STOCK)
+        try:
+            q = strategy.get_quote(asset)
+        except Exception:
+            continue
+        bid = getattr(q, "bid", None)
+        ask = getattr(q, "ask", None)
+        try:
+            bid_f = float(bid)
+            ask_f = float(ask)
+        except Exception:
+            continue
+        if ask_f <= 0 or bid_f < 0:
+            continue
+        mid = (bid_f + ask_f) / 2.0
+        if mid <= 0:
+            continue
+        spread_pct = (ask_f - bid_f) / mid
+        if spread_pct >= float(min_spread_pct):
+            return asset
+    return None
+
+
+def _find_option(
+    strategy: _HarnessStrategy,
+    underlying: Asset,
+    *,
+    expiry,
+    put_or_call: str,
+    strike: float,
+    max_spread_pct: float | None,
+):
+    step = _strike_step(underlying.symbol)
+    for offset in range(0, 11):
+        candidate_strike = strike + offset * step
+        asset = strategy.options_helper.find_next_valid_option(underlying, candidate_strike, expiry, put_or_call=put_or_call)
+        if asset is None:
+            continue
+        evaluation = strategy.options_helper.evaluate_option_market(asset, max_spread_pct=max_spread_pct)
+        if evaluation.has_bid_ask and evaluation.buy_price and evaluation.sell_price:
+            return asset
+    return None
+
+
+def _build_spx_iron_condor(strategy: _HarnessStrategy, *, days_out: int, short_distance: float, wing_width: float, order_type, smart_limit):
+    underlying = Asset("SPX", asset_type=Asset.AssetType.INDEX)
+    expiry = _pick_expiry(strategy, underlying, days_out)
+    atm = _pick_atm_strike(strategy, underlying, expiry)
+    step = _strike_step("SPX")
+    atm_rounded = round(atm / step) * step
+
+    put_short = atm_rounded - short_distance
+    put_long = put_short - wing_width
+    call_short = atm_rounded + short_distance
+    call_long = call_short + wing_width
+
+    put_short_asset = strategy.options_helper.find_next_valid_option(underlying, put_short, expiry, put_or_call="put")
+    put_long_asset = strategy.options_helper.find_next_valid_option(underlying, put_long, expiry, put_or_call="put")
+    call_short_asset = strategy.options_helper.find_next_valid_option(underlying, call_short, expiry, put_or_call="call")
+    call_long_asset = strategy.options_helper.find_next_valid_option(underlying, call_long, expiry, put_or_call="call")
+    assert put_short_asset and put_long_asset and call_short_asset and call_long_asset
+
+    open_legs = [
+        strategy.create_order(put_long_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(put_short_asset, 1, Order.OrderSide.SELL_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(call_short_asset, 1, Order.OrderSide.SELL_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(call_long_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+    ]
+    close_legs = [
+        strategy.create_order(put_long_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(put_short_asset, 1, Order.OrderSide.BUY_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(call_short_asset, 1, Order.OrderSide.BUY_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(call_long_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+    ]
+    return open_legs, close_legs
+
+
+def _build_spx_call_butterfly(strategy: _HarnessStrategy, *, days_out: int, width: float, order_type, smart_limit):
+    underlying = Asset("SPX", asset_type=Asset.AssetType.INDEX)
+    expiry = _pick_expiry(strategy, underlying, days_out)
+    atm = _pick_atm_strike(strategy, underlying, expiry)
+    step = _strike_step("SPX")
+    mid_strike = round(atm / step) * step
+    low = mid_strike - width
+    high = mid_strike + width
+
+    low_asset = strategy.options_helper.find_next_valid_option(underlying, low, expiry, put_or_call="call")
+    mid_asset = strategy.options_helper.find_next_valid_option(underlying, mid_strike, expiry, put_or_call="call")
+    high_asset = strategy.options_helper.find_next_valid_option(underlying, high, expiry, put_or_call="call")
+    assert low_asset and mid_asset and high_asset
+
+    open_legs = [
+        strategy.create_order(low_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(mid_asset, 2, Order.OrderSide.SELL_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(high_asset, 1, Order.OrderSide.BUY_TO_OPEN, order_type=order_type, smart_limit=smart_limit),
+    ]
+    close_legs = [
+        strategy.create_order(low_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(mid_asset, 2, Order.OrderSide.BUY_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+        strategy.create_order(high_asset, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=order_type, smart_limit=smart_limit),
+    ]
+    return open_legs, close_legs
+
+
+def _assert_open_close_fill(
+    strategy: _HarnessStrategy,
+    open_order,
+    close_order,
+    *,
+    drive_smart_limit: bool,
+    timeout_open: int,
+    timeout_close: int,
+):
+    submitted_open = strategy.submit_order(open_order)
+    open_parent = submitted_open[0] if isinstance(submitted_open, list) else submitted_open
+    ok_open, reprices_open, open_elapsed = _wait_fill(strategy, open_parent, timeout=timeout_open, drive_smart_limit=drive_smart_limit)
+    assert ok_open, f"Open did not fill (reprices={reprices_open}, elapsed={open_elapsed:.1f}s)"
+
+    submitted_close = strategy.submit_order(close_order)
+    close_parent = submitted_close[0] if isinstance(submitted_close, list) else submitted_close
+    ok_close, reprices_close, close_elapsed = _wait_fill(
+        strategy, close_parent, timeout=timeout_close, drive_smart_limit=drive_smart_limit
+    )
+    if not ok_close:
+        if isinstance(close_order, list):
+            close_mkt_legs = [strategy.create_order(leg.asset, leg.quantity, leg.side, order_type=Order.OrderType.MARKET) for leg in close_order]
+            submitted_mkt = strategy.submit_order(close_mkt_legs, is_multileg=True, order_type="market")
+            mkt_parent = submitted_mkt[0] if isinstance(submitted_mkt, list) else submitted_mkt
+            _wait_fill(strategy, mkt_parent, timeout=60, drive_smart_limit=False)
+        else:
+            mkt_close = strategy.create_order(close_order.asset, close_order.quantity, close_order.side, order_type=Order.OrderType.MARKET)
+            submitted_mkt = strategy.submit_order(mkt_close)
+            _wait_fill(strategy, submitted_mkt, timeout=60, drive_smart_limit=False)
+        pytest.fail(f"Close did not fill (reprices={reprices_close}, elapsed={close_elapsed:.1f}s)")
+
+
+def test_tradier_matrix_stock_liquid_and_wide_spread():
+    broker = _tradier()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=60)
+    liquid = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    wide = _pick_wide_spread_stock(strategy, ["GME", "AMC", "PLTR", "SOFI", "F", "T"], min_spread_pct=0.002)
+    if wide is None:
+        pytest.skip("No wide-spread stock found in candidate list")
+
+    for asset in (liquid, wide):
+        buy = strategy.create_order(asset, 1, Order.OrderSide.BUY, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg)
+        sell = strategy.create_order(asset, 1, Order.OrderSide.SELL, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg)
+        _assert_open_close_fill(strategy, buy, sell, drive_smart_limit=True, timeout_open=180, timeout_close=180)
+
+
+def test_tradier_matrix_single_leg_call_and_put_liquid_and_wide_spread():
+    broker = _tradier()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=60)
+    underlying = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    expiry_liquid = _pick_expiry(strategy, underlying, 7)
+    expiry_wide = _pick_expiry(strategy, underlying, 180)
+    atm = _pick_atm_strike(strategy, underlying, expiry_liquid)
+    step = _strike_step("SPY")
+    atm_rounded = round(atm / step) * step
+
+    call_liquid = _find_option(strategy, underlying, expiry=expiry_liquid, put_or_call="call", strike=atm_rounded, max_spread_pct=0.5)
+    put_liquid = _find_option(strategy, underlying, expiry=expiry_liquid, put_or_call="put", strike=atm_rounded, max_spread_pct=0.5)
+    call_wide = _find_option(strategy, underlying, expiry=expiry_wide, put_or_call="call", strike=atm_rounded + (20 * step), max_spread_pct=None)
+
+    if call_liquid is None or put_liquid is None or call_wide is None:
+        pytest.skip("Could not find suitable option contracts for matrix test")
+
+    for opt in (call_liquid, put_liquid, call_wide):
+        open_order = strategy.create_order(opt, 1, Order.OrderSide.BUY_TO_OPEN, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg)
+        close_order = strategy.create_order(opt, 1, Order.OrderSide.SELL_TO_CLOSE, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg)
+        _assert_open_close_fill(strategy, open_order, close_order, drive_smart_limit=True, timeout_open=240, timeout_close=240)
+
+
+def test_tradier_matrix_short_option_single_leg_smart_limit_or_skip():
+    broker = _tradier()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=60)
+    underlying = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    expiry = _pick_expiry(strategy, underlying, 7)
+    atm = _pick_atm_strike(strategy, underlying, expiry)
+    step = _strike_step("SPY")
+    strike = round(atm / step) * step
+
+    call_asset = _find_option(strategy, underlying, expiry=expiry, put_or_call="call", strike=strike, max_spread_pct=0.75)
+    if call_asset is None:
+        pytest.skip("No suitable shortable option found")
+
+    open_order = strategy.create_order(call_asset, 1, Order.OrderSide.SELL_TO_OPEN, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg)
+    submitted_open = strategy.submit_order(open_order)
+    ok_open, _, _ = _wait_fill(strategy, submitted_open, timeout=180, drive_smart_limit=True)
+    if not ok_open and str(getattr(submitted_open, "status", "")).lower() in {"rejected", "error"}:
+        pytest.skip("Broker rejected short option open (insufficient permissions/margin in paper)")
+    assert ok_open, "Short option open did not fill"
+
+    close_order = strategy.create_order(call_asset, 1, Order.OrderSide.BUY_TO_CLOSE, order_type=Order.OrderType.SMART_LIMIT, smart_limit=cfg)
+    submitted_close = strategy.submit_order(close_order)
+    ok_close, _, _ = _wait_fill(strategy, submitted_close, timeout=240, drive_smart_limit=True)
+    assert ok_close, "Short option close did not fill"
+
+
+def test_tradier_matrix_multileg_credit_condor_and_debit_butterfly_smart_limit_spx():
+    broker = _tradier()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    strategy.initialize(parameters=None)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=60)
+
+    open_legs, close_legs = _build_spx_iron_condor(
+        strategy,
+        days_out=7,
+        short_distance=50.0,
+        wing_width=50.0,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+    )
+    _assert_open_close_fill(strategy, open_legs, close_legs, drive_smart_limit=True, timeout_open=360, timeout_close=360)
+
+    open_bfly, close_bfly = _build_spx_call_butterfly(
+        strategy,
+        days_out=7,
+        width=50.0,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+    )
+    _assert_open_close_fill(strategy, open_bfly, close_bfly, drive_smart_limit=True, timeout_open=360, timeout_close=360)
+
+
+def test_tradier_matrix_multileg_limit_parity_without_debit_credit_spx():
+    broker = _tradier()
+    if hasattr(broker, "is_market_open") and not broker.is_market_open():
+        pytest.skip("Market is closed")
+
+    strategy = _HarnessStrategy(broker=broker)
+    strategy.initialize(parameters=None)
+
+    open_legs, close_legs = _build_spx_iron_condor(
+        strategy,
+        days_out=7,
+        short_distance=50.0,
+        wing_width=50.0,
+        order_type=Order.OrderType.LIMIT,
+        smart_limit=None,
+    )
+
+    submitted_open = strategy.submit_order(open_legs, is_multileg=True, order_type=Order.OrderType.LIMIT)
+    open_parent = submitted_open[0] if isinstance(submitted_open, list) else submitted_open
+    ok_open, _, _ = _wait_fill(strategy, open_parent, timeout=300, drive_smart_limit=False)
+    assert ok_open, "Package LIMIT open did not fill"
+
+    submitted_close = strategy.submit_order(close_legs, is_multileg=True, order_type=Order.OrderType.LIMIT)
+    close_parent = submitted_close[0] if isinstance(submitted_close, list) else submitted_close
+    ok_close, _, _ = _wait_fill(strategy, close_parent, timeout=300, drive_smart_limit=False)
+    if not ok_close:
+        submitted_mkt = strategy.submit_order(close_legs, is_multileg=True, order_type="market")
+        mkt_parent = submitted_mkt[0] if isinstance(submitted_mkt, list) else submitted_mkt
+        _wait_fill(strategy, mkt_parent, timeout=60, drive_smart_limit=False)
+        pytest.fail("Package LIMIT close did not fill")
+

--- a/tests/test_smart_limit_multileg_unit.py
+++ b/tests/test_smart_limit_multileg_unit.py
@@ -254,3 +254,186 @@ def test_alpaca_modify_order_updates_identifier_and_child_parent(mocker):
 
     assert parent.identifier == new_id
     assert child.parent_identifier == new_id
+
+
+def test_multileg_reprice_crosses_credit_to_even_uses_cancel_replace(mocker):
+    broker = _BrokerStub(name="tradier")
+    broker.IS_BACKTESTING_BROKER = False
+
+    tracked_orders: list[Order] = []
+    broker.get_tracked_orders = mocker.Mock(side_effect=lambda _name: tracked_orders)
+    broker.cancel_order = mocker.Mock()
+    broker.submit_orders = mocker.Mock(return_value=[Order("unit", asset=Asset("SPY"), quantity=1, side=Order.OrderSide.BUY)])
+    broker.modify_order = mocker.Mock()
+    broker.submit_order = mocker.Mock()
+
+    strategy = _MinimalStrategy(broker)
+    strategy.logger = SimpleNamespace(error=lambda *_a, **_k: None)
+
+    executor = StrategyExecutor(strategy=strategy)
+    strategy._executor = executor  # noqa: SLF001 - test wiring
+
+    # Quotes engineered to produce a ladder that crosses 0: mid=-0.05, final=+0.05 -> step1=0.0 (even)
+    leg_buy = _leg("unit", _option("SPY", 500), Order.OrderSide.BUY_TO_OPEN)
+    leg_sell = _leg("unit", _option("SPY", 505), Order.OrderSide.SELL_TO_OPEN)
+    parent = Order(
+        "unit",
+        asset=Asset("SPY"),
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        order_class=Order.OrderClass.MULTILEG,
+        child_orders=[leg_buy, leg_sell],
+        status=Order.OrderStatus.OPEN,
+        smart_limit=SmartLimitConfig(preset=SmartLimitPreset.FAST, step_seconds=1, final_hold_seconds=999),
+        identifier="parent-id",
+    )
+    parent.limit_price = 0.05
+    parent._smart_limit_state = {  # noqa: SLF001 - direct state injection
+        "created_at": 0.0,
+        "step_index": 0,
+        "steps": parent.smart_limit.get_step_count(),
+        "step_seconds": parent.smart_limit.get_step_seconds(),
+        "final_hold_seconds": parent.smart_limit.get_final_hold_seconds(),
+        "multileg_order_type": "credit",
+    }
+    tracked_orders.append(parent)
+
+    def _get_quote(asset, **_kwargs):
+        if asset == leg_buy.asset:
+            return _Quote(bid=0.50, ask=0.60)
+        return _Quote(bid=0.55, ask=0.65)
+
+    mocker.patch.object(strategy, "get_quote", side_effect=_get_quote)
+    mocker.patch("lumibot.strategies.strategy_executor.time.monotonic", return_value=1.1)  # step_index -> 1
+
+    executor._process_smart_limit_orders()
+
+    # Type change requires cancel+replace (modify_order cannot change debit/credit/even).
+    assert broker.cancel_order.called
+    assert broker.submit_orders.called
+    _, kwargs = broker.submit_orders.call_args
+    assert kwargs["order_type"] == "even"
+    assert kwargs["price"] is None
+
+
+def test_smart_limit_skips_quote_fetch_when_step_does_not_advance(mocker):
+    broker = _BrokerStub(name="tradier")
+    broker.IS_BACKTESTING_BROKER = False
+
+    tracked_orders: list[Order] = []
+    broker.get_tracked_orders = mocker.Mock(side_effect=lambda _name: tracked_orders)
+    broker.cancel_order = mocker.Mock()
+    broker.submit_orders = mocker.Mock()
+    broker.modify_order = mocker.Mock()
+
+    strategy = _MinimalStrategy(broker)
+    strategy.logger = SimpleNamespace(error=lambda *_a, **_k: None)
+
+    executor = StrategyExecutor(strategy=strategy)
+    strategy._executor = executor  # noqa: SLF001 - test wiring
+
+    order = Order(
+        "unit",
+        asset=Asset("SPY"),
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        status=Order.OrderStatus.OPEN,
+        smart_limit=SmartLimitConfig(preset=SmartLimitPreset.FAST, step_seconds=5, final_hold_seconds=999),
+        identifier="oid",
+    )
+    order.limit_price = 1.0
+    order._smart_limit_state = {  # noqa: SLF001
+        "created_at": 0.0,
+        "step_index": 0,
+        "steps": order.smart_limit.get_step_count(),
+        "step_seconds": order.smart_limit.get_step_seconds(),
+        "final_hold_seconds": order.smart_limit.get_final_hold_seconds(),
+    }
+    tracked_orders.append(order)
+
+    get_quote = mocker.patch.object(strategy, "get_quote", return_value=_Quote(bid=1.0, ask=1.1))
+    mocker.patch("lumibot.strategies.strategy_executor.time.monotonic", return_value=1.0)  # still step 0
+
+    executor._process_smart_limit_orders()
+
+    assert not get_quote.called
+    assert not broker.modify_order.called
+    assert not broker.cancel_order.called
+
+
+def test_multileg_quote_exception_does_not_crash(mocker):
+    broker = _BrokerStub(name="tradier")
+    broker.IS_BACKTESTING_BROKER = False
+
+    tracked_orders: list[Order] = []
+    broker.get_tracked_orders = mocker.Mock(side_effect=lambda _name: tracked_orders)
+    broker.cancel_order = mocker.Mock()
+    broker.submit_orders = mocker.Mock()
+    broker.modify_order = mocker.Mock()
+
+    strategy = _MinimalStrategy(broker)
+    strategy.logger = SimpleNamespace(error=lambda *_a, **_k: None)
+
+    executor = StrategyExecutor(strategy=strategy)
+    strategy._executor = executor  # noqa: SLF001 - test wiring
+
+    leg_buy = _leg("unit", _option("SPY", 500), Order.OrderSide.BUY_TO_OPEN)
+    leg_sell = _leg("unit", _option("SPY", 505), Order.OrderSide.SELL_TO_OPEN)
+    parent = Order(
+        "unit",
+        asset=Asset("SPY"),
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        order_class=Order.OrderClass.MULTILEG,
+        child_orders=[leg_buy, leg_sell],
+        status=Order.OrderStatus.OPEN,
+        smart_limit=SmartLimitConfig(preset=SmartLimitPreset.FAST, step_seconds=1, final_hold_seconds=999),
+        identifier="parent-id",
+    )
+    parent.limit_price = 0.30
+    parent._smart_limit_state = {  # noqa: SLF001
+        "created_at": 0.0,
+        "step_index": 0,
+        "steps": parent.smart_limit.get_step_count(),
+        "step_seconds": parent.smart_limit.get_step_seconds(),
+        "final_hold_seconds": parent.smart_limit.get_final_hold_seconds(),
+        "multileg_order_type": "debit",
+    }
+    tracked_orders.append(parent)
+
+    mocker.patch.object(strategy, "get_quote", side_effect=RuntimeError("connection interrupted"))
+    mocker.patch("lumibot.strategies.strategy_executor.time.monotonic", return_value=1.1)
+
+    executor._process_smart_limit_orders()
+
+    assert not broker.modify_order.called
+    assert not broker.cancel_order.called
+    assert not broker.submit_orders.called
+
+
+def test_multileg_submit_missing_quotes_downgrades_to_market(mocker):
+    broker = _BrokerStub(name="tradier")
+    broker.IS_BACKTESTING_BROKER = False
+    broker.submit_orders = mocker.Mock(return_value="ok")
+    strategy = _MinimalStrategy(broker)
+
+    leg_buy = _leg("unit", _option("SPY", 500), Order.OrderSide.BUY_TO_OPEN)
+    leg_sell = _leg("unit", _option("SPY", 505), Order.OrderSide.SELL_TO_OPEN)
+    leg_buy.order_type = Order.OrderType.SMART_LIMIT
+    leg_sell.order_type = Order.OrderType.SMART_LIMIT
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST)
+    leg_buy.smart_limit = cfg
+    leg_sell.smart_limit = cfg
+
+    def _get_quote(_asset, **_kwargs):
+        return _Quote(bid=None, ask=None)
+
+    mocker.patch.object(strategy, "get_quote", side_effect=_get_quote)
+
+    strategy.submit_order([leg_buy, leg_sell], is_multileg=True)
+
+    _, kwargs = broker.submit_orders.call_args
+    assert kwargs["order_type"] == Order.OrderType.MARKET

--- a/tests/test_smart_limit_single_leg_unit.py
+++ b/tests/test_smart_limit_single_leg_unit.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from lumibot.entities import Asset, Order, SmartLimitConfig, SmartLimitPreset
+from lumibot.strategies.strategy import Strategy
+from lumibot.strategies.strategy_executor import StrategyExecutor
+
+
+@dataclass(frozen=True)
+class _Quote:
+    bid: float
+    ask: float
+
+
+class _BrokerStub:
+    IS_BACKTESTING_BROKER = False
+
+    def __init__(self):
+        self.name = "stub"
+        self.submit_order = None
+        self.modify_order = None
+        self.cancel_order = None
+        self.get_tracked_orders = None
+
+
+class _MinimalStrategy(Strategy):
+    """Strategy stub that avoids Strategy.__init__ (no broker side effects)."""
+
+    def __init__(self, broker):
+        self.broker = broker
+        self._name = "unit"
+        self.logger = SimpleNamespace(error=lambda *_a, **_k: None)
+
+    def log_message(self, *_args, **_kwargs):
+        return
+
+    def _validate_order(self, _order):  # noqa: SLF001 - intentional override for unit tests
+        return True
+
+    def on_trading_iteration(self):
+        return
+
+
+def test_single_leg_submit_sets_initial_limit_and_state(mocker):
+    broker = _BrokerStub()
+    strategy = _MinimalStrategy(broker)
+
+    mocker.patch.object(strategy, "get_quote", return_value=_Quote(bid=1.00, ask=1.20))
+
+    called_order_types = []
+
+    def _submit(order):
+        called_order_types.append(order.order_type)
+        return order
+
+    broker.submit_order = mocker.Mock(side_effect=_submit)
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, final_hold_seconds=30)
+    order = Order(
+        "unit",
+        asset=Asset("SPY", asset_type=Asset.AssetType.STOCK),
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+    )
+
+    submitted = strategy.submit_order(order)
+    assert submitted is order
+
+    # The broker sees the order as LIMIT (SMART_LIMIT is an internal wrapper).
+    assert called_order_types == [Order.OrderType.LIMIT]
+    assert order.order_type == Order.OrderType.SMART_LIMIT
+    assert order.limit_price is not None
+    assert order._smart_limit_state["steps"] >= 1  # noqa: SLF001 - state contract
+    assert order._smart_limit_state["step_seconds"] >= 1  # noqa: SLF001 - state contract
+
+
+def test_single_leg_executor_reprices_using_modify_order(mocker):
+    broker = _BrokerStub()
+    broker.modify_order = mocker.Mock()
+    broker.cancel_order = mocker.Mock()
+
+    tracked: list[Order] = []
+    broker.get_tracked_orders = mocker.Mock(return_value=tracked)
+
+    strategy = _MinimalStrategy(broker)
+    executor = StrategyExecutor(strategy=strategy)
+    strategy._executor = executor  # noqa: SLF001 - test wiring
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, step_seconds=1, final_hold_seconds=999)
+    order = Order(
+        "unit",
+        asset=Asset("SPY", asset_type=Asset.AssetType.STOCK),
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+        status=Order.OrderStatus.OPEN,
+        identifier="oid",
+    )
+    order.limit_price = 1.10
+    order._smart_limit_state = {  # noqa: SLF001 - direct state injection
+        "created_at": 0.0,
+        "step_index": 0,
+        "steps": cfg.get_step_count(),
+        "step_seconds": cfg.get_step_seconds(),
+        "final_hold_seconds": cfg.get_final_hold_seconds(),
+    }
+    tracked.append(order)
+
+    mocker.patch.object(strategy, "get_quote", return_value=_Quote(bid=1.00, ask=1.20))
+    mocker.patch("lumibot.strategies.strategy_executor.time.monotonic", return_value=1.1)
+
+    executor._process_smart_limit_orders()
+
+    assert broker.modify_order.called
+    _, kwargs = broker.modify_order.call_args
+    # With FAST preset (3 steps), step 1 targets the midpoint->ask ladder, i.e. ~1.15.
+    assert abs(float(kwargs["limit_price"]) - 1.15) < 1e-6
+    assert not broker.cancel_order.called
+
+
+def test_single_leg_final_hold_cancels(mocker):
+    broker = _BrokerStub()
+    broker.modify_order = mocker.Mock()
+    broker.cancel_order = mocker.Mock()
+
+    tracked: list[Order] = []
+    broker.get_tracked_orders = mocker.Mock(return_value=tracked)
+
+    strategy = _MinimalStrategy(broker)
+    executor = StrategyExecutor(strategy=strategy)
+    strategy._executor = executor  # noqa: SLF001 - test wiring
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, step_seconds=1, final_hold_seconds=2)
+    order = Order(
+        "unit",
+        asset=Asset("SPY", asset_type=Asset.AssetType.STOCK),
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+        status=Order.OrderStatus.OPEN,
+        identifier="oid",
+    )
+    order.limit_price = 1.10
+    order._smart_limit_state = {  # noqa: SLF001 - direct state injection
+        "created_at": 0.0,
+        "step_index": 0,
+        "steps": cfg.get_step_count(),
+        "step_seconds": cfg.get_step_seconds(),
+        "final_hold_seconds": cfg.get_final_hold_seconds(),
+    }
+    tracked.append(order)
+
+    mocker.patch.object(strategy, "get_quote", return_value=_Quote(bid=1.00, ask=1.20))
+    # final_hold_start = step_seconds*(steps-1) = 2; cancel after +2 seconds => >=4
+    mocker.patch("lumibot.strategies.strategy_executor.time.monotonic", return_value=4.1)
+
+    executor._process_smart_limit_orders()
+    assert broker.cancel_order.called
+    assert not broker.modify_order.called
+
+
+def test_single_leg_quote_exception_does_not_crash_or_modify(mocker):
+    broker = _BrokerStub()
+    broker.modify_order = mocker.Mock()
+    broker.cancel_order = mocker.Mock()
+
+    tracked: list[Order] = []
+    broker.get_tracked_orders = mocker.Mock(return_value=tracked)
+
+    strategy = _MinimalStrategy(broker)
+    executor = StrategyExecutor(strategy=strategy)
+    strategy._executor = executor  # noqa: SLF001 - test wiring
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, step_seconds=1, final_hold_seconds=999)
+    order = Order(
+        "unit",
+        asset=Asset("SPY", asset_type=Asset.AssetType.STOCK),
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+        status=Order.OrderStatus.OPEN,
+        identifier="oid",
+    )
+    order.limit_price = 1.10
+    order._smart_limit_state = {  # noqa: SLF001 - direct state injection
+        "created_at": 0.0,
+        "step_index": 0,
+        "steps": cfg.get_step_count(),
+        "step_seconds": cfg.get_step_seconds(),
+        "final_hold_seconds": cfg.get_final_hold_seconds(),
+    }
+    tracked.append(order)
+
+    mocker.patch.object(strategy, "get_quote", side_effect=RuntimeError("connection interrupted"))
+    mocker.patch("lumibot.strategies.strategy_executor.time.monotonic", return_value=1.1)
+
+    executor._process_smart_limit_orders()
+    assert not broker.modify_order.called
+    assert not broker.cancel_order.called
+
+
+def test_single_leg_state_with_zero_step_seconds_is_defensive(mocker):
+    broker = _BrokerStub()
+    broker.modify_order = mocker.Mock()
+    broker.cancel_order = mocker.Mock()
+
+    tracked: list[Order] = []
+    broker.get_tracked_orders = mocker.Mock(return_value=tracked)
+
+    strategy = _MinimalStrategy(broker)
+    executor = StrategyExecutor(strategy=strategy)
+    strategy._executor = executor  # noqa: SLF001 - test wiring
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, step_seconds=1, final_hold_seconds=999)
+    order = Order(
+        "unit",
+        asset=Asset("SPY", asset_type=Asset.AssetType.STOCK),
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+        status=Order.OrderStatus.OPEN,
+        identifier="oid",
+    )
+    order.limit_price = 1.10
+    order._smart_limit_state = {  # noqa: SLF001 - direct state injection
+        "created_at": 0.0,
+        "step_index": 0,
+        "steps": cfg.get_step_count(),
+        "step_seconds": 0,  # corrupt/invalid
+        "final_hold_seconds": cfg.get_final_hold_seconds(),
+    }
+    tracked.append(order)
+
+    mocker.patch.object(strategy, "get_quote", return_value=_Quote(bid=1.00, ask=1.20))
+    mocker.patch("lumibot.strategies.strategy_executor.time.monotonic", return_value=1.1)
+
+    executor._process_smart_limit_orders()
+
+    assert order._smart_limit_state["step_seconds"] >= 1  # noqa: SLF001 - defensive clamp
+    assert broker.modify_order.called
+
+
+def test_single_leg_sell_ladder_moves_toward_bid(mocker):
+    broker = _BrokerStub()
+    broker.modify_order = mocker.Mock()
+    broker.cancel_order = mocker.Mock()
+
+    tracked: list[Order] = []
+    broker.get_tracked_orders = mocker.Mock(return_value=tracked)
+
+    strategy = _MinimalStrategy(broker)
+    executor = StrategyExecutor(strategy=strategy)
+    strategy._executor = executor  # noqa: SLF001 - test wiring
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, step_seconds=1, final_hold_seconds=999)
+    order = Order(
+        "unit",
+        asset=Asset("SPY", asset_type=Asset.AssetType.STOCK),
+        quantity=1,
+        side=Order.OrderSide.SELL,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+        status=Order.OrderStatus.OPEN,
+        identifier="oid",
+    )
+    order.limit_price = 100.0
+    order._smart_limit_state = {  # noqa: SLF001 - direct state injection
+        "created_at": 0.0,
+        "step_index": 0,
+        "steps": cfg.get_step_count(),
+        "step_seconds": cfg.get_step_seconds(),
+        "final_hold_seconds": cfg.get_final_hold_seconds(),
+    }
+    tracked.append(order)
+
+    # bid/ask produce mid=100, final(bid)=99, step1=99.5
+    mocker.patch.object(strategy, "get_quote", return_value=_Quote(bid=99.0, ask=101.0))
+    mocker.patch("lumibot.strategies.strategy_executor.time.monotonic", return_value=1.1)
+
+    executor._process_smart_limit_orders()
+
+    _, kwargs = broker.modify_order.call_args
+    assert abs(float(kwargs["limit_price"]) - 99.5) < 1e-6
+
+
+def test_single_leg_modify_failure_falls_back_to_cancel_and_resubmit(mocker):
+    broker = _BrokerStub()
+    broker.modify_order = mocker.Mock(side_effect=RuntimeError("connection interrupted"))
+    broker.cancel_order = mocker.Mock()
+
+    submitted_types: list[str] = []
+
+    def _submit(order):
+        submitted_types.append(str(order.order_type))
+        return order
+
+    broker.submit_order = mocker.Mock(side_effect=_submit)
+
+    tracked: list[Order] = []
+    broker.get_tracked_orders = mocker.Mock(return_value=tracked)
+
+    strategy = _MinimalStrategy(broker)
+    executor = StrategyExecutor(strategy=strategy)
+    strategy._executor = executor  # noqa: SLF001 - test wiring
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, step_seconds=1, final_hold_seconds=999)
+    order = Order(
+        "unit",
+        asset=Asset("SPY", asset_type=Asset.AssetType.STOCK),
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+        status=Order.OrderStatus.OPEN,
+        identifier="oid",
+    )
+    order.limit_price = 1.10
+    order._smart_limit_state = {  # noqa: SLF001
+        "created_at": 0.0,
+        "step_index": 0,
+        "steps": cfg.get_step_count(),
+        "step_seconds": cfg.get_step_seconds(),
+        "final_hold_seconds": cfg.get_final_hold_seconds(),
+    }
+    tracked.append(order)
+
+    mocker.patch.object(strategy, "get_quote", return_value=_Quote(bid=1.00, ask=1.20))
+    mocker.patch("lumibot.strategies.strategy_executor.time.monotonic", return_value=1.1)
+
+    executor._process_smart_limit_orders()
+
+    assert broker.modify_order.called
+    assert broker.cancel_order.called
+    assert broker.submit_order.called
+    assert Order.OrderType.LIMIT in submitted_types
+
+
+def test_single_leg_final_hold_cancel_failure_is_swallowed(mocker):
+    broker = _BrokerStub()
+    broker.modify_order = mocker.Mock()
+    broker.cancel_order = mocker.Mock(side_effect=RuntimeError("cancel failed"))
+
+    tracked: list[Order] = []
+    broker.get_tracked_orders = mocker.Mock(return_value=tracked)
+
+    strategy = _MinimalStrategy(broker)
+    executor = StrategyExecutor(strategy=strategy)
+    strategy._executor = executor  # noqa: SLF001 - test wiring
+
+    cfg = SmartLimitConfig(preset=SmartLimitPreset.FAST, final_price_pct=1.0, step_seconds=1, final_hold_seconds=2)
+    order = Order(
+        "unit",
+        asset=Asset("SPY", asset_type=Asset.AssetType.STOCK),
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.SMART_LIMIT,
+        smart_limit=cfg,
+        status=Order.OrderStatus.OPEN,
+        identifier="oid",
+    )
+    order.limit_price = 1.10
+    order._smart_limit_state = {  # noqa: SLF001
+        "created_at": 0.0,
+        "step_index": 0,
+        "steps": cfg.get_step_count(),
+        "step_seconds": cfg.get_step_seconds(),
+        "final_hold_seconds": cfg.get_final_hold_seconds(),
+    }
+    tracked.append(order)
+
+    mocker.patch("lumibot.strategies.strategy_executor.time.monotonic", return_value=4.1)
+    # No exception should propagate.
+    executor._process_smart_limit_orders()
+    assert broker.cancel_order.called

--- a/tests/test_smart_limit_utils_unit.py
+++ b/tests/test_smart_limit_utils_unit.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from lumibot.tools.smart_limit_utils import (
+    build_price_ladder,
+    compute_final_price,
+    compute_final_price_from_mid,
+    compute_mid,
+    infer_tick_size,
+    round_to_tick,
+)
+
+
+def test_compute_final_price_clamps_pct():
+    bid, ask = 100.0, 101.0
+    mid = compute_mid(bid, ask)
+
+    assert compute_final_price(bid, ask, "buy", -1.0) == mid
+    assert compute_final_price(bid, ask, "buy", 0.0) == mid
+    assert compute_final_price(bid, ask, "buy", 1.0) == ask
+    assert compute_final_price(bid, ask, "buy", 2.0) == ask
+
+    assert compute_final_price(bid, ask, "sell", -1.0) == mid
+    assert compute_final_price(bid, ask, "sell", 0.0) == mid
+    assert compute_final_price(bid, ask, "sell", 1.0) == bid
+    assert compute_final_price(bid, ask, "sell", 2.0) == bid
+
+
+def test_compute_final_price_from_mid_clamps_pct():
+    mid = 10.0
+    aggressive = 12.0
+    assert compute_final_price_from_mid(mid, aggressive, -1.0) == mid
+    assert compute_final_price_from_mid(mid, aggressive, 0.0) == mid
+    assert compute_final_price_from_mid(mid, aggressive, 1.0) == aggressive
+    assert compute_final_price_from_mid(mid, aggressive, 2.0) == aggressive
+
+
+def test_build_price_ladder_includes_mid_and_final():
+    mid = 100.0
+    final = 101.0
+    ladder = build_price_ladder(mid, final, 3)
+    assert ladder == [100.0, 100.5, 101.0]
+
+
+def test_build_price_ladder_step_count_one_returns_final_only():
+    assert build_price_ladder(100.0, 101.0, 1) == [101.0]
+    assert build_price_ladder(100.0, 101.0, 0) == [101.0]
+
+
+def test_infer_tick_size_prefers_larger_common_ticks():
+    # By design, `infer_tick_size` returns the first supported tick that both bid/ask are multiples of.
+    # For normal 2-decimal prices this is almost always 0.01.
+    assert infer_tick_size(1.00, 1.10) == 0.01
+    assert infer_tick_size(1.00, 1.05) == 0.01
+    assert infer_tick_size(1.01, 1.06) == 0.01
+
+
+@pytest.mark.parametrize(
+    ("side", "price", "tick", "expected"),
+    [
+        ("buy", 1.01, 0.05, 1.05),
+        ("sell", 1.04, 0.05, 1.00),
+        (None, 1.03, 0.05, 1.05),
+    ],
+)
+def test_round_to_tick(side, price, tick, expected):
+    assert round_to_tick(price, tick, side=side) == expected

--- a/tests/test_thetadata_download_status_progress.py
+++ b/tests/test_thetadata_download_status_progress.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+
+import pytest
+
+from lumibot.entities import Asset
+from lumibot.tools import thetadata_helper
+
+
+def test_advance_download_status_progress_is_contract_specific_for_options():
+    thetadata_helper.clear_download_status()
+
+    active_contract = Asset(
+        symbol="SPX",
+        asset_type="option",
+        strike=3000,
+        expiration=datetime(2026, 12, 5).date(),
+        right="CALL",
+    )
+    other_contract = Asset(
+        symbol="SPX",
+        asset_type="option",
+        strike=3100,
+        expiration=datetime(2026, 12, 5).date(),
+        right="CALL",
+    )
+
+    thetadata_helper.set_download_status(
+        active_contract,
+        "USD",
+        "quote",
+        "day",
+        0,
+        12,
+    )
+
+    # Same underlying symbol, different strike -> must not advance.
+    thetadata_helper.advance_download_status_progress(
+        asset=other_contract, data_type="quote", timespan="day", step=1
+    )
+    status = thetadata_helper.get_download_status()
+    assert status["current"] == 0
+
+    # Matching contract -> advances.
+    thetadata_helper.advance_download_status_progress(
+        asset=active_contract, data_type="quote", timespan="day", step=1
+    )
+    status = thetadata_helper.get_download_status()
+    assert status["current"] == 1
+
+
+def test_get_historical_eod_data_tracks_progress_per_outer_window(monkeypatch):
+    thetadata_helper.clear_download_status()
+
+    asset = Asset(symbol="AAPL", asset_type="stock")
+
+    # Choose a range that deterministically creates 2 windows with max_span=364 days.
+    start_dt = datetime(2024, 1, 1)
+    end_dt = datetime(2025, 1, 10)
+
+    calls = {"count": 0}
+
+    def fake_get_request(*_args, **_kwargs):
+        calls["count"] += 1
+        return {
+            "header": {"format": ["date", "ms_of_day", "ms_of_day2", "open", "high", "low", "close", "volume"]},
+            "response": [["2024-01-02", 0, 0, 1.0, 1.0, 1.0, 1.0, 100]],
+        }
+
+    monkeypatch.setattr(thetadata_helper, "get_request", fake_get_request)
+
+    df = thetadata_helper.get_historical_eod_data(
+        asset=asset,
+        start_dt=start_dt,
+        end_dt=end_dt,
+        datastyle="ohlc",
+        apply_corporate_actions=False,
+    )
+
+    assert df is not None
+    status = thetadata_helper.get_download_status()
+    assert status["active"] is False
+    assert status["timespan"] == "day"
+    assert status["total"] == 2
+    assert status["current"] == 2
+    assert status["progress"] == 100
+

--- a/tests/test_tradier_stream_optional_unit.py
+++ b/tests/test_tradier_stream_optional_unit.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+from lumibot.brokers.tradier import Tradier
+from lumibot.entities import Asset, Order
+
+
+def test_tradier_submit_multileg_without_stream_does_not_crash(mocker):
+    # Avoid Tradier.__init__ (no network / credentials).
+    broker = Tradier.__new__(Tradier)
+    broker.tradier = SimpleNamespace(
+        orders=SimpleNamespace(multileg_order=mocker.Mock(return_value={"id": "oid"}))
+    )
+    broker._unprocessed_orders = []
+    broker.name = "Tradier"
+    broker.NEW_ORDER = "new"
+    # Ensure the attribute is absent to reproduce the historical AttributeError.
+    if hasattr(broker, "stream"):
+        delattr(broker, "stream")
+
+    underlying = "SPY"
+    exp = date(2026, 1, 16)
+    leg1 = Order(
+        "unit",
+        asset=Asset(underlying, asset_type=Asset.AssetType.OPTION, expiration=exp, strike=500.0, right="call"),
+        quantity=1,
+        side=Order.OrderSide.BUY_TO_OPEN,
+        order_type=Order.OrderType.LIMIT,
+    )
+    leg2 = Order(
+        "unit",
+        asset=Asset(underlying, asset_type=Asset.AssetType.OPTION, expiration=exp, strike=505.0, right="call"),
+        quantity=1,
+        side=Order.OrderSide.SELL_TO_OPEN,
+        order_type=Order.OrderType.LIMIT,
+    )
+
+    parent = broker._submit_multileg_order([leg1, leg2], order_type="debit", duration="day", price=0.1, tag="t")  # noqa: SLF001
+    assert parent.identifier == "oid"
+


### PR DESCRIPTION
### Why
- `download_status` should report progress for the **single asset currently downloading** (e.g., one option contract: symbol + strike + exp + right), not whole-backtest progress.
- Options share the same underlying symbol; progress updates must be contract-specific to avoid cross-contract corruption when requests complete out of order.

### What
- Tighten `advance_download_status_progress()` matching so option progress only advances when `symbol + exp + strike + right` matches the active tracked contract.
- Add deterministic `download_status` tracking for EOD history downloads (`get_historical_eod_data`):
  - `total = number of outer date windows`
  - `current += 1` per completed outer window
  - `finalize_download_status()` at end (keeps final counters visible for UI polling)
- Update `docs/BACKTESTING_ARCHITECTURE.md` to clarify `current/total` semantics (per-asset operation) and reference finalize behavior.
- Add unit tests covering option contract matching + EOD window progress.

### Notes
- This intentionally does **not** attempt to estimate “total downloads for the entire backtest” or underlying-wide chain progress.
