### PR TITLE
v4.4.50 - Option lifecycle settlement + ThetaData MTM fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,23 @@
 
 ## 4.4.50 - Unreleased
 
+### Added
+- Option lifecycle event support in backtesting for option expiration outcomes: `assigned`, `exercised`, and `expired` (in addition to `cash_settled`).
+- Regression coverage for equity/ETF physical settlement and index cash settlement paths at expiration.
+
 ### Changed
 - Indicators HTML: improve subplot scaling so indicator panels render with sane proportions across mixed plots.
 - Indicators export: make HTML export non-fatal so backtests still complete if HTML rendering fails.
+- Options expiration behavior now follows broker-style settlement defaults:
+  - Equity/ETF options settle physically at expiration (short ITM -> assignment, long ITM -> exercise when account constraints allow).
+  - Index options settle to cash at intrinsic value.
+- Trade artifacts now preserve option-expiration lifecycle statuses in `trades.csv` / `trades.parquet` and `trade_events` exports so downstream consumers can render assignment/exercise/cash-settlement explicitly.
 
 ### Fixed
 - ThetaData backtesting: keep intraday index minute/hour fetch bounds aligned to the simulation timestamp instead of forcing full-window end coverage.
 - Acceptance baselines: refresh 0DTE backdoor baseline metrics and timing metadata to match current provider data revisions.
 - Acceptance CI: allow a bounded queue-fill threshold for `spx_short_straddle_repro` while keeping strict queue-free checks for other ThetaData acceptance cases.
+- Long ITM equity option expirations now avoid unrealistic forced delivery when account constraints are not met; these contracts expire unexercised in backtests.
 
 ## 4.4.49 - 2026-02-10
 ### Added

--- a/docs/OPTIONS_EXPIRATION_ASSIGNMENT_POLICY.md
+++ b/docs/OPTIONS_EXPIRATION_ASSIGNMENT_POLICY.md
@@ -1,0 +1,110 @@
+# Options Expiration, Exercise, Assignment, and Settlement Policy
+
+**Last Updated:** 2026-02-25
+**Status:** Active policy (Phase 1 implemented on 2026-02-25; early-assignment model still optional/future)
+**Audience:** LumiBot maintainers, strategy authors, BotSpot consumers
+
+---
+
+## Purpose
+
+Define the default broker-like behavior LumiBot should use for option expiration outcomes, including:
+
+- Physical settlement (shares delivered) vs cash settlement
+- Long auto-exercise and short assignment outcomes at expiration
+- Handling of unsupported exercise/assignment due to buying power or share constraints
+- Optional early assignment simulation model
+- Artifact/event semantics that downstream systems can rely on
+
+This policy follows LumiBot's core principle of broker realism (`docs/BACKTESTING_ARCHITECTURE.md`).
+
+---
+
+## Default Settlement Rules
+
+### 1) Product-based settlement type (not long-vs-short based)
+
+- **Equity/ETF options:** default to **physical settlement** (deliver/receive shares)
+- **Index options:** default to **cash settlement**
+
+### 2) Expiration outcome matrix (default)
+
+- **Long ITM equity/ETF option:** auto-exercise unless a risk control blocks exercise (see below)
+- **Short ITM equity/ETF option:** assigned (shares delivered/received)
+- **OTM option (all products):** expires worthless
+- **ITM index option (long or short):** cash-settled intrinsic value
+
+### 3) Risk controls for unsupported delivery
+
+When account constraints would make exercise/assignment unsupported:
+
+- Prefer broker-like protective actions:
+  - attempt to close/auto-liquidate before cutoff,
+  - then apply contrary exercise instruction (DNE) behavior for longs if still unsupported,
+  - avoid silently forcing unrealistic unlimited negative cash/short stock by default.
+- Allow explicit opt-in config for permissive behavior (force exercise/assignment with negative balances) for research users.
+
+---
+
+## Event and Artifact Semantics
+
+Expiration outcomes should be explicit in the event stream and artifacts.
+
+### Required trade event statuses/types
+
+- `exercised` for long option exercise
+- `assigned` for short option assignment
+- `expired` for OTM expiration
+- `cash_settled` for index options and any explicit cash-settlement paths
+
+### Underlying delivery logging
+
+For physically-settled outcomes, emit both:
+
+1. Option lifecycle event row (`exercised` or `assigned`)
+2. Underlying stock trade row that reflects delivered shares
+
+This keeps accounting correct and preserves auditability in:
+
+- `*_trade_events.csv/.parquet`
+- `*_trades.csv/.parquet`
+- `*_trades.html`
+
+---
+
+## Early Assignment Policy
+
+Early assignment should be supported as an **optional model**.
+
+- Default mode should prioritize deterministic expiration handling.
+- Optional early assignment mode can apply deterministic heuristics for short American-style equity/ETF options.
+- Do not apply early assignment logic to cash-settled index options.
+
+---
+
+## Why This Policy
+
+Public exchange, FINRA, and broker documentation consistently show:
+
+- Settlement is primarily **product-defined** (equity/ETF physical, many index options cash), not “short assigned / long cash-settled.”
+- ITM options are generally auto-exercised by exception unless contrary instructions are submitted.
+- Brokers may liquidate or block unsupported exercise/assignment near expiration for risk.
+
+---
+
+## References
+
+- Cboe: Why Option Settlement Style Matters
+  - https://www.cboe.com/insights/posts/why-option-settlement-style-matters/
+- Cboe XSP cash settlement explainer
+  - https://www.cboe.com/tradable_products/sp_500/mini_spx_options/cash_settlement/
+- FINRA Information Notice (exercise cut-off + contrary exercise advice)
+  - https://www.finra.org/rules-guidance/notices/information-notice-020321
+- FINRA Rule 2360 exercise assignment allocation methods
+  - https://www.finra.org/filing-reporting/regulatory-filing-systems/options-allocation-exercise-assignment-notices
+- Schwab: Options exercise/assignment and expiration guide
+  - https://www.schwab.com/learn/story/options-exercise-assignment-and-more-beginners-guide
+- Fidelity: Option auto-exercise rules
+  - https://www.fidelity.com/options-trading/options-auto-exercise-rules
+- IBKR: Expiration and corporate-action related liquidations
+  - https://www.ibkrguides.com/kb/en-us/article-1767.htm

