### PR TITLE
v4.4.59 - IBKR downloader timeout and stale cache hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.4.59 - Unreleased
 
+### Fixed
+- Data Downloader queue client now uses a dedicated configurable connect-timeout budget instead of a hardcoded `5s`, which prevents IBKR/VIX history refreshes from failing closed on slow downloader connections.
+- IBKR history loading now fails closed when a refresh leaves the requested window underfilled, so stale cached slices are no longer returned as if they were complete history.
+
 ## 4.4.58 - 2026-04-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.4.59 - Unreleased
+
 ## 4.4.58 - 2026-04-01
 
 ### Added

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -45,7 +45,6 @@ from ..backtesting import (
 from ..components.agents import AgentManager
 from ..credentials import (
     BACKTESTING_END,
-    BACKTESTING_QUIET_LOGS,
     BACKTESTING_SHOW_PROGRESS_BAR,
     BACKTESTING_START,
     BROKER,

--- a/lumibot/tools/data_downloader_queue_client.py
+++ b/lumibot/tools/data_downloader_queue_client.py
@@ -127,6 +127,7 @@ QUEUE_POLL_INTERVAL = float(os.environ.get("THETADATA_QUEUE_POLL_INTERVAL", "0.2
 # or via env var if they truly want infinite waits.
 QUEUE_TIMEOUT = float(os.environ.get("THETADATA_QUEUE_TIMEOUT", "600"))
 MAX_CONCURRENT_REQUESTS = int(os.environ.get("THETADATA_MAX_CONCURRENT", "8"))  # Max requests in flight
+QUEUE_CONNECT_HTTP_TIMEOUT = float(os.environ.get("THETADATA_QUEUE_CONNECT_HTTP_TIMEOUT", "15"))
 QUEUE_SUBMIT_HTTP_TIMEOUT = float(os.environ.get("THETADATA_QUEUE_SUBMIT_HTTP_TIMEOUT", "120"))
 QUEUE_STATUS_HTTP_TIMEOUT = float(os.environ.get("THETADATA_QUEUE_STATUS_HTTP_TIMEOUT", "10"))
 QUEUE_RESULT_HTTP_TIMEOUT = float(os.environ.get("THETADATA_QUEUE_RESULT_HTTP_TIMEOUT", "120"))
@@ -380,7 +381,7 @@ class QueueClient:
             resp = self._get_session().get(
                 f"{self.base_url}/queue/stats",
                 headers={self.api_key_header: self.api_key},
-                timeout=(5, QUEUE_STATUS_HTTP_TIMEOUT),
+                timeout=(QUEUE_CONNECT_HTTP_TIMEOUT, QUEUE_STATUS_HTTP_TIMEOUT),
             )
             resp.raise_for_status()
             return resp.json()
@@ -512,7 +513,7 @@ class QueueClient:
                     submit_url,
                     json=payload,
                     headers={self.api_key_header: self.api_key},
-                    timeout=(5, QUEUE_SUBMIT_HTTP_TIMEOUT),
+                    timeout=(QUEUE_CONNECT_HTTP_TIMEOUT, QUEUE_SUBMIT_HTTP_TIMEOUT),
                 )
             except (
                 requests_exceptions.ReadTimeout,
@@ -645,7 +646,7 @@ class QueueClient:
             resp = self._get_session().get(
                 f"{self.base_url}/queue/status/{request_id}",
                 headers={self.api_key_header: self.api_key},
-                timeout=(5, QUEUE_STATUS_HTTP_TIMEOUT),
+                timeout=(QUEUE_CONNECT_HTTP_TIMEOUT, QUEUE_STATUS_HTTP_TIMEOUT),
             )
             if resp.status_code == 404:
                 # Request not found, remove from tracking
@@ -704,7 +705,7 @@ class QueueClient:
             resp = self._get_session().get(
                 f"{self.base_url}/queue/{request_id}/result",
                 headers={self.api_key_header: self.api_key},
-                timeout=(5, QUEUE_RESULT_HTTP_TIMEOUT),
+                timeout=(QUEUE_CONNECT_HTTP_TIMEOUT, QUEUE_RESULT_HTTP_TIMEOUT),
             )
             data = resp.json()
             status_code = resp.status_code

--- a/lumibot/tools/ibkr_helper.py
+++ b/lumibot/tools/ibkr_helper.py
@@ -902,6 +902,32 @@ def get_price_data(
         frame = frame.drop(columns=["missing"], errors="ignore")
     if asset_type in {"stock", "index"} and str(timestep_component).endswith("day"):
         frame = _repair_isolated_split_spikes_daily(frame)
+    placeholder_covered = _window_is_placeholder_covered(df_cache, start_local=start_local, end_local=end_local)
+    if not frame.empty:
+        try:
+            covers_requested_window = frame_covers_requested_window(
+                frame,
+                asset=asset,
+                timestep=timestep,
+                start_dt=start_utc,
+                end_dt=end_utc,
+            )
+        except Exception:
+            covers_requested_window = False
+        if not covers_requested_window:
+            logger.warning(
+                "IBKR cached history remained underfilled after refresh for %s/%s timestep=%s exchange=%s source=%s; "
+                "returning empty frame (placeholder_covered=%s)",
+                getattr(asset, "symbol", None),
+                getattr(quote, "symbol", None) if quote else None,
+                timestep,
+                effective_exchange,
+                history_source,
+                placeholder_covered,
+            )
+            return frame.iloc[0:0].copy()
+    elif placeholder_covered:
+        return frame
     return frame
 
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.58",
+    version="4.4.59",
     author="Robert Grzesik",
     author_email="rob@lumiwealth.com",
     description="Backtesting and Trading Library, Made by Lumiwealth",

--- a/tests/test_ibkr_helper_unit.py
+++ b/tests/test_ibkr_helper_unit.py
@@ -276,3 +276,57 @@ def test_ibkr_downloader_payload_contract_rejects_partial_or_uncacheable_history
                 }
             }
         )
+
+
+def test_ibkr_get_price_data_fails_closed_when_cached_window_stays_underfilled_after_refresh_error(monkeypatch, tmp_path):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    monkeypatch.setattr(ibkr_helper, "LUMIBOT_CACHE_FOLDER", tmp_path.as_posix())
+
+    asset = Asset(symbol="VIX", asset_type=Asset.AssetType.INDEX)
+    quote = Asset(symbol="USD", asset_type=Asset.AssetType.FOREX)
+    start = datetime(2026, 3, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 3, 20, tzinfo=timezone.utc)
+
+    cache_file = ibkr_helper._cache_file_for(
+        asset=asset,
+        quote=quote,
+        timestep="day",
+        exchange=None,
+        source=ibkr_helper.IBKR_DEFAULT_INDEX_HISTORY_SOURCE,
+        include_after_hours=True,
+    )
+    stale_idx = pd.date_range(
+        end=pd.Timestamp(end).tz_convert("America/New_York") - pd.Timedelta(days=10),
+        periods=5,
+        freq="B",
+    )
+    stale = pd.DataFrame(
+        {
+            "open": [20.0, 21.0, 22.0, 23.0, 24.0],
+            "high": [21.0, 22.0, 23.0, 24.0, 25.0],
+            "low": [19.0, 20.0, 21.0, 22.0, 23.0],
+            "close": [20.5, 21.5, 22.5, 23.5, 24.5],
+            "volume": [0, 0, 0, 0, 0],
+            "missing": [False, False, False, False, False],
+        },
+        index=stale_idx,
+    )
+    ibkr_helper._write_cache_frame(cache_file, stale)
+
+    def _raise_fetch_error(**kwargs):
+        raise RuntimeError("submit timed out")
+
+    monkeypatch.setattr(ibkr_helper, "_fetch_history_between_dates", _raise_fetch_error)
+
+    df = ibkr_helper.get_price_data(
+        asset=asset,
+        quote=quote,
+        timestep="day",
+        start_dt=start,
+        end_dt=end,
+        exchange=None,
+        include_after_hours=True,
+    )
+
+    assert df.empty

--- a/tests/test_thetadata_queue_client.py
+++ b/tests/test_thetadata_queue_client.py
@@ -17,7 +17,10 @@ import pytest
 import requests
 
 from lumibot.tools.data_downloader_queue_client import (
+    QUEUE_CONNECT_HTTP_TIMEOUT,
     QUEUE_POLL_INTERVAL,
+    QUEUE_STATUS_HTTP_TIMEOUT,
+    QUEUE_SUBMIT_HTTP_TIMEOUT,
     QUEUE_TIMEOUT,
     QueueClient,
     QueuedRequestInfo,
@@ -436,6 +439,8 @@ class TestServerStats:
 
         assert stats["pending_count"] == 5
         assert stats["processing_count"] == 2
+        _, kwargs = mock_get.call_args
+        assert kwargs["timeout"] == (QUEUE_CONNECT_HTTP_TIMEOUT, QUEUE_STATUS_HTTP_TIMEOUT)
 
     @patch.object(requests.Session, 'get')
     def test_fetch_server_queue_stats_error(self, mock_get):
@@ -601,8 +606,8 @@ class TestSubmitNetworkTimeout:
         _, first_kwargs = mock_post.call_args_list[0]
         assert "timeout" in first_kwargs
         connect_timeout, read_timeout = first_kwargs["timeout"]
-        assert connect_timeout > 0
-        assert read_timeout > 0
+        assert connect_timeout == QUEUE_CONNECT_HTTP_TIMEOUT
+        assert read_timeout == QUEUE_SUBMIT_HTTP_TIMEOUT
 
 
 class TestStatusRefreshRecovery:


### PR DESCRIPTION
What / Why:\nThis hotfix addresses the live IBKR/VIX failure path. The downloader-side self-heal probe was stabilized separately in production, and this PR fixes the consumer-side behavior in LumiBot so slow downloader connections do not collapse into stale cache reuse.\n\nRisk:\nAffects only Data Downloader queue HTTP timeout handling and IBKR cache acceptance rules. Main risk is returning empty data instead of stale partial data when coverage is underfilled, which is the intended fail-closed behavior.\n\nTests run:\n- pytest -q tests/test_thetadata_queue_client.py\n- pytest -q tests/test_ibkr_helper_unit.py -k 'downloader_payload_contract or frame_covers_requested_window or stale or caches_history or no_overlap or later_empty_page or fails_closed_when_cached_window_stays_underfilled_after_refresh_error'\n\nPerf evidence:\nNot a performance PR.\n\nDocs:\n- CHANGELOG.md updated under 4.4.59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Queue client connection timeout is now configurable (longer default) to improve reliability during history refreshes.
  * IBKR history loading now fails closed: when a refresh yields an incomplete window, the system returns empty data instead of stale cached slices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->