### PR TITLE
v4.4.49 - Parquet backtest artifacts + contract logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## 4.4.49 - Unreleased
 
-- TBD
+### Added
+- Backtesting artifacts: add `LUMIBOT_BACKTEST_PARQUET_MODE` with `required` contract mode (fail-fast on parquet export failures) and structured parquet export logs (rows/cols/bytes/duration, coerced columns).
+
+### Changed
+- Indicators: always emit `*_indicators.csv` + `*_indicators.parquet`, even when a strategy produced no markers/lines/OHLC (empty indicators = valid artifact).
+- Trade events: always emit `*_trade_events.csv` + `*_trade_events.parquet` (empty events = valid artifact).
+
+### Fixed
+- Stats: stop embedding raw `Asset` objects in the `positions` stats snapshot; sanitize object-ish stats columns before parquet export to prevent `Conversion failed for column positions with type object`.
 
 ## 4.4.48 - 2026-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
-## 4.4.49 - Unreleased
-
+## 4.4.49 - 2026-02-10
 ### Added
 - Backtesting artifacts: add `LUMIBOT_BACKTEST_PARQUET_MODE` with `required` contract mode (fail-fast on parquet export failures) and structured parquet export logs (rows/cols/bytes/duration, coerced columns).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.4.49 - Unreleased
+
+- TBD
+
 ## 4.4.48 - 2026-02-10
 
 ### Added

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -70,6 +70,20 @@ This page documents environment variables used by LumiBot, with an emphasis on *
 - Purpose: Enables/disables artifact generation.
 - Values: `True` / `False` (string).
 
+### `LUMIBOT_BACKTEST_PARQUET_MODE`
+- Purpose: Controls parquet export semantics for backtest artifacts (indicators/trades/stats/trade events).
+- Values:
+  - `best_effort` (default): parquet failures log warnings; CSV remains the compatibility layer.
+  - `required`: parquet export failures raise and should fail the backtest (artifact contract mode).
+- Notes:
+  - This is intended for BotManager/BotSpot backtests where downstream tooling depends on Parquet for performance.
+  - BotManager should set `LUMIBOT_BACKTEST_PARQUET_MODE=required` for production backtests.
+- Where:
+  - Mode parsing + sanitizers: `lumibot/tools/parquet_utils.py`
+  - Stats parquet: `lumibot/strategies/_strategy.py`
+  - Indicators/trades parquet: `lumibot/tools/indicators.py`
+  - Trade events parquet: `lumibot/brokers/broker.py`
+
 ### `BACKTESTING_QUIET_LOGS`
 - Purpose: Reduce log noise during backtests.
 - Values: `true` / `false` (string).