--- a/docs/investigations/2026-02-25_OPTIONS_ASSIGNMENT_EXERCISE_INVESTIGATION.md
+++ b/docs/investigations/2026-02-25_OPTIONS_ASSIGNMENT_EXERCISE_INVESTIGATION.md
@@ -1,0 +1,291 @@
+# Options Assignment/Exercise Investigation (LumiBot + BotSpot)
+
+**Date:** 2026-02-25
+**Status:** Research complete + Phase 1 implementation integrated (2026-02-25)
+**Scope:** LumiBot backtesting engine + generated artifacts + BotSpot consumers
+
+---
+
+## Executive Summary
+
+Current LumiBot backtesting behavior cash-settles option expirations through a single `cash_settled` path. It does not currently model physical exercise/assignment outcomes for equity/ETF options.
+
+Broker/exchange behavior indicates default realism should be:
+
+- equity/ETF options: physical settlement (long exercise, short assignment),
+- index options: cash settlement.
+
+To align with broker realism, LumiBot should move from a one-size-fits-all cash settlement model to a product-aware expiration engine with explicit `exercised` / `assigned` / `expired` / `cash_settled` event semantics, plus underlying stock delivery rows.
+
+As of 2026-02-25, this Phase 1 behavior has been implemented in LumiBot and propagated to BotSpot consumers where fill-only assumptions existed.
+
+---
+
+## Implementation Snapshot (2026-02-25)
+
+### LumiBot core
+
+- Added broker lifecycle event support for `assigned`, `exercised`, and `expired` alongside `cash_settled`.
+- Added product-aware expiration routing:
+  - equity/ETF-like options -> physical settlement (exercise/assignment + underlying delivery),
+  - index-like options -> cash settlement.
+- Added DNE-like guard for unsupported long exercise (insufficient account support) with `expired` lifecycle event.
+- Added/updated tests for:
+  - short put assignment share delivery,
+  - long call exercise share delivery,
+  - unsupported long ITM expiration handling,
+  - index-option ITM cash settlement,
+  - status propagation in trades CSV/parquet outputs.
+
+### BotSpot propagation
+
+- `botspot_react`
+  - chart parsers now accept lifecycle statuses (`cash_settled`, `assigned`, `exercised`, `expired`) in addition to fills.
+  - centralized and unit-tested lifecycle status utility.
+- `botspot_node`
+  - trade status normalization updated to canonicalize assignment/exercise/cash-settle/expiry variants.
+  - artifact description updated from "every fill" to lifecycle-event semantics.
+- `botspot_agent`
+  - trades artifact summary updated from fill-only counting to terminal lifecycle-event counting.
+  - prompt enum/docs updated to include `ASSIGNED` and `EXERCISED`.
+  - added tests covering lifecycle summary behavior.
+
+---
+
+## External Behavior Findings (What Brokers/Rules Actually Do)
+
+## 1) Settlement style is product-defined
+
+- Cboe states that equity and ETF options physically deliver shares when exercised/assigned, while index options (e.g., SPX/XSP) are cash settled.
+- This means default behavior should not be “shorts assigned, longs cash-settled.”
+
+## 2) ITM auto-exercise baseline and contrary instructions
+
+- FINRA notices describe exercise-by-exception flows for expiring standardized equity options and the use of Contrary Exercise Advice (DNE/override mechanics).
+- Fidelity documents a common auto-exercise threshold of $0.01 ITM.
+
+## 3) Assignment distribution mechanics
+
+- FINRA requires member firms to use approved allocation methods (FIFO/random/random-equivalent) when assigning exercise notices to short positions.
+- Simulators cannot reproduce exact market-wide assignment randomness ex ante, but can model deterministic broker-like outcomes at account level.
+
+## 4) Unsupported exercise/assignment risk controls
+
+- Broker guidance (Schwab, IBKR) shows firms may liquidate/close positions or block exercise/assignment outcomes when accounts cannot support resulting delivery or margin requirements.
+- IBKR explicitly reserves the right to prohibit exercise and/or close short options when assignment/exercise would create margin deficit.
+
+## 5) Early assignment is possible but path-dependent
+
+- Short American options can be assigned early.
+- QuantConnect's documented default assignment model is heuristic for early assignment and deterministic for ITM assignment at expiration.
+
+---
+
+## LumiBot Current-State Findings
+
+## A) Expiration handling is currently cash-settlement-centric
+
+- `lumibot/backtesting/backtesting_broker.py:1131` defines `cash_settle_options_contract(...)`.
+- `lumibot/backtesting/backtesting_broker.py:1315` `process_expired_option_contracts(...)` calls cash settlement on expiration.
+- No physical delivery branch (exercise/assignment) exists in this expiration workflow.
+
+## B) Broker event model has no assignment/exercise constants
+
+- `lumibot/brokers/broker.py:99-106` defines event constants including `CASH_SETTLED`, but no `ASSIGNED` / `EXERCISED` event constants.
+- `lumibot/brokers/broker.py:2153-2187` and `2189-2225` handle known event types; no dedicated assignment/exercise branches.
+
+## C) Order status enum and helper logic are fill/cash-settle focused
+
+- `lumibot/entities/order.py:102` `VALID_STATUS` lacks assignment/exercise statuses.
+- `lumibot/entities/order.py:163-174` `OrderStatus` enum lacks assignment/exercise statuses.
+- `lumibot/entities/order.py:1229-1232` `is_filled()` currently treats only `filled/fill/cash_settled` as terminal filled states.
+
+## D) Indicators already partially anticipate new statuses
+
+- `lumibot/tools/indicators.py:32-43` marker status allowlist already includes `assigned`, `assignment`, `exercise`, `exercised`, and `expired`.
+
+This is useful: plotting code is partly prepared even if broker/status plumbing is not.
+
+## E) Existing tests encode cash-settlement assumptions
+
+- `tests/backtest/test_example_strategies.py:322-333` asserts `cash_settled` behavior for options hold-to-expiry.
+- `tests/test_indicator_subplots.py:204-285` validates `cash_settled` status retention in CSV/parquet and tooltips.
+
+## F) Asset typing relevant to settlement routing
+
+- `lumibot/entities/asset.py:159-168` includes `stock` and `index` types (ETF treated as stock-type in this model).
+
+---
+
+## Artifact Propagation Findings (LumiBot)
+
+- Trade events are exported via `Broker.export_trade_events_to_csv(...)` (`lumibot/brokers/broker.py:2370+`) to CSV and parquet.
+- Backtest analysis writes:
+  - `*_trade_events.csv/.parquet` from broker export,
+  - `*_trades.csv/.parquet` through plot path (`plot_returns`) when plotting enabled,
+  - plus trades HTML/indicator artifacts.
+
+Implication: new statuses must be consistently carried through both full trade-events export and simplified trades export.
+
+---
+
+## Downstream Consumer Findings (BotSpot)
+
+## 1) botspot_react
+
+### Hard fill-only chart assumptions
+
+- `src/pages/BacktestChartPage.js:47-73`
+  - Parser comments and filters only keep rows with `status === 'fill'`.
+- `src/components/BacktestIndicatorChart/BacktestIndicatorChart.js:188-192`
+  - Trade markers shown only for fill-like statuses (`fill`/`filled`/contains `fill`).
+
+### Generic status table ingestion is mostly fine
+
+- `src/hooks/useTradesData.js:92-112` passes through `status` and asset fields without strict fill filtering.
+
+Net: chart overlays will drop assignment/exercise/cash-settled lifecycle rows unless updated.
+
+## 2) botspot_node
+
+- `src/services/dataEnvelope.service.ts:460-480`
+  - only normalizes `fill/filled`, does not map or describe new terminal statuses.
+- `src/Backtest/backtest.service.ts:61`
+  - artifact description says trades.csv is "every fill," which becomes semantically outdated once lifecycle events broaden.
+
+## 3) botspot_agent
+
+- `src/botspot_agent/artifacts.py:45-83`
+  - summary logic counts only `status == "fill"`; can incorrectly report "0 fills" for assignment/exercise-heavy runs.
+- `src/botspot_agent/runtime.py:614`
+  - guidance text frames trades artifacts as fill counts first.
+- `src/botspot_agent/strategy/prompts/shared/shared_entities.py:102+`
+  - prompt-side enum includes `cash_settled`/`expired` but no assignment/exercise statuses.
+
+---
+
+## Recommended LumiBot Behavior (Default)
+
+1. **Physical settlement for equity/ETF options (stock-type underlyings).**
+2. **Cash settlement for index options (index-type underlyings).**
+3. **Expiration defaults:**
+   - long ITM equity/ETF -> exercise,
+   - short ITM equity/ETF -> assignment,
+   - OTM -> expire worthless,
+   - index ITM -> cash settled.
+4. **Unsupported account outcomes:**
+   - attempt protective close/liquidation pre-expiration cutoff,
+   - if still unsupported, apply broker-like DNE/abandon behavior for longs,
+   - avoid force-opening unbounded negative balances by default.
+5. **Early assignment:** optional heuristic model (not hard default), deterministic and explainable.
+
+---
+
+## Proposed Implementation Plan (Phased)
+
+## Phase 1: Expiration-day physical settlement + explicit events
+
+- Add broker constants and status support for:
+  - `ASSIGNED`, `EXERCISED`, `EXPIRED` lifecycle events.
+- Extend order status model and helper predicates to recognize these as terminal lifecycle outcomes where appropriate.
+- Replace single cash-settlement expiration branch with settlement router:
+  - route by underlying product type (`index` vs non-index).
+- For physical settlement:
+  - emit option lifecycle event row (`assigned` or `exercised`),
+  - generate underlying stock delivery row with correct side/quantity at strike.
+- Preserve existing cash settlement for index options.
+
+## Phase 2: Risk controls and DNE-like behavior
+
+- Add account-support checks before forced exercise/assignment at expiration.
+- Add broker-like fallback policy:
+  - pre-close liquidation attempt,
+  - DNE-like suppression for unsupported long exercise.
+- Add explicit strategy/broker config knobs for strictness.
+
+## Phase 3: Optional early assignment model
+
+- Add opt-in early assignment model for short American-style equity/ETF options.
+- Deterministic heuristic baseline (e.g., deep ITM + low extrinsic near expiry; ex-dividend bias for calls).
+- Keep index options excluded from early physical assignment.
+
+---
+
+## Test Plan
+
+## A) LumiBot unit tests
+
+- Settlement routing unit tests:
+  - stock/ETF underlying -> physical,
+  - index underlying -> cash.
+- Event/status tests:
+  - `assigned`, `exercised`, `expired` flow through `_process_trade_event` and order lifecycle.
+- Position accounting tests:
+  - underlying shares and option positions adjust correctly for each scenario.
+
+## B) LumiBot integration/backtest tests
+
+Add deterministic scenario strategies and assertions for:
+
+1. short put ITM expiry -> assigned (long shares appear)
+2. short covered call ITM expiry -> shares called away
+3. long call ITM expiry with sufficient cash -> exercised (shares acquired)
+4. long put ITM expiry with sufficient shares -> exercised (shares delivered)
+5. long ITM but unsupported account -> protective close or DNE path
+6. index option ITM expiry -> cash-settled (no shares delivered)
+7. OTM expiries -> `expired` lifecycle event
+
+## C) Artifact contract tests
+
+Validate propagation in:
+
+- `*_trade_events.csv/.parquet`
+- `*_trades.csv/.parquet`
+- trades tooltip and marker generation
+- `*_trades.html`
+- `*_indicators.csv/.parquet` and indicators HTML (where statuses appear in tooltips)
+
+Also expand existing tests that currently lock only `cash_settled` assumptions.
+
+## D) Acceptance backtests
+
+- Add at least one acceptance case with physical assignment/exercise outcomes and fixed expected status mix.
+- Extend acceptance assertions to include status histogram checks (not just return metrics), and verify artifact presence/content for new statuses.
+
+## E) Downstream BotSpot tests
+
+- botspot_react: chart parsers/renderers should include new lifecycle statuses when plotting trade markers.
+- botspot_node: envelope normalization and artifact descriptions should treat trades as lifecycle events, not fills-only.
+- botspot_agent: artifact summarizer should count terminal execution/lifecycle events instead of `fill` only.
+
+---
+
+## Key Risks
+
+1. Status proliferation can break legacy fill-only consumers.
+2. `is_filled()` and equivalent-status assumptions may silently misclassify new lifecycle outcomes if not updated holistically.
+3. Realistic risk handling (unsupported exercise/assignment) is broker-specific and needs explicit documented defaults.
+4. Early assignment simulation can become non-deterministic/noisy unless heuristic and seed behavior are controlled.
+
+---
+
+## Sources
+
+- Cboe settlement style explainer (equity/ETF physical; index cash)
+  - https://www.cboe.com/insights/posts/why-option-settlement-style-matters/
+- Cboe XSP cash-settlement page
+  - https://www.cboe.com/tradable_products/sp_500/mini_spx_options/cash_settlement/
+- FINRA exercise cut-off and contrary advice notice
+  - https://www.finra.org/rules-guidance/notices/information-notice-020321
+- FINRA options assignment allocation rules page
+  - https://www.finra.org/filing-reporting/regulatory-filing-systems/options-allocation-exercise-assignment-notices
+- Fidelity option auto-exercise rules
+  - https://www.fidelity.com/options-trading/options-auto-exercise-rules
+- Schwab exercise/assignment basics and expiration handling
+  - https://www.schwab.com/learn/story/options-exercise-assignment-and-more-beginners-guide
+- IBKR expiration/corporate action related liquidations
+  - https://www.ibkrguides.com/kb/en-us/article-1767.htm
+- QuantConnect option assignment model docs
+  - https://www.quantconnect.com/docs/v2/writing-algorithms/reality-modeling/options-models/assignment
+- QuantConnect option exercise orders docs
+  - https://www.quantconnect.com/docs/v2/writing-algorithms/trading-and-orders/order-types/option-exercise-orders

--- a/docsrc/backtesting.pandas.rst
+++ b/docsrc/backtesting.pandas.rst
@@ -189,6 +189,20 @@ Then, the strategy and backtesting code might look like this:
         pandas_data=pandas_data,
     )
 
