### PR TITLE
backtest: fix console print settings being overwritten

### DIFF
--- a/lumibot/tools/lumibot_logger.py
+++ b/lumibot/tools/lumibot_logger.py
@@ -622,7 +622,7 @@ class StrategyLoggerAdapter(logging.LoggerAdapter):
             self.extra = extra_dict
 
 
-def _ensure_handlers_configured(is_backtest=False):
+def _ensure_handlers_configured(is_backtest=False, skip_if_configured=False):
     """
     Ensure that the root logger has the appropriate handlers configured.
     This is called once globally to set up consistent formatting, but we also
@@ -643,9 +643,14 @@ def _ensure_handlers_configured(is_backtest=False):
         Whether we are in a backtesting (default False). This can also be determined from the IS_BACKTESTING
         environment variable, but is provided here as an optional parameter for cases
         where we might want to explicitly control this behavior without relying on environment variables.
-
+    skip_if_configured : bool, optional
+        If True, will skip re-applying log levels if handlers are already configured. This avoids
+        overriding any changes to the defaults if this is not the first time calling.
     """
     global _handlers_configured, _BACKTESTING_QUIET_LOGS_ENABLED
+
+    if skip_if_configured and _handlers_configured:
+        return
 
     # Resolve baseline log level from the environment (default INFO)
     default_level = os.environ.get('LUMIBOT_LOG_LEVEL', 'INFO').upper()
@@ -921,7 +926,7 @@ def set_console_log_level(level: str):
     >>> set_console_log_level('DEBUG')  # Enable debug logging in console
     >>> set_console_log_level('ERROR')  # Only show errors and critical messages in console
     """
-    _ensure_handlers_configured()
+    _ensure_handlers_configured(skip_if_configured=True)
 
     # Check both "root" and "lumibot" logger to ensure we get the correct root logger.
     # Currently, "lumibot" is used in _ensure_handlers_configured() to set up the console handler, but "root" is
@@ -956,7 +961,7 @@ def add_file_handler(file_path: str, level: str = 'INFO', is_backtest: bool = Fa
     >>> from lumibot.tools.lumibot_logger import add_file_handler
     >>> add_file_handler('/path/to/lumibot.log', 'DEBUG')
     """
-    _ensure_handlers_configured(is_backtest=is_backtest)
+    _ensure_handlers_configured(is_backtest=is_backtest, skip_if_configured=True)
     
     try:
         file_level = getattr(logging, level.upper())


### PR DESCRIPTION
This pull request introduces an improvement to the logger configuration logic in `lumibot_logger.py`. The main change is to allow skipping the re-application of log levels and handler setup if the logger handlers are already configured, which prevents overwriting custom log level changes made after the initial setup.

Logger configuration improvements:

* Added a `skip_if_configured` parameter to the `_ensure_handlers_configured` function to allow skipping handler configuration if already set up. [[1]](diffhunk://#diff-c028dbd6ed61adf4917f70c7dfa258f7a0f31c116bb82e1ef39d73d4c9f21eb5L625-R625) [[2]](diffhunk://#diff-c028dbd6ed61adf4917f70c7dfa258f7a0f31c116bb82e1ef39d73d4c9f21eb5L646-R654)
* Updated `set_console_log_level` and `add_file_handler` to use the new `skip_if_configured=True` argument, preventing unintended log level overrides when these functions are called multiple times. [[1]](diffhunk://#diff-c028dbd6ed61adf4917f70c7dfa258f7a0f31c116bb82e1ef39d73d4c9f21eb5L924-R929) [[2]](diffhunk://#diff-c028dbd6ed61adf4917f70c7dfa258f7a0f31c116bb82e1ef39d73d4c9f21eb5L959-R964)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging system stability by preventing unintended reconfiguration of log levels and file handlers when setup methods are called multiple times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->