### PR TITLE
v4.4.44 - Hotfix: ship add_ohlc in PyPI wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
+## 4.4.44 - 2026-01-30
+
+### Added
+- Charting: `Strategy.add_ohlc()` and `Strategy.get_ohlc_df()` for exporting OHLC (candlestick) indicator series.
+- Indicators: `plot_indicators()` now supports OHLC series in `*_indicators.html` and exports `type=ohlc` rows in `*_indicators.csv`.
+- Docs: add seconds-level backtesting guidance and expand seconds-mode notes.
+
+### Changed
+- Charting: `Strategy.add_line()` now returns the appended dict (consistent with other chart helpers).
+- Docs: recommend `add_ohlc()` for plotting price bars and `add_line()` for single-value indicators.
+
+### Fixed
+- Release: correct PyPI packaging so `lumibot==4.4.44` includes `Strategy.add_ohlc()` (the published `4.4.43` wheel was missing it).
+
 ## 4.4.43 - 2026-01-30
+
+**NOTE:** The PyPI `lumibot==4.4.43` artifact was published from an older commit and does **not** include the changes
+listed below. Upgrade to `lumibot==4.4.44`.
 
 ### Added
 - Charting: `Strategy.add_ohlc()` and `Strategy.get_ohlc_df()` for exporting OHLC (candlestick) indicator series.