+Options Expiration Settlement Policy
+------------------------------------
+
+Pandas backtesting follows broker-style defaults for options expiration:
+
+- Equity/ETF options are physically settled at expiration.
+  - Short in-the-money contracts are modeled as ``assigned``.
+  - Long in-the-money contracts are modeled as ``exercised`` when account constraints allow delivery.
+- Index options are cash settled at intrinsic value and exported as ``cash_settled``.
+- Out-of-the-money contracts expire as ``expired``.
+
+These statuses are written to the trade artifacts so downstream systems can distinguish
+normal fills from expiration lifecycle events.
+
 Optional: Environment Variables
 -------------------------------
 If you prefer not to specify `backtesting_start` and `backtesting_end` in code, you can set the following environment variables, and LumiBot will automatically detect them:

--- a/docsrc/backtesting.trades_files.rst
+++ b/docsrc/backtesting.trades_files.rst
@@ -9,6 +9,21 @@ The **Trades HTML** and **Trades CSV** files provide detailed information about 
 - **Portfolio Value:** The value of the portfolio at each time point.
 - **Cash:** The amount of cash available at each time point.
 
+Option Lifecycle Statuses
+-------------------------
+
+For options backtests, expiration outcomes are exported as explicit lifecycle events in the trade artifacts.
+
+- ``cash_settled``: cash settlement at intrinsic value (used for cash-settled products, such as index options).
+- ``assigned``: short in-the-money physically-settled option assignment at expiration.
+- ``exercised``: long in-the-money physically-settled option exercise at expiration.
+- ``expired``: out-of-the-money expiration (or long ITM contracts that cannot be exercised due to account constraints in simulation).
+
+When physical settlement occurs, LumiBot also writes the underlying delivery row as a separate trade event
+(``status=fill``) with ``type`` set to the originating lifecycle event (for example, ``type=assigned`` or
+``type=exercised``). This allows downstream charting/reporting systems to distinguish ordinary trades from
+assignment/exercise delivery.
+
 .. figure:: _html/images/trades_example.png
    :alt: Trades example
    :width: 600px

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -75,6 +75,21 @@ TYPICAL_FUTURES_MARGINS = {
     "DEFAULT": 5000,  # Conservative default
 }
 
+INDEX_ROOT_ALIASES = {
+    "SPXW": "SPX",
+    "RUTW": "RUT",
+    "VIXW": "VIX",
+    "NDXP": "NDX",
+}
+
+INDEX_LIKE_SYMBOLS = {
+    "SPX", "SPXW",
+    "NDX", "NDXP",
+    "VIX", "VIXW",
+    "RUT", "RUTW",
+    "XSP", "DJX", "OEX", "XEO",
+}
+
 
 def get_futures_margin_requirement(asset: Asset) -> float:
     """
@@ -904,16 +919,9 @@ class BacktestingBroker(Broker):
 
     def _process_cash_settlement(self, order, price, quantity):
         """
-        BackTesting needs to create/update positions when orders are filled becuase there is no broker to do it
+        Delegate to Broker-level lifecycle handling.
         """
-        existing_position = self.get_tracked_position(order.strategy, order.asset)
         super()._process_cash_settlement(order, price, quantity)
-        if existing_position:
-            existing_position.add_order(order, quantity)  # Add will update quantity, but not double count the order
-            if existing_position.quantity == 0:
-                logger.info("Position %r liquidated" % existing_position)
-                self._filled_positions.remove(existing_position)
-                self._cancel_open_orders_for_asset(order.strategy, order.asset, {order.identifier})
 
     def _update_parent_order_status(self, order: Order):
         """Update the status of a parent order based on the status of its child orders."""
@@ -1128,90 +1136,70 @@ class BacktestingBroker(Broker):
             wait_until_complete=True,
         )
 
-    def cash_settle_options_contract(self, position, strategy):
-        """Cash settle an options contract position. This method will calculate the
-        profit/loss of the position and add it to the cash position of the strategy. This
-        method will not actually sell the contract, it will just add the profit/loss to the
-        cash position and set the position to 0. Note: only for backtesting"""
+    def _infer_underlying_asset_from_strategy(self, strategy, symbol: str) -> Asset | None:
+        """Best-effort: reuse the strategy's explicit non-option underlying asset when available."""
+        try:
+            symbol_norm = (symbol or "").upper()
+        except Exception:
+            symbol_norm = symbol
 
-        # Check to make sure we are in backtesting mode
-        if not self.IS_BACKTESTING_BROKER:
-            logger.error("Cannot cash settle options contract in live trading")
-            return
+        vars_obj = getattr(strategy, "vars", None)
+        if vars_obj is None:
+            return None
 
-        # Check that the position is an options contract
-        if position.asset.asset_type != "option":
-            logger.error(f"Cannot cash settle non-option contract {position.asset}")
-            return
+        candidates: list[Asset] = []
+        try:
+            if hasattr(vars_obj, "all"):
+                values = list(vars_obj.all().values())
+            else:
+                values = list(getattr(vars_obj, "_vars_dict", {}).values())
+        except Exception:
+            values = []
 
-        def _infer_underlying_asset_from_strategy(symbol: str) -> Asset | None:
-            """Best-effort: reuse the strategy's own underlying Asset object when available.
+        def _maybe_add(value: object) -> None:
+            if not isinstance(value, Asset):
+                return
+            if getattr(value, "symbol", None) != symbol_norm:
+                return
+            if getattr(value, "asset_type", None) == Asset.AssetType.OPTION:
+                return
+            candidates.append(value)
 
-            Some Strategy Library demos construct option Assets without `underlying_asset=...`.
-            In that case we should NOT guess based on symbol strings; instead, look for an
-            explicit non-option Asset already attached to the strategy (e.g. `self.vars.underlying_asset`).
-            """
-            try:
-                symbol_norm = (symbol or "").upper()
-            except Exception:
-                symbol_norm = symbol
+        for value in values:
+            if isinstance(value, (list, tuple, set)):
+                for item in value:
+                    _maybe_add(item)
+            else:
+                _maybe_add(value)
 
-            vars_obj = getattr(strategy, "vars", None)
-            if vars_obj is None:
-                return None
-
-            candidates: list[Asset] = []
-            try:
-                if hasattr(vars_obj, "all"):
-                    values = list(vars_obj.all().values())
-                else:
-                    values = list(getattr(vars_obj, "_vars_dict", {}).values())
-            except Exception:
-                values = []
-
-            def _maybe_add(value: object) -> None:
-                if not isinstance(value, Asset):
-                    return
-                if getattr(value, "symbol", None) != symbol_norm:
-                    return
-                if getattr(value, "asset_type", None) == Asset.AssetType.OPTION:
-                    return
-                candidates.append(value)
-
-            for value in values:
-                if isinstance(value, (list, tuple, set)):
-                    for item in value:
-                        _maybe_add(item)
-                else:
-                    _maybe_add(value)
-
-            if not candidates:
-                return None
-            if len(candidates) == 1:
-                return candidates[0]
-
-            for candidate in candidates:
-                if getattr(candidate, "asset_type", None) == Asset.AssetType.INDEX:
-                    return candidate
+        if not candidates:
+            return None
+        if len(candidates) == 1:
             return candidates[0]
 
-        # First check if the option asset has an underlying asset, otherwise try to reuse the
-        # strategy's explicit underlying Asset (keeps asset_type deterministic for indices).
-        underlying_asset = position.asset.underlying_asset
-        if underlying_asset is None:
-            underlying_asset = _infer_underlying_asset_from_strategy(getattr(position.asset, "symbol", None))
-        if underlying_asset is None:
-            underlying_asset = Asset(symbol=position.asset.symbol, asset_type="stock")
+        for candidate in candidates:
+            if getattr(candidate, "asset_type", None) == Asset.AssetType.INDEX:
+                return candidate
+        return candidates[0]
 
-        # Get the price of the underlying asset.
+    def _resolve_underlying_asset_for_option(self, option_asset: Asset, strategy) -> Asset:
+        underlying_asset = option_asset.underlying_asset
+        if underlying_asset is None:
+            underlying_asset = self._infer_underlying_asset_from_strategy(strategy, getattr(option_asset, "symbol", None))
+        if underlying_asset is None:
+            underlying_asset = Asset(symbol=option_asset.symbol, asset_type="stock")
+        return underlying_asset
+
+    def _get_underlying_price_for_settlement(self, underlying_asset: Asset, strategy) -> tuple[float, Asset]:
         underlying_price = None
         last_price_error = None
+        resolved_asset = underlying_asset
 
         def _try_last_price(asset: Asset) -> None:
-            nonlocal underlying_price, last_price_error, underlying_asset
+            nonlocal underlying_price, last_price_error, resolved_asset
             try:
                 underlying_price = self.get_last_price(asset)
-                underlying_asset = asset
+                resolved_asset = asset
                 last_price_error = None
             except Exception as exc:
                 underlying_price = None
@@ -1219,42 +1207,23 @@ class BacktestingBroker(Broker):
 
         _try_last_price(underlying_asset)
 
-        # Index options can arrive without an explicit underlying_asset. In that case we initially
-        # try the underlying as a stock (historical behavior), but SPX/NDX/VIX-style index symbols
-        # are not valid stocks in ThetaData and can produce placeholder-only minute series. When that
-        # happens (or when the price is None), retry as an index before failing.
-        if underlying_price is None and getattr(underlying_asset, "asset_type", None) == Asset.AssetType.STOCK:
-            symbol_upper = str(getattr(underlying_asset, "symbol", "") or "").upper()
-            index_root_aliases = {
-                "SPXW": "SPX",
-                "RUTW": "RUT",
-                "VIXW": "VIX",
-                "NDXP": "NDX",
-            }
-            index_root = index_root_aliases.get(symbol_upper, symbol_upper)
-            index_like_symbols = {
-                "SPX", "SPXW",
-                "NDX", "NDXP",
-                "VIX", "VIXW",
-                "RUT", "RUTW",
-                "XSP", "DJX", "OEX", "XEO",
-            }
-            if symbol_upper in index_like_symbols:
+        if underlying_price is None and getattr(resolved_asset, "asset_type", None) == Asset.AssetType.STOCK:
+            symbol_upper = str(getattr(resolved_asset, "symbol", "") or "").upper()
+            index_root = INDEX_ROOT_ALIASES.get(symbol_upper, symbol_upper)
+            if symbol_upper in INDEX_LIKE_SYMBOLS:
                 _try_last_price(Asset(symbol=index_root, asset_type="index"))
 
         if underlying_price is None and last_price_error is not None:
