### PR TITLE
Release 4.4.35: IBKR futures backtest speedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 4.4.34 - Unreleased
+## 4.4.35 - Unreleased
+
+### Changed
+- IBKR futures backtesting: cut downloader roundtrips by caching history windows across iterations and preferring native bar sizes (e.g., 15-min) when available.
+
+## 4.4.34 - 2026-01-19
 
 ### Added
 - IBKR futures: add acceptance backtest strategy covering market/limit/stop/stop-limit/trailing/smart-limit and OCO/OTO/bracket semantics.

--- a/docs/investigations/2026-01-19_IBKR_FUTURES_SPEEDUP_4.4.35.md
+++ b/docs/investigations/2026-01-19_IBKR_FUTURES_SPEEDUP_4.4.35.md
@@ -1,0 +1,37 @@
+# IBKR Futures Speedup (4.4.35)
+
+## Problem
+
+Production IBKR futures backtests were extremely slow (hours for a 1-week window). Logs showed repeated
+`ibkr/iserver/marketdata/history` requests and frequent queue timeouts/retries.
+
+The worst-case trigger was intraday strategies requesting timesteps like `"15minute"` (or `"5minute"`)
+using `AssetType.CONT_FUTURE`.
+
+## Root Cause
+
+`InteractiveBrokersRESTBacktesting._pull_source_symbol_bars(...)` had a futures prefetch optimization,
+but it only activated when the *requested timestep string* was exactly `"minute"`, `"hour"`, or `"day"`.
+
+For `"15minute"`, the prefetch path did not run, so the system repeatedly fetched history from the
+downloader on every strategy iteration.
+
+## Fix (4.4.35)
+
+- Treat the timestep **unit** (minute/hour/day) as the key for the IBKR futures prefetch logic.
+  - Example: `"15minute"` and `"1minute"` both resolve to unit `"minute"`, so they share a single
+    minute-resolution cache dataset for the backtest window.
+- Ensure `PandasData.find_asset_in_data_store(...)` recognizes `cont_future` as a futures-like asset
+  so the legacy `(asset, USD)` cache key can be used for resampled timesteps.
+
+## Test Coverage
+
+- `tests/test_ibkr_futures_prefetch_unit.py` asserts that repeated `"15minute"` futures requests
+  only call `ibkr_helper.get_price_data(...)` once (prefetch + reuse).
+
+## Expected Impact
+
+- Large reduction in downloader roundtrips for intraday futures strategies with non-`"minute"` strings.
+- Eliminates repeated "fetching 3000 minute bars" loops per iteration for strategies running on
+  `15minute` bars (they now prefetch once for the run window).
+

--- a/lumibot/backtesting/interactive_brokers_rest_backtesting.py
+++ b/lumibot/backtesting/interactive_brokers_rest_backtesting.py
@@ -302,9 +302,11 @@ class InteractiveBrokersRESTBacktesting(PandasData):
 
         end_dt = self.get_datetime()
         # IBKR crypto/futures trade outside equity calendars; do not add the default 5-day padding.
-        start_dt, _ = self.get_start_datetime_and_ts_unit(length, timestep, start_dt=end_dt, start_buffer=timedelta(0))
+        start_dt, ts_unit = self.get_start_datetime_and_ts_unit(
+            length, timestep, start_dt=end_dt, start_buffer=timedelta(0)
+        )
+        ts_unit = str(ts_unit or "").strip().lower()
         asset_type = str(getattr(asset_separated, "asset_type", "") or "").lower()
-        ts_unit = str(timestep or "").strip().lower()
         if asset_type in {"future", "cont_future"} and ts_unit in {"minute", "hour", "day"}:
             # Futures strategies frequently request very small slices (e.g., `length=2`) at the
             # beginning of the backtest window. If we only fetch the tiny requested slice, IBKR's

--- a/lumibot/data_sources/pandas_data.py
+++ b/lumibot/data_sources/pandas_data.py
@@ -389,7 +389,7 @@ class PandasData(DataSourceBacktesting):
         if quote is not None:
             candidates.append((asset, quote))
 
-        if isinstance(asset, Asset) and asset.asset_type in ["option", "future", "stock", "index"]:
+        if isinstance(asset, Asset) and asset.asset_type in ["option", "future", "cont_future", "stock", "index"]:
             candidates.append((asset, Asset("USD", "forex")))
 
         candidates.append(asset)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.34",
+    version="4.4.35",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/tests/test_ibkr_futures_prefetch_unit.py
+++ b/tests/test_ibkr_futures_prefetch_unit.py
@@ -1,0 +1,45 @@
+import datetime as dt
+from unittest.mock import patch
+
+import pandas as pd
+import pytz
+
+from lumibot.backtesting import InteractiveBrokersRESTBacktesting
+from lumibot.entities import Asset
+
+
+def _minute_df(start: dt.datetime, end: dt.datetime) -> pd.DataFrame:
+    idx = pd.date_range(start=start, end=end, freq="1min", tz="America/New_York", inclusive="left")
+    df = pd.DataFrame(index=idx)
+    df["open"] = 100.0
+    df["high"] = 101.0
+    df["low"] = 99.0
+    df["close"] = 100.5
+    df["volume"] = 1
+    df["missing"] = False
+    return df
+
+
+def test_ibkr_futures_prefetch_reuses_minute_series_for_15minute_requests():
+    tz = pytz.timezone("America/New_York")
+    start = tz.localize(dt.datetime(2026, 1, 12, 0, 0, 0))
+    end = tz.localize(dt.datetime(2026, 1, 19, 0, 0, 0))
+
+    data_source = InteractiveBrokersRESTBacktesting(datetime_start=start, datetime_end=end, exchange="CME")
+    data_source._update_datetime(start)
+
+    asset = Asset("MES", asset_type=Asset.AssetType.CONT_FUTURE)
+
+    df = _minute_df(start - dt.timedelta(days=3), end)
+
+    with patch("lumibot.tools.ibkr_helper.get_price_data", return_value=df) as mocked:
+        bars_1 = data_source.get_historical_prices(asset, 200, "15minute")
+        assert bars_1 is not None
+        assert bars_1.df is not None
+
+        data_source._update_datetime(start + dt.timedelta(minutes=15))
+        bars_2 = data_source.get_historical_prices(asset, 200, "15minute")
+        assert bars_2 is not None
+
+        # Prefetch should occur once; subsequent calls should reuse cached data.
+        assert mocked.call_count == 1


### PR DESCRIPTION
Targets the production slowness seen in futures strategies using timesteps like 15minute (e.g. MesEmaRsiTrend).\n\nChanges:\n- Bump version to 4.4.35\n- IBKR futures: treat intraday timestep unit (minute/hour/day) as the cache/prefetch key so 15minute/5minute reuse the minute series instead of re-downloading each iteration\n- PandasData: treat cont_future like future for cache key lookup\n- Add unit test ensuring repeated 15minute cont_future requests only hit ibkr_helper.get_price_data once\n\nDocs:\n- docs/investigations/2026-01-19_IBKR_FUTURES_SPEEDUP_4.4.35.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * IBKR futures backtesting is now significantly faster with optimized caching of historical data windows across iterations and improved recognition of native intraday bar sizes (e.g., 15-minute intervals)

* **Tests**
  * Added unit tests validating IBKR futures data prefetching and cache reuse behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->