--- a/docs/investigations/2026-02-10_PARQUET_ARTIFACT_CONTRACT.md
+++ b/docs/investigations/2026-02-10_PARQUET_ARTIFACT_CONTRACT.md
@@ -1,0 +1,79 @@
+# PARQUET ARTIFACT CONTRACT (BACKTEST RESULTS)
+
+> Root cause + fix plan for missing backtest Parquet artifacts and slow downstream DuckDB queries.
+
+**Last Updated:** 2026-02-10  
+**Status:** Active  
+**Audience:** Developers + AI Agents  
+
+---
+
+## Overview
+
+BotSpot tooling relies on DuckDB queries against backtest artifacts. CSV parsing over presigned S3 URLs is slow and causes repeated "Querying indicators.csv" steps to take 10s-40s. Parquet artifacts are the intended fast path, but production backtests were not reliably emitting/uploading Parquet, which prevented the Node service from switching to the Parquet sibling.
+
+This investigation documents why Parquet was missing and how we made Parquet export **observable** and **contract-enforceable** for BotManager-driven backtests.
+
+## Symptoms
+
+- S3 backtest results had `*_indicators.csv`, `*_trades.csv`, `*_stats.csv`, etc. but **no `*.parquet` siblings**.
+- BotSpot agent/server logs showed repeated expensive CSV scanning (DuckDB over HTTP) instead of Parquet.
+
+## Root Cause
+
+`StrategyExecutor._trace_stats()` was storing a nested Python object in stats rows:
+
+- `positions` was written as a list of dicts containing **raw `Asset` objects**
+- `pandas.DataFrame.to_parquet()` (pyarrow) cannot reliably serialize arbitrary Python objects nested inside object-typed columns
+- Stats Parquet export failed with an error like:
+  - `Conversion failed for column positions with type object`
+- The Parquet export was previously **best-effort** (caught + warning), so the backtest completed and uploaded CSVs, but Parquet was silently absent.
+
+## Fixes Implemented
+
+### 1) Stop Embedding Raw Objects in Stats Rows
+
+- `StrategyExecutor._trace_stats()` now serializes `position.asset` via `asset.to_minimal_dict()` (fallback to string) so stats rows are JSON/parquet-friendly.
+
+### 2) Defense-In-Depth Sanitizer Before Parquet Export
+
+- Added `lumibot/tools/parquet_utils.py`:
+  - `coerce_object_columns_to_json_strings(df)` converts object-ish columns (lists/dicts/custom objects) into JSON strings.
+  - Decimal values are coerced to float for Arrow compatibility.
+  - `write_parquet_with_logging(...)` provides:
+    - success logs including rows/cols/bytes/duration + coerced columns
+    - failure logs with an explicit error code (`PARQUET_EXPORT_FAILED`) and samples of object columns
+    - optional fail-fast behavior when Parquet is required.
+
+Stats parquet now uses the sanitizer to ensure nested payloads cannot break Parquet writes.
+
+### 3) Always Emit Empty Indicators + Trade Events Artifacts
+
+Downstream systems treat missing artifacts as "Artifact not found" errors.
+
+- `plot_indicators()` now always writes `*_indicators.csv` + `*_indicators.parquet` even when no chart data exists (empty indicators = valid artifact).
+- `Broker.export_trade_events_to_csv()` now always writes `*_trade_events.csv` + `*_trade_events.parquet` even when there are no events (empty events = valid artifact).
+
+### 4) Parquet Contract Mode (Fail-Fast)
+
+New env var:
+
+- `LUMIBOT_BACKTEST_PARQUET_MODE`
+  - `best_effort` (default): warn and continue (CSV compatibility layer)
+  - `required`: raise on Parquet failure (backtest should fail)
+
+BotManager production backtests should set `LUMIBOT_BACKTEST_PARQUET_MODE=required` so missing Parquet is never silently ignored.
+
+## Tests Added / Updated
+
+- Stats parquet regression for object-ish `positions` (previously failed in prod).
+- Trace stats regression ensuring raw `Asset` objects are not embedded in stats rows.
+- Indicators regression ensuring empty indicator artifacts are still emitted.
+
+## Deployment Notes
+
+For Parquet to show up in BotSpot:
+
+1. LumiBot must emit Parquet successfully (contract mode recommended).
+2. BotManager runner image must upload `*.parquet` artifacts and enforce required artifacts when configured.
+3. BotSpot Node should prefer/query Parquet siblings and cache artifact downloads across calls.

--- a/docsrc/environment_variables.rst
+++ b/docsrc/environment_variables.rst
@@ -81,6 +81,17 @@ SHOW_PLOT / SHOW_INDICATORS / SHOW_TEARSHEET
 - Purpose: Enable/disable artifact generation.
 - Values: ``True`` / ``False`` (string).
 
+LUMIBOT_BACKTEST_PARQUET_MODE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Control parquet export semantics for backtest artifacts (indicators/trades/stats/trade events).
+- Values:
+  - ``best_effort`` (default): parquet failures log warnings; CSV remains the compatibility layer.
+  - ``required``: parquet export failures raise and should fail the backtest (artifact contract mode).
+- Notes:
+  - This is primarily intended for BotManager/BotSpot backtests where downstream tools depend on Parquet for performance.
+  - When set to ``required``, a parquet export error should fail the backtest so missing artifacts are never silently ignored.
+
 BACKTESTING_QUIET_LOGS
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -22,6 +22,11 @@ from lumibot.tools.lumibot_logger import get_logger
 logger = get_logger(__name__)
 
 from lumibot.tools.lumibot_logger import get_logger, get_strategy_logger
+from lumibot.tools.parquet_utils import (
+    coerce_object_columns_to_json_strings,
+    is_parquet_required,
+    write_parquet_with_logging,
+)
 from ..data_sources import DataSource
 from ..entities import Asset, Order, Position, Quote
 from ..entities.chains import normalize_option_chains
@@ -2363,23 +2368,33 @@ class Broker(ABC):
         return self.data_source.get_quote(asset, quote, exchange)
 
     def export_trade_events_to_csv(self, filename):
-        if len(self._trade_event_log_df) > 0:
-            output_df = self._trade_event_log_df.set_index("time")
+        df = self._trade_event_log_df
+        if df is None:
+            df = pd.DataFrame()
+
+        if df.empty:
+            columns = getattr(self, "_trade_event_log_columns", None) or TRADE_EVENT_LOG_COLUMNS
+            df = pd.DataFrame(columns=list(columns))
+            df.to_csv(filename, index=False)
+        else:
+            # Preserve legacy "time as index" CSV formatting for readability.
+            output_df = df.set_index("time") if "time" in df.columns else df
             output_df.to_csv(filename)
 
