### PR TITLE
v4.4.43 - Hotfix: add_ohlc actually shipped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ backtest_runs/
 context*.json
 !context7.json
 /tests/backtest/_manual_runs
+
+# Local scratch / diagnostics (never commit)
+tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 4.4.42 - Unreleased
+## 4.4.43 - Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+
+## 4.4.42 - 2026-01-30
 
 ### Added
 - Charting: `Strategy.add_ohlc()` and `Strategy.get_ohlc_df()` for exporting OHLC (candlestick) indicator series.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,23 @@
 # Changelog
 
-## 4.4.43 - Unreleased
+## 4.4.43 - 2026-01-30
 
 ### Added
+- Charting: `Strategy.add_ohlc()` and `Strategy.get_ohlc_df()` for exporting OHLC (candlestick) indicator series.
+- Indicators: `plot_indicators()` now supports OHLC series in `*_indicators.html` and exports `type=ohlc` rows in `*_indicators.csv`.
+- Docs: add seconds-level backtesting guidance and expand seconds-mode notes.
 
 ### Changed
+- Charting: `Strategy.add_line()` now returns the appended dict (consistent with other chart helpers).
+- Docs: recommend `add_ohlc()` for plotting price bars and `add_line()` for single-value indicators.
 
 ### Fixed
+- Backtest executor safe-sleep overload now applies only in backtests and uses real sleep outside backtesting.
 
 ## 4.4.42 - 2026-01-30
+
+**NOTE:** The PyPI `lumibot==4.4.42` artifact was published from an older commit and does **not** include the changes
+listed below. Upgrade to `lumibot==4.4.43`.
 
 ### Added
 - Charting: `Strategy.add_ohlc()` and `Strategy.get_ohlc_df()` for exporting OHLC (candlestick) indicator series.

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.42",
+    version="4.4.43",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",


### PR DESCRIPTION
Fixes production crash where strategies calling Strategy.add_ohlc() fail under lumibot==4.4.42 because the published PyPI wheel did not include add_ohlc/get_ohlc_df.

What / Why
- Cut a hotfix release (4.4.43) that actually contains the OHLC indicator support.
- Update CHANGELOG to document that 4.4.42 on PyPI is missing these changes.

Risk
- Low: no code changes beyond release bookkeeping; just publishing the already-merged OHLC feature.

Tests
- Rely on GitHub CI (sharded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OHLC-related capabilities for charting and indicators

* **Changed**
  * Charting function `add_line` now returns the appended dictionary for improved API consistency

* **Bug Fixes**
  * Fixed backtest executor to properly apply safe-sleep behavior only during backtesting operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->