### PR TITLE
Backtest hour min lookup error

### DIFF
--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -37,6 +37,13 @@ class PolygonDataBacktesting(PandasData):
             allow_option_quote_fallback=True, **kwargs
         )
 
+        # Polygon's philosophy: always cache the finest granularity available and resample
+        # up on demand.  When a strategy calls get_historical_prices(..., timestep="1 day")
+        # after a prior "15 minute" call has warmed the cache, the cached minute data must
+        # be allowed to satisfy the day request so Data.get_bars() can resample minute → day.
+        # This is the *opposite* of ThetaData, which requires exact timestep matches.
+        self.allow_day_resampling = True
+
         # Memory limit, off by default
         self.MAX_STORAGE_BYTES = max_memory
         

--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -122,6 +122,14 @@ class ThetaDataBacktestingPandas(PandasData):
         super().__init__(datetime_start=datetime_start, datetime_end=datetime_end, pandas_data=pandas_data,
                          allow_option_quote_fallback=False, **kwargs)
 
+        # ThetaData stores minute and day data under SEPARATE canonical keys
+        # (asset, quote, "minute") vs (asset, quote, "day") and applies provider-specific
+        # split-spike repair / split-adjustment only to day bars.  Allowing a cached minute
+        # dataset to silently satisfy a day-bar lookup would bypass that normalisation.
+        # Set allow_day_resampling=False so find_asset_in_data_store always requires an
+        # exact timestep match and forces an explicit day fetch when day bars are needed.
+        self.allow_day_resampling = False
+
         # Default to minute; broker can flip to day for daily strategies.
         self._timestep = self.MIN_TIMESTEP
         # PERF: Avoid scanning the entire pandas_data store on every quote/snapshot call to infer day-mode.

--- a/lumibot/data_sources/pandas_data.py
+++ b/lumibot/data_sources/pandas_data.py
@@ -25,7 +25,8 @@ class PandasData(DataSourceBacktesting):
         {"timestep": "minute", "representations": ["1M", "minute"]},
     ]
 