-            parquet_filename = (
-                filename[:-4] + ".parquet" if str(filename).lower().endswith(".csv") else str(filename) + ".parquet"
-            )
-            try:
-                self._trade_event_log_df.to_parquet(
-                    parquet_filename,
-                    index=False,
-                    engine="pyarrow",
-                    compression="zstd",
-                )
-            except Exception as exc:
-                # Never fail end-of-run export due to parquet; CSV is the compatibility layer.
-                self.logger.warning("Failed to write trade events parquet file %s: %s", parquet_filename, exc)
+        parquet_filename = (
+            filename[:-4] + ".parquet" if str(filename).lower().endswith(".csv") else str(filename) + ".parquet"
+        )
+        required = bool(self.IS_BACKTESTING_BROKER) and is_parquet_required()
+        write_parquet_with_logging(
+            df=df,
+            path=parquet_filename,
+            artifact="trade_events",
+            logger=self.logger,
+            index=False,
+            required=required,
+            compression="zstd",
+            sanitizer=coerce_object_columns_to_json_strings,
+        )
 
     def set_strategy_name(self, strategy_name):
         """

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -2368,6 +2368,8 @@ class Broker(ABC):
         return self.data_source.get_quote(asset, quote, exchange)
 
     def export_trade_events_to_csv(self, filename):
+        safe_logger = getattr(self, "logger", None) or logger
+
         df = self._trade_event_log_df
         if df is None:
             df = pd.DataFrame()
@@ -2389,7 +2391,7 @@ class Broker(ABC):
             df=df,
             path=parquet_filename,
             artifact="trade_events",
-            logger=self.logger,
+            logger=safe_logger,
             index=False,
             required=required,
             compression="zstd",

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -23,6 +23,11 @@ from termcolor import colored
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.tools.lumibot_logger import get_logger, get_strategy_logger
+from lumibot.tools.parquet_utils import (
+    coerce_object_columns_to_json_strings,
+    is_parquet_required,
+    write_parquet_with_logging,
+)
 
 from ..backtesting import (
     AlpacaBacktesting,
@@ -1350,15 +1355,17 @@ class _Strategy:
                 stats_parquet_file = (
                     self._stats_file[:-4] + ".parquet" if self._stats_file.lower().endswith(".csv") else self._stats_file + ".parquet"
                 )
-                try:
-                    self._stats.to_parquet(
-                        stats_parquet_file,
-                        engine="pyarrow",
-                        compression="zstd",
-                    )
-                except Exception as exc:
-                    # Never fail end-of-run stats due to parquet export; CSV is the compatibility layer.
-                    self.logger.warning("Failed to write stats parquet file %s: %s", stats_parquet_file, exc)
+                required = bool(self.is_backtesting) and is_parquet_required()
+                write_parquet_with_logging(
+                    df=self._stats,
+                    path=stats_parquet_file,
+                    artifact="stats",
+                    logger=self.logger,
+                    index=True,
+                    required=required,
+                    compression="zstd",
+                    sanitizer=coerce_object_columns_to_json_strings,
+                )
 
             self._strategy_returns_df = day_deduplicate(self._stats)
 

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -878,9 +878,26 @@ class StrategyExecutor(Thread):
         positions_list = []
         positions = self.strategy.get_positions()
         for position in positions:
+            # IMPORTANT: Never put raw Asset objects into stats rows.
+            # They break parquet export (pyarrow cannot serialize arbitrary Python objects),
+            # and they bloat logs. Keep this minimal and JSON/parquet-friendly.
+            asset_value = getattr(position, "asset", None)
+            try:
+                if asset_value is not None and hasattr(asset_value, "to_minimal_dict"):
+                    asset_value = asset_value.to_minimal_dict()
+            except Exception:
+                # Fall back to a string representation to keep tracing resilient.
+                asset_value = str(asset_value)
+
+            quantity_value = getattr(position, "quantity", None)
+            try:
+                quantity_value = float(quantity_value) if quantity_value is not None else 0.0
+            except Exception:
+                quantity_value = 0.0
+
             pos_dict = {
-                "asset": position.asset,
-                "quantity": position.quantity,
+                "asset": asset_value,
+                "quantity": quantity_value,
             }
             positions_list.append(pos_dict)
 

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -19,6 +19,11 @@ from plotly.subplots import make_subplots
 from .yahoo_helper import YahooHelper as yh
 
 from lumibot.tools.lumibot_logger import get_logger
+from lumibot.tools.parquet_utils import (
+    coerce_object_columns_to_json_strings,
+    is_parquet_required,
+    write_parquet_with_logging,
+)
 
 logger = get_logger(__name__)
 
@@ -502,12 +507,11 @@ def plot_indicators(
     if chart_ohlc_df is not None and not chart_ohlc_df.empty:
         plot_names.update(chart_ohlc_df["plot_name"].unique())
 
-    # Convert to sorted list to ensure consistent order
-    plot_names = sorted(list(plot_names))
-
-    # Ensure num_subplots is at least 1 to avoid ValueError in make_subplots
-    num_subplots = max(1, len(plot_names))
-    subplot_titles = plot_names if num_subplots > 0 else ["default_plot"]
+    # Convert to sorted list to ensure consistent order. Ensure at least one subplot exists
+    # even when the strategy emitted no chart data (empty indicators should still produce artifacts).
+    plot_names = sorted(list(plot_names)) or ["default_plot"]
+    num_subplots = len(plot_names)
+    subplot_titles = plot_names
 
     # Create subplots without shared x-axes
     fig = make_subplots(
@@ -695,20 +699,24 @@ def plot_indicators(
     # Chart Titles and Layouts
     ###############################
 
+    # Set title and layout
+    # Calculate height based on number of subplots
+    # 400px per subplot
+    height = max(800, num_subplots * 400)
+
+    title_text = f"Indicators for {strategy_name}" if strategy_name else "Indicators"
+    if not has_chart_data:
+        title_text = title_text + " (no indicator data)"
+
+    fig.update_layout(
+        title_text=title_text,
+        title_font_size=30,
+        template="plotly_dark",
+        height=height,  # Dynamic height based on number of subplots
+        margin=dict(t=150),  # Add more space between title and first subplot
+    )
+
     if has_chart_data:
-        # Set title and layout
-        # Calculate height based on number of subplots
-        # 400px per subplot
-        height = max(800, num_subplots * 400)
-
-        fig.update_layout(
-            title_text=f"Indicators for {strategy_name}",
-            title_font_size=30,
-            template="plotly_dark",
-            height=height,  # Dynamic height based on number of subplots
-            margin=dict(t=150),  # Add more space between title and first subplot
-        )
-
         # Range selector buttons
         rangeselector_buttons = list([
             dict(count=1, label="1m", step="month", stepmode="backward"),
@@ -747,46 +755,67 @@ def plot_indicators(
                 col=1
             )
 
-        disable_ui = (
-            os.environ.get("LUMIBOT_DISABLE_UI", "").strip().lower() in ("1", "true", "yes")
-            or bool(os.environ.get("PYTEST_CURRENT_TEST"))
-        )
+    disable_ui = (
+        os.environ.get("LUMIBOT_DISABLE_UI", "").strip().lower() in ("1", "true", "yes")
+        or bool(os.environ.get("PYTEST_CURRENT_TEST"))
+    )
 
-        # Create graph (auto_open disabled for CI/tests).
-        fig.write_html(plot_file_html, auto_open=show_indicators and not disable_ui)
+    # Create graph (auto_open disabled for CI/tests).
+    fig.write_html(plot_file_html, auto_open=show_indicators and not disable_ui)
 
-        # Get the file name for the CSV file by removing the .html extension and adding .csv
-        csv_file = plot_file_html.replace(".html", ".csv")
+    # Get the file name for the CSV file by removing the .html extension and adding .csv
+    csv_file = plot_file_html.replace(".html", ".csv")
 
-        # Export chart markers and lines to CSV - combine them and sort by datetime
-        export_dfs = []
-        if chart_markers_df is not None and not chart_markers_df.empty:
-            markers_out = chart_markers_df.copy()
-            markers_out["type"] = "marker"
-            export_dfs.append(markers_out)
-        if chart_lines_df is not None and not chart_lines_df.empty:
-            lines_out = chart_lines_df.copy()
-            lines_out["type"] = "line"
-            export_dfs.append(lines_out)
-        if chart_ohlc_df is not None and not chart_ohlc_df.empty:
-            ohlc_out = chart_ohlc_df.copy()
-            ohlc_out["type"] = "ohlc"
-            export_dfs.append(ohlc_out)
+    # Export chart markers and lines to CSV - combine them and sort by datetime
+    standard_columns = [
+        "datetime",
+        "name",
+        "plot_name",
+        "type",
+        "value",
+        "symbol",
+        "size",
+        "color",
+        "detail_text",
+        "open",
+        "high",
+        "low",
+        "close",
+    ]
+    export_dfs = []
+    if chart_markers_df is not None and not chart_markers_df.empty:
+        markers_out = chart_markers_df.copy()
+        markers_out["type"] = "marker"
+        export_dfs.append(markers_out)
+    if chart_lines_df is not None and not chart_lines_df.empty:
+        lines_out = chart_lines_df.copy()
+        lines_out["type"] = "line"
+        export_dfs.append(lines_out)
+    if chart_ohlc_df is not None and not chart_ohlc_df.empty:
+        ohlc_out = chart_ohlc_df.copy()
+        ohlc_out["type"] = "ohlc"
+        export_dfs.append(ohlc_out)
 
-        if export_dfs:
-            combined_df = pd.concat(export_dfs, ignore_index=True).sort_values(by="datetime")
-            combined_df.to_csv(csv_file, index=False)
-            parquet_file = csv_file.replace(".csv", ".parquet")
-            try:
-                combined_df.to_parquet(
-                    parquet_file,
-                    index=False,
-                    engine="pyarrow",
-                    compression="zstd",
-                )
-            except Exception as exc:
-                # Never fail backtest post-processing due to parquet export; CSV is the compatibility layer.
-                logger.warning("Failed to write indicators parquet file %s: %s", parquet_file, exc)
+    if export_dfs:
+        combined_df = pd.concat(export_dfs, ignore_index=True).sort_values(by="datetime")
+    else:
+        # Always emit indicators.csv so downstream systems can reliably query it.
+        # Some strategies produce no markers/lines/OHLC; treat this as "empty indicators", not a missing artifact.
+        combined_df = pd.DataFrame(columns=standard_columns)
+
+    combined_df.to_csv(csv_file, index=False)
+    parquet_file = csv_file.replace(".csv", ".parquet")
+    required = is_parquet_required()
+    write_parquet_with_logging(
+        df=combined_df,
+        path=parquet_file,
+        artifact="indicators",
+        logger=logger,
+        index=False,
+        required=required,
+        compression="zstd",
+        sanitizer=coerce_object_columns_to_json_strings,
+    )
 
 
 def plot_returns(
@@ -828,16 +857,16 @@ def plot_returns(
         empty_trades_for_csv = pd.DataFrame(columns=standard_trade_columns)
         empty_trades_for_csv.to_csv(trades_csv_file, index=False)
         trades_parquet_file = trades_csv_file.replace(".csv", ".parquet")
-        try:
-            empty_trades_for_csv.to_parquet(
-                trades_parquet_file,
-                index=False,
-                engine="pyarrow",
-                compression="zstd",
-            )
-        except Exception as exc:
-            # Never fail backtest post-processing due to parquet export; CSV is the compatibility layer.
-            logger.warning("Failed to write trades parquet file %s: %s", trades_parquet_file, exc)
+        write_parquet_with_logging(
+            df=empty_trades_for_csv,
+            path=trades_parquet_file,
+            artifact="trades",
+            logger=logger,
+            index=False,
+            required=is_parquet_required(),
+            compression="zstd",
+            sanitizer=coerce_object_columns_to_json_strings,
+        )
     else:
         # Prepare a copy of trades_df for CSV export, ensuring standard columns
         trades_df_for_csv = trades_df.copy()
@@ -850,16 +879,16 @@ def plot_returns(
         trades_df_for_csv.to_csv(trades_csv_file, index=False)
         logger.info(f"Trades data saved to CSV: {trades_csv_file}")
         trades_parquet_file = trades_csv_file.replace(".csv", ".parquet")
-        try:
-            trades_df_for_csv.to_parquet(
-                trades_parquet_file,
-                index=False,
-                engine="pyarrow",
-                compression="zstd",
-            )
-        except Exception as exc:
-            # Never fail backtest post-processing due to parquet export; CSV is the compatibility layer.
-            logger.warning("Failed to write trades parquet file %s: %s", trades_parquet_file, exc)
+        write_parquet_with_logging(
+            df=trades_df_for_csv,
+            path=trades_parquet_file,
+            artifact="trades",
+            logger=logger,
+            index=False,
+            required=is_parquet_required(),
+            compression="zstd",
+            sanitizer=coerce_object_columns_to_json_strings,
+        )
     # --- End: CSV Generation for trades_df ---
 
     dfs_concat = []

--- a/lumibot/tools/parquet_utils.py
+++ b/lumibot/tools/parquet_utils.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+import pandas as pd
+
+_TRUTHY = {"required", "require", "strict", "1", "true", "yes"}
+
+
+@dataclass(frozen=True)
+class ParquetWriteStats:
+    artifact: str
+    path: str
+    rows: int
+    cols: int
+    bytes: int
+    duration_s: float
+    coerced_columns: list[str]
+
+
+def get_backtest_parquet_mode() -> str:
+    """Return parquet mode for backtests.
+
+    Supported values:
+    - "best_effort" (default): parquet failures log a warning; CSV remains the compatibility layer.
+    - "required": parquet failures raise and should fail the backtest (contract mode).
+    """
+
+    raw = (os.environ.get("LUMIBOT_BACKTEST_PARQUET_MODE", "") or "").strip().lower()
+    if raw in _TRUTHY:
+        return "required"
+    return "best_effort"
+
+
+def is_parquet_required() -> bool:
+    return get_backtest_parquet_mode() == "required"
+
+
+def _json_default(value: Any) -> str:
+    # Fall back to string conversion for non-serializable objects (Asset, enums, etc.).
+    try:
+        return str(value)
+    except Exception:
+        return "<unserializable>"
+
+
+def _is_decimal(value: Any) -> bool:
+    try:
+        from decimal import Decimal
+
+        return isinstance(value, Decimal)
+    except Exception:
+        return False
+
+
+def coerce_object_columns_to_json_strings(df: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
+    """Return a copy of df where object-ish columns are coerced to JSON strings when needed.
+
+    This is defensive: PyArrow/parquet can't reliably serialize arbitrary Python objects
+    (e.g., Asset instances inside lists/dicts). We keep pure string columns untouched.
+    """
+
+    if df.empty:
+        return df.copy(), []
+
+    out = df.copy()
+    coerced: list[str] = []
+
+    for col in out.columns:
+        try:
+            series = out[col]
+        except Exception:
+            continue
+
+        if str(series.dtype) != "object":
+            continue
+
+        non_null = series.dropna()
+        if non_null.empty:
+            continue
+
+        # If the column is already "pure string", keep it.
+        sample_types = {type(v) for v in non_null.head(25).tolist()}
+        if sample_types.issubset({str}):
+            continue
+
+        def _coerce_value(v: Any) -> Any:
+            if v is None:
+                return None
+            if isinstance(v, str):
+                return v
+            # Keep primitives as-is to avoid unnecessary quoting in JSON (Arrow can store them).
+            if isinstance(v, (int, float, bool)):
+                return v
+            # Decimal is common in trading code; Arrow handles floats reliably.
+            if _is_decimal(v):
+                try:
+                    return float(v)
+                except Exception:
+                    return _json_default(v)
+            try:
+                return json.dumps(v, default=_json_default, separators=(",", ":"), sort_keys=True)
+            except Exception:
+                return _json_default(v)
+
+        out[col] = series.map(_coerce_value)
+        coerced.append(col)
+
+    return out, coerced
+
+
+def write_parquet_with_logging(
+    *,
+    df: pd.DataFrame,
+    path: str,
+    artifact: str,
+    logger: Any,
+    index: bool,
+    required: bool,
+    compression: str = "zstd",
+    engine: str = "pyarrow",
+    sanitizer: Optional[Callable[[pd.DataFrame], tuple[pd.DataFrame, list[str]]]] = None,
+) -> ParquetWriteStats:
+    """Write df to parquet with strong logging. Raises on failure when required=True."""
+
+    start = time.monotonic()
+    coerced_columns: list[str] = []
+
+    df_to_write = df
+    if sanitizer is not None:
+        try:
+            df_to_write, coerced_columns = sanitizer(df_to_write)
+        except Exception as exc:
+            # Sanitizer should never be the reason we fail silently; include context and re-raise in required mode.
+            msg = f"Parquet sanitizer failed for {artifact} ({path}): {exc}"
+            if required:
+                raise RuntimeError(msg) from exc
+            logger.warning(msg)
+            df_to_write = df
+            coerced_columns = []
+
+    def _do_write(*, compression_value: str | None) -> None:
+        df_to_write.to_parquet(
+            path,
+            index=index,
+            engine=engine,
+            compression=compression_value,
+        )
+
+    try:
+        try:
+            _do_write(compression_value=compression)
+        except Exception as exc:
+            # Fallback for environments where the preferred compression codec isn't available.
+            msg_text = str(exc).lower()
+            if compression and ("unsupported" in msg_text and "compression" in msg_text):
+                logger.warning(
+                    "PARQUET_COMPRESSION_FALLBACK: %s parquet write failed with compression=%s; retrying with compression=None | path=%s error=%s",
+                    artifact,
+                    compression,
+                    path,
+                    exc,
+                )
+                _do_write(compression_value=None)
+            else:
+                raise
+
+        duration_s = float(time.monotonic() - start)
+        bytes_written = int(os.path.getsize(path)) if os.path.exists(path) else 0
+
+        stats = ParquetWriteStats(
+            artifact=artifact,
+            path=path,
+            rows=int(len(df_to_write)),
+            cols=int(len(df_to_write.columns)),
+            bytes=bytes_written,
+            duration_s=duration_s,
+            coerced_columns=coerced_columns,
+        )
+        # Prefer structured log fields when available; fall back to normal logger formatting.
+        try:
+            logger.info(
+                "Wrote parquet artifact: %s",
+                artifact,
+                extra={
+                    "artifact": artifact,
+                    "path": path,
+                    "rows": stats.rows,
+                    "cols": stats.cols,
+                    "bytes": stats.bytes,
+                    "duration_s": stats.duration_s,
+                    "coerced_columns": stats.coerced_columns,
+                    "parquet_mode": "required" if required else "best_effort",
+                },
+            )
+        except Exception:
+            logger.info(
+                "Wrote parquet artifact %s path=%s rows=%s cols=%s bytes=%s duration_s=%.3f coerced_columns=%s mode=%s",
+                artifact,
+                path,
+                stats.rows,
+                stats.cols,
+                stats.bytes,
+                stats.duration_s,
+                ",".join(stats.coerced_columns),
+                "required" if required else "best_effort",
+            )
+        return stats
+    except Exception as exc:
+        # Provide extra context for debugging, especially in required mode.
+        object_cols = []
+        object_col_samples: dict[str, str] = {}
+        try:
+            object_cols = [c for c in df.columns if str(df[c].dtype) == "object"]
+            for c in object_cols[:25]:
+                series = df[c]
+                sample_val = None
+                try:
+                    non_null = series.dropna()
+                    if not non_null.empty:
+                        sample_val = non_null.iloc[0]
+                except Exception:
+                    sample_val = None
+                if sample_val is not None:
+                    object_col_samples[c] = f"type={type(sample_val).__name__} value={repr(sample_val)[:200]}"
+        except Exception:
+            object_cols = []
+
+        details = f"path={path} mode={'required' if required else 'best_effort'} object_columns={object_cols} samples={object_col_samples} error={exc}"
+        msg = f"PARQUET_EXPORT_FAILED: {artifact} parquet export failed | {details}"
+        try:
+            logger.error(
+                msg,
+                extra={
+                    "artifact": artifact,
+                    "path": path,
+                    "parquet_mode": "required" if required else "best_effort",
+                    "object_columns": object_cols,
+                    "object_column_samples": object_col_samples,
+                },
+            )
+        except Exception:
+            logger.error(
+                "PARQUET_EXPORT_FAILED: %s parquet export failed | path=%s mode=%s object_columns=%s samples=%s error=%s",
+                artifact,
+                path,
+                "required" if required else "best_effort",
+                ",".join(object_cols),
+                str(object_col_samples),
+                exc,
+            )
+
+        if required:
+            raise RuntimeError(msg) from exc
+
+        logger.warning("Parquet export is best-effort; continuing with CSV compatibility layer.")
+        # Return a zeroed stats object for best-effort mode.
+        return ParquetWriteStats(
+            artifact=artifact,
+            path=path,
+            rows=int(len(df)),
+            cols=int(len(df.columns)),
+            bytes=0,
+            duration_s=float(time.monotonic() - start),
+            coerced_columns=coerced_columns,
+        )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.48",
+    version="4.4.49",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/tests/test_indicators_detail_text_edge_cases.py
+++ b/tests/test_indicators_detail_text_edge_cases.py
@@ -108,6 +108,25 @@ def test_plot_indicators_handles_lines_missing_detail_text_column(tmp_path, monk
     mock_write.assert_called_once()
 
 
+def test_plot_indicators_emits_empty_csv_and_parquet_when_no_chart_data(tmp_path, monkeypatch) -> None:
+    """Regression: indicators artifacts should exist even when a strategy emits no data."""
+    mock_write = MagicMock()
+    monkeypatch.setattr("plotly.graph_objects.Figure.write_html", mock_write)
+
+    plot_indicators(
+        plot_file_html=str(tmp_path / "plot.html"),
+        chart_markers_df=None,
+        chart_lines_df=None,
+        chart_ohlc_df=None,
+        strategy_name="Test",
+        show_indicators=True,
+    )
+
+    mock_write.assert_called_once()
+    assert (tmp_path / "plot.csv").exists()
+    assert (tmp_path / "plot.parquet").exists()
+
+
 def test_plot_indicators_handles_markers_missing_detail_text_column(tmp_path, monkeypatch) -> None:
     mock_write = MagicMock()
     monkeypatch.setattr("plotly.graph_objects.Figure.write_html", mock_write)

--- a/tests/test_strategy_dump_stats_regression.py
+++ b/tests/test_strategy_dump_stats_regression.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 import pandas as pd
 
 from lumibot.backtesting import BacktestingBroker, PandasDataBacktesting
+from lumibot.entities import Asset
 from lumibot.strategies.strategy import Strategy
 
 
@@ -103,3 +104,40 @@ def test_dump_stats_emits_parquet_file_when_stats_file_is_set(tmp_path) -> None:
     parquet_df = pd.read_parquet(stats_parquet)
     assert not parquet_df.empty
     assert "portfolio_value" in parquet_df.columns
+
+
+def test_dump_stats_parquet_is_resilient_to_object_positions(tmp_path) -> None:
+    """Regression: stats.parquet export must not crash when positions contain objects.
+
+    Production failure was triggered by stats rows containing nested Python objects
+    (e.g., Asset instances). We now coerce object-ish columns to JSON strings before
+    parquet export so backtests fail loudly only in required/contract mode.
+    """
+    broker = PandasDataBacktesting(
+        datetime_start=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        datetime_end=datetime(2026, 1, 5, tzinfo=timezone.utc),
+    )
+    backtesting_broker = BacktestingBroker(data_source=broker)
+    strat = _StatsOnlyStrategy(broker=backtesting_broker)
+
+    strat._benchmark_asset = None
+    strat._stats_file = str(tmp_path / "stats.csv")
+
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    strat._append_row(
+        {
+            "datetime": start,
+            "portfolio_value": 100_000.0,
+            # Old behavior included raw Asset objects; keep a variant here to ensure
+            # sanitizer continues to protect parquet export.
+            "positions": [{"asset": Asset("SPY"), "quantity": 1}],
+        }
+    )
+
+    strat._dump_stats()
+
+    stats_parquet = tmp_path / "stats.parquet"
+    assert stats_parquet.exists()
+    parquet_df = pd.read_parquet(stats_parquet)
+    assert "positions" in parquet_df.columns
+    assert isinstance(parquet_df["positions"].iloc[0], str)

--- a/tests/test_strategy_executor_trace_stats_positions.py
+++ b/tests/test_strategy_executor_trace_stats_positions.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from lumibot.entities import Asset, Position
+from lumibot.strategies.strategy_executor import StrategyExecutor
+
+
+class _TraceStatsStubStrategy:
+    __test__ = False
+
+    def __init__(self):
+        self._rows: list[dict] = []
+        self.portfolio_value = 123.45
+        self.cash = 67.89
+
+    def trace_stats(self, context, snapshot_before):  # noqa: ANN001
+        return {}
+
+    def get_datetime(self):
+        return datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    def get_positions(self):
+        return [
+            Position(strategy="test", asset=Asset("SPY"), quantity=1),
+        ]
+
+    def _append_row(self, row: dict) -> None:
+        self._rows.append(row)
+
+
+def test_strategy_executor_trace_stats_does_not_embed_asset_objects() -> None:
+    """Regression: trace_stats must not embed raw Asset objects into stats rows.
+
+    These objects are not reliably serializable (parquet/pyarrow) and bloat logs.
+    """
+    strategy = _TraceStatsStubStrategy()
+    dummy_executor = type("_DummyExecutor", (), {"strategy": strategy})()
+
+    StrategyExecutor._trace_stats(dummy_executor, context=None, snapshot_before={})
+
+    assert strategy._rows
+    row = strategy._rows[-1]
+    assert "positions" in row
+    assert isinstance(row["positions"], list)
+    assert row["positions"], "expected at least one position"
+    assert isinstance(row["positions"][0]["asset"], (dict, str))


### PR DESCRIPTION
## What / Why\n\nAdd Parquet sidecar artifacts (indicators/trades/stats/trade_events) with strong success/failure logging + sanitizer so BotSpot can query backtests ~10x faster and stop failing silently on object-typed columns (notably stats.positions).\n\n## Risk\n- Changes backtest analysis artifact emission paths; any mismatch could impact BotManager uploader / BotSpot consumers.\n- Parquet required mode can fail backtests when enabled; default remains best-effort unless LUMIBOT_BACKTEST_PARQUET_MODE=required.\n\n## Tests\n- Local: targeted pytest additions for stats positions + empty indicators artifacts.\n- CI: please ensure full suite is green on this PR (sharded).\n\n## Docs\n- docs/investigations/2026-02-10_PARQUET_ARTIFACT_CONTRACT.md\n- docs/ENV_VARS.md + docsrc/environment_variables.rst\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LUMIBOT_BACKTEST_PARQUET_MODE to control Parquet export semantics (best_effort vs required) with fail-fast option.

* **Bug Fixes**
  * Sanitized stats/position serialization to avoid embedding raw objects; prevents Parquet type errors.
  * Always emit indicators and trade-events artifacts (CSV and Parquet), even when empty.

* **Documentation**
  * Added Parquet artifact contract and env var documentation.

* **Tests**
  * Added regression tests for empty-artifact emission and object serialization.

* **Chore**
  * Bumped package version to 4.4.49.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Deploy marker commit: `deploy 4.4.49`.