--- a/docs/ADD_OHLC_IMPLEMENTATION.md
+++ b/docs/ADD_OHLC_IMPLEMENTATION.md
@@ -1,0 +1,503 @@
+# ADD_OHLC Implementation Specification
+
+**Title:** Adding OHLC (Candlestick) Data Support to Lumibot Charts
+**Last Updated:** 2026-01-28
+**Status:** Specification Complete - Ready for Implementation
+**Audience:** AI Agents / Developers implementing this feature
+
+---
+
+## Overview
+
+This document specifies how to add `add_ohlc()` method support to Lumibot, enabling strategies to plot OHLC (Open, High, Low, Close) data as candlestick or bar charts instead of only single-value lines.
+
+**Current State:** Lumibot only supports `add_line()` which plots a single value per timestamp.
+
+**Desired State:** Add `add_ohlc()` to plot 4 values (open, high, low, close) per timestamp, rendered as candlesticks in TradingView.
+
+---
+
+## Background Research
+
+### Industry Standards for OHLC Methods
+
+| Library | Candlestick Method | Parameters |
+|---------|-------------------|------------|
+| **TradingView Pine Script** | `plotcandle()` | open, high, low, close, color, wickcolor |
+| **TradingView Pine Script** | `plotbar()` | open, high, low, close, color |
+| **Plotly** | `go.Candlestick()` | open, high, low, close |
+| **mplfinance** | `candlestick_ohlc()` | open, high, low, close |
+
+### Key Insight: Data Structure vs Visual Representation
+
+The difference between "candlestick" and "bar" charts is purely **visual** (how TradingView renders the data), not a difference in **data structure**. Both use the same 4 values: open, high, low, close.
+
+**Therefore:** We only need ONE method (`add_ohlc`) that provides the data. The visual representation (candlestick vs bar) is a TradingView display preference, not a data concern.
+
+### What About Other Multi-Value Indicators?
+
+Research across TradingView, MetaTrader, and other platforms shows only **two fundamental data structures** for indicators:
+
+| Structure | Values per Timestamp | Examples |
+|-----------|---------------------|----------|
+| **Single value** | 1 | SMA, EMA, RSI, Bollinger upper/middle/lower |
+| **OHLC** | 4 | Price bars, Heikin Ashi, custom OHLC overlays |
+
+Multi-line indicators like Bollinger Bands are just **multiple single-value lines** (3 separate `add_line()` calls for upper, middle, lower).
+
+More complex structures like footprint/order flow charts require tick-by-tick order book data that backtests don't have - not relevant for Lumibot.
+
+---
+
+## Implementation Specification
+
+### 1. New Method: `add_ohlc()` in `strategy.py`
+
+**Location:** `lumibot/strategies/strategy.py` (add after `add_line()` method around line 3710)
+
+**Method Signature:**
+
+```python
+def add_ohlc(
+    self,
+    name: str,
+    open: float,
+    high: float,
+    low: float,
+    close: float,
+    color: str = None,
+    border_color: str = None,
+    wick_color: str = None,
+    detail_text: str = None,
+    dt: Union[datetime.datetime, pd.Timestamp] = None,
+    plot_name: str = "default_plot",
+    asset: Asset = None
+):
+    """Adds an OHLC (candlestick) data point to the indicator chart.
+
+    This can be used to plot price bars, Heikin Ashi candles, or any other
+    OHLC data on the chart. The data will be rendered as candlesticks in
+    TradingView.
+
+    Parameters
+    ----------
+    name : str
+        The name of the OHLC series. This is used to identify the series
+        on the chart and group data points together.
+    open : float
+        The opening price for this bar.
+    high : float
+        The highest price for this bar.
+    low : float
+        The lowest price for this bar.
+    close : float
+        The closing price for this bar.
+    color : str, optional
+        The fill color of the candlestick body. If not specified, will use
+        green for bullish (close > open) and red for bearish (close < open).
+    border_color : str, optional
+        The border color of the candlestick body. Defaults to same as color.
+    wick_color : str, optional
+        The color of the candlestick wicks. Defaults to same as color.
+    detail_text : str, optional
+        Additional text to display when the candle is hovered over.
+    dt : datetime.datetime or pandas.Timestamp, optional
+        The datetime for this bar. Defaults to current strategy datetime.
+    plot_name : str, optional
+        The name of the subplot. Default "default_plot" adds to main chart.
+    asset : Asset, optional
+        The Asset object associated with this OHLC data. Enables proper
+        multi-symbol charting where OHLC data displays as overlay on its
+        corresponding asset's price chart.
+
+    Example
+    -------
+    >>> # Plot a custom OHLC bar
+    >>> self.add_ohlc(
+    ...     name="Heikin Ashi",
+    ...     open=ha_open,
+    ...     high=ha_high,
+    ...     low=ha_low,
+    ...     close=ha_close,
+    ...     color="green" if ha_close > ha_open else "red"
+    ... )
+
+    >>> # Plot OHLC for a specific asset
+    >>> self.add_ohlc(
+    ...     name="SPY Price",
+    ...     open=spy_open,
+    ...     high=spy_high,
+    ...     low=spy_low,
+    ...     close=spy_close,
+    ...     asset=spy_asset
+    ... )
+    """
+```
+
+**Implementation Details:**
+
+1. **Validation:** Same pattern as `add_line()` - validate all parameters
+2. **Data Storage:** Append to `self._chart_ohlc_list` (new list, similar to `_chart_lines_list`)
+3. **OHLC Validation:** Ensure `high >= max(open, close)` and `low <= min(open, close)`
+
+**Data Structure to Store:**
+
+```python
+{
+    "datetime": dt,
+    "name": name,
+    "type": "ohlc",  # NEW: Distinguish from "line" type
+    "open": open,
+    "high": high,
+    "low": low,
+    "close": close,
+    "color": color,
+    "border_color": border_color,
+    "wick_color": wick_color,
+    "detail_text": detail_text,
+    "plot_name": plot_name,
+    # Asset fields (same as add_line)
+    "asset_symbol": asset.symbol if asset else None,
+    "asset_type": asset.asset_type if asset else None,
+    "asset_expiration": str(asset.expiration) if asset and asset.expiration else None,
+    "asset_strike": asset.strike if asset else None,
+    "asset_right": asset.right if asset else None,
+    "asset_multiplier": asset.multiplier if asset else None,
+    "quote_symbol": asset._quote_asset.symbol if asset and hasattr(asset, '_quote_asset') and asset._quote_asset else None,
+    "asset_display_name": str(asset) if asset else None,
+}
+```
+
+### 2. New Method: `get_ohlc_df()` in `strategy.py`
+
+**Location:** Add after `get_lines_df()` method
+
+```python
+def get_ohlc_df(self):
+    """Returns a dataframe of the OHLC data on the indicator chart.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The OHLC data on the indicator chart.
+    """
+    df = pd.DataFrame(self._chart_ohlc_list)
+    return df
+```
+
+### 3. Initialize Storage in `_Strategy.__init__()`
+
+**Location:** `lumibot/strategies/_strategy.py` - find where `_chart_lines_list` is initialized
+
+Add:
+```python
+self._chart_ohlc_list = []
+```
+
+### 4. Update `indicators.py` to Handle OHLC Data
+
+**Location:** `lumibot/tools/indicators.py`
+
+**Changes to `plot_indicators()` function:**
+
+1. **Add `chart_ohlc_df` parameter:**
+```python
+def plot_indicators(
+    plot_file_html="indicators.html",
+    chart_markers_df=None,
+    chart_lines_df=None,
+    chart_ohlc_df=None,  # NEW PARAMETER
+    strategy_name=None,
+    show_indicators=True,
+):
+```
+
+2. **Process OHLC data similar to lines:**
+```python
+if chart_ohlc_df is not None and not chart_ohlc_df.empty:
+    chart_ohlc_df = chart_ohlc_df.copy()
+    if "plot_name" not in chart_ohlc_df.columns:
+        chart_ohlc_df["plot_name"] = "default_plot"
+    else:
+        chart_ohlc_df["plot_name"] = chart_ohlc_df["plot_name"].fillna("default_plot")
+```
+
+3. **Add OHLC traces to Plotly chart:**
+```python
+if chart_ohlc_df is not None and not chart_ohlc_df.empty:
+    for plot_name, plot_df in chart_ohlc_df.groupby("plot_name"):
+        for ohlc_name, group_df in plot_df.groupby("name"):
+            row = plot_names.index(plot_name) + 1
+
+            fig.add_trace(
+                go.Candlestick(
+                    x=group_df["datetime"],
+                    open=group_df["open"],
+                    high=group_df["high"],
+                    low=group_df["low"],
+                    close=group_df["close"],
+                    name=ohlc_name,
+                    # Colors can be customized based on data
+                ),
+                row=row,
+                col=1
+            )
+```
+
+4. **Update CSV export to include OHLC data:**
+```python
+# When exporting to CSV, include OHLC data
+if chart_ohlc_df is not None and not chart_ohlc_df.empty:
+    chart_ohlc_df = chart_ohlc_df.copy()
+    chart_ohlc_df["type"] = "ohlc"
+    # Include in combined_df
+```
+
+### 5. CSV Format Changes
+
+**Current CSV columns (lines):**
+```
+datetime,name,value,color,style,width,detail_text,plot_name,type,asset_symbol,...
+```
+
+**New CSV columns (OHLC):**
+```
+datetime,name,open,high,low,close,color,border_color,wick_color,detail_text,plot_name,type,asset_symbol,...
+```
+
+**Combined Format (both lines and OHLC in same CSV):**
+- `type` column distinguishes: `"line"` vs `"ohlc"`
+- For lines: `open`, `high`, `low`, `close` columns are empty/NA
+- For OHLC: `value` column is empty/NA
+
+### 6. Call `plot_indicators()` with OHLC Data
+
+**Location:** Find where `plot_indicators()` is called (likely in backtesting result generation)
+
+Update the call to include OHLC data:
+```python
+plot_indicators(
+    plot_file_html=indicators_file,
+    chart_markers_df=strategy.get_markers_df(),
+    chart_lines_df=strategy.get_lines_df(),
+    chart_ohlc_df=strategy.get_ohlc_df(),  # NEW
+    strategy_name=strategy.name,
+    show_indicators=show_indicators,
+)
+```
+
+---
+
+## Frontend Changes (botspot_react)
+
+### 7. Update `BacktestChartPage.js` to Parse OHLC Data
+
+**Location:** `src/pages/BacktestChartPage.js`
+
+Currently, the CSV parsing only handles lines with a single `value` column. Update to detect and parse OHLC data:
+
+```javascript
+// When parsing indicators.csv, check for OHLC columns
+const hasOhlcData = headers.includes('open') && headers.includes('high') &&
+                    headers.includes('low') && headers.includes('close');
+
+// Group by type
+const lineData = rows.filter(r => r.type === 'line');
+const ohlcData = rows.filter(r => r.type === 'ohlc');
+```
+
+### 8. Update `Chart.js` to Render OHLC Data
+
+**Location:** `src/components/Chart.js`
+
+The `IndicatorDatafeed` class needs to handle OHLC data:
+
+1. **Store OHLC series separately from line series:**
+```javascript
+this.ohlcMap = {};  // NEW: Store OHLC series
+
+this.indicatorData.forEach(ind => {
+  if (ind.type === 'ohlc' && ind.name && ind.points?.length > 0) {
+    this.ohlcMap[ind.name] = this.ensureUniqueTimestamps(ind.points);
+    // Store metadata
+  }
+});
+```
+
+2. **Modify `getBars()` to return OHLC data:**
+
+Currently `getBars()` creates fake OHLC where all values are the same:
+```javascript
+// CURRENT (wrong for OHLC)
+const bar = {
+  time: point.time,
+  open: point.value,
+  high: point.value,
+  low: point.value,
+  close: point.value,
+};
+```
+
+For actual OHLC data:
+```javascript
+// NEW (for real OHLC)
+const bar = {
+  time: point.time,
+  open: point.open,
+  high: point.high,
+  low: point.low,
+  close: point.close,
+};
+```
+
+3. **Update `resolveSymbol()` for OHLC symbols:**
+
+When a symbol is OHLC type, set appropriate flags for TradingView to render candlesticks instead of lines.
+
+---
+
+## Testing Requirements
+
+### Unit Tests for `add_ohlc()`
+
+**Location:** `tests/test_add_ohlc.py` (new file)
+
+1. **Test basic OHLC data storage:**
+```python
+def test_add_ohlc_basic():
+    strategy = create_test_strategy()
+    strategy.add_ohlc("Test", open=100, high=105, low=98, close=102)
+    df = strategy.get_ohlc_df()
+    assert len(df) == 1
+    assert df.iloc[0]["open"] == 100
+    assert df.iloc[0]["high"] == 105
+    assert df.iloc[0]["low"] == 98
+    assert df.iloc[0]["close"] == 102
+```
+
+2. **Test OHLC validation (high >= max, low <= min):**
+```python
+def test_add_ohlc_invalid_high_low():
+    strategy = create_test_strategy()
+    # high < close should warn or fix
+    strategy.add_ohlc("Test", open=100, high=99, low=98, close=102)
+    # Verify behavior (warning logged or values adjusted)
+```
+
+3. **Test color defaulting (green for bullish, red for bearish):**
+```python
+def test_add_ohlc_default_colors():
+    strategy = create_test_strategy()
+    strategy.add_ohlc("Bullish", open=100, high=105, low=98, close=104)  # close > open
+    strategy.add_ohlc("Bearish", open=104, high=105, low=98, close=100)  # close < open
+    df = strategy.get_ohlc_df()
+    # Verify appropriate default colors assigned
+```
+
+4. **Test asset association:**
+```python
+def test_add_ohlc_with_asset():
+    strategy = create_test_strategy()
+    asset = Asset("SPY", asset_type="stock")
+    strategy.add_ohlc("SPY", open=400, high=405, low=398, close=403, asset=asset)
+    df = strategy.get_ohlc_df()
+    assert df.iloc[0]["asset_symbol"] == "SPY"
+```
+
+5. **Test datetime handling:**
+```python
+def test_add_ohlc_custom_datetime():
+    strategy = create_test_strategy()
+    custom_dt = datetime.datetime(2024, 1, 15, 10, 30, 0)
+    strategy.add_ohlc("Test", open=100, high=105, low=98, close=102, dt=custom_dt)
+    df = strategy.get_ohlc_df()
+    assert df.iloc[0]["datetime"] == custom_dt
+```
+
+### Integration Tests
+
+1. **Test CSV export contains OHLC data correctly**
+2. **Test mixed line + OHLC data in same CSV**
+3. **Test Plotly chart generation with OHLC traces**
+
+---
+
+## Documentation Updates
+
+### 1. Update `docsrc/strategy_methods.data.rst`
+
+Add documentation for the new `add_ohlc()` method with examples.
+
+### 2. Update `docsrc/getting_started.rst`
+
+Add example showing how to plot custom OHLC data like Heikin Ashi.
+
+### 3. Add Example Strategy
+
+Create example in `examples/` showing OHLC usage:
+```python
+# Example: Plotting Heikin Ashi candles alongside regular price
+def on_trading_iteration(self):
+    bars = self.get_historical_prices(self.asset, 2)
+
+    # Calculate Heikin Ashi
+    ha_close = (bars.open + bars.high + bars.low + bars.close) / 4
+    ha_open = (prev_ha_open + prev_ha_close) / 2
+    ha_high = max(bars.high, ha_open, ha_close)
+    ha_low = min(bars.low, ha_open, ha_close)
+
+    # Plot as OHLC
+    self.add_ohlc(
+        name="Heikin Ashi",
+        open=ha_open,
+        high=ha_high,
+        low=ha_low,
+        close=ha_close,
+        asset=self.asset
+    )
+```
+
+---
+
+## Implementation Checklist
+
+- [ ] Add `_chart_ohlc_list = []` in `_Strategy.__init__()`
+- [ ] Implement `add_ohlc()` method in `strategy.py`
+- [ ] Implement `get_ohlc_df()` method in `strategy.py`
+- [ ] Update `plot_indicators()` in `indicators.py` to accept OHLC data
+- [ ] Add Plotly candlestick trace generation
+- [ ] Update CSV export to include OHLC columns
+- [ ] Update wherever `plot_indicators()` is called to pass OHLC data
+- [ ] Write unit tests for `add_ohlc()`
+- [ ] Write integration tests for CSV/chart generation
+- [ ] Update Sphinx documentation in `docsrc/`
+- [ ] Create example strategy using `add_ohlc()`
+- [ ] (Future) Update botspot_react frontend to parse and display OHLC data
+
+---
+
+## Notes for Implementers
+
+### Why `add_ohlc` vs `add_candle` or `add_bar`?
+
+We chose `add_ohlc` because:
+1. **It describes the data structure** (Open, High, Low, Close) not the visual style
+2. **TradingView decides the visual** - users can toggle between candlestick and bar views
+3. **Matches industry terminology** - "OHLC data" is universally understood
+4. **Avoids confusion** - "candle" and "bar" both represent the same 4 data points
+
+### Relationship to Existing `add_line()`
+
+- `add_line()` = 1 value per timestamp (for SMA, EMA, RSI, etc.)
+- `add_ohlc()` = 4 values per timestamp (for price bars, Heikin Ashi, etc.)
+
+These are the only two data structures needed. Everything else is either:
+- Multiple `add_line()` calls (Bollinger Bands = 3 lines)
+- Visual styling of single values (histogram = line with different display)
+
+### Frontend Priority
+
+The Lumibot backend changes are the priority. Frontend (botspot_react) changes can be done in a follow-up phase since:
+1. The CSV will be generated with OHLC data
+2. The existing Chart.js can still function (it just won't render OHLC as candlesticks yet)
+3. Frontend changes require separate testing and deployment

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -1603,23 +1603,26 @@ class BacktestingBroker(Broker):
 
         """
 
-        # OPTIMIZATION: Get orders only once per list to minimize lock acquisitions
-        # This function is called 179k times
+        # This function is called once per bar (minute-level: ~100k/year). Avoid allocating lists
+        # or copying buckets when there are no pending orders.
         strategy_name = strategy.name
-        pending_orders = []
 
-        # Get unprocessed orders once with single lock acquisition
-        if hasattr(self, '_unprocessed_orders'):
-            unprocessed = self._unprocessed_orders.get_list()  # One lock acquisition
-            # Use list comprehension which is faster than extend with filter
-            pending_orders.extend([o for o in unprocessed if o.strategy == strategy_name])
+        unprocessed_bucket = getattr(self, "_unprocessed_orders", None)
+        new_bucket = getattr(self, "_new_orders", None)
+        if not unprocessed_bucket and not new_bucket:
+            return
 
-        # Get new orders once with single lock acquisition
-        if hasattr(self, '_new_orders'):
-            new_orders = self._new_orders.get_list()  # One lock acquisition
-            pending_orders.extend([o for o in new_orders if o.strategy == strategy_name])
+        pending_orders: list[Order] = []
+        if unprocessed_bucket:
+            for order in unprocessed_bucket:
+                if getattr(order, "strategy", None) == strategy_name:
+                    pending_orders.append(order)
+        if new_bucket:
+            for order in new_bucket:
+                if getattr(order, "strategy", None) == strategy_name:
+                    pending_orders.append(order)
 
-        if len(pending_orders) == 0:
+        if not pending_orders:
             return
 
         # Prefetching: Track assets and schedule prefetch

--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -1588,6 +1588,18 @@ class ThetaDataBacktestingPandas(PandasData):
                         end_requirement,
                     )
                     return None
+                # If the cached dataset already covers the requirement, treat it as reusable and
+                # avoid thrashing (STALE → REFRESH loops). This is especially important for
+                # option quote datasets in cold-local/warm-S3 production runs.
+                quotes_ok = (not require_quote_data) or existing_has_quotes or existing_quotes_missing
+                if (
+                    start_ok
+                    and end_ok
+                    and existing_rows >= requested_length
+                    and quotes_ok
+                    and (not require_ohlc_data or existing_has_ohlc)
+                ):
+                    return None
                 if is_index_asset and end_ok and existing_rows >= requested_length:
                     logger.info(
                         "[THETA][CACHE][REUSE] asset=%s/%s (%s) coverage meets requirement; skipping refetch. existing_end=%s target_end=%s",
@@ -2982,7 +2994,9 @@ class ThetaDataBacktestingPandas(PandasData):
                             data_end = getattr(candidate_data, "datetime_end", None)
                             if data_end is None:
                                 data_end = self._normalize_default_timezone(candidate_df.index.max())
-                            if data_end is not None and dt <= data_end:
+                            normalized_dt = self._normalize_default_timezone(dt) if dt is not None else None
+                            normalized_end = self._normalize_default_timezone(data_end) if data_end is not None else None
+                            if normalized_dt is not None and normalized_end is not None and normalized_dt <= normalized_end:
                                 should_refresh = False
             except Exception:
                 should_refresh = True
@@ -3630,7 +3644,9 @@ class ThetaDataBacktestingPandas(PandasData):
                     candidate_df = getattr(candidate_data, "df", None)
                     if candidate_df is not None and not candidate_df.empty and self._frame_has_quote_columns(candidate_df):
                         data_end = getattr(candidate_data, "datetime_end", None)
-                        if data_end is not None and dt <= data_end:
+                        normalized_dt = self._normalize_default_timezone(dt) if dt is not None else None
+                        normalized_end = self._normalize_default_timezone(data_end) if data_end is not None else None
+                        if normalized_dt is not None and normalized_end is not None and normalized_dt <= normalized_end:
                             should_refresh = False
                             fast_data = candidate_data
         except Exception:

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -751,7 +751,7 @@ class _Strategy:
                     else (position.asset, self._quote_asset)
                 )
                 quantity = position.quantity
-                price = prices.get(asset, 0)
+                price = prices.get(asset)
 
                 # If the asset is the quote asset, then we already have included it from cash
                 # Eg. if we have a position of USDT and USDT is the quote_asset then we already consider it as cash
@@ -760,9 +760,22 @@ class _Strategy:
                         self._quote_asset,
                         self._quote_asset,
                     ):
-                        price = 0
+                        continue
                     elif isinstance(asset, Asset) and asset == self._quote_asset:
-                        price = 0
+                        continue
+
+                # Normalize "missing" prices to None so forward-fill fallback can apply.
+                # Some data sources return 0 or NaN for "no price" (common on non-trading timestamps).
+                if price is not None:
+                    try:
+                        price_float = float(price)
+                    except (TypeError, ValueError):
+                        price = None
+                    else:
+                        if (not math.isfinite(price_float)) or price_float == 0:
+                            price = None
+                        else:
+                            price = price_float
 
                 # Track valid prices for forward-fill fallback
                 if price is not None:

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -1952,7 +1952,36 @@ class StrategyExecutor(Thread):
             if is_pure_pandas_data_source:
                 self.broker.initialize_market_calendars(data_source.get_trading_days_pandas())
             else:
-                self.broker.initialize_market_calendars(get_trading_days(market))
+                # PERFORMANCE: default get_trading_days() spans 1950->today, which can cost 10s+
+                # in option-heavy backtests. For backtesting, bound the calendar to the backtest
+                # window (+/- a small buffer) so schedule generation is O(window) instead of
+                # O(75 years).
+                if self.strategy.is_backtesting:
+                    try:
+                        start = getattr(self.strategy, "_backtesting_start", None) or getattr(
+                            self.strategy, "backtesting_start", None
+                        )
+                        end = getattr(self.strategy, "_backtesting_end", None) or getattr(
+                            self.strategy, "backtesting_end", None
+                        )
+                        tzinfo = getattr(getattr(self.broker, "data_source", None), "tzinfo", None) or LUMIBOT_DEFAULT_PYTZ
+
+                        if start is not None and end is not None:
+                            buffer = timedelta(days=14)
+                            self.broker.initialize_market_calendars(
+                                get_trading_days(
+                                    market=market,
+                                    start_date=start - buffer,
+                                    end_date=end + buffer,
+                                    tzinfo=tzinfo,
+                                )
+                            )
+                        else:
+                            self.broker.initialize_market_calendars(get_trading_days(market))
+                    except Exception:
+                        self.broker.initialize_market_calendars(get_trading_days(market))
+                else:
+                    self.broker.initialize_market_calendars(get_trading_days(market))
 
             #####
             # Main strategy execution loop

--- a/lumibot/tools/backtest_cache.py
+++ b/lumibot/tools/backtest_cache.py
@@ -101,6 +101,12 @@ class BacktestCacheManager:
         # downloaded in this process so we can safely reuse the local copy for the remainder of the run.
         self._downloaded_remote_keys: set[str] = set()
         self._downloaded_remote_keys_lock = threading.Lock()
+        # Negative cache for remote keys that are missing in S3. Some backtest code paths can
+        # repeatedly request the same cache file (especially when coverage metadata thrashes).
+        # Without a miss-cache we end up doing thousands of failing S3 calls, which can dominate
+        # cold-local/warm-S3 production runs.
+        self._missing_remote_keys: set[str] = set()
+        self._missing_remote_keys_lock = threading.Lock()
 
         # Lightweight per-process accounting so we can quantify S3 hydration cost in production.
         # NOTE: This deliberately avoids logging per-object at INFO (too spammy); we log a single
@@ -162,6 +168,13 @@ class BacktestCacheManager:
                     with self._downloaded_remote_keys_lock:
                         self._downloaded_remote_keys.add(remote_key)
                     return False
+
+            # If we've already observed this remote key missing in S3 during the current process,
+            # don't keep re-hitting S3 (miss storms can dominate option-heavy runs).
+            if not local_path.exists() and not force_download:
+                with self._missing_remote_keys_lock:
+                    if remote_key in self._missing_remote_keys:
+                        return False
 
             with self._downloaded_remote_keys_lock:
                 already_downloaded = remote_key in self._downloaded_remote_keys
@@ -253,6 +266,8 @@ class BacktestCacheManager:
                 logger.debug(
                     "[REMOTE_CACHE][MISS] %s (reason=%s)", remote_key, self._describe_error(exc)
                 )
+                with self._missing_remote_keys_lock:
+                    self._missing_remote_keys.add(remote_key)
                 # In S3 mode, we intentionally leave no local cache on a miss to force fresh fetch.
                 if local_path.exists():
                     try:

--- a/lumibot/tools/helpers.py
+++ b/lumibot/tools/helpers.py
@@ -30,8 +30,6 @@ from ..constants import LUMIBOT_DEFAULT_PYTZ, LUMIBOT_DEFAULT_TIMEZONE
 #
 # We cache schedules by **year** (market, year, tz) and then slice to the requested window.
 # Key: (market, year, tz_str)
-_TRADING_CALENDAR_YEAR_CACHE = {}
-
 # Slice cache (best-effort; primarily avoids repeated `.loc[]` slicing for identical windows).
 # Key: (market, start_date_str, end_date_str, tz_str)
 _TRADING_CALENDAR_CACHE = {}
@@ -41,6 +39,34 @@ _TRADING_CALENDAR_CACHE = {}
 # strategy logs. Throttle to at most ~1 line/second per (output, prefix) when not in quiet mode.
 _PROGRESS_LAST_PRINT: "weakref.WeakKeyDictionary[object, dict[str, tuple[float, str]]]" = weakref.WeakKeyDictionary()
 _PROGRESS_LAST_PRINT_FALLBACK: dict[tuple[int, str], tuple[float, str]] = {}
+
+
+def _format_datetime_to_tz(dtm, tzinfo: pytz.BaseTzInfo):
+    if pd.isna(dtm):
+        return dtm
+    return pd.Timestamp(dtm).tz_convert(tzinfo).to_pydatetime()
+
+
+@lru_cache(maxsize=256)
+def _get_trading_schedule_for_year(market: str, year: int, tz_name: str) -> pd.DataFrame:
+    """Return a cached trading schedule for a full calendar year.
+
+    NOTE: This function is intentionally module-scoped and `lru_cache`'d (thread-safe) to
+    avoid repeated expensive schedule builds under backtest concurrency.
+    """
+    tzinfo = pytz.timezone(tz_name)
+    year_start = pd.Timestamp(year=year, month=1, day=1)
+    year_end = pd.Timestamp(year=year, month=12, day=31)
+
+    if market == "24/7":
+        cal = TwentyFourSevenCalendar(tzinfo=tzinfo)
+    else:
+        cal = mcal.get_calendar(market)
+
+    schedule = cal.schedule(start_date=year_start, end_date=year_end, tz=tzinfo)
+    schedule.market_open = schedule.market_open.apply(lambda v: _format_datetime_to_tz(v, tzinfo))
+    schedule.market_close = schedule.market_close.apply(lambda v: _format_datetime_to_tz(v, tzinfo))
+    return schedule
 
 
 def get_chunks(l, chunk_size):
@@ -158,13 +184,6 @@ def get_trading_days(
     if not isinstance(tzinfo, pytz.BaseTzInfo):
         raise TypeError('tzinfo must be a pytz.tzinfo object.')
 
-    # More robust datetime conversion with explicit timezone handling
-    def format_datetime(dtm):
-        if pd.isna(dtm):
-            return dtm
-        # Convert to Python datetime and ensure proper timezone conversion
-        return pd.Timestamp(dtm).tz_convert(tzinfo).to_pydatetime()
-
     def ensure_tz_aware(dtm, tzinfo):
         dtm = pd.to_datetime(dtm)
         return dtm.tz_convert(tzinfo) if dtm.tz is not None else dtm.tz_localize(tzinfo)
@@ -202,30 +221,12 @@ def get_trading_days(
     if cache_key in _TRADING_CALENDAR_CACHE:
         return _TRADING_CALENDAR_CACHE[cache_key].copy()
 
-    def _get_year_schedule(year: int) -> pd.DataFrame:
-        year_key = (market, int(year), str(tzinfo))
-        cached_year = _TRADING_CALENDAR_YEAR_CACHE.get(year_key)
-        if cached_year is not None:
-            return cached_year
-
-        year_start = pd.Timestamp(year=year, month=1, day=1)
-        year_end = pd.Timestamp(year=year, month=12, day=31)
-        if market == "24/7":
-            cal = TwentyFourSevenCalendar(tzinfo=tzinfo)
-        else:
-            cal = mcal.get_calendar(market)
-
-        schedule = cal.schedule(start_date=year_start, end_date=year_end, tz=tzinfo)
-        schedule.market_open = schedule.market_open.apply(format_datetime)
-        schedule.market_close = schedule.market_close.apply(format_datetime)
-        _TRADING_CALENDAR_YEAR_CACHE[year_key] = schedule
-        return schedule
-
     start_year = int(start_day.year)
     end_year = int(schedule_end_day.year)
+    tz_name = getattr(tzinfo, "zone", None) or str(tzinfo)
     year_schedules = []
     for year in range(start_year, end_year + 1):
-        year_schedules.append(_get_year_schedule(year))
+        year_schedules.append(_get_trading_schedule_for_year(market, int(year), tz_name))
 
     full_schedule = year_schedules[0] if len(year_schedules) == 1 else pd.concat(year_schedules, axis=0)
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.43",
+    version="4.4.44",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/tests/backtest/backtest_performance_history.csv
+++ b/tests/backtest/backtest_performance_history.csv
@@ -7235,3 +7235,7 @@ timestamp,test_name,data_source,trading_days,execution_time_seconds,git_commit,l
 2026-01-27T19:02:10.083698,test_acceptance_ibkr_mes_futures_acceptance,unknown,,6.407,340ed4e7,4.4.41,,,,,Auto-tracked from test_acceptance_backtests_ci
 2026-01-27T21:02:44.774164,test_acceptance_backdoor_smartlimit,unknown,,210.067,8020e12e,4.4.41,,,,,Auto-tracked from test_acceptance_backtests_ci
 2026-01-27T21:06:26.716069,test_acceptance_spx_short_straddle,unknown,,213.94,8020e12e,4.4.41,,,,,Auto-tracked from test_acceptance_backtests_ci
+2026-01-28T01:35:25.382456,test_acceptance_backdoor_smartlimit,unknown,,183.476,dee823d8,4.4.42,,,,,Auto-tracked from test_acceptance_backtests_ci
+2026-01-28T01:38:30.612331,test_acceptance_spx_short_straddle,unknown,,174.229,dee823d8,4.4.42,,,,,Auto-tracked from test_acceptance_backtests_ci
+2026-01-28T02:50:26.849100,test_acceptance_spx_short_straddle,unknown,,165.928,dee823d8,4.4.42,,,,,Auto-tracked from test_acceptance_backtests_ci
+2026-01-28T02:53:19.643089,test_acceptance_backdoor_smartlimit,unknown,,163.98,dee823d8,4.4.42,,,,,Auto-tracked from test_acceptance_backtests_ci

--- a/tests/backtest/test_portfolio_value_forward_fill_zero_price.py
+++ b/tests/backtest/test_portfolio_value_forward_fill_zero_price.py
@@ -1,0 +1,56 @@
+import datetime
+import logging
+import threading
+from types import SimpleNamespace
+
+from lumibot.entities import Asset
+from lumibot.strategies.strategy import Strategy
+
+
+class _PortfolioValueZeroPriceStrategy(Strategy):
+    @property
+    def cash(self):
+        return float(self._cash)
+
+    def update_broker_balances(self, force_update=False):
+        return None
+
+
+def test_update_portfolio_value_forward_fills_on_zero_price():
+    """
+    Regression test: portfolio value must not collapse to cash when a data source
+    returns 0 for a held asset price on a non-trading timestamp.
+
+    Observed in production-like runs as a ~99% drop in portfolio value on Sunday
+    timestamps (e.g., 2019-06-09) when the held position's mark price was 0.
+    """
+    gld = Asset("GLD", Asset.AssetType.STOCK)
+    usd = Asset("USD", Asset.AssetType.FOREX)
+
+    position = SimpleNamespace(asset=gld, quantity=10, avg_fill_price=None)
+    broker = SimpleNamespace(
+        get_tracked_positions=lambda _: [position],
+        data_source=object(),
+        option_source=None,
+        datetime=datetime.datetime(2019, 6, 9, 19, 0, 0, tzinfo=datetime.timezone.utc),
+    )
+
+    strategy = _PortfolioValueZeroPriceStrategy.__new__(_PortfolioValueZeroPriceStrategy)
+    strategy.is_backtesting = True
+    strategy._executor = SimpleNamespace(lock=threading.Lock())
+    strategy._name = "test"
+    strategy._quote_asset = usd
+    strategy.broker = broker
+    strategy.logger = logging.getLogger("test.portfolio_value.zero_price")
+
+    # Starting cash and last known price (e.g., last close before the non-trading timestamp).
+    strategy._cash = 1000.0
+    strategy._last_known_prices = {gld: 100.0}
+
+    # Simulate a data source returning 0.0 for "no price".
+    strategy._get_price_from_source = lambda _source, _asset: 0.0
+
+    pv = Strategy._update_portfolio_value(strategy)
+    assert pv == 2000.0
+    assert strategy._last_known_prices[gld] == 100.0
+


### PR DESCRIPTION
Fixes production crash where strategies calling Strategy.add_ohlc() fail because the published PyPI wheels for 4.4.42 and 4.4.43 were built from an older commit and did not include add_ohlc/get_ohlc_df.

What / Why
- Bump to 4.4.44 and add deploy marker.
- Update CHANGELOG with explicit notes that 4.4.42/4.4.43 PyPI artifacts were missing the OHLC feature.

Risk
- Low: release bookkeeping + packaging correction.

Tests
- GitHub CI (sharded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OHLC (candlestick) support for strategies with add_ohlc and get_ohlc_df
  * OHLC output available in indicators exports (HTML, CSV)

* **Changed**
  * Charting: add_line now returns the appended result dict

* **Bug Fixes**
  * Packaging fixed so version 4.4.44 properly includes OHLC changes; upgrade recommended

* **Documentation**
  * Comprehensive docs and examples added for OHLC usage

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->