### PR TITLE
v4.4.56 - tearsheet metrics JSON contract release

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: Lumiwealth
+custom:
+  - https://botspot.trade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 4.4.56 - Unreleased
 
+### Changed
+- Bump minimum `quantstats-lumi` dependency to `>=1.1.1` to pick up tearsheet scalar-metric normalization and contract-test coverage.
+
+### Fixed
+- Tearsheet summary artifact compatibility with `quantstats-lumi` machine-readable metric contract (typed scalar values, no `%` string leakage in JSON scalar values).
+
 ## 4.4.55 - 2026-03-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.4.56 - Unreleased
+
 ## 4.4.55 - 2026-03-15
 
 ### Added

--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,51 @@
+{
+  "version": "v1.0.0",
+  "entity": {
+    "type": "organisation",
+    "role": "owner",
+    "name": "Lumiwealth",
+    "email": "rob@botspot.trade",
+    "phone": "",
+    "description": "Lumiwealth builds open source tools for algorithmic trading and financial markets. Our flagship project, Lumibot, is a Python framework used by 14,000+ students and developers to build, backtest, and deploy trading bots across stocks, options, crypto, forex, and futures.",
+    "webpageUrl": {
+      "url": "https://lumiwealth.com"
+    }
+  },
+  "projects": [
+    {
+      "guid": "lumibot",
+      "name": "Lumibot",
+      "description": "Backtesting and Trading Bots Made Easy for Crypto, Stocks, Options, Futures, FOREX and more. Lumibot is a Python library that makes it simple to build and deploy algorithmic trading strategies with multiple broker integrations (Alpaca, Interactive Brokers, Tradier, Coinbase) and data sources (Yahoo Finance, ThetaData, Polygon).",
+      "webpageUrl": {
+        "url": "https://lumibot.lumiwealth.com"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/Lumiwealth/lumibot"
+      },
+      "licenses": ["GPL-3.0"],
+      "tags": ["python", "trading", "backtesting", "algorithmic-trading", "fintech", "quantitative-finance", "stocks", "options", "crypto", "forex", "futures"]
+    }
+  ],
+  "funding": {
+    "channels": [
+      {
+        "guid": "github-sponsors",
+        "type": "payment-provider",
+        "address": "https://github.com/sponsors/Lumiwealth",
+        "description": "GitHub Sponsors"
+      }
+    ],
+    "plans": [
+      {
+        "guid": "development",
+        "status": "active",
+        "name": "Core Development & Maintenance",
+        "description": "Ongoing development of Lumibot: new broker integrations, data source support, backtesting improvements, bug fixes, documentation, and community support.",
+        "amount": 100000,
+        "currency": "USD",
+        "frequency": "one-time"
+      }
+    ],
+    "history": []
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ bcrypt
 pytest
 yappi>=1.6.0
 scipy>=1.14.0
-quantstats-lumi>=1.1.0
+quantstats-lumi>=1.1.1
 python-dotenv  # Secret Storage
 ccxt>=4.4.80
 termcolor>=2.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.55",
+    version="4.4.56",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
         "yappi>=1.6.0",
         # SciPy 1.14.0+ supports NumPy 2.x
         "scipy>=1.14.0",
-        "quantstats-lumi>=1.1.0",
+        "quantstats-lumi>=1.1.1",
         "python-dotenv",  # Secret Storage
         "ccxt>=4.4.80",
         "termcolor",


### PR DESCRIPTION
## What
- bump `quantstats-lumi` minimum dependency to `>=1.1.1` (satisfied by newly published `1.1.2`)
- document 4.4.56 changelog notes for tearsheet metrics JSON contract alignment

## Why
- ensure Lumibot installs a QuantStats build that emits typed tearsheet metric scalars and preserves unit semantics

## Validation
- pytest:
  - `tests/test_tearsheet_metrics_json.py`
  - `tests/test_tearsheet_custom_metrics_hook.py`
  - `tests/test_trader_tearsheet_metrics_passthrough.py`
  - `tests/test_ui_defaults.py`
  - `tests/test_tearsheet_quantstats_retry_unit.py`
  - `tests/test_tearsheet_flat_returns.py`
- fresh backtest artifacts and parity checks generated under `tmp/tearsheet_metrics_validation/artifacts_run6`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 4.4.56

* **Bug Fixes**
  * Fixed tearsheet summary artifact compatibility to ensure proper handling of scalar values.

* **Chores**
  * Bumped minimum dependency version to enable enhanced tearsheet functionality and expanded test coverage.
  * Added funding configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->