-    def __init__(self, *args, pandas_data=None, auto_adjust=True, allow_option_quote_fallback: bool = False, **kwargs):
+    def __init__(self, *args, pandas_data=None, auto_adjust=True, allow_option_quote_fallback: bool = False,
+                 allow_day_resampling: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
         self.option_quote_fallback_allowed = allow_option_quote_fallback
         self.name = "pandas"
@@ -35,6 +36,16 @@ class PandasData(DataSourceBacktesting):
         self._date_index = None
         self._date_supply = None
         self._timestep = "minute"
+        # Controls whether minute-level cached data may satisfy day-bar lookup requests.
+        #
+        # True  (default) — Polygon and base PandasData: minute data can be resampled to day
+        #                    bars by Data.get_bars(), so find_asset_in_data_store accepts a
+        #                    minute dataset for a day request.
+        # False           — ThetaData: each timestep has its own normalised/adjusted dataset;
+        #                    minute data must never silently proxy for day data.  This prevents
+        #                    bypassing ThetaData's split-spike repair and forces an explicit day
+        #                    fetch when day bars are needed.
+        self.allow_day_resampling: bool = allow_day_resampling
         # PERF: `find_asset_in_data_store()` is called in tight loops (quotes + history). Cache the
         # resolved key for repeated `(asset, quote, timestep)` lookups within a backtest run.
         self._find_asset_in_data_store_cache = {}
@@ -414,14 +425,24 @@ class PandasData(DataSourceBacktesting):
                 # Hour requests can be satisfied by either hour data or minute data (resample).
                 return data_ts in {"hour", "minute"}
             if requested_unit == "day":
-                # IMPORTANT:
-                # Keep explicit day requests pinned to native day datasets.
+                # IMPORTANT — two conflicting philosophies exist across data sources:
                 #
-                # Allowing minute datasets to satisfy day requests can silently bypass provider-
-                # specific day-bar normalization (for example split-spike repair/timestamp
-                # alignment in IBKR helpers), and can trigger expensive minute fetch churn in
-                # daily-cadence backtests.
-                if requested_asset_type in {"stock", "index"}:
+                # allow_day_resampling=False (ThetaData):
+                #   Keep explicit day requests pinned to native day datasets.
+                #   ThetaData stores minute and day data under separate canonical keys
+                #   (asset, quote, "minute") vs (asset, quote, "day").  Allowing minute
+                #   data to satisfy day requests would silently bypass ThetaData's
+                #   split-spike repair / split-adjustment normalisation and could trigger
+                #   expensive re-fetch churn in daily-cadence backtests.
+                #
+                # allow_day_resampling=True (Polygon, base PandasData — the default):
+                #   Polygon's _update_pandas_data always tries to obtain the finest
+                #   granularity available and relies on Data.get_bars() to resample
+                #   minute → day on demand.  If only minute data is cached for a stock,
+                #   the day request must be allowed to reach Data.get_bars() so the
+                #   resampling path fires.  The same applies to user-provided minute
+                #   CSV data in the plain PandasData source.
+                if not self.allow_day_resampling:
                     return data_ts == "day"
                 return data_ts in {"day", "minute"}
             # Fallback: require exact match for other timesteps.

--- a/tests/test_pandas_data.py
+++ b/tests/test_pandas_data.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 import pandas as pd
+import pytz
 
 from lumibot.data_sources import PandasData
 from lumibot.entities import Asset
@@ -164,12 +165,21 @@ class TestGetHistoricalPricesMinuteToDayRegression:
     @staticmethod
     def _make_ds(minute_data: Data, asset: Asset, quote: Asset, current_dt) -> PandasData:
         """
-        Build a minimal PandasData instance (no load_data() call) with _data_store
-        pointing to the supplied minute-level Data object and _datetime set.
+        Build a PandasData instance using the real constructor with the supplied
+        minute-level Data object in its store and _datetime set to current_dt.
+
+        Uses the real constructor (not PandasData.__new__) so that all instance
+        attributes — including allow_day_resampling — are properly initialised.
+        Overrides _datetime after construction to position the backtest clock.
         """
-        ds = PandasData.__new__(PandasData)
-        ds._data_store = {(asset, quote): minute_data}
-        ds._find_asset_in_data_store_cache = {}
+        tz = pytz.timezone("America/New_York")
+        start = datetime(2025, 1, 2, 9, 30, tzinfo=tz)
+        end = datetime(2025, 1, 3, 16, 0, tzinfo=tz)
+        ds = PandasData(
+            datetime_start=start,
+            datetime_end=end,
+            pandas_data=[minute_data],
+        )
         ds._datetime = current_dt
         return ds
 
@@ -192,21 +202,12 @@ class TestGetHistoricalPricesMinuteToDayRegression:
 
     def test_1day_request_returns_none_for_stock_with_only_minute_data(self):
         """
-        BUG DEMONSTRATION (integration level): get_historical_prices returns None
-        when a STOCK asset has only minute data and a '1 day' timestep is requested.
+        FIX VERIFIED: get_historical_prices with timestep="1 day" no longer returns None
+        when a STOCK asset has only minute data in the store.
 
-        The failure path:
-          get_historical_prices(spy, 3, "1 day")
-            → _pull_source_symbol_bars(spy, 3, "1 day")
-              → find_asset_in_data_store(spy, quote, "1 day")
-                → _accepts_timestep: stock guard → returns False → key not found
-              → logs warning "asset does not have data" → returns None
-            → get_historical_prices returns None
-
-        NOTE: When the underlying bug is fixed, this test will fail because
-        result_day will be a non-None Bars object. At that point, update the
-        assertion to ``assert result_day is not None`` and add a check that
-        result_day.df has OHLCV daily bars.
+        With allow_day_resampling=True (the PandasData default), find_asset_in_data_store
+        accepts the minute dataset for a day request and Data.get_bars() resamples
+        minute → day bars, so the result is a non-None Bars object.
         """
         spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
         quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
@@ -214,28 +215,22 @@ class TestGetHistoricalPricesMinuteToDayRegression:
         current_dt = minute_data.df.index[100].to_pydatetime()
         ds = self._make_ds(minute_data, spy, quote, current_dt)
 
-        result_day = ds.get_historical_prices(spy, length=3, timestep="1 day", quote=quote)
+        result_day = ds.get_historical_prices(spy, length=1, timestep="1 day", quote=quote)
 
-        # Current (buggy) behavior: None is returned because find_asset_in_data_store
-        # cannot match minute data to a day request for a stock asset.
-        assert result_day is None, (
-            "BUG DEMONSTRATED: get_historical_prices must return None for "
-            "stock + only-minute-data + day timestep request. "
-            "If this assertion fails, the bug has been fixed — update it to "
-            "assert result_day is not None."
+        assert result_day is not None, (
+            "FIX VERIFIED: get_historical_prices must return resampled day bars for a "
+            "stock asset when only minute data is in the store and allow_day_resampling=True."
         )
 
     def test_1day_request_after_15m_request_same_asset(self):
         """
-        BUG DEMONSTRATION: mirrors the exact live-backtest failure sequence.
+        FIX VERIFIED: mirrors the exact live-backtest failure sequence.
 
         Step 1: call get_historical_prices with "15 minute" → succeeds (not None).
-        Step 2: call get_historical_prices with "1 day"     → returns None (BUG).
+        Step 2: call get_historical_prices with "1 day"     → now also succeeds (not None).
 
-        Both calls use the same asset and the same underlying minute data store.
-        After step 1 populates the lookup cache with the minute-timestep key,
-        step 2 should still be able to locate the store (different cache key),
-        but the stock guard prevents it.
+        With allow_day_resampling=True, the second call finds the cached minute data and
+        Data.get_bars() resamples it to daily bars instead of returning None.
         """
         spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
         quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
@@ -244,43 +239,34 @@ class TestGetHistoricalPricesMinuteToDayRegression:
         ds = self._make_ds(minute_data, spy, quote, current_dt)
 
         # Step 1 – 15-minute bars: find_asset_in_data_store succeeds
-        result_15m = ds.get_historical_prices(spy, length=5, timestep="15 minute", quote=quote)
-        # We only need the lookup to succeed; actual bar content may be None if the
-        # iter_count falls before the requested window, so we just check it doesn't
-        # raise and that the lookup key was resolved (cache populated).
+        ds.get_historical_prices(spy, length=5, timestep="15 minute", quote=quote)
         assert (spy, quote) in ds._find_asset_in_data_store_cache.values(), (
             "After the 15-minute call the lookup cache must contain the (spy, quote) key."
         )
 
-        # Step 2 – 1-day bars: returns None despite minute data being present (BUG)
-        result_day = ds.get_historical_prices(spy, length=3, timestep="1 day", quote=quote)
-        assert result_day is None, (
-            "BUG DEMONSTRATED: after a successful 15-minute call, a subsequent 1-day "
-            "call on the same stock still returns None because the stock guard in "
-            "_accepts_timestep rejects the cached minute data store."
+        # Step 2 – 1-day bars: now returns resampled bars instead of None (FIX)
+        result_day = ds.get_historical_prices(spy, length=1, timestep="1 day", quote=quote)
+        assert result_day is not None, (
+            "FIX VERIFIED: after a successful 15-minute call, a subsequent 1-day call on "
+            "the same stock must return resampled day bars (allow_day_resampling=True)."
         )
 
     def test_crypto_1day_request_with_only_minute_data_not_blocked(self):
         """
-        Contrast test: crypto assets are NOT affected by the stock guard, so a
-        day request on a crypto asset with only minute data is NOT blocked.
+        Symmetry test: crypto assets behave the same as stocks with allow_day_resampling=True —
+        day requests on a crypto asset with only minute data are satisfied via resampling.
 
-        This confirms the asymmetry and provides a baseline for what the correct
-        stock behavior should look like after the fix.
+        Both stock and crypto assets use the same allow_day_resampling flag path, so this
+        test verifies the uniform behavior post-fix.
         """
         btc = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
         usd = Asset("USD", asset_type=Asset.AssetType.FOREX)
         minute_data = self._make_minute_data(btc, usd, n_bars=120)
         current_dt = minute_data.df.index[100].to_pydatetime()
-
-        ds = PandasData.__new__(PandasData)
-        ds._data_store = {(btc, usd): minute_data}
-        ds._find_asset_in_data_store_cache = {}
-        ds._datetime = current_dt
+        ds = self._make_ds(minute_data, btc, usd, current_dt)
 
         # For crypto, find_asset_in_data_store must find the minute data for day requests.
         found = ds.find_asset_in_data_store((btc, usd), quote=None, timestep="day")
         assert found == (btc, usd), (
-            "Crypto with minute data must still satisfy day requests (stock guard must "
-            "not affect crypto assets)."
+            "Crypto with minute data must satisfy day requests (allow_day_resampling=True)."
         )

--- a/tests/test_pandas_data.py
+++ b/tests/test_pandas_data.py
@@ -117,3 +117,170 @@ class TestPandasData:
         assert snapshot["last_trade_time"] == idx[-1].to_pydatetime()
         assert snapshot["last_bid_time"] == idx[-1].to_pydatetime()
         assert snapshot["last_ask_time"] == idx[-1].to_pydatetime()
+
+
+class TestGetHistoricalPricesMinuteToDayRegression:
+    """
+    Integration-level regression tests for the stock/index guard in _accepts_timestep
+    (pandas_data.py lines ~416-426) that silently blocks minute-to-day resampling.
+
+    The guard reads:
+        if requested_unit == "day":
+            if requested_asset_type in {"stock", "index"}:
+                return data_ts == "day"   # minute data REJECTED for stocks
+
+    This causes get_historical_prices(asset, timestep="1 day") to return None whenever
+    only minute-level data is present for a stock/index asset, even though data.py's
+    get_bars() (lines 1307-1312) supports minute→day resampling.
+
+    Observed failure scenario (live backtest):
+      1. get_historical_prices(asset, 5, timestep="15 minute") – works fine
+      2. get_historical_prices(asset, 3, timestep="1 day")     – returns None (BUG)
+    """
+
+    @staticmethod
+    def _make_minute_data(asset: Asset, quote: Asset, n_bars: int = 120) -> Data:
+        """
+        Build n_bars of 1-minute bars starting at NYSE open on 2025-01-02.
+        Uses UTC so no tz-localize issues arise inside Data.__init__.
+        """
+        idx = pd.date_range("2025-01-02 14:30:00", periods=n_bars, freq="1min", tz="UTC")
+        price = [100.0 + i * 0.01 for i in range(n_bars)]
+        df = pd.DataFrame(
+            {
+                "open": price,
+                "high": [p + 0.5 for p in price],
+                "low": [p - 0.5 for p in price],
+                "close": price,
+                "volume": [1000] * n_bars,
+            },
+            index=idx,
+        )
+        data = Data(asset=asset, df=df, timestep="minute", quote=quote)
+        # Prime datalines so data.get_bars() is callable if the lookup ever succeeds.
+        data.repair_times_and_fill(data.df.index)
+        return data
+
+    @staticmethod
+    def _make_ds(minute_data: Data, asset: Asset, quote: Asset, current_dt) -> PandasData:
+        """
+        Build a minimal PandasData instance (no load_data() call) with _data_store
+        pointing to the supplied minute-level Data object and _datetime set.
+        """
+        ds = PandasData.__new__(PandasData)
+        ds._data_store = {(asset, quote): minute_data}
+        ds._find_asset_in_data_store_cache = {}
+        ds._datetime = current_dt
+        return ds
+
+    def test_15m_request_finds_minute_data_store(self):
+        """
+        Baseline: find_asset_in_data_store must find the minute store for a
+        15-minute intraday request.  This is the call that works before the day
+        request fails.
+        """
+        spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+        quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+        minute_data = self._make_minute_data(spy, quote)
+        current_dt = minute_data.df.index[60].to_pydatetime()
+        ds = self._make_ds(minute_data, spy, quote, current_dt)
+
+        found = ds.find_asset_in_data_store(spy, quote=quote, timestep="15 minute")
+        assert found == (spy, quote), (
+            "15-minute request must locate the minute data store for SPY."
+        )
+
+    def test_1day_request_returns_none_for_stock_with_only_minute_data(self):
+        """
+        BUG DEMONSTRATION (integration level): get_historical_prices returns None
+        when a STOCK asset has only minute data and a '1 day' timestep is requested.
+
+        The failure path:
+          get_historical_prices(spy, 3, "1 day")
+            → _pull_source_symbol_bars(spy, 3, "1 day")
+              → find_asset_in_data_store(spy, quote, "1 day")
+                → _accepts_timestep: stock guard → returns False → key not found
+              → logs warning "asset does not have data" → returns None
+            → get_historical_prices returns None
+
+        NOTE: When the underlying bug is fixed, this test will fail because
+        result_day will be a non-None Bars object. At that point, update the
+        assertion to ``assert result_day is not None`` and add a check that
+        result_day.df has OHLCV daily bars.
+        """
+        spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+        quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+        minute_data = self._make_minute_data(spy, quote, n_bars=120)
+        current_dt = minute_data.df.index[100].to_pydatetime()
+        ds = self._make_ds(minute_data, spy, quote, current_dt)
+
+        result_day = ds.get_historical_prices(spy, length=3, timestep="1 day", quote=quote)
+
+        # Current (buggy) behavior: None is returned because find_asset_in_data_store
+        # cannot match minute data to a day request for a stock asset.
+        assert result_day is None, (
+            "BUG DEMONSTRATED: get_historical_prices must return None for "
+            "stock + only-minute-data + day timestep request. "
+            "If this assertion fails, the bug has been fixed — update it to "
+            "assert result_day is not None."
+        )
+
+    def test_1day_request_after_15m_request_same_asset(self):
+        """
+        BUG DEMONSTRATION: mirrors the exact live-backtest failure sequence.
+
+        Step 1: call get_historical_prices with "15 minute" → succeeds (not None).
+        Step 2: call get_historical_prices with "1 day"     → returns None (BUG).
+
+        Both calls use the same asset and the same underlying minute data store.
+        After step 1 populates the lookup cache with the minute-timestep key,
+        step 2 should still be able to locate the store (different cache key),
+        but the stock guard prevents it.
+        """
+        spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+        quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+        minute_data = self._make_minute_data(spy, quote, n_bars=120)
+        current_dt = minute_data.df.index[100].to_pydatetime()
+        ds = self._make_ds(minute_data, spy, quote, current_dt)
+
+        # Step 1 – 15-minute bars: find_asset_in_data_store succeeds
+        result_15m = ds.get_historical_prices(spy, length=5, timestep="15 minute", quote=quote)
+        # We only need the lookup to succeed; actual bar content may be None if the
+        # iter_count falls before the requested window, so we just check it doesn't
+        # raise and that the lookup key was resolved (cache populated).
+        assert (spy, quote) in ds._find_asset_in_data_store_cache.values(), (
+            "After the 15-minute call the lookup cache must contain the (spy, quote) key."
+        )
+
+        # Step 2 – 1-day bars: returns None despite minute data being present (BUG)
+        result_day = ds.get_historical_prices(spy, length=3, timestep="1 day", quote=quote)
+        assert result_day is None, (
+            "BUG DEMONSTRATED: after a successful 15-minute call, a subsequent 1-day "
+            "call on the same stock still returns None because the stock guard in "
+            "_accepts_timestep rejects the cached minute data store."
+        )
+
+    def test_crypto_1day_request_with_only_minute_data_not_blocked(self):
+        """
+        Contrast test: crypto assets are NOT affected by the stock guard, so a
+        day request on a crypto asset with only minute data is NOT blocked.
+
+        This confirms the asymmetry and provides a baseline for what the correct
+        stock behavior should look like after the fix.
+        """
+        btc = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+        usd = Asset("USD", asset_type=Asset.AssetType.FOREX)
+        minute_data = self._make_minute_data(btc, usd, n_bars=120)
+        current_dt = minute_data.df.index[100].to_pydatetime()
+
+        ds = PandasData.__new__(PandasData)
+        ds._data_store = {(btc, usd): minute_data}
+        ds._find_asset_in_data_store_cache = {}
+        ds._datetime = current_dt
+
+        # For crypto, find_asset_in_data_store must find the minute data for day requests.
+        found = ds.find_asset_in_data_store((btc, usd), quote=None, timestep="day")
+        assert found == (btc, usd), (
+            "Crypto with minute data must still satisfy day requests (stock guard must "
+            "not affect crypto assets)."
+        )

--- a/tests/test_pandas_data_find_asset_timestep_match.py
+++ b/tests/test_pandas_data_find_asset_timestep_match.py
@@ -1,9 +1,23 @@
 from __future__ import annotations
 
+import pytz
 import pandas as pd
+from datetime import datetime
 
 from lumibot.data_sources.pandas_data import PandasData
 from lumibot.entities import Asset, Data
+
+# ---------------------------------------------------------------------------
+# Module-level datetime constants used by the real-constructor helpers below.
+# PandasData.__init__ → DataSourceBacktesting.__init__ requires a timezone-aware
+# datetime_start so that get_timezone_from_datetime() does not crash.  Using the
+# real constructor (rather than __new__) means any future attribute added to
+# find_asset_in_data_store will be present, making test failures meaningful
+# rather than cryptic AttributeErrors.
+# ---------------------------------------------------------------------------
+_TZ = pytz.timezone("America/New_York")
+_START = datetime(2025, 1, 2, 9, 30, tzinfo=_TZ)
+_END = datetime(2025, 1, 3, 16, 0, tzinfo=_TZ)
 
 
 def _minute_df(tz: str = "America/New_York") -> pd.DataFrame:
@@ -25,12 +39,23 @@ def _day_df(tz: str = "America/New_York") -> pd.DataFrame:
 
 
 def _make_ds(data_store: dict, allow_day_resampling: bool = True) -> PandasData:
-    """Build a minimal PandasData-like object without calling __init__."""
-    ds = PandasData.__new__(PandasData)
-    ds._data_store = data_store
-    ds._find_asset_in_data_store_cache = {}
-    ds.allow_day_resampling = allow_day_resampling
-    return ds
+    """Build a PandasData instance using the real constructor.
+
+    Passes the Data objects in *data_store* as a list; PandasData._set_pandas_data_keys()
+    derives the same (asset, quote) 2-tuple key from each Data object's .asset/.quote
+    attributes, so the resulting _data_store is equivalent to passing the dict directly.
+
+    Using the real constructor (rather than PandasData.__new__()) ensures all instance
+    attributes are properly initialised, so a test failure is a meaningful assertion
+    error rather than a cryptic AttributeError if find_asset_in_data_store is ever
+    changed to read an additional attribute.
+    """
+    return PandasData(
+        datetime_start=_START,
+        datetime_end=_END,
+        pandas_data=list(data_store.values()),
+        allow_day_resampling=allow_day_resampling,
+    )
 
 
 def test_find_asset_in_data_store_does_not_return_daily_for_minute_requests():
@@ -256,16 +281,13 @@ def _make_full_pandas_ds(day_df_data: pd.DataFrame, minute_df_data: pd.DataFrame
     store.  This mirrors the situation after a first 15m get_historical_prices call has
     populated minute data, and then a day call is made.
     """
-    from datetime import datetime, timezone
-    from lumibot.entities import Data
-
     minute_data = Data(spy, minute_df_data, timestep="minute", quote=quote)
-
-    ds = PandasData.__new__(PandasData)
-    ds._data_store = {(spy, quote): minute_data}
-    ds._find_asset_in_data_store_cache = {}
-    ds.allow_day_resampling = allow_day_resampling
-    return ds
+    return PandasData(
+        datetime_start=_START,
+        datetime_end=_END,
+        pandas_data=[minute_data],
+        allow_day_resampling=allow_day_resampling,
+    )
 
 
 def test_get_historical_prices_day_after_minute_cache_allow_resampling():
@@ -275,8 +297,6 @@ def test_get_historical_prices_day_after_minute_cache_allow_resampling():
 
     This is the exact failure scenario from the bug report (Polygon path).
     """
-    from datetime import datetime, timezone
-
     spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
     quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
 
@@ -290,15 +310,17 @@ def test_get_historical_prices_day_after_minute_cache_allow_resampling():
 
     minute_data = Data(spy, minute_df, timestep="minute", quote=quote)
 
-    ds = PandasData.__new__(PandasData)
-    ds._data_store = {(spy, quote): minute_data}
-    ds._find_asset_in_data_store_cache = {}
-    ds.allow_day_resampling = True  # Polygon / base PandasData default
+    ds = PandasData(
+        datetime_start=_START,
+        datetime_end=_END,
+        pandas_data=[minute_data],
+        allow_day_resampling=True,  # Polygon / base PandasData default
+    )
 
-    # Simulate the backtest clock sitting at end of the trading day
+    # Simulate the backtest clock sitting at end of the trading day.
+    # get_datetime() is monkey-patched so _pull_source_symbol_bars gets the right "now"
+    # without having to advance the backtesting iterator.
     now = pd.Timestamp("2025-01-02 16:00:00", tz="America/New_York").to_pydatetime()
-
-    # Patch get_datetime so _pull_source_symbol_bars knows "now"
     ds.get_datetime = lambda: now
 
     response = ds._pull_source_symbol_bars(spy, length=1, timestep="day", quote=quote)
@@ -313,8 +335,6 @@ def test_get_historical_prices_day_after_minute_cache_no_resampling():
     With allow_day_resampling=False (ThetaData), the same scenario must return None from
     _pull_source_symbol_bars so that the caller is forced to fetch native day bars.
     """
-    from datetime import datetime, timezone
-
     spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
     quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
 
@@ -327,10 +347,12 @@ def test_get_historical_prices_day_after_minute_cache_no_resampling():
 
     minute_data = Data(spy, minute_df, timestep="minute", quote=quote)
 
-    ds = PandasData.__new__(PandasData)
-    ds._data_store = {(spy, quote): minute_data}
-    ds._find_asset_in_data_store_cache = {}
-    ds.allow_day_resampling = False  # ThetaData-style: exact match required
+    ds = PandasData(
+        datetime_start=_START,
+        datetime_end=_END,
+        pandas_data=[minute_data],
+        allow_day_resampling=False,  # ThetaData-style: exact match required
+    )
 
     now = pd.Timestamp("2025-01-02 16:00:00", tz="America/New_York").to_pydatetime()
     ds.get_datetime = lambda: now
@@ -348,7 +370,7 @@ def test_get_historical_prices_day_after_minute_cache_no_resampling():
 
 def test_pandas_data_default_allow_day_resampling_is_true():
     """PandasData defaults allow_day_resampling=True (Polygon / base PandasData behaviour)."""
-    from datetime import datetime, timezone
+    from datetime import timezone
 
     ds = PandasData(
         datetime_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
@@ -360,7 +382,7 @@ def test_pandas_data_default_allow_day_resampling_is_true():
 
 def test_pandas_data_explicit_false_allow_day_resampling():
     """allow_day_resampling=False can be passed explicitly to PandasData."""
-    from datetime import datetime, timezone
+    from datetime import timezone
 
     ds = PandasData(
         datetime_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
@@ -375,7 +397,7 @@ def test_thetadata_backtesting_sets_allow_day_resampling_false(monkeypatch):
     """ThetaDataBacktestingPandas must hard-set allow_day_resampling=False."""
     import lumibot.tools.thetadata_helper as thetadata_helper
     from lumibot.backtesting.thetadata_backtesting_pandas import ThetaDataBacktestingPandas
-    from datetime import datetime, timezone
+    from datetime import timezone
 
     monkeypatch.setattr(ThetaDataBacktestingPandas, "kill_processes_by_name", lambda *_a, **_kw: None)
     monkeypatch.setattr(thetadata_helper, "reset_theta_terminal_tracking", lambda *_a, **_kw: None)
@@ -396,7 +418,7 @@ def test_polygon_backtesting_sets_allow_day_resampling_true(monkeypatch):
     """PolygonDataBacktesting must hard-set allow_day_resampling=True."""
     from lumibot.backtesting.polygon_backtesting import PolygonDataBacktesting
     from lumibot.tools.polygon_helper import PolygonClient
-    from datetime import datetime, timezone
+    from datetime import timezone
 
     monkeypatch.setattr(PolygonClient, "create", lambda api_key: None)
 

--- a/tests/test_pandas_data_find_asset_timestep_match.py
+++ b/tests/test_pandas_data_find_asset_timestep_match.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
-
 import pandas as pd
 
 from lumibot.data_sources.pandas_data import PandasData
@@ -9,13 +7,21 @@ from lumibot.entities import Asset, Data
 
 
 def _minute_df(tz: str = "America/New_York") -> pd.DataFrame:
-    idx = pd.date_range("2025-01-01", periods=3, freq="1min", tz=tz)
-    return pd.DataFrame({"open": [1, 2, 3], "high": [1, 2, 3], "low": [1, 2, 3], "close": [1, 2, 3], "volume": [0, 0, 0]}, index=idx)
+    idx = pd.date_range("2025-01-02 09:30", periods=60, freq="1min", tz=tz)
+    price = [100.0 + i * 0.01 for i in range(60)]
+    return pd.DataFrame(
+        {"open": price, "high": price, "low": price, "close": price, "volume": [1000] * 60},
+        index=idx,
+    )
 
 
 def _day_df(tz: str = "America/New_York") -> pd.DataFrame:
-    idx = pd.date_range("2025-01-01", periods=3, freq="D", tz=tz)
-    return pd.DataFrame({"open": [1, 2, 3], "high": [1, 2, 3], "low": [1, 2, 3], "close": [1, 2, 3], "volume": [0, 0, 0]}, index=idx)
+    idx = pd.date_range("2025-01-02", periods=5, freq="D", tz=tz)
+    return pd.DataFrame(
+        {"open": [1, 2, 3, 4, 5], "high": [1, 2, 3, 4, 5], "low": [1, 2, 3, 4, 5],
+         "close": [1, 2, 3, 4, 5], "volume": [0, 0, 0, 0, 0]},
+        index=idx,
+    )
 
 
 def test_find_asset_in_data_store_does_not_return_daily_for_minute_requests():
@@ -26,6 +32,7 @@ def test_find_asset_in_data_store_does_not_return_daily_for_minute_requests():
 
     ds = PandasData.__new__(PandasData)
     ds._data_store = {(base, quote): daily}  # type: ignore[attr-defined]
+    ds._find_asset_in_data_store_cache = {}
 
     # Simulate how crypto/forex often passes assets as a tuple while quote=None.
     asset_tuple = (base, quote)
@@ -34,6 +41,7 @@ def test_find_asset_in_data_store_does_not_return_daily_for_minute_requests():
 
 
 def test_find_asset_in_data_store_allows_minute_data_to_satisfy_day_requests():
+    """Crypto assets with only minute data can still satisfy day-bar requests (unchanged behavior)."""
     base = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
     quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
 
@@ -41,8 +49,121 @@ def test_find_asset_in_data_store_allows_minute_data_to_satisfy_day_requests():
 
     ds = PandasData.__new__(PandasData)
     ds._data_store = {(base, quote): minute}  # type: ignore[attr-defined]
+    ds._find_asset_in_data_store_cache = {}
 
     asset_tuple = (base, quote)
     assert ds.find_asset_in_data_store(asset_tuple, quote=None, timestep="day") == (base, quote)
     assert ds.find_asset_in_data_store(asset_tuple, quote=None, timestep="minute") == (base, quote)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the stock/index guard introduced in _accepts_timestep
+# (pandas_data.py lines ~416-426):
+#
+#   if requested_unit == "day":
+#       if requested_asset_type in {"stock", "index"}:
+#           return data_ts == "day"   # <-- minute data REJECTED for stocks
+#       return data_ts in {"day", "minute"}
+#
+# Effect: a strategy that loads only minute data for a stock (e.g., via a 15m bar
+# fetch) and then calls get_historical_prices(..., timestep="1 day") receives None,
+# even though data.py's get_bars() (lines 1307-1312) fully supports minute-to-day
+# resampling.
+# ---------------------------------------------------------------------------
+
+
+def test_find_asset_in_data_store_stock_minute_data_day_request_returns_none():
+    """
+    BUG DEMONSTRATION: find_asset_in_data_store returns None when a STOCK asset
+    has only minute data in the store and a day-bar request is made.
+
+    This is the root cause of the silent get_historical_prices failure observed in
+    live backtests that call get_historical_prices(asset, timestep="15 minute") first
+    and then get_historical_prices(asset, timestep="1 day").
+
+    The 15-minute call caches minute data in _data_store for the stock. The
+    subsequent day call is then gated out by the stock guard in _accepts_timestep
+    before data.get_bars() is ever reached.
+
+    NOTE: When the bug is fixed (the stock guard is removed or relaxed), the assertion
+    ``assert day_key is None`` below will fail.  At that point change it to
+    ``assert day_key == (spy, quote)`` and add a test that the returned Bars are
+    non-empty daily bars.
+    """
+    spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    minute_data = Data(spy, _minute_df(), timestep="minute", quote=quote)
+
+    ds = PandasData.__new__(PandasData)
+    ds._data_store = {(spy, quote): minute_data}
+    ds._find_asset_in_data_store_cache = {}
+
+    # 15-minute request: minute data IS accepted → key is found (works correctly)
+    min_key = ds.find_asset_in_data_store(spy, quote=quote, timestep="15 minute")
+    assert min_key == (spy, quote), (
+        "15-minute request must find the minute data store so the strategy can read intraday bars."
+    )
+
+    # 1-day request: minute data is NOT accepted for stocks → None returned (BUG)
+    # data.py get_bars() would happily resample minute → day if it were reached, but it
+    # never is because _accepts_timestep blocks the lookup at pandas_data.py:424-425.
+    day_key = ds.find_asset_in_data_store(spy, quote=quote, timestep="day")
+    assert day_key is None, (
+        "BUG: find_asset_in_data_store returns None for stock + minute data + day request. "
+        "Fix: relax the stock guard in _accepts_timestep so minute data can satisfy day "
+        "requests and reach data.get_bars() minute-to-day resampling."
+    )
+
+
+def test_find_asset_in_data_store_stock_vs_crypto_asymmetry():
+    """
+    Demonstrates the stock/crypto asymmetry introduced by the stock guard.
+
+    Crypto (BTC) with minute data → day request returns the key (unchanged).
+    Stock (SPY) with minute data → day request returns None (broken by the guard).
+    """
+    usd = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+    # --- Crypto: minute data still satisfies day requests ---
+    btc = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+    btc_minute = Data(btc, _minute_df(), timestep="minute", quote=usd)
+    ds_crypto = PandasData.__new__(PandasData)
+    ds_crypto._data_store = {(btc, usd): btc_minute}
+    ds_crypto._find_asset_in_data_store_cache = {}
+
+    assert ds_crypto.find_asset_in_data_store((btc, usd), quote=None, timestep="day") == (btc, usd), (
+        "Crypto with minute data should still satisfy day requests."
+    )
+
+    # --- Stock: minute data NO LONGER satisfies day requests (the bug) ---
+    spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    spy_minute = Data(spy, _minute_df(), timestep="minute", quote=usd)
+    ds_stock = PandasData.__new__(PandasData)
+    ds_stock._data_store = {(spy, usd): spy_minute}
+    ds_stock._find_asset_in_data_store_cache = {}
+
+    assert ds_stock.find_asset_in_data_store(spy, quote=usd, timestep="day") is None, (
+        "BUG: Stock with minute data should also satisfy day requests (same as crypto), "
+        "but the stock guard in _accepts_timestep blocks this."
+    )
+
+
+def test_find_asset_in_data_store_index_minute_data_day_request_returns_none():
+    """
+    The same stock guard also blocks INDEX assets from using minute data for day requests.
+    """
+    spx = Asset("SPX", asset_type=Asset.AssetType.INDEX)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    minute_data = Data(spx, _minute_df(), timestep="minute", quote=quote)
+
+    ds = PandasData.__new__(PandasData)
+    ds._data_store = {(spx, quote): minute_data}
+    ds._find_asset_in_data_store_cache = {}
+
+    # Minute requests still work for index assets
+    assert ds.find_asset_in_data_store(spx, quote=quote, timestep="minute") == (spx, quote)
+
+    # Day requests are blocked for index assets too (same guard as stocks)
+    assert ds.find_asset_in_data_store(spx, quote=quote, timestep="day") is None
+
 

--- a/tests/test_pandas_data_find_asset_timestep_match.py
+++ b/tests/test_pandas_data_find_asset_timestep_match.py
@@ -24,15 +24,22 @@ def _day_df(tz: str = "America/New_York") -> pd.DataFrame:
     )
 
 
+def _make_ds(data_store: dict, allow_day_resampling: bool = True) -> PandasData:
+    """Build a minimal PandasData-like object without calling __init__."""
+    ds = PandasData.__new__(PandasData)
+    ds._data_store = data_store
+    ds._find_asset_in_data_store_cache = {}
+    ds.allow_day_resampling = allow_day_resampling
+    return ds
+
+
 def test_find_asset_in_data_store_does_not_return_daily_for_minute_requests():
     base = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
     quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
 
     daily = Data(base, _day_df(), timestep="day", quote=quote)
 
-    ds = PandasData.__new__(PandasData)
-    ds._data_store = {(base, quote): daily}  # type: ignore[attr-defined]
-    ds._find_asset_in_data_store_cache = {}
+    ds = _make_ds({(base, quote): daily})
 
     # Simulate how crypto/forex often passes assets as a tuple while quote=None.
     asset_tuple = (base, quote)
@@ -47,9 +54,7 @@ def test_find_asset_in_data_store_allows_minute_data_to_satisfy_day_requests():
 
     minute = Data(base, _minute_df(), timestep="minute", quote=quote)
 
-    ds = PandasData.__new__(PandasData)
-    ds._data_store = {(base, quote): minute}  # type: ignore[attr-defined]
-    ds._find_asset_in_data_store_cache = {}
+    ds = _make_ds({(base, quote): minute})
 
     asset_tuple = (base, quote)
     assert ds.find_asset_in_data_store(asset_tuple, quote=None, timestep="day") == (base, quote)
@@ -57,113 +62,350 @@ def test_find_asset_in_data_store_allows_minute_data_to_satisfy_day_requests():
 
 
 # ---------------------------------------------------------------------------
-# Regression tests for the stock/index guard introduced in _accepts_timestep
-# (pandas_data.py lines ~416-426):
+# Tests for the allow_day_resampling flag — the fix for the Polygon vs ThetaData
+# conflict described in the original bug report.
 #
-#   if requested_unit == "day":
-#       if requested_asset_type in {"stock", "index"}:
-#           return data_ts == "day"   # <-- minute data REJECTED for stocks
-#       return data_ts in {"day", "minute"}
+# allow_day_resampling=True  (default, Polygon / base PandasData):
+#   minute data in the store CAN satisfy a day-bar lookup for stocks/indices so
+#   that Data.get_bars() minute→day resampling fires.
 #
-# Effect: a strategy that loads only minute data for a stock (e.g., via a 15m bar
-# fetch) and then calls get_historical_prices(..., timestep="1 day") receives None,
-# even though data.py's get_bars() (lines 1307-1312) fully supports minute-to-day
-# resampling.
+# allow_day_resampling=False (ThetaData):
+#   Exact timestep match is required. A cached minute dataset must NEVER proxy
+#   for a day request so that ThetaData's split-adjusted day bars are used.
 # ---------------------------------------------------------------------------
 
 
-def test_find_asset_in_data_store_stock_minute_data_day_request_returns_none():
+def test_find_asset_in_data_store_stock_minute_data_day_request_allow_resampling():
     """
-    BUG DEMONSTRATION: find_asset_in_data_store returns None when a STOCK asset
-    has only minute data in the store and a day-bar request is made.
+    FIX VERIFICATION: With allow_day_resampling=True (Polygon / base PandasData default),
+    a stock asset that only has minute data in the store can satisfy a day-bar request.
 
-    This is the root cause of the silent get_historical_prices failure observed in
-    live backtests that call get_historical_prices(asset, timestep="15 minute") first
-    and then get_historical_prices(asset, timestep="1 day").
-
-    The 15-minute call caches minute data in _data_store for the stock. The
-    subsequent day call is then gated out by the stock guard in _accepts_timestep
-    before data.get_bars() is ever reached.
-
-    NOTE: When the bug is fixed (the stock guard is removed or relaxed), the assertion
-    ``assert day_key is None`` below will fail.  At that point change it to
-    ``assert day_key == (spy, quote)`` and add a test that the returned Bars are
-    non-empty daily bars.
+    This is the root cause of the silent get_historical_prices failure when a live backtest
+    calls get_historical_prices(asset, timestep="15 minute") first and then
+    get_historical_prices(asset, timestep="1 day").  With allow_day_resampling=True the
+    second call finds the minute data and lets Data.get_bars() resample it to daily bars.
     """
     spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
     quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
     minute_data = Data(spy, _minute_df(), timestep="minute", quote=quote)
 
-    ds = PandasData.__new__(PandasData)
-    ds._data_store = {(spy, quote): minute_data}
-    ds._find_asset_in_data_store_cache = {}
+    # Default (allow_day_resampling=True) — the fix
+    ds = _make_ds({(spy, quote): minute_data}, allow_day_resampling=True)
 
-    # 15-minute request: minute data IS accepted → key is found (works correctly)
+    # 15-minute request: minute data IS accepted (works correctly both before and after fix)
     min_key = ds.find_asset_in_data_store(spy, quote=quote, timestep="15 minute")
     assert min_key == (spy, quote), (
         "15-minute request must find the minute data store so the strategy can read intraday bars."
     )
 
-    # 1-day request: minute data is NOT accepted for stocks → None returned (BUG)
-    # data.py get_bars() would happily resample minute → day if it were reached, but it
-    # never is because _accepts_timestep blocks the lookup at pandas_data.py:424-425.
+    # 1-day request: with allow_day_resampling=True, minute data IS now accepted for stocks
     day_key = ds.find_asset_in_data_store(spy, quote=quote, timestep="day")
-    assert day_key is None, (
-        "BUG: find_asset_in_data_store returns None for stock + minute data + day request. "
-        "Fix: relax the stock guard in _accepts_timestep so minute data can satisfy day "
-        "requests and reach data.get_bars() minute-to-day resampling."
+    assert day_key == (spy, quote), (
+        "With allow_day_resampling=True, minute data must satisfy day requests so that "
+        "Data.get_bars() can resample minute → day bars."
     )
 
 
-def test_find_asset_in_data_store_stock_vs_crypto_asymmetry():
+def test_find_asset_in_data_store_stock_minute_data_day_request_no_resampling():
     """
-    Demonstrates the stock/crypto asymmetry introduced by the stock guard.
+    With allow_day_resampling=False (ThetaData), a stock with only minute data in the
+    store must NOT satisfy a day-bar request.  This forces an explicit day-bar fetch and
+    preserves ThetaData's split-adjusted day-bar normalisation.
+    """
+    spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    minute_data = Data(spy, _minute_df(), timestep="minute", quote=quote)
 
-    Crypto (BTC) with minute data → day request returns the key (unchanged).
-    Stock (SPY) with minute data → day request returns None (broken by the guard).
+    # ThetaData-style (allow_day_resampling=False)
+    ds = _make_ds({(spy, quote): minute_data}, allow_day_resampling=False)
+
+    # 15-minute request still works (minute data satisfies minute requests)
+    min_key = ds.find_asset_in_data_store(spy, quote=quote, timestep="15 minute")
+    assert min_key == (spy, quote)
+
+    # 1-day request must NOT find the minute data (forces fresh day-bar fetch)
+    day_key = ds.find_asset_in_data_store(spy, quote=quote, timestep="day")
+    assert day_key is None, (
+        "With allow_day_resampling=False (ThetaData), minute data must not satisfy day requests."
+    )
+
+
+def test_find_asset_in_data_store_stock_vs_crypto_symmetry_allow_resampling():
+    """
+    With allow_day_resampling=True, stocks and crypto behave symmetrically:
+    both can use minute data to satisfy day requests.
     """
     usd = Asset("USD", asset_type=Asset.AssetType.FOREX)
 
-    # --- Crypto: minute data still satisfies day requests ---
+    # Crypto: minute data satisfies day requests
     btc = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
     btc_minute = Data(btc, _minute_df(), timestep="minute", quote=usd)
-    ds_crypto = PandasData.__new__(PandasData)
-    ds_crypto._data_store = {(btc, usd): btc_minute}
-    ds_crypto._find_asset_in_data_store_cache = {}
-
+    ds_crypto = _make_ds({(btc, usd): btc_minute}, allow_day_resampling=True)
     assert ds_crypto.find_asset_in_data_store((btc, usd), quote=None, timestep="day") == (btc, usd), (
-        "Crypto with minute data should still satisfy day requests."
+        "Crypto with minute data should satisfy day requests."
     )
 
-    # --- Stock: minute data NO LONGER satisfies day requests (the bug) ---
+    # Stock: minute data also satisfies day requests with allow_day_resampling=True
     spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
     spy_minute = Data(spy, _minute_df(), timestep="minute", quote=usd)
-    ds_stock = PandasData.__new__(PandasData)
-    ds_stock._data_store = {(spy, usd): spy_minute}
-    ds_stock._find_asset_in_data_store_cache = {}
-
-    assert ds_stock.find_asset_in_data_store(spy, quote=usd, timestep="day") is None, (
-        "BUG: Stock with minute data should also satisfy day requests (same as crypto), "
-        "but the stock guard in _accepts_timestep blocks this."
+    ds_stock = _make_ds({(spy, usd): spy_minute}, allow_day_resampling=True)
+    assert ds_stock.find_asset_in_data_store(spy, quote=usd, timestep="day") == (spy, usd), (
+        "Stock with minute data should also satisfy day requests when allow_day_resampling=True."
     )
 
 
-def test_find_asset_in_data_store_index_minute_data_day_request_returns_none():
+def test_find_asset_in_data_store_stock_vs_crypto_no_resampling():
     """
-    The same stock guard also blocks INDEX assets from using minute data for day requests.
+    With allow_day_resampling=False (ThetaData), BOTH stocks AND crypto/other types
+    must use exact timestep matching — minute data never satisfies a day request.
+    This is stricter than the old stock/index-only guard but correct for ThetaData
+    because it stores data under separate (asset, quote, timestep) canonical keys.
+    """
+    usd = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+    # Crypto: minute data must NOT satisfy day requests with allow_day_resampling=False
+    btc = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+    btc_minute = Data(btc, _minute_df(), timestep="minute", quote=usd)
+    ds_crypto = _make_ds({(btc, usd): btc_minute}, allow_day_resampling=False)
+    assert ds_crypto.find_asset_in_data_store((btc, usd), quote=None, timestep="day") is None, (
+        "With allow_day_resampling=False, even crypto minute data must not satisfy day requests."
+    )
+
+    # Stock: same
+    spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    spy_minute = Data(spy, _minute_df(), timestep="minute", quote=usd)
+    ds_stock = _make_ds({(spy, usd): spy_minute}, allow_day_resampling=False)
+    assert ds_stock.find_asset_in_data_store(spy, quote=usd, timestep="day") is None
+
+
+def test_find_asset_in_data_store_index_minute_data_day_request_allow_resampling():
+    """
+    INDEX assets behave the same as stocks: with allow_day_resampling=True they can
+    use minute data for day requests; with allow_day_resampling=False they cannot.
     """
     spx = Asset("SPX", asset_type=Asset.AssetType.INDEX)
     quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
     minute_data = Data(spx, _minute_df(), timestep="minute", quote=quote)
 
-    ds = PandasData.__new__(PandasData)
-    ds._data_store = {(spx, quote): minute_data}
-    ds._find_asset_in_data_store_cache = {}
+    # Minute requests always work regardless of flag
+    ds = _make_ds({(spx, quote): minute_data}, allow_day_resampling=True)
+    assert ds.find_asset_in_data_store(spx, quote=quote, timestep="minute") == (spx, quote)
+
+    # Day request: allowed when allow_day_resampling=True
+    assert ds.find_asset_in_data_store(spx, quote=quote, timestep="day") == (spx, quote)
+
+
+def test_find_asset_in_data_store_index_minute_data_day_request_no_resampling():
+    """
+    The same INDEX guard: with allow_day_resampling=False, day requests are blocked.
+    """
+    spx = Asset("SPX", asset_type=Asset.AssetType.INDEX)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    minute_data = Data(spx, _minute_df(), timestep="minute", quote=quote)
+
+    ds = _make_ds({(spx, quote): minute_data}, allow_day_resampling=False)
 
     # Minute requests still work for index assets
     assert ds.find_asset_in_data_store(spx, quote=quote, timestep="minute") == (spx, quote)
 
-    # Day requests are blocked for index assets too (same guard as stocks)
+    # Day requests are blocked
     assert ds.find_asset_in_data_store(spx, quote=quote, timestep="day") is None
 
 
+def test_find_asset_in_data_store_native_day_data_always_found():
+    """
+    Regardless of allow_day_resampling, native day data must always satisfy day requests.
+    """
+    spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    day_data = Data(spy, _day_df(), timestep="day", quote=quote)
+
+    for flag in (True, False):
+        ds = _make_ds({(spy, quote): day_data}, allow_day_resampling=flag)
+        assert ds.find_asset_in_data_store(spy, quote=quote, timestep="day") == (spy, quote), (
+            f"Native day data must always satisfy day requests (allow_day_resampling={flag})."
+        )
+
+
+def test_find_asset_in_data_store_day_data_never_satisfies_minute_request():
+    """
+    Day data must never satisfy minute requests, regardless of allow_day_resampling.
+    """
+    spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    day_data = Data(spy, _day_df(), timestep="day", quote=quote)
+
+    for flag in (True, False):
+        ds = _make_ds({(spy, quote): day_data}, allow_day_resampling=flag)
+        assert ds.find_asset_in_data_store(spy, quote=quote, timestep="minute") is None, (
+            f"Day data must never satisfy minute requests (allow_day_resampling={flag})."
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end regression test: 15m request → 1d request on a stock.
+#
+# Simulates the exact live-backtest scenario described in the bug report using
+# PandasData._pull_source_symbol_bars directly (no live network calls).
+# ---------------------------------------------------------------------------
+
+def _make_full_pandas_ds(day_df_data: pd.DataFrame, minute_df_data: pd.DataFrame,
+                         spy: Asset, quote: Asset, allow_day_resampling: bool) -> PandasData:
+    """
+    Build a PandasData instance that has BOTH a minute dataset and a day dataset in its
+    store.  This mirrors the situation after a first 15m get_historical_prices call has
+    populated minute data, and then a day call is made.
+    """
+    from datetime import datetime, timezone
+    from lumibot.entities import Data
+
+    minute_data = Data(spy, minute_df_data, timestep="minute", quote=quote)
+
+    ds = PandasData.__new__(PandasData)
+    ds._data_store = {(spy, quote): minute_data}
+    ds._find_asset_in_data_store_cache = {}
+    ds.allow_day_resampling = allow_day_resampling
+    return ds
+
+
+def test_get_historical_prices_day_after_minute_cache_allow_resampling():
+    """
+    Regression: after a 15m request has populated minute data for a stock, a subsequent
+    1d get_historical_prices call must return non-None Bars when allow_day_resampling=True.
+
+    This is the exact failure scenario from the bug report (Polygon path).
+    """
+    from datetime import datetime, timezone
+
+    spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+    # Build a minute DataFrame covering a full trading day (390 1-min bars)
+    idx = pd.date_range("2025-01-02 09:31", periods=390, freq="1min", tz="America/New_York")
+    price = [450.0 + i * 0.01 for i in range(390)]
+    minute_df = pd.DataFrame(
+        {"open": price, "high": price, "low": price, "close": price, "volume": [1000] * 390},
+        index=idx,
+    )
+
+    minute_data = Data(spy, minute_df, timestep="minute", quote=quote)
+
+    ds = PandasData.__new__(PandasData)
+    ds._data_store = {(spy, quote): minute_data}
+    ds._find_asset_in_data_store_cache = {}
+    ds.allow_day_resampling = True  # Polygon / base PandasData default
+
+    # Simulate the backtest clock sitting at end of the trading day
+    now = pd.Timestamp("2025-01-02 16:00:00", tz="America/New_York").to_pydatetime()
+
+    # Patch get_datetime so _pull_source_symbol_bars knows "now"
+    ds.get_datetime = lambda: now
+
+    response = ds._pull_source_symbol_bars(spy, length=1, timestep="day", quote=quote)
+    assert response is not None, (
+        "With allow_day_resampling=True and a full trading day of minute data in the store, "
+        "a day-bar request must return non-None (resampled) bars."
+    )
+
+
+def test_get_historical_prices_day_after_minute_cache_no_resampling():
+    """
+    With allow_day_resampling=False (ThetaData), the same scenario must return None from
+    _pull_source_symbol_bars so that the caller is forced to fetch native day bars.
+    """
+    from datetime import datetime, timezone
+
+    spy = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+    idx = pd.date_range("2025-01-02 09:31", periods=390, freq="1min", tz="America/New_York")
+    price = [450.0 + i * 0.01 for i in range(390)]
+    minute_df = pd.DataFrame(
+        {"open": price, "high": price, "low": price, "close": price, "volume": [1000] * 390},
+        index=idx,
+    )
+
+    minute_data = Data(spy, minute_df, timestep="minute", quote=quote)
+
+    ds = PandasData.__new__(PandasData)
+    ds._data_store = {(spy, quote): minute_data}
+    ds._find_asset_in_data_store_cache = {}
+    ds.allow_day_resampling = False  # ThetaData-style: exact match required
+
+    now = pd.Timestamp("2025-01-02 16:00:00", tz="America/New_York").to_pydatetime()
+    ds.get_datetime = lambda: now
+
+    response = ds._pull_source_symbol_bars(spy, length=1, timestep="day", quote=quote)
+    assert response is None, (
+        "With allow_day_resampling=False (ThetaData), minute data must not satisfy a day request. "
+        "_pull_source_symbol_bars must return None so the caller fetches native day bars."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Verify that PandasData.__init__ correctly initialises the flag.
+# ---------------------------------------------------------------------------
+
+def test_pandas_data_default_allow_day_resampling_is_true():
+    """PandasData defaults allow_day_resampling=True (Polygon / base PandasData behaviour)."""
+    from datetime import datetime, timezone
+
+    ds = PandasData(
+        datetime_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        datetime_end=datetime(2025, 1, 5, tzinfo=timezone.utc),
+        pandas_data={},
+    )
+    assert ds.allow_day_resampling is True
+
+
+def test_pandas_data_explicit_false_allow_day_resampling():
+    """allow_day_resampling=False can be passed explicitly to PandasData."""
+    from datetime import datetime, timezone
+
+    ds = PandasData(
+        datetime_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        datetime_end=datetime(2025, 1, 5, tzinfo=timezone.utc),
+        pandas_data={},
+        allow_day_resampling=False,
+    )
+    assert ds.allow_day_resampling is False
+
+
+def test_thetadata_backtesting_sets_allow_day_resampling_false(monkeypatch):
+    """ThetaDataBacktestingPandas must hard-set allow_day_resampling=False."""
+    import lumibot.tools.thetadata_helper as thetadata_helper
+    from lumibot.backtesting.thetadata_backtesting_pandas import ThetaDataBacktestingPandas
+    from datetime import datetime, timezone
+
+    monkeypatch.setattr(ThetaDataBacktestingPandas, "kill_processes_by_name", lambda *_a, **_kw: None)
+    monkeypatch.setattr(thetadata_helper, "reset_theta_terminal_tracking", lambda *_a, **_kw: None)
+
+    ds = ThetaDataBacktestingPandas(
+        datetime_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        datetime_end=datetime(2025, 1, 5, tzinfo=timezone.utc),
+        username="test",
+        password="test",
+    )
+    assert ds.allow_day_resampling is False, (
+        "ThetaDataBacktestingPandas must set allow_day_resampling=False to preserve "
+        "split-adjusted day-bar integrity."
+    )
+
+
+def test_polygon_backtesting_sets_allow_day_resampling_true(monkeypatch):
+    """PolygonDataBacktesting must hard-set allow_day_resampling=True."""
+    from lumibot.backtesting.polygon_backtesting import PolygonDataBacktesting
+    from lumibot.tools.polygon_helper import PolygonClient
+    from datetime import datetime, timezone
+
+    monkeypatch.setattr(PolygonClient, "create", lambda api_key: None)
+
+    ds = PolygonDataBacktesting(
+        datetime_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        datetime_end=datetime(2025, 1, 5, tzinfo=timezone.utc),
+        api_key="test",
+    )
+    assert ds.allow_day_resampling is True, (
+        "PolygonDataBacktesting must set allow_day_resampling=True so that cached minute "
+        "data can satisfy day requests via Data.get_bars() resampling."
+    )


### PR DESCRIPTION
This pull request introduces a configurable mechanism for controlling whether minute-level cached data can satisfy day-bar lookup requests in backtesting data sources, addressing inconsistencies across providers like Polygon and ThetaData. The changes add an `allow_day_resampling` flag to the `PandasData` class and its derivatives, update the timestep-matching logic, and provide comprehensive tests and documentation for this behavior.

Key changes:

### Data source configuration and logic

* Added an `allow_day_resampling` parameter (defaulting to `True`) to `PandasData` and its subclasses, allowing each data source to specify whether minute data may be resampled to fulfill day-bar requests. This is set to `True` for Polygon and base PandasData, and `False` for ThetaData to enforce provider-specific normalization rules. [[1]](diffhunk://#diff-8b527d89896bcae2cc736711848c75af956d9f8ae0a2799742ddf84fab9ce877L28-R29) [[2]](diffhunk://#diff-afb8bfea060e21c6f44b97fbfea5eeecba3a68d5371d419cbce876c715178c89R40-R46) [[3]](diffhunk://#diff-228b2034d06a774af2305f1e6df6878d53540a6773e9b0704b1e0fbc5f921997R125-R132)
* Updated the `_accepts_timestep` method in `PandasData` to use the new `allow_day_resampling` flag, with detailed comments explaining the rationale and differences between data sources. This ensures that day requests are only satisfied by minute data when appropriate. [[1]](diffhunk://#diff-8b527d89896bcae2cc736711848c75af956d9f8ae0a2799742ddf84fab9ce877L417-R445) [[2]](diffhunk://#diff-8b527d89896bcae2cc736711848c75af956d9f8ae0a2799742ddf84fab9ce877R39-R48)

### Testing and regression coverage

* Added a new regression test class (`TestGetHistoricalPricesMinuteToDayRegression`) to verify correct (and buggy) behavior when requesting day bars from minute-only data, especially for stocks versus crypto assets. The tests document and demonstrate the previously buggy behavior and provide a baseline for future fixes.
* Refactored and improved test utilities in `test_pandas_data_find_asset_timestep_match.py` to support the new configuration, ensuring that tests accurately reflect the new timestep-matching logic. [[1]](diffhunk://#diff-aea54d6c2048772874b230c8ba9c409ed09de62a2b7c2a588dd3debd7db3b228L3-R33) [[2]](diffhunk://#diff-aea54d6c2048772874b230c8ba9c409ed09de62a2b7c2a588dd3debd7db3b228L27-R42)

These changes make the data source behavior more explicit and configurable, prevent silent bypassing of provider-specific normalization, and improve test coverage and documentation for this critical aspect of the backtesting engine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to control whether minute-level data may be resampled to satisfy day-bar requests (defaults to enabled).
  * Polygon backtesting now permits on-demand resampling from minute to day data.
  * ThetaData backtesting enforces exact-timestep day matching (resampling disabled).

* **Tests**
  * Expanded tests covering minute-to-day resampling behavior across asset types and access patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->