-            # Common production failure mode: ThetaData returns placeholder-only minute bars for an
-            # index while daily close remains available. Use day-close as the settlement proxy.
             message = str(last_price_error)
             if "[THETA][COVERAGE]" in message:
                 try:
-                    bars = strategy.get_historical_prices(underlying_asset, length=1, timestep="day")
+                    bars = strategy.get_historical_prices(resolved_asset, length=1, timestep="day")
                     df = getattr(bars, "df", None)
                     if df is not None and not df.empty and "close" in df.columns:
                         underlying_price = float(df["close"].iloc[-1])
                         logger.warning(
-                            "[CASH_SETTLE][FALLBACK] get_last_price(%s) failed (%s); settling using daily close=%s",
-                            underlying_asset,
+                            "[OPTION_SETTLEMENT][FALLBACK] get_last_price(%s) failed (%s); settling using daily close=%s",
+                            resolved_asset,
                             message.splitlines()[0],
                             underlying_price,
                         )
@@ -1264,57 +1233,159 @@ class BacktestingBroker(Broker):
         if underlying_price is None:
             if last_price_error is not None:
                 raise last_price_error
-            raise ValueError(f"Unable to price underlying {underlying_asset} for cash settlement of {position.asset}")
+            raise ValueError(f"Unable to price underlying {resolved_asset} for settlement")
 
-        # Calculate profit/loss per contract
-        if position.asset.right == "CALL":
-            profit_loss_per_contract = underlying_price - position.asset.strike
+        return float(underlying_price), resolved_asset
+
+    def _intrinsic_value_per_contract(self, option_asset: Asset, underlying_price: float) -> float:
+        if option_asset.right == Asset.OptionRight.CALL:
+            return max(0.0, float(underlying_price) - float(option_asset.strike))
+        return max(0.0, float(option_asset.strike) - float(underlying_price))
+
+    def _is_cash_settled_index_option(self, option_asset: Asset, underlying_asset: Asset) -> bool:
+        if getattr(underlying_asset, "asset_type", None) == Asset.AssetType.INDEX:
+            return True
+        symbol_upper = str(getattr(option_asset, "symbol", "") or "").upper()
+        return symbol_upper in INDEX_LIKE_SYMBOLS
+
+    def _dispatch_option_expiration_event(self, position, strategy, event_type: str, price: float) -> None:
+        side = Order.OrderSide.SELL if position.quantity > 0 else Order.OrderSide.BUY
+        order = strategy.create_order(position.asset, abs(position.quantity), side)
+        self.stream.dispatch(
+            event_type,
+            wait_until_complete=True,
+            order=order,
+            price=float(price),
+            filled_quantity=abs(float(position.quantity)),
+        )
+
+    def _dispatch_underlying_delivery_fill(
+        self,
+        strategy,
+        underlying_asset: Asset,
+        side: str,
+        quantity: float,
+        strike_price: float,
+        settlement_kind: str,
+    ) -> None:
+        if quantity <= 0:
+            return
+
+        order = strategy.create_order(underlying_asset, quantity, side)
+        # Tag delivery rows so downstream tooling can distinguish assignment/exercise fills.
+        order.order_type = settlement_kind
+        self._execute_filled_order(
+            order=order,
+            price=float(strike_price),
+            filled_quantity=Decimal(str(quantity)),
+            strategy=strategy,
+        )
+
+    def _can_support_long_exercise(self, strategy, underlying_asset: Asset, option_asset: Asset, contracts: float) -> bool:
+        shares = float(contracts) * float(option_asset.multiplier)
+        if option_asset.right == Asset.OptionRight.CALL:
+            required_cash = Decimal(str(option_asset.strike)) * Decimal(str(shares))
+            current_cash = strategy.get_cash()
+            if current_cash is None:
+                return False
+            return Decimal(str(current_cash)) >= required_cash
+
+        if option_asset.right == Asset.OptionRight.PUT:
+            underlying_position = self.get_tracked_position(strategy.name, underlying_asset)
+            if underlying_position is None:
+                return False
+            return float(underlying_position.quantity) >= shares
+
+        return False
+
+    def settle_expired_option_contract(self, position, strategy):
+        if position.asset.asset_type != Asset.AssetType.OPTION:
+            logger.error(f"Cannot settle non-option contract {position.asset}")
+            return
+
+        contracts = abs(float(position.quantity))
+        if contracts <= 0:
+            return
+
+        underlying_asset = self._resolve_underlying_asset_for_option(position.asset, strategy)
+        underlying_price, underlying_asset = self._get_underlying_price_for_settlement(underlying_asset, strategy)
+        intrinsic_per_contract = self._intrinsic_value_per_contract(position.asset, underlying_price)
+
+        if intrinsic_per_contract <= 0:
+            self._dispatch_option_expiration_event(position, strategy, self.EXPIRED_OPTION, price=0.0)
+            return
+
+        if self._is_cash_settled_index_option(position.asset, underlying_asset):
+            self.cash_settle_options_contract(position, strategy)
+            return
+
+        if position.quantity > 0:
+            if not self._can_support_long_exercise(strategy, underlying_asset, position.asset, contracts):
+                logger.warning(
+                    "[OPTION_EXPIRY][DNE] Long ITM option %s could not be exercised due to account constraints; expiring without exercise.",
+                    position.asset,
+                )
+                self._dispatch_option_expiration_event(position, strategy, self.EXPIRED_OPTION, price=0.0)
+                return
+            option_event_type = self.EXERCISED
         else:
-            profit_loss_per_contract = position.asset.strike - underlying_price
+            option_event_type = self.ASSIGNED
 
-        # Calculate profit/loss for the position
-        profit_loss = profit_loss_per_contract * position.quantity * position.asset.multiplier
+        if position.asset.right == Asset.OptionRight.CALL:
+            underlying_side = Order.OrderSide.BUY if position.quantity > 0 else Order.OrderSide.SELL
+        else:
+            underlying_side = Order.OrderSide.SELL if position.quantity > 0 else Order.OrderSide.BUY
 
-        # Adjust profit/loss based on the option type and position
-        if position.quantity > 0 and profit_loss < 0:
-            profit_loss = 0  # Long position can't lose more than the premium paid
-        elif position.quantity < 0 and profit_loss > 0:
-            profit_loss = 0  # Short position can't gain more than the cash collected
+        self._dispatch_option_expiration_event(
+            position,
+            strategy,
+            option_event_type,
+            price=intrinsic_per_contract,
+        )
 
-        # Add the profit/loss to the cash position
+        self._dispatch_underlying_delivery_fill(
+            strategy=strategy,
+            underlying_asset=underlying_asset,
+            side=underlying_side,
+            quantity=contracts * float(position.asset.multiplier),
+            strike_price=float(position.asset.strike),
+            settlement_kind=option_event_type,
+        )
+
+    def cash_settle_options_contract(self, position, strategy):
+        """Cash settle an options contract (used by cash-settled index options)."""
+        if not self.IS_BACKTESTING_BROKER:
+            logger.error("Cannot cash settle options contract in live trading")
+            return
+        if position.asset.asset_type != Asset.AssetType.OPTION:
+            logger.error(f"Cannot cash settle non-option contract {position.asset}")
+            return
+
+        underlying_asset = self._resolve_underlying_asset_for_option(position.asset, strategy)
+        underlying_price, _ = self._get_underlying_price_for_settlement(underlying_asset, strategy)
+        intrinsic_per_contract = self._intrinsic_value_per_contract(position.asset, underlying_price)
+        profit_loss = intrinsic_per_contract * float(position.quantity) * float(position.asset.multiplier)
+
         current_cash = strategy.get_cash()
         if current_cash is None:
-            # self.strategy.logger.warning("strategy.get_cash() returned None during cash_settle_options_contract. Defaulting to 0.")
             current_cash = Decimal(0)
         else:
-            current_cash = Decimal(str(current_cash)) # Ensure it's Decimal
+            current_cash = Decimal(str(current_cash))
 
-        new_cash = current_cash + Decimal(str(profit_loss))
+        strategy._set_cash_position(float(current_cash + Decimal(str(profit_loss))))
 
-        # Update the cash position
-        strategy._set_cash_position(float(new_cash)) # _set_cash_position expects float
-
-        # Set the side
-        if position.quantity > 0:
-            side = "sell"
-        else:
-            side = "buy"
-
-        # Create offsetting order
+        side = Order.OrderSide.SELL if position.quantity > 0 else Order.OrderSide.BUY
         order = strategy.create_order(position.asset, abs(position.quantity), side)
-
-        # Send filled order event
         self.stream.dispatch(
             self.CASH_SETTLED,
             wait_until_complete=True,
             order=order,
-            price=abs(profit_loss / position.quantity / position.asset.multiplier),
-            filled_quantity=abs(position.quantity),
+            price=float(intrinsic_per_contract),
+            filled_quantity=abs(float(position.quantity)),
         )
 
     def process_expired_option_contracts(self, strategy):
-        """Checks if options or futures contracts have expried and converts
-        to cash.
+        """Process expiration lifecycle events for options contracts.
 
         Parameters
         ----------
@@ -1353,8 +1424,8 @@ class BacktestingBroker(Broker):
                 # get "stuck" indefinitely in long daily-cadence backtests.
                 self._cancel_open_orders_for_asset(strategy.name, position.asset, set())
 
-                # Cash settle the options contract
-                self.cash_settle_options_contract(position, strategy)
+                if position.asset.asset_type == Asset.AssetType.OPTION:
+                    self.settle_expired_option_contract(position, strategy)
 
     def _apply_trade_cost(self, strategy, trade_cost: Decimal) -> None:
         if not trade_cost:
@@ -3783,6 +3854,48 @@ class BacktestingBroker(Broker):
                 broker._process_trade_event(
                     order,
                     broker.CASH_SETTLED,
+                    price=price,
+                    filled_quantity=filled_quantity,
+                    multiplier=order.asset.multiplier,
+                )
+                return True
+            except:
+                logger.error(traceback.format_exc())
+
+        @broker.stream.add_action(broker.ASSIGNED)
+        def on_trade_event(order, price, filled_quantity):
+            try:
+                broker._process_trade_event(
+                    order,
+                    broker.ASSIGNED,
+                    price=price,
+                    filled_quantity=filled_quantity,
+                    multiplier=order.asset.multiplier,
+                )
+                return True
+            except:
+                logger.error(traceback.format_exc())
+
+        @broker.stream.add_action(broker.EXERCISED)
+        def on_trade_event(order, price, filled_quantity):
+            try:
+                broker._process_trade_event(
+                    order,
+                    broker.EXERCISED,
+                    price=price,
+                    filled_quantity=filled_quantity,
+                    multiplier=order.asset.multiplier,
+                )
+                return True
+            except:
+                logger.error(traceback.format_exc())
+
+        @broker.stream.add_action(broker.EXPIRED_OPTION)
+        def on_trade_event(order, price, filled_quantity):
+            try:
+                broker._process_trade_event(
+                    order,
+                    broker.EXPIRED_OPTION,
                     price=price,
                     filled_quantity=filled_quantity,
                     multiplier=order.asset.multiplier,

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -102,6 +102,9 @@ class Broker(ABC):
     MODIFIED_ORDER = "modified"
     PARTIALLY_FILLED_ORDER = "partial_fill"
     CASH_SETTLED = "cash_settled"
+    ASSIGNED = "assigned"
+    EXERCISED = "exercised"
+    EXPIRED_OPTION = "expired"
     ERROR_ORDER = "error"
     PLACEHOLDER_ORDER = "placeholder"
 
@@ -1275,19 +1278,21 @@ class Broker(ABC):
         self._error_orders.append(order)
         return order
 
-    def _process_cash_settlement(self, order, price, quantity):
+    def _process_option_lifecycle_event(self, order, price, quantity, lifecycle_status, lifecycle_label):
+        price_value = 0.0 if price is None else float(price)
+        quantity_value = 0.0 if quantity is None else float(quantity)
+
         self.logger.info(
             colored(
-                f"Cash Settled: {order.side} {quantity} of {order.asset.symbol} at {price:,.8f} {'USD'} per share",
+                f"{lifecycle_label}: {order.side} {quantity_value} of {order.asset.symbol} at {price_value:,.8f} USD per share",
                 color="green",
             )
         )
-
         self._new_orders.remove(order.identifier, key="identifier")
         self._unprocessed_orders.remove(order.identifier, key="identifier")
         self._partially_filled_orders.remove(order.identifier, key="identifier")
-        order.add_transaction(price, quantity)
-        order.status = self.CASH_SETTLED
+        order.add_transaction(price_value, quantity_value)
+        order.status = lifecycle_status
         order.set_filled()
         self._filled_orders.append(order)
 
@@ -1299,7 +1304,7 @@ class Broker(ABC):
             # due to exploding open positions).
             if getattr(self, "IS_BACKTESTING_BROKER", False):
                 try:
-                    position.add_order(order, Decimal(str(quantity)))
+                    position.add_order(order, Decimal(str(quantity_value)))
                 except Exception:
                     # Fallback: still record the settlement order even if quantity normalization failed.
                     position.add_order(order)
@@ -1310,10 +1315,51 @@ class Broker(ABC):
                     except Exception:
                         # SafeList/remove semantics vary by broker; leaving a 0-qty position is acceptable.
                         pass
+                    try:
+                        # Expired/settled contracts should not leave active close orders behind.
+                        self._cancel_open_orders_for_asset(order.strategy, order.asset, {order.identifier})
+                    except Exception:
+                        pass
             else:
                 # Add the order to the already existing position; don't update quantity here because it's
                 # handled by querying broker positions in live trading.
                 position.add_order(order)
+
+    def _process_cash_settlement(self, order, price, quantity):
+        self._process_option_lifecycle_event(
+            order=order,
+            price=price,
+            quantity=quantity,
+            lifecycle_status=self.CASH_SETTLED,
+            lifecycle_label="Cash Settled",
+        )
+
+    def _process_assigned_option(self, order, price, quantity):
+        self._process_option_lifecycle_event(
+            order=order,
+            price=price,
+            quantity=quantity,
+            lifecycle_status=self.ASSIGNED,
+            lifecycle_label="Assigned",
+        )
+
+    def _process_exercised_option(self, order, price, quantity):
+        self._process_option_lifecycle_event(
+            order=order,
+            price=price,
+            quantity=quantity,
+            lifecycle_status=self.EXERCISED,
+            lifecycle_label="Exercised",
+        )
+
+    def _process_expired_option(self, order, price, quantity):
+        self._process_option_lifecycle_event(
+            order=order,
+            price=price,
+            quantity=quantity,
+            lifecycle_status=self.EXPIRED_OPTION,
+            lifecycle_label="Expired",
+        )
 
     def _process_crypto_quote(self, order, quantity, price):
         """Used to process the quote side of a crypto trade."""
@@ -2183,6 +2229,15 @@ class Broker(ABC):
             elif type_event == self.CASH_SETTLED:
                 self._process_cash_settlement(stored_order, price, filled_quantity)
                 stored_order.order_type = self.CASH_SETTLED
+            elif type_event == self.ASSIGNED:
+                self._process_assigned_option(stored_order, price, filled_quantity)
+                stored_order.order_type = self.ASSIGNED
+            elif type_event == self.EXERCISED:
+                self._process_exercised_option(stored_order, price, filled_quantity)
+                stored_order.order_type = self.EXERCISED
+            elif type_event == self.EXPIRED_OPTION:
+                self._process_expired_option(stored_order, price, filled_quantity)
+                stored_order.order_type = self.EXPIRED_OPTION
             else:
                 self.logger.warning(f"Unknown trade event type: {type_event}")
         else:
@@ -2221,6 +2276,15 @@ class Broker(ABC):
             elif Order.is_equivalent_status(type_event, self.CASH_SETTLED):
                 self._process_cash_settlement(stored_order, price, filled_quantity)
                 stored_order.order_type = self.CASH_SETTLED
+            elif Order.is_equivalent_status(type_event, self.ASSIGNED):
+                self._process_assigned_option(stored_order, price, filled_quantity)
+                stored_order.order_type = self.ASSIGNED
+            elif Order.is_equivalent_status(type_event, self.EXERCISED):
+                self._process_exercised_option(stored_order, price, filled_quantity)
+                stored_order.order_type = self.EXERCISED
+            elif Order.is_equivalent_status(type_event, self.EXPIRED_OPTION):
+                self._process_expired_option(stored_order, price, filled_quantity)
+                stored_order.order_type = self.EXPIRED_OPTION
             else:
                 self.logger.warning(f"Unknown trade event type: {type_event}")
 

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -99,12 +99,28 @@ class StrEnum(str, Enum):
 SELL = "sell"
 BUY = "buy"
 
-VALID_STATUS = ["unprocessed", "new", "open", "submitted", "fill", "partial_fill", "cancelling", "canceled", "error", "cash_settled"]
+VALID_STATUS = [
+    "unprocessed",
+    "new",
+    "open",
+    "submitted",
+    "fill",
+    "partial_fill",
+    "cancelling",
+    "canceled",
+    "error",
+    "cash_settled",
+    "assigned",
+    "assignment",
+    "exercise",
+    "exercised",
+    "expired",
+]
 STATUS_ALIAS_MAP = {
     "cancelled": "canceled",
     "cancel": "canceled",
     "cash": "cash_settled",
-    "expired": "canceled",  # Alpaca/Tradier status
+    "expired": "expired",  # Alpaca/Tradier status
     "filled": "fill",  # IBKR/Alpaca/Tradier status
     "partially_filled": "partial_filled",  # Alpaca/Tradier status
     "pending": "open",  # Tradier status
@@ -128,6 +144,8 @@ STATUS_ALIAS_MAP = {
     "calculated": "open",  # Alpaca status
     "accepted_for_bidding": "open",  # Alpaca status
     "held": "open",  # Alpaca status
+    "assignment": "assigned",
+    "exercise": "exercised",
 }
 
 NONE_TYPE = type(None)  # Order is shadowing 'type' parameter, this is a workaround to still access type(None)
@@ -170,6 +188,8 @@ class Order:
         FILLED = "fill"
         PARTIALLY_FILLED = "partial_fill"
         CASH_SETTLED = "cash_settled"
+        ASSIGNED = "assigned"
+        EXERCISED = "exercised"
         ERROR = "error"
         EXPIRED = "expired"
 
@@ -1215,7 +1235,7 @@ class Order:
         bool
             True if the order has been cancelled, False otherwise.
         """
-        return self.status.lower() in ["cancelled", "canceled", "cancel", "error"]
+        return self.status.lower() in ["cancelled", "canceled", "cancel", "error", "expired"]
 
     def is_filled(self):
         """
@@ -1228,7 +1248,15 @@ class Order:
         """
         if self.position_filled:
             return True
-        elif self.status.lower() in ["filled", "fill", "cash_settled"]:
+        elif self.status.lower() in [
+            "filled",
+            "fill",
+            "cash_settled",
+            "assigned",
+            "assignment",
+            "exercise",
+            "exercised",
+        ]:
             return True
         else:
             return False

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1001,9 +1001,18 @@ class _Strategy:
                             if quote_mark is not None:
                                 return quote_mark
 
-                        # If snapshot probing failed but day quote carried a positive trade-derived
-                        # price, keep that as a last-resort mark to avoid dropping valuation to None.
+                        # If snapshot probing failed, avoid forcing day-quote marks for established
+                        # positions when we already have a prior valid mark to forward-fill from.
+                        # This prevents stale day quotes from creating artificial intraday MTM cliffs.
+                        has_last_known_price = False
+                        try:
+                            has_last_known_price = base_asset in getattr(self, "_last_known_prices", {})
+                        except Exception:
+                            has_last_known_price = False
+
                         if day_quote_mark is not None:
+                            if has_last_known_price:
+                                return None
                             return day_quote_mark
             except Exception as e:
                 self.logger.debug("ThetaData quote-mark lookup failed for %s: %s", base_asset, e)

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -970,13 +970,16 @@ class _Strategy:
                     else:
                         quote = get_quote(base_asset, timestep=timestep_hint or "minute")
                     quote_mark = _thetadata_quote_mark(quote)
-                    if quote_mark is not None:
-                        return quote_mark
+                    day_quote_mark = quote_mark
+                    if timestep_hint != "day":
+                        if quote_mark is not None:
+                            return quote_mark
 
                     # Daily-cadence fallback: intraday quote snapshots are the most robust source
-                    # of option marks when EOD/history endpoints are missing for a contract.
+                    # of option marks. Even when day quotes exist, they can be stale in some
+                    # provider/cache states; prefer snapshot mark when available.
                     if timestep_hint == "day":
-                        # Only attempt snapshot-only fallback when it's safe to do so.
+                        # Only attempt snapshot-only lookup when it's safe to do so.
                         #
                         # Some unit tests (and custom sources) override `get_quote()` at the class
                         # level and treat repeated calls as an error (or always return the same
@@ -984,17 +987,24 @@ class _Strategy:
                         # ThetaDataBacktestingPandas implementation is guaranteed to understand
                         # `snapshot_only`. For non-bound callables (e.g., instance-level stubs used
                         # by tests), allow the fallback.
+                        can_try_snapshot = True
                         func = getattr(get_quote, "__func__", None)
                         if func is not None and func is not ThetaDataBacktestingPandas.get_quote:
-                            return None
-                        quote_kwargs = {"timestep": "minute", "snapshot_only": True}
-                        if quote_asset is not None:
-                            quote = get_quote(base_asset, quote=quote_asset, **quote_kwargs)
-                        else:
-                            quote = get_quote(base_asset, **quote_kwargs)
-                        quote_mark = _thetadata_quote_mark(quote)
-                        if quote_mark is not None:
-                            return quote_mark
+                            can_try_snapshot = False
+                        if can_try_snapshot:
+                            quote_kwargs = {"timestep": "minute", "snapshot_only": True}
+                            if quote_asset is not None:
+                                quote = get_quote(base_asset, quote=quote_asset, **quote_kwargs)
+                            else:
+                                quote = get_quote(base_asset, **quote_kwargs)
+                            quote_mark = _thetadata_quote_mark(quote)
+                            if quote_mark is not None:
+                                return quote_mark
+
+                        # If snapshot probing failed but day quote carried a positive trade-derived
+                        # price, keep that as a last-resort mark to avoid dropping valuation to None.
+                        if day_quote_mark is not None:
+                            return day_quote_mark
             except Exception as e:
                 self.logger.debug("ThetaData quote-mark lookup failed for %s: %s", base_asset, e)
             return None

--- a/scripts/check_ibkr_daily_history_depth.py
+++ b/scripts/check_ibkr_daily_history_depth.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+Check IBKR daily-history depth for stocks/indexes through LumiBot's IBKR helper.
+
+Example:
+  python3 scripts/check_ibkr_daily_history_depth.py \
+    --symbols SPY:stock QQQ:stock SPX:index NDX:index VIX:index \
+    --min-years 10 \
+    --probe-years 25
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Iterable
+
+import pandas as pd
+
+from lumibot.entities import Asset
+from lumibot.tools import ibkr_helper
+
+
+DEFAULT_SYMBOLS: list[str] = [
+    "SPY:stock",
+    "QQQ:stock",
+    "SPX:index",
+    "NDX:index",
+    "VIX:index",
+]
+
+
+@dataclass
+class SymbolSpec:
+    symbol: str
+    asset_type: str
+
+
+def _parse_symbol_specs(items: Iterable[str]) -> list[SymbolSpec]:
+    parsed: list[SymbolSpec] = []
+    allowed_types = {"stock", "index"}
+    for raw in items:
+        token = str(raw).strip()
+        if ":" not in token:
+            raise ValueError(f"Invalid symbol token '{token}'. Expected SYMBOL:TYPE (e.g. SPY:stock).")
+        symbol, asset_type = token.split(":", 1)
+        symbol = symbol.strip().upper()
+        asset_type = asset_type.strip().lower()
+        if asset_type not in allowed_types:
+            raise ValueError(
+                f"Unsupported asset type '{asset_type}' for '{token}'. Allowed: {sorted(allowed_types)}."
+            )
+        parsed.append(SymbolSpec(symbol=symbol, asset_type=asset_type))
+    return parsed
+
+
+def _format_dt(value: pd.Timestamp) -> str:
+    return value.isoformat()
+
+
+def _as_utc(value: datetime | pd.Timestamp) -> pd.Timestamp:
+    ts = pd.Timestamp(value)
+    if ts.tzinfo is None:
+        return ts.tz_localize("UTC")
+    return ts.tz_convert("UTC")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--symbols",
+        nargs="+",
+        default=DEFAULT_SYMBOLS,
+        help="Space-separated SYMBOL:TYPE entries (TYPE: stock|index).",
+    )
+    parser.add_argument(
+        "--min-years",
+        type=float,
+        default=10.0,
+        help="Minimum required daily-history depth in years (default: 10).",
+    )
+    parser.add_argument(
+        "--probe-years",
+        type=float,
+        default=25.0,
+        help="How far back to request from IBKR (default: 25). Must be >= min-years.",
+    )
+    parser.add_argument(
+        "--end-date",
+        type=str,
+        default=None,
+        help="Optional end date in YYYY-MM-DD. Defaults to now.",
+    )
+    parser.add_argument(
+        "--source",
+        type=str,
+        default="Trades",
+        help="IBKR history source (default: Trades).",
+    )
+    args = parser.parse_args()
+
+    if args.probe_years < args.min_years:
+        print("--probe-years must be >= --min-years", file=sys.stderr)
+        return 2
+
+    end_dt = (
+        datetime.strptime(args.end_date, "%Y-%m-%d")
+        if args.end_date
+        else datetime.now()
+    )
+    start_dt = end_dt - timedelta(days=int(args.probe_years * 365.2425))
+    min_cutoff = end_dt - timedelta(days=int(args.min_years * 365.2425))
+
+    try:
+        symbols = _parse_symbol_specs(args.symbols)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    print(f"Probe window: {start_dt.date()} -> {end_dt.date()} (source={args.source})")
+    print(f"Minimum required depth: {args.min_years:.2f} years (cutoff <= {min_cutoff.date()})")
+    print("")
+
+    any_fail = False
+    for spec in symbols:
+        asset = Asset(spec.symbol, asset_type=spec.asset_type)
+        try:
+            df = ibkr_helper.get_price_data(
+                asset=asset,
+                quote=None,
+                timestep="day",
+                start_dt=start_dt,
+                end_dt=end_dt,
+                exchange=None,
+                include_after_hours=True,
+                source=args.source,
+            )
+        except Exception as exc:  # pragma: no cover - live API failures
+            any_fail = True
+            print(f"[FAIL] {spec.symbol}:{spec.asset_type} error: {exc.__class__.__name__}: {exc}")
+            continue
+
+        if df is None or df.empty:
+            any_fail = True
+            print(f"[FAIL] {spec.symbol}:{spec.asset_type} no rows returned")
+            continue
+
+        idx = pd.to_datetime(df.index)
+        earliest = idx.min()
+        latest = idx.max()
+        years = max(0.0, (latest - earliest).days / 365.2425)
+        status = "PASS" if _as_utc(earliest) <= _as_utc(min_cutoff) else "FAIL"
+        if status == "FAIL":
+            any_fail = True
+        print(
+            f"[{status}] {spec.symbol}:{spec.asset_type} rows={len(df)} "
+            f"start={_format_dt(earliest)} end={_format_dt(latest)} years={years:.2f}"
+        )
+
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backtesting_broker.py
+++ b/tests/test_backtesting_broker.py
@@ -12,7 +12,7 @@ import pytz
 try:
     from lumibot.backtesting.backtesting_broker import BacktestingBroker
     from lumibot.data_sources import PandasData
-    from lumibot.entities import Asset, Order, Quote # Import Asset if needed by mocked methods
+    from lumibot.entities import Asset, Order, Position, Quote # Import Asset if needed by mocked methods
 except ImportError:
     # Add path modification if running tests directly and lumibot is not installed
     import sys
@@ -20,7 +20,33 @@ except ImportError:
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
     from lumibot.backtesting.backtesting_broker import BacktestingBroker
     from lumibot.data_sources import PandasData
-    from lumibot.entities import Asset, Order, Quote
+    from lumibot.entities import Asset, Order, Position, Quote
+
+
+class _OptionSettlementStrategyStub:
+    def __init__(self, broker, cash=100_000.0, name="option_settlement_test"):
+        self.broker = broker
+        self.name = name
+        self._name = name
+        self.cash = float(cash)
+        self.minutes_before_closing = 0
+        self.buy_trading_fees = []
+        self.sell_trading_fees = []
+        self.vars = type("Vars", (), {})()
+
+    def get_cash(self):
+        return self.cash
+
+    def _set_cash_position(self, cash):
+        self.cash = float(cash)
+
+    def create_order(self, asset, quantity, side):
+        return Order(
+            asset=asset,
+            quantity=quantity,
+            side=side,
+            strategy=self.name,
+        )
 
 
 class TestBacktestingBroker:
@@ -222,6 +248,151 @@ class TestBacktestingBroker:
         parquet_df = pd.read_parquet(out_csv.with_suffix(".parquet"))
         assert "time" in parquet_df.columns
         assert "status" in parquet_df.columns
+
+    def test_option_expiry_short_put_assignment_delivers_stock(self):
+        start = dt(2023, 8, 1)
+        end = dt(2023, 8, 2)
+        data_source = PandasData(datetime_start=start, datetime_end=end, pandas_data={})
+        broker = BacktestingBroker(data_source=data_source)
+        strategy = _OptionSettlementStrategyStub(broker=broker, cash=50_000.0)
+
+        underlying = Asset(symbol="AAPL", asset_type="stock")
+        option = Asset(
+            symbol="AAPL",
+            asset_type="option",
+            expiration=datetime.date(2023, 8, 1),
+            strike=100,
+            right=Asset.OptionRight.PUT,
+            multiplier=100,
+            underlying_asset=underlying,
+        )
+        broker._filled_positions.append(Position(strategy.name, option, quantity=-1))
+        broker.get_last_price = MagicMock(return_value=95.0)
+
+        broker.settle_expired_option_contract(
+            broker.get_tracked_position(strategy.name, option),
+            strategy,
+        )
+
+        events = broker._trade_event_log_df
+        option_events = events[(events["symbol"] == "AAPL") & (events["asset.asset_type"] == "option")]
+        stock_events = events[(events["symbol"] == "AAPL") & (events["asset.asset_type"] == "stock")]
+
+        assert "assigned" in option_events["status"].tolist()
+        assert "assigned" in option_events["type"].tolist()
+        assert not stock_events.empty
+        assert "fill" in stock_events["status"].tolist()
+        assert "assigned" in stock_events["type"].tolist()
+
+        stock_position = broker.get_tracked_position(strategy.name, underlying)
+        assert stock_position is not None
+        assert stock_position.quantity == 100.0
+        assert broker.get_tracked_position(strategy.name, option) is None
+
+    def test_option_expiry_long_call_exercise_delivers_stock_when_supported(self):
+        start = dt(2023, 8, 1)
+        end = dt(2023, 8, 2)
+        data_source = PandasData(datetime_start=start, datetime_end=end, pandas_data={})
+        broker = BacktestingBroker(data_source=data_source)
+        strategy = _OptionSettlementStrategyStub(broker=broker, cash=10_000.0)
+
+        underlying = Asset(symbol="MSFT", asset_type="stock")
+        option = Asset(
+            symbol="MSFT",
+            asset_type="option",
+            expiration=datetime.date(2023, 8, 1),
+            strike=50,
+            right=Asset.OptionRight.CALL,
+            multiplier=100,
+            underlying_asset=underlying,
+        )
+        broker._filled_positions.append(Position(strategy.name, option, quantity=1))
+        broker.get_last_price = MagicMock(return_value=55.0)
+
+        broker.settle_expired_option_contract(
+            broker.get_tracked_position(strategy.name, option),
+            strategy,
+        )
+
+        events = broker._trade_event_log_df
+        option_events = events[(events["symbol"] == "MSFT") & (events["asset.asset_type"] == "option")]
+        stock_events = events[(events["symbol"] == "MSFT") & (events["asset.asset_type"] == "stock")]
+
+        assert "exercised" in option_events["status"].tolist()
+        assert "exercised" in option_events["type"].tolist()
+        assert not stock_events.empty
+        assert "fill" in stock_events["status"].tolist()
+        assert "exercised" in stock_events["type"].tolist()
+        assert broker.get_tracked_position(strategy.name, underlying).quantity == 100.0
+        assert broker.get_tracked_position(strategy.name, option) is None
+
+    def test_option_expiry_long_call_itm_with_insufficient_cash_expires(self):
+        start = dt(2023, 8, 1)
+        end = dt(2023, 8, 2)
+        data_source = PandasData(datetime_start=start, datetime_end=end, pandas_data={})
+        broker = BacktestingBroker(data_source=data_source)
+        strategy = _OptionSettlementStrategyStub(broker=broker, cash=100.0)
+
+        underlying = Asset(symbol="NVDA", asset_type="stock")
+        option = Asset(
+            symbol="NVDA",
+            asset_type="option",
+            expiration=datetime.date(2023, 8, 1),
+            strike=300,
+            right=Asset.OptionRight.CALL,
+            multiplier=100,
+            underlying_asset=underlying,
+        )
+        broker._filled_positions.append(Position(strategy.name, option, quantity=1))
+        broker.get_last_price = MagicMock(return_value=350.0)
+
+        broker.settle_expired_option_contract(
+            broker.get_tracked_position(strategy.name, option),
+            strategy,
+        )
+
+        events = broker._trade_event_log_df
+        option_events = events[(events["symbol"] == "NVDA") & (events["asset.asset_type"] == "option")]
+        stock_events = events[(events["symbol"] == "NVDA") & (events["asset.asset_type"] == "stock")]
+
+        assert "expired" in option_events["status"].tolist()
+        assert "expired" in option_events["type"].tolist()
+        assert stock_events.empty
+        assert broker.get_tracked_position(strategy.name, underlying) is None
+
+    def test_option_expiry_index_option_itm_cash_settles(self):
+        start = dt(2023, 8, 1)
+        end = dt(2023, 8, 2)
+        data_source = PandasData(datetime_start=start, datetime_end=end, pandas_data={})
+        broker = BacktestingBroker(data_source=data_source)
+        strategy = _OptionSettlementStrategyStub(broker=broker, cash=1_000.0)
+
+        underlying = Asset(symbol="SPX", asset_type="index")
+        option = Asset(
+            symbol="SPX",
+            asset_type="option",
+            expiration=datetime.date(2023, 8, 1),
+            strike=5000,
+            right=Asset.OptionRight.CALL,
+            multiplier=100,
+            underlying_asset=underlying,
+        )
+        broker._filled_positions.append(Position(strategy.name, option, quantity=1))
+        broker.get_last_price = MagicMock(return_value=5100.0)
+
+        broker.settle_expired_option_contract(
+            broker.get_tracked_position(strategy.name, option),
+            strategy,
+        )
+
+        events = broker._trade_event_log_df
+        option_events = events[(events["symbol"] == "SPX") & (events["asset.asset_type"] == "option")]
+        stock_events = events[(events["symbol"] == "SPX") & (events["asset.asset_type"] == "stock")]
+
+        assert "cash_settled" in option_events["status"].tolist()
+        assert "cash_settled" in option_events["type"].tolist()
+        assert stock_events.empty
+        assert strategy.cash == 11_000.0
 
 
 # New Test Class for Time Advancement Logic

--- a/tests/test_indicator_subplots.py
+++ b/tests/test_indicator_subplots.py
@@ -284,6 +284,110 @@ def test_plot_returns_preserves_cash_settled_status(tmp_path, monkeypatch):
     trades_parquet = pd.read_parquet(plot_path.with_suffix(".parquet"))
     assert "cash_settled" in trades_parquet["status"].tolist()
 
+
+def test_plot_returns_preserves_assignment_and_exercise_statuses(tmp_path, monkeypatch):
+    plot_path = tmp_path / "plot_assignment_exercise.html"
+
+    def _fake_write_html(self, file, auto_open=True, **kwargs):
+        return file
+
+    monkeypatch.setattr(go.Figure, "write_html", _fake_write_html, raising=False)
+
+    idx = pd.to_datetime(
+        ["2025-09-20 00:00:00-04:00", "2025-09-21 00:00:00-04:00"]
+    ).tz_convert("UTC")
+
+    strategy_df = pd.DataFrame(
+        {
+            "return": [0.0, 0.0],
+            "cash": [100000, 100000],
+            "positions": [[], []],
+        },
+        index=idx,
+    )
+
+    benchmark_df = pd.DataFrame(
+        {
+            "return": [0.0, 0.0],
+            "open": [1.0, 1.0],
+            "high": [1.0, 1.0],
+            "low": [1.0, 1.0],
+            "close": [1.0, 1.0],
+        },
+        index=idx,
+    )
+
+    trades_df = pd.DataFrame(
+        [
+            {
+                "time": "2025-09-20 00:00:00-04:00",
+                "side": "buy",
+                "status": "assigned",
+                "filled_quantity": 1,
+                "symbol": "AAPL",
+                "asset.asset_type": "option",
+                "asset.right": "PUT",
+                "asset.strike": 100,
+                "asset.expiration": "2025-09-20",
+                "price": 5.0,
+                "type": "assigned",
+                "asset.multiplier": 100,
+                "trade_cost": pd.NA,
+            },
+            {
+                "time": "2025-09-21 00:00:00-04:00",
+                "side": "buy",
+                "status": "fill",
+                "filled_quantity": 100,
+                "symbol": "AAPL",
+                "asset.asset_type": "stock",
+                "asset.right": None,
+                "asset.strike": float("nan"),
+                "asset.expiration": None,
+                "price": 100.0,
+                "type": "exercised",
+                "asset.multiplier": 1,
+                "trade_cost": pd.NA,
+            },
+            {
+                "time": "2025-09-21 00:00:00-04:00",
+                "side": "sell",
+                "status": "exercised",
+                "filled_quantity": 1,
+                "symbol": "AAPL",
+                "asset.asset_type": "option",
+                "asset.right": "CALL",
+                "asset.strike": 90,
+                "asset.expiration": "2025-09-21",
+                "price": 10.0,
+                "type": "exercised",
+                "asset.multiplier": 100,
+                "trade_cost": pd.NA,
+            },
+        ]
+    )
+
+    plot_returns(
+        strategy_df,
+        "Strategy",
+        benchmark_df,
+        "Benchmark",
+        plot_file_html=str(plot_path),
+        trades_df=trades_df,
+        show_plot=True,
+        initial_budget=1,
+    )
+
+    trades_csv = pd.read_csv(plot_path.with_suffix(".csv"))
+    statuses = trades_csv["status"].tolist()
+    assert "assigned" in statuses
+    assert "exercised" in statuses
+
+    trades_parquet = pd.read_parquet(plot_path.with_suffix(".parquet"))
+    parquet_statuses = trades_parquet["status"].tolist()
+    assert "assigned" in parquet_statuses
+    assert "exercised" in parquet_statuses
+
     def test_named_lines(self, pandas_data_fixture):
         """Test the named lines"""
         strategy_name = "TestIndicatorStrategy"

--- a/tests/test_thetadata_option_daily_mtm_snapshot.py
+++ b/tests/test_thetadata_option_daily_mtm_snapshot.py
@@ -166,6 +166,55 @@ def test_thetadata_daily_option_mtm_falls_back_to_day_price_if_snapshot_missing(
     ]
 
 
+def test_thetadata_daily_option_mtm_uses_forward_fill_when_snapshot_missing() -> None:
+    """If snapshot is missing and we already have a mark, return None so forward-fill is used."""
+
+    class DummyBroker:
+        datetime = datetime(2025, 3, 26, 9, 30)
+
+    class DummyStrategy:
+        is_backtesting = True
+        broker = DummyBroker()
+        logger = logging.getLogger("lumibot.test")
+        _quote_asset = Asset("USD", asset_type="forex")
+        _last_known_prices = {}
+
+        def _get_sleeptime_seconds(self):
+            return 24 * 3600
+
+    dummy_strategy = DummyStrategy()
+
+    option_asset = Asset(
+        symbol="SPY",
+        asset_type="option",
+        expiration=date(2025, 4, 11),
+        strike=582.5,
+        right="put",
+    )
+    dummy_strategy._last_known_prices[option_asset] = 15.59
+
+    source = object.__new__(ThetaDataBacktestingPandas)
+    called = {}
+
+    def fake_get_quote(asset, quote=None, exchange=None, timestep="minute", **kwargs):
+        calls = called.setdefault("calls", [])
+        calls.append({"timestep": timestep, "snapshot_only": bool(kwargs.get("snapshot_only", False))})
+        if timestep == "day":
+            return SimpleNamespace(bid=12.68, ask=15.23, price=None)
+        assert timestep == "minute"
+        assert bool(kwargs.get("snapshot_only", False)) is True
+        return SimpleNamespace(bid=None, ask=None, price=None)
+
+    source.get_quote = fake_get_quote
+
+    price = _Strategy._get_price_from_source(dummy_strategy, source, option_asset)
+    assert price is None
+    assert called["calls"] == [
+        {"timestep": "day", "snapshot_only": False},
+        {"timestep": "minute", "snapshot_only": True},
+    ]
+
+
 def test_thetadata_daily_option_mtm_prefers_snapshot_over_stale_day_nbbo() -> None:
     """Daily MTM should prefer snapshot mark even if day quote has two-sided NBBO."""
 

--- a/tests/test_thetadata_option_daily_mtm_snapshot.py
+++ b/tests/test_thetadata_option_daily_mtm_snapshot.py
@@ -70,3 +70,146 @@ def test_thetadata_daily_option_mtm_uses_intraday_snapshot_quote() -> None:
         {"timestep": "day", "snapshot_only": False},
         {"timestep": "minute", "snapshot_only": True},
     ]
+
+
+def test_thetadata_daily_option_mtm_prefers_snapshot_over_day_price_without_nbbo() -> None:
+    """If day quote has only trade `price` (no NBBO), prefer intraday snapshot mark."""
+
+    class DummyBroker:
+        datetime = datetime(2025, 3, 26, 9, 30)
+
+    class DummyStrategy:
+        is_backtesting = True
+        broker = DummyBroker()
+        logger = logging.getLogger("lumibot.test")
+        _quote_asset = Asset("USD", asset_type="forex")
+
+        def _get_sleeptime_seconds(self):
+            return 24 * 3600
+
+    dummy_strategy = DummyStrategy()
+
+    option_asset = Asset(
+        symbol="SPY",
+        asset_type="option",
+        expiration=date(2025, 4, 11),
+        strike=582.5,
+        right="put",
+    )
+
+    source = object.__new__(ThetaDataBacktestingPandas)
+    called = {}
+
+    def fake_get_quote(asset, quote=None, exchange=None, timestep="minute", **kwargs):
+        calls = called.setdefault("calls", [])
+        calls.append({"timestep": timestep, "snapshot_only": bool(kwargs.get("snapshot_only", False))})
+        if timestep == "day":
+            return SimpleNamespace(bid=None, ask=None, price=48.21)
+        assert timestep == "minute"
+        assert bool(kwargs.get("snapshot_only", False)) is True
+        return SimpleNamespace(bid=15.38, ask=15.80, price=None)
+
+    source.get_quote = fake_get_quote
+
+    price = _Strategy._get_price_from_source(dummy_strategy, source, option_asset)
+    assert price == 15.59
+    assert called["calls"] == [
+        {"timestep": "day", "snapshot_only": False},
+        {"timestep": "minute", "snapshot_only": True},
+    ]
+
+
+def test_thetadata_daily_option_mtm_falls_back_to_day_price_if_snapshot_missing() -> None:
+    """Keep last-resort day trade price when snapshot probing returns no actionable quote."""
+
+    class DummyBroker:
+        datetime = datetime(2025, 3, 26, 9, 30)
+
+    class DummyStrategy:
+        is_backtesting = True
+        broker = DummyBroker()
+        logger = logging.getLogger("lumibot.test")
+        _quote_asset = Asset("USD", asset_type="forex")
+
+        def _get_sleeptime_seconds(self):
+            return 24 * 3600
+
+    dummy_strategy = DummyStrategy()
+
+    option_asset = Asset(
+        symbol="SPY",
+        asset_type="option",
+        expiration=date(2025, 4, 11),
+        strike=582.5,
+        right="put",
+    )
+
+    source = object.__new__(ThetaDataBacktestingPandas)
+    called = {}
+
+    def fake_get_quote(asset, quote=None, exchange=None, timestep="minute", **kwargs):
+        calls = called.setdefault("calls", [])
+        calls.append({"timestep": timestep, "snapshot_only": bool(kwargs.get("snapshot_only", False))})
+        if timestep == "day":
+            return SimpleNamespace(bid=None, ask=None, price=48.21)
+        assert timestep == "minute"
+        assert bool(kwargs.get("snapshot_only", False)) is True
+        return SimpleNamespace(bid=None, ask=None, price=None)
+
+    source.get_quote = fake_get_quote
+
+    price = _Strategy._get_price_from_source(dummy_strategy, source, option_asset)
+    assert price == 48.21
+    assert called["calls"] == [
+        {"timestep": "day", "snapshot_only": False},
+        {"timestep": "minute", "snapshot_only": True},
+    ]
+
+
+def test_thetadata_daily_option_mtm_prefers_snapshot_over_stale_day_nbbo() -> None:
+    """Daily MTM should prefer snapshot mark even if day quote has two-sided NBBO."""
+
+    class DummyBroker:
+        datetime = datetime(2025, 10, 8, 9, 30)
+
+    class DummyStrategy:
+        is_backtesting = True
+        broker = DummyBroker()
+        logger = logging.getLogger("lumibot.test")
+        _quote_asset = Asset("USD", asset_type="forex")
+
+        def _get_sleeptime_seconds(self):
+            return 24 * 3600
+
+    dummy_strategy = DummyStrategy()
+
+    option_asset = Asset(
+        symbol="SPY",
+        asset_type="option",
+        expiration=date(2025, 10, 10),
+        strike=668.0,
+        right="put",
+    )
+
+    source = object.__new__(ThetaDataBacktestingPandas)
+    called = {}
+
+    def fake_get_quote(asset, quote=None, exchange=None, timestep="minute", **kwargs):
+        calls = called.setdefault("calls", [])
+        calls.append({"timestep": timestep, "snapshot_only": bool(kwargs.get("snapshot_only", False))})
+        if timestep == "day":
+            # Stale day quote (mirrors the problematic y7kYMO pattern).
+            return SimpleNamespace(bid=12.68, ask=15.23, price=None)
+        assert timestep == "minute"
+        assert bool(kwargs.get("snapshot_only", False)) is True
+        # Snapshot has the actionable current mark.
+        return SimpleNamespace(bid=0.67, ask=0.68, price=None)
+
+    source.get_quote = fake_get_quote
+
+    price = _Strategy._get_price_from_source(dummy_strategy, source, option_asset)
+    assert price == 0.675
+    assert called["calls"] == [
+        {"timestep": "day", "snapshot_only": False},
+        {"timestep": "minute", "snapshot_only": True},
+    ]


### PR DESCRIPTION
## Summary
- model broker-like option expiration behavior in backtesting:
  - physically settle equity/ETF options (`assigned` for short ITM, `exercised` for long ITM when constraints allow)
  - cash-settle index options (`cash_settled`)
  - emit explicit `expired` lifecycle events for OTM expiration / non-exercised constrained long ITM
- propagate lifecycle statuses through broker/order handling and trade artifacts (`trades.csv`/`.parquet`, `trade_events.csv`/`.parquet`)
- add regression tests for short/long put/call assignment/exercise/cash-settlement behavior and artifact status preservation
- document expiration settlement policy and artifact semantics (`docs/` + `docsrc/`)
- keep prior 4.4.50 fixes for daily ThetaData option MTM snapshot-vs-fallback behavior

## Validation
- `pytest -q tests/test_backtesting_broker.py tests/test_order.py tests/test_thetadata_spx_index_options.py -k "option or assigned or exercised or cash_settled or expired"`
- `pytest -q tests/test_backtesting_broker.py tests/test_order.py`
- `pytest -q tests/test_indicator_subplots.py -k "assigned or exercised or cash_settled or parquet or csv or status"`
- `pytest -q tests/test_thetadata_spx_index_options.py`
- spot-check scenario matrix run (7 deterministic backtests) with generated artifacts:
  - stock short put/call assignment
  - stock long call/put exercise
  - index call/put cash settlement
  - stock OTM expiry
  - summary: `tmp/options_settlement_spotcheck_2026-02-24.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced option expiration lifecycle events (assigned, exercised, expired) with settlement behavior for physical vs cash-settled products.

* **Bug Fixes**
  * Refined daily options pricing to prefer valid intraday snapshots, safely fall back to day-end marks, and avoid stale intraday returns.
  * Improved error handling so missing snapshot data no longer breaks daily backtests.

* **Documentation**
  * Added detailed Options Expiration & Assignment policy and investigation notes; updated backtesting docs and changelog.

* **Tests**
  * Added unit tests for pricing precedence, snapshot probing, forward-fill safety, and expanded option-expiration coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core backtesting order/position lifecycle by introducing new terminal option statuses and physical settlement flows, which can affect accounting and any consumers assuming fill-only semantics. Also tweaks ThetaData option mark-to-market selection, which may shift backtest valuations for daily-cadence strategies.
> 
> **Overview**
> Backtesting now models **broker-style option expiration lifecycles**: equity/ETF options physically settle (short ITM -> `assigned`, long ITM -> `exercised` when account constraints allow; otherwise `expired`), while index-like options remain `cash_settled` based on intrinsic value, and physical settlement additionally emits a tagged underlying-share delivery `fill`.
> 
> This propagates the new lifecycle statuses through `Broker`/`Order` status handling (including aliases) and preserves them in exported trade artifacts (`*_trades.*` and `*_trade_events.*`), with new regression tests covering settlement paths and artifact status retention.
> 
> Separately, ThetaData daily option MTM logic now prefers intraday snapshot NBBO marks over potentially stale day quotes, falls back safely, and can defer to forward-fill when a prior mark exists; docs were updated and a small IBKR history-depth probe script was added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9847d3a77e17a3cf76537d2a89f6b2586cb00d1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->