### PR TITLE
v4.4.62 - Fix flat-price fabrication in backtesting broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
 # Changelog
 
-## 4.4.62 - Unreleased
+## 4.4.62 - 2026-04-15
 
-## 4.4.60 - Unreleased
+### Fixed
+- **CRITICAL: Flat-price fabrication bug in backtesting fills.** `BacktestingBroker._pandas_fill_path` previously picked `df_original.iloc[-1:]` when the "bars at or after self.datetime" filter came back empty, OR `df_original.iloc[0]` when the filter caught rows far in the future. Both paths could silently price every fill at a single bar's OPEN that had nothing to do with the simulation time, producing deterministic constant prices across multi-year backtests. Observed incident: BotSpot "Alpha Picks" backtest where 72 of 84 stocks froze at the OPEN of 2026-04-10 for every fill across 2022-2024. The fix rejects future bars outside a narrow window (2 days for daily, 2 hours for hourly, 5 minutes for minute), prefers the most recent bar at or before the simulation time, and refuses to fabricate a fill when no bar exists within a reasonable window of `self.datetime`. A second-layer `max_fill_distance` sanity check (7 days for daily, 1 day for intraday) hard-rejects any fill price derived from a bar too far from the simulation clock, cancelling the offending iteration rather than producing a garbage fill. Provider-agnostic; applies to every data source that flows through `PANDAS` / `InteractiveBrokersREST` fill paths (ThetaData, IBKR, Polygon, etc.).
+- IBKR history loading now fails open by returning available real bars instead of synthesizing an empty dataset when the cache refresh leaves the requested window underfilled (commit `5de1362a`, April 14).
+- Interactive Brokers REST backtesting data source now prefers an already-loaded daily stock/index series for `get_last_price`/`get_quote` before triggering a separate intraday minute fetch, which avoids unnecessary VIX/USD midpoint history requests during daily-cadence backtests (commit `5de1362a`, April 14).
+- `Order.to_dict()` now emits `identifier` and `avg_fill_price` consistently so downstream consumers that rely on these fields on serialized orders no longer see missing keys after backtest-time fills (commit `e3cb48fe`, April 15).
 
-## 4.4.59 - Unreleased
+### Added
+- Release readiness script now verifies that every referenced artifact file actually exists on disk (not just that `artifact_path` is non-empty), preventing stale pointer references from passing the deployment gate (commit `323b6488`, April 12).
+- LumiBot matrix runner emits `lumibot_runner_state.json` checkpoint files during long runs so in-flight case state is inspectable during multi-hour acceptance runs (commit `6944e22c`, April 12).
+
+## 4.4.61 - 2026-04-01
+
+Release bookkeeping only. No functional code changes from 4.4.60.
+
+## 4.4.60 - 2026-04-01
 
 ### Fixed
 - Data Downloader queue client now uses a dedicated configurable connect-timeout budget instead of a hardcoded `5s`, which prevents IBKR/VIX history refreshes from failing closed on slow downloader connections.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,19 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/discord/1045669553608851456?label=Discord)](https://discord.gg/TmMsJCKY3T)
 
-# Lumibot: Algorithmic Trading Made Easy
+# Lumibot: Algorithmic Trading for Stocks, Options, Crypto, Futures & Forex
 
-**The same code runs your backtest and your live trading.** Python framework for stocks, options, crypto, futures, and forex with built-in AI trading agent support.
+**The same code runs your backtest and your live trading.** The only open-source Python trading library with full options support, built-in AI trading agents, and 5+ broker integrations.
+
+If you find Lumibot useful, a star helps others discover it.
+
+## Use Lumibot Your Way
+
+| Path | Description |
+|------|-------------|
+| **Open source** | Build, backtest, and self-host trading strategies with Python. Free forever. |
+| **[BotSpot](https://botspot.trade/sales?utm_source=lumibot+docs&utm_medium=documentation&utm_campaign=GitHub+Readme)** | Deploy strategies to the cloud with AI assistance, monitoring, and scheduling. No code required. |
+| **Data providers** | Multiple supported. Yahoo Finance is free. ThetaData, Polygon, DataBento, and others available. |
 
 ## Quick Start
 
@@ -58,6 +68,41 @@ That same strategy code works with live brokers. Just swap the broker class.
 
 **Switching from Backtrader?** See our [migration guide](docs/MIGRATING_FROM_BACKTRADER.md) for a side-by-side comparison with code examples.
 
+## Deploy Live
+
+### Option A: BotSpot (managed cloud)
+
+[BotSpot](https://botspot.trade/sales?utm_source=lumibot+docs&utm_medium=documentation&utm_campaign=GitHub+Readme) runs your Lumibot strategies on hosted infrastructure with scheduling, monitoring, and live execution. Build strategies with AI, no coding required.
+
+- Create trading bots using natural language
+- Backtest with historical data
+- Deploy to trade automatically 24/7
+- Join a community of algorithmic traders
+
+**[Get started at BotSpot.trade](https://botspot.trade/sales?utm_source=lumibot+docs&utm_medium=documentation&utm_campaign=GitHub+Readme)**
+
+### Option B: Self-hosted (full control)
+
+Run Lumibot on your own machine with any supported broker:
+
+```python
+from lumibot.brokers import Alpaca
+from lumibot.traders import Trader
+
+ALPACA_CONFIG = {
+    "API_KEY": "your-key",
+    "API_SECRET": "your-secret",
+    "PAPER": True,
+}
+
+broker = Alpaca(ALPACA_CONFIG)
+strategy = MyStrategy(broker=broker)
+
+trader = Trader()
+trader.add_strategy(strategy)
+trader.run_all()
+```
+
 ## Supported Brokers & Data Sources
 
 | Brokers (live trading) | Data Sources (backtesting) |
@@ -70,11 +115,11 @@ That same strategy code works with live brokers. Just swap the broker class.
 | Bitunix | CCXT |
 | ProjectX | Alpaca |
 
-## Recommended Data Provider
+### Recommended Data Provider
 
 For the deepest historical coverage (stocks, options, futures, indexes), we recommend [ThetaData](https://www.thetadata.net/). Use promo code **`BotSpot10`** for 10% off your first order.
 
-> **Affiliate disclosure:** This is a referral link. ThetaData directly supports the BotSpot ecosystem, and using this code helps fund continued development of Lumibot.
+> *Affiliate disclosure: This is a referral link. Using this code supports the continued development of Lumibot as an open-source project.*
 
 ## AI Trading Agents
 
@@ -90,17 +135,6 @@ Start here:
 - [Stock Agent Example](https://github.com/Lumiwealth/lumibot/blob/dev/lumibot/example_strategies/agent_stock_backtest.py)
 - [Options Agent Example](https://github.com/Lumiwealth/lumibot/blob/dev/lumibot/example_strategies/agent_option_backtest.py)
 - [Full Guide](https://github.com/Lumiwealth/lumibot/blob/dev/docs/AI_TRADING_AGENTS.md)
-
-## Deploy with BotSpot
-
-Want to build and deploy trading bots without code? [BotSpot](https://botspot.trade/sales?utm_source=lumibot+docs&utm_medium=documentation&utm_campaign=GitHub+Readme) lets you:
-
-- Build trading bots using natural language and AI
-- Backtest with historical data
-- Deploy to trade automatically
-- Join a community of algorithmic traders
-
-**[Get started at BotSpot.trade](https://botspot.trade/sales?utm_source=lumibot+docs&utm_medium=documentation&utm_campaign=GitHub+Readme)**
 
 ## Community Strategies
 
@@ -165,7 +199,7 @@ Learn to build, backtest, and deploy trading strategies using AI. Join 2,400+ tr
 
 ## DISCLAIMER
 
-> **THIS SOFTWARE IS PROVIDED FOR EDUCATIONAL AND INFORMATIONAL PURPOSES ONLY. IT IS NOT FINANCIAL ADVICE. THE AUTHORS AND CONTRIBUTORS ASSUME NO RESPONSIBILITY FOR YOUR TRADING RESULTS. ALGORITHMIC TRADING INVOLVES SUBSTANTIAL RISK OF LOSS. PAST BACKTEST PERFORMANCE DOES NOT GUARANTEE FUTURE RESULTS. USE THIS SOFTWARE AT YOUR OWN RISK.**
+> **THIS SOFTWARE IS PROVIDED FOR EDUCATIONAL AND INFORMATIONAL PURPOSES ONLY. IT IS NOT FINANCIAL ADVICE AND DOES NOT CONSTITUTE A RECOMMENDATION TO BUY OR SELL ANY SECURITY. LUMIBOT AND BOTSPOT ARE NOT REGISTERED BROKER-DEALERS OR FINANCIAL ADVISORS. ALGORITHMIC TRADING INVOLVES SUBSTANTIAL RISK OF LOSS, INCLUDING THE POSSIBILITY OF LOSSES GREATER THAN YOUR INITIAL INVESTMENT. SOFTWARE BUGS AND ERRORS CAN LEAD TO RAPID FINANCIAL LOSSES. PAST BACKTEST PERFORMANCE DOES NOT GUARANTEE FUTURE RESULTS. USE THIS SOFTWARE AT YOUR OWN RISK. YOU ARE SOLELY RESPONSIBLE FOR COMPLIANCE WITH ALL APPLICABLE LAWS AND REGULATIONS REGARDING THE ASSETS YOU CHOOSE TO TRADE.**
 
 ---
 

--- a/docsrc/deployment.rst
+++ b/docsrc/deployment.rst
@@ -3,27 +3,52 @@
 Deployment Guide
 ================
 
-This guide will walk you through the deployment process for your trading strategy. We will cover the following topics:
+This guide walks you through the options for deploying your Lumibot trading strategy to run 24/7. You have two paths:
 
-- **Choosing Your Deployment Platform:** Decide whether to deploy on **Render** or **Replit**.
-- **Deploying to Render:** Step-by-step instructions for deploying on Render.
-- **Deploying to Replit:** Step-by-step instructions for deploying on Replit.
-- **Secrets Configuration:** Detailed information on setting up your environment variables.
-- **Broker Configuration:** Required secrets for different brokers.
-- **General Environment Variables:** Additional environment variables required for the strategy to function correctly.
+- **Option A — BotSpot (recommended):** Managed cloud deployment. No servers to configure, broker integrations built in, paper and live trading, strategy monitoring. Best for most users.
+- **Option B — Self-hosted (Render or Replit):** Deploy it yourself on a general-purpose cloud host. Full control, you manage everything. Best for developers who want to own the infrastructure.
 
-Before deploying your application, ensure that you have the necessary environment variables configured. The environment variables are crucial for the successful deployment of your application. We will cover the required environment variables for different brokers and general environment variables that are essential for the strategy to function correctly.
+Pick the option that matches how much infrastructure you want to manage. Both run the exact same Lumibot strategy code.
+
+Option A — Deploy on BotSpot (Recommended)
+------------------------------------------
+
+`BotSpot <https://botspot.trade/?utm_source=lumibot+docs&utm_medium=documentation&utm_campaign=deployment_guide>`_ is the managed cloud platform built on Lumibot. You upload or describe your strategy, pick a broker, and BotSpot runs it for you 24/7 with monitoring, scheduling, and failure alerts. Most Lumibot users should start here.
+
+**Why BotSpot:**
+
+- **No infrastructure to manage.** No servers, no deploy files, no environment-variable setup.
+- **Broker integrations built in.** Alpaca, Interactive Brokers, Tradier, Schwab, and more already wired up.
+- **Backtest in the browser.** Test your strategy on historical data with one click before going live.
+- **Marketplace of proven strategies.** Browse community strategies and deploy any of them without writing code.
+- **Paper and live trading.** Start in paper mode, switch to live when you are ready.
+- **AI strategy builder.** Describe what you want in plain English and BotSpot generates Lumibot code for you.
+
+`Get started on BotSpot <https://botspot.trade/?utm_source=lumibot+docs&utm_medium=documentation&utm_campaign=deployment_guide>`_ and deploy in minutes, no coding required.
+
+.. tip::
+
+   **Already have a Lumibot strategy you wrote locally?** You can bring your own code into BotSpot through the strategy editor. You can also use BotSpot's AI agent to adapt existing strategies.
+
+Option B — Self-hosted Deployment (Render or Replit)
+----------------------------------------------------
+
+If you want full control of your infrastructure, you can deploy Lumibot yourself on any cloud host that runs Python. This guide covers the two platforms we have tested end-to-end: **Render** and **Replit**.
+
+.. note::
+
+   Self-hosting means you manage the server, environment variables, broker credentials, and uptime. If any of that sounds like more work than you want to take on, use :doc:`Option A — BotSpot <deployment>` instead.
 
 Example Strategy for Deployment
 -------------------------------
 
 .. important::
 
-   **Important:** This example strategy is for those without a strategy ready to deploy. If you have your own strategy, skip to `Choosing Your Deployment Platform <#id1>`_.
+   **Important:** This example strategy is for those without a strategy ready to deploy. If you have your own strategy, skip to `Choosing Your Self-hosted Platform <#id1>`_.
 
-Use this example to see the deployment process in action. It’s not intended for real-money use. More details are available in the GitHub repository: `Example Algorithm GitHub <https://github.com/Lumiwealth-Strategies/stock_example_algo>`_
+Use this example to see the self-hosted deployment process in action. It's not intended for real-money use. More details are available in the GitHub repository: `Example Algorithm GitHub <https://github.com/Lumiwealth-Strategies/stock_example_algo>`_
 
-To run the example strategy, click the Deploy to Render button or the Run on Repl.it button. See `Deploying to Render <#id2>`_ and `Deploying to Replit <#id3>`_ for more details.
+To run the example strategy yourself, click the Deploy to Render button or the Run on Repl.it button below. If you would rather skip the infrastructure setup entirely, `deploy it on BotSpot <https://botspot.trade/?utm_source=lumibot+docs&utm_medium=documentation&utm_campaign=deployment_guide>`_ instead.
 
 .. raw:: html
 
@@ -36,20 +61,21 @@ To run the example strategy, click the Deploy to Render button or the Run on Rep
         </a>
     </div>
 
-Render is recommended for ease of use and affordability. Replit is more expensive but great for in-browser code editing, if you want to see/edit the code directly in your browser.
-
 .. tip::
 
    **Tip:** Scroll down to the :ref:`Secrets Configuration <secrets-configuration>` section for detailed information on setting up your environment variables.
 
-Choosing Your Deployment Platform
----------------------------------
+Choosing Your Self-hosted Platform
+----------------------------------
 
-We recommend using **Render** for deployment because it is easier to use and more affordable compared to Replit. However, **Replit** is an excellent choice for developers who want to edit code directly in the browser.
+If you have decided to self-host, pick between **Render** and **Replit**:
+
+- **Render** costs about **$7/month**. It is easier to use and more affordable, and is our recommendation for self-hosted deployment.
+- **Replit** costs about **$25/month**. It is more expensive but is a great choice if you want to edit your code directly in the browser.
 
 .. note::
 
-   **Render** costs **$7/month**, while **Replit** is priced at **$25/month**. Choose the platform that best fits your needs and budget.
+   Neither Render nor Replit are affiliated with Lumibot or BotSpot. Prices and features may change; check their websites for current pricing.
 
 Deploying to Render
 -------------------

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -2726,7 +2726,65 @@ class BacktestingBroker(Broker):
                             continue
                         df = df_original[df_original.index >= now_ts]
                     else:
-                        df = df_original[df_original.index >= self.datetime]
+                        # FABRICATION GUARD (2026-04-15 incident fix):
+                        # The previous logic (`df_original[>= self.datetime]` then
+                        # `iloc[-1:]` fallback) can silently fabricate fills by picking
+                        # a bar that is far in the future when `df_original` contains
+                        # rows well beyond `self.datetime`. Observed symptom: Alpha Picks
+                        # stock fills frozen at the *open of 2026-04-10* for every fill
+                        # across 2022-2024 because that row was the penultimate bar in
+                        # `df_original` and the forward filter caught it.
+                        #
+                        # Correct semantics for a daily-cadence market fill:
+                        # 1) Prefer a bar within a narrow future window (same session or
+                        #    the next session) so we still price forward when the current
+                        #    bar is available.
+                        # 2) Otherwise fall back to the most recent bar AT OR BEFORE
+                        #    `self.datetime` — never to an arbitrary future bar.
+                        # 3) If nothing is within a reasonable window of `self.datetime`,
+                        #    refuse to fill (skip the order) rather than inventing a price.
+                        sim_ts = pd.Timestamp(self.datetime)
+                        # Normalize timezone so comparisons are consistent with the frame index.
+                        try:
+                            if getattr(df_original.index, "tz", None) is not None:
+                                if sim_ts.tz is None:
+                                    sim_ts = sim_ts.tz_localize(df_original.index.tz)
+                                else:
+                                    sim_ts = sim_ts.tz_convert(df_original.index.tz)
+                        except Exception:
+                            pass
+
+                        if str(timestep) == "day":
+                            future_window = timedelta(days=2)
+                        elif str(timestep) == "hour":
+                            future_window = timedelta(hours=2)
+                        else:
+                            future_window = timedelta(minutes=5)
+
+                        future_bars = df_original[
+                            (df_original.index >= sim_ts)
+                            & (df_original.index <= sim_ts + future_window)
+                        ]
+                        if len(future_bars) > 0:
+                            df = future_bars.iloc[:1]
+                        else:
+                            past_bars = df_original[df_original.index <= sim_ts]
+                            if len(past_bars) == 0:
+                                # No bar at or before sim time AND no bar in the future
+                                # window. Refuse to fabricate a fill. Skip this order this
+                                # iteration; it will retry next bar.
+                                if strategy is not None:
+                                    display_symbol = getattr(order.asset, "symbol", order.asset)
+                                    order_identifier = getattr(order, "identifier", None)
+                                    if order_identifier is None:
+                                        order_identifier = getattr(order, "id", "<unknown>")
+                                    strategy.log_message(
+                                        f"[DIAG] No bar near {self.datetime} for {display_symbol}; "
+                                        f"refusing to fabricate fill for {order.order_type} id={order_identifier}",
+                                        color="yellow",
+                                    )
+                                continue
+                            df = past_bars.iloc[-1:]
 
                     # If the dataframe is empty, then we should get the last row of the original dataframe
                     # because it is the best data we have
@@ -2734,6 +2792,34 @@ class BacktestingBroker(Broker):
                         df = df_original.iloc[-1:]
 
                     dt = df.index[0]
+                    # FABRICATION GUARD (2026-04-15 incident fix): never price a fill
+                    # from a bar that is more than `max_fill_distance_days` away from the
+                    # simulated clock. This catches the flat-price class of bugs where
+                    # upstream returns a frame whose rows are far in the future relative
+                    # to `self.datetime`.
+                    try:
+                        selected_ts = pd.Timestamp(dt)
+                        sim_ts_for_check = pd.Timestamp(self.datetime)
+                        if getattr(selected_ts, "tz", None) is not None and sim_ts_for_check.tz is None:
+                            sim_ts_for_check = sim_ts_for_check.tz_localize(selected_ts.tz)
+                        elif getattr(selected_ts, "tz", None) is None and sim_ts_for_check.tz is not None:
+                            sim_ts_for_check = sim_ts_for_check.tz_localize(None)
+                        elif getattr(selected_ts, "tz", None) is not None and sim_ts_for_check.tz is not None:
+                            sim_ts_for_check = sim_ts_for_check.tz_convert(selected_ts.tz)
+                        max_fill_distance = timedelta(days=7) if str(timestep) == "day" else timedelta(days=1)
+                        if abs(selected_ts - sim_ts_for_check) > max_fill_distance:
+                            logger.error(
+                                "[FILL][REJECT] Selected bar %s is %s away from sim dt %s for %s; "
+                                "refusing to fabricate fill (order=%s).",
+                                selected_ts,
+                                abs(selected_ts - sim_ts_for_check),
+                                sim_ts_for_check,
+                                getattr(order.asset, "symbol", order.asset),
+                                getattr(order, "identifier", getattr(order, "id", "<unknown>")),
+                            )
+                            continue
+                    except Exception as _distance_err:  # noqa: F841
+                        pass
                     open = df["open"].iloc[0]
                     high = df["high"].iloc[0]
                     low = df["low"].iloc[0]

--- a/lumibot/backtesting/interactive_brokers_rest_backtesting.py
+++ b/lumibot/backtesting/interactive_brokers_rest_backtesting.py
@@ -197,6 +197,18 @@ class InteractiveBrokersRESTBacktesting(PandasData):
                 except Exception:
                     pass
 
+        # If a native daily stock/index series is already loaded, prefer it over triggering a
+        # separate minute fetch. This preserves daily-cadence semantics and avoids unnecessary
+        # intraday index requests such as VIX/USD midpoint history during daily backtests.
+        if asset_type in {"stock", "index"}:
+            day_key = (base_asset, quote_asset, "day", self._normalize_exchange_key(effective_exchange))
+            day_data = self._data_store.get(day_key)
+            if day_data is not None:
+                try:
+                    return day_data.get_last_price(now)
+                except Exception:
+                    pass
+
         minute_key = (base_asset, quote_asset, "minute", self._normalize_exchange_key(effective_exchange))
         if minute_key not in self._fully_loaded_series:
             try:
@@ -259,6 +271,26 @@ class InteractiveBrokersRESTBacktesting(PandasData):
                     pass
                 self._fully_loaded_series.add(day_key)
 
+            day_data = self._data_store.get(day_key)
+            if day_data is not None:
+                try:
+                    ohlcv_bid_ask_dict = day_data.get_quote(now)
+                    return Quote(
+                        asset=base_asset,
+                        price=ohlcv_bid_ask_dict.get("close"),
+                        bid=ohlcv_bid_ask_dict.get("bid"),
+                        ask=ohlcv_bid_ask_dict.get("ask"),
+                        volume=ohlcv_bid_ask_dict.get("volume"),
+                        timestamp=now,
+                        bid_size=ohlcv_bid_ask_dict.get("bid_size"),
+                        ask_size=ohlcv_bid_ask_dict.get("ask_size"),
+                        raw_data=ohlcv_bid_ask_dict,
+                    )
+                except Exception:
+                    pass
+
+        if asset_type in {"stock", "index"}:
+            day_key = (base_asset, quote_asset, "day", self._normalize_exchange_key(effective_exchange))
             day_data = self._data_store.get(day_key)
             if day_data is not None:
                 try:

--- a/lumibot/data_sources/pandas_data.py
+++ b/lumibot/data_sources/pandas_data.py
@@ -263,7 +263,12 @@ class PandasData(DataSourceBacktesting):
                 if pd.isna(price):
                     # Provide more specific error message for index assets
                     if hasattr(asset, 'asset_type') and asset.asset_type == Asset.AssetType.INDEX:
-                        logger.warning(f"Index asset `{asset.symbol}` returned NaN price. This could be due to missing data for the index or a subscription issue if using Polygon.io. Note that some index data (like SPX) requires a paid subscription. Consider using Yahoo Finance for broader index data coverage.")
+                        logger.warning(
+                            "Index asset `%s` returned a NaN price. This data source did not provide usable "
+                            "index data for the requested window. Verify that index coverage and any required "
+                            "subscriptions are enabled for the active provider.",
+                            asset.symbol,
+                        )
                     else:
                         logger.info(f"Error getting last price for {tuple_to_find}: price is NaN")
                     return None
@@ -292,7 +297,12 @@ class PandasData(DataSourceBacktesting):
         else:
             # Provide more specific error message when asset not found in data store
             if hasattr(asset, 'asset_type') and asset.asset_type == Asset.AssetType.INDEX:
-                logger.warning(f"The index asset `{asset.symbol}` does not exist or does not have data. Index data may not be available from this data source. If using Polygon, note that some index data (like SPX) requires a paid subscription. Consider using Yahoo Finance for broader index data coverage.")
+                logger.warning(
+                    "The index asset `%s` does not exist or has no data in this data source. Verify that the "
+                    "active provider supports index data for this symbol and that any required subscriptions "
+                    "are enabled.",
+                    asset.symbol,
+                )
             return None
 
     def get_quote(self, asset, quote=None, exchange=None) -> Quote:
@@ -488,7 +498,12 @@ class PandasData(DataSourceBacktesting):
             data = self._data_store[asset_to_find]
         else:
             if hasattr(asset, 'asset_type') and asset.asset_type == Asset.AssetType.INDEX:
-                logger.warning(f"The index asset `{asset.symbol}` does not exist or does not have data. Index data may not be available from this data source. If using Polygon, note that some index data (like SPX) requires a paid subscription. Consider using Yahoo Finance for broader index data coverage.")
+                logger.warning(
+                    "The index asset `%s` does not exist or has no data in this data source. Verify that the "
+                    "active provider supports index data for this symbol and that any required subscriptions "
+                    "are enabled.",
+                    asset.symbol,
+                )
             else:
                 logger.warning(f"The asset: `{asset}` does not exist or does not have data.")
             return
@@ -521,7 +536,12 @@ class PandasData(DataSourceBacktesting):
             data = self._data_store[asset_to_find]
         else:
             if hasattr(asset, 'asset_type') and asset.asset_type == Asset.AssetType.INDEX:
-                logger.warning(f"The index asset `{asset.symbol}` does not exist or does not have data. Index data may not be available from this data source. If using Polygon, note that some index data (like SPX) requires a paid subscription. Consider using Yahoo Finance for broader index data coverage.")
+                logger.warning(
+                    "The index asset `%s` does not exist or has no data in this data source. Verify that the "
+                    "active provider supports index data for this symbol and that any required subscriptions "
+                    "are enabled.",
+                    asset.symbol,
+                )
             else:
                 logger.warning(f"The asset: `{asset}` does not exist or does not have data.")
             return

--- a/lumibot/data_sources/polars_data.py
+++ b/lumibot/data_sources/polars_data.py
@@ -547,7 +547,12 @@ class PolarsData(DataSourceBacktesting):
                 if pd.isna(price):
                     # Provide more specific error message for index assets
                     if hasattr(asset, 'asset_type') and asset.asset_type == Asset.AssetType.INDEX:
-                        logger.warning(f"Index asset `{asset.symbol}` returned NaN price. This could be due to missing data for the index or a subscription issue if using Polygon.io. Note that some index data (like SPX) requires a paid subscription. Consider using Yahoo Finance for broader index data coverage.")
+                        logger.warning(
+                            "Index asset `%s` returned a NaN price. This data source did not provide usable "
+                            "index data for the requested window. Verify that index coverage and any required "
+                            "subscriptions are enabled for the active provider.",
+                            asset.symbol,
+                        )
                     else:
                         logger.debug(f"Error getting last price for {tuple_to_find}: price is NaN")
                     return None
@@ -559,7 +564,12 @@ class PolarsData(DataSourceBacktesting):
         else:
             # Provide more specific error message when asset not found in data store
             if hasattr(asset, 'asset_type') and asset.asset_type == Asset.AssetType.INDEX:
-                logger.warning(f"The index asset `{asset.symbol}` does not exist or does not have data. Index data may not be available from this data source. If using Polygon, note that some index data (like SPX) requires a paid subscription. Consider using Yahoo Finance for broader index data coverage.")
+                logger.warning(
+                    "The index asset `%s` does not exist or has no data in this data source. Verify that the "
+                    "active provider supports index data for this symbol and that any required subscriptions "
+                    "are enabled.",
+                    asset.symbol,
+                )
             return None
 
     def get_quote(self, asset, quote=None, exchange=None) -> Quote:
@@ -698,7 +708,12 @@ class PolarsData(DataSourceBacktesting):
             data = self._data_store[asset_to_find]
         else:
             if hasattr(asset, 'asset_type') and asset.asset_type == Asset.AssetType.INDEX:
-                logger.warning(f"The index asset `{asset.symbol}` does not exist or does not have data. Index data may not be available from this data source. If using Polygon, note that some index data (like SPX) requires a paid subscription. Consider using Yahoo Finance for broader index data coverage.")
+                logger.warning(
+                    "The index asset `%s` does not exist or has no data in this data source. Verify that the "
+                    "active provider supports index data for this symbol and that any required subscriptions "
+                    "are enabled.",
+                    asset.symbol,
+                )
             else:
                 logger.warning(f"The asset: `{asset}` does not exist or does not have data.")
             return
@@ -819,7 +834,12 @@ class PolarsData(DataSourceBacktesting):
             data = self._data_store[asset_to_find]
         else:
             if hasattr(asset, 'asset_type') and asset.asset_type == Asset.AssetType.INDEX:
-                logger.warning(f"The index asset `{asset.symbol}` does not exist or does not have data. Index data may not be available from this data source. If using Polygon, note that some index data (like SPX) requires a paid subscription. Consider using Yahoo Finance for broader index data coverage.")
+                logger.warning(
+                    "The index asset `%s` does not exist or has no data in this data source. Verify that the "
+                    "active provider supports index data for this symbol and that any required subscriptions "
+                    "are enabled.",
+                    asset.symbol,
+                )
             else:
                 logger.warning(f"The asset: `{asset}` does not exist or does not have data.")
             return

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -1465,8 +1465,25 @@ class Order:
                 order_dict[key] = value
 
         # Add essential properties that might be stored with underscores
+        #
+        # WHY THIS MATTERS:
+        # to_dict() above iterates self.__dict__ and skips any attribute whose
+        # name starts with an underscore. But several of our most important
+        # fields use the `self._foo` backing-store + `@property foo` pattern
+        # (identifier, avg_fill_price, status, quantity). Without these explicit
+        # emissions, those fields would be silently dropped when serializing
+        # Orders — which is exactly what happened historically with the
+        # BotSpot order-history endpoint (timestamp/price/order_id nulls).
         order_dict['quantity'] = float(self.quantity) if isinstance(self.quantity, Decimal) else self.quantity
         order_dict['status'] = self.status
+        # `identifier` is the canonical order ID that downstream consumers
+        # (strategy listener, UI, broker adapters) rely on for dedup and display.
+        order_dict['identifier'] = self._identifier
+        # `avg_fill_price` is the weighted fill price for filled/partially-filled
+        # orders — the single most important field for P&L and trade review.
+        order_dict['avg_fill_price'] = (
+            float(self._avg_fill_price) if self._avg_fill_price is not None else None
+        )
 
         return order_dict
 

--- a/lumibot/tools/ibkr_helper.py
+++ b/lumibot/tools/ibkr_helper.py
@@ -917,7 +917,8 @@ def get_price_data(
         if not covers_requested_window:
             logger.warning(
                 "IBKR cached history remained underfilled after refresh for %s/%s timestep=%s exchange=%s source=%s; "
-                "returning empty frame (placeholder_covered=%s)",
+                "returning available real bars instead of synthesizing an empty dataset "
+                "(placeholder_covered=%s)",
                 getattr(asset, "symbol", None),
                 getattr(quote, "symbol", None) if quote else None,
                 timestep,
@@ -925,7 +926,6 @@ def get_price_data(
                 history_source,
                 placeholder_covered,
             )
-            return frame.iloc[0:0].copy()
     elif placeholder_covered:
         return frame
     return frame

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.4.60",
+    version="4.4.62",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/backtest/backtest_performance_history.csv
+++ b/tests/backtest/backtest_performance_history.csv
@@ -7579,3 +7579,5 @@ timestamp,test_name,data_source,trading_days,execution_time_seconds,git_commit,l
 2026-03-30T12:53:08.140299,test_agent_runtime_emits_future_timestamp_warning_without_blocking,unknown,,0.119,b09445af,4.4.56,,,,,Auto-tracked from test_agent_runtime_backtest
 2026-03-30T12:53:08.408426,test_agent_runtime_invalid_asset_type_emits_observability_warning,unknown,,0.123,b09445af,4.4.56,,,,,Auto-tracked from test_agent_runtime_backtest
 2026-03-30T12:53:08.772168,test_builtin_docs_search_returns_local_doc_snippets,unknown,,0.218,b09445af,4.4.56,,,,,Auto-tracked from test_agent_runtime_backtest
+2026-04-09T22:07:57.377694,test_ibkr_stale_end_marks_missing_window_to_avoid_repeated_history_fetches,unknown,,0.546,8220de35,4.4.60,,,,,Auto-tracked from test_ibkr_helper_stale_end_negative_cache
+2026-04-09T22:07:57.699330,test_ibkr_placeholder_window_suppresses_subwindow_refetch_after_restart,unknown,,0.219,8220de35,4.4.60,,,,,Auto-tracked from test_ibkr_helper_stale_end_negative_cache

--- a/tests/backtest/strategies/iron_condor_0dte.py
+++ b/tests/backtest/strategies/iron_condor_0dte.py
@@ -12,7 +12,6 @@ from lumibot.backtesting import PolygonDataBacktesting
 from lumibot.credentials import IS_BACKTESTING
 
 from lumibot.components.options_helper import OptionsHelper
-from lumibot.components.vix_helper import VixHelper
 
 from datetime import time, timedelta
 import math
@@ -73,12 +72,12 @@ class IronCondor0DTE(Strategy):
         except Exception:
             pass
 
-        # Helpers for options selection and VIX-based filters
+        # Helpers for options selection and provider-backed index filters
         self.options_helper = OptionsHelper(self)
-        self.vix_helper = VixHelper(self)
 
         # Use persistent storage for state that must survive restarts and across lifecycle hooks
         self.vars.underlying_asset = Asset("SPX", asset_type=Asset.AssetType.INDEX)  # SPX index as the underlying for SPX options
+        self.vars.vix_asset = Asset("VIX", asset_type=Asset.AssetType.INDEX)  # Provider-backed VIX index feed
         self.vars.opened_today = 0  # how many positions opened today
         self.vars.underlying_ref_price = None  # reference price for SPX to compute daily % change filter
         self.vars.vix_ref_price = None  # reference price for VIX to compute daily % change filter
@@ -106,6 +105,13 @@ class IronCondor0DTE(Strategy):
     def _minutes_to(self, dt, end_dt) -> int:
         # Helper to compute minutes between two datetimes
         return int((end_dt - dt).total_seconds() // 60)
+
+    def _get_vix_price(self):
+        # Use the configured data provider for VIX instead of a helper-side Yahoo fallback.
+        price = self.get_last_price(self.vars.vix_asset)
+        if price is None:
+            return None
+        return float(price)
 
     def _get_today_expiry(self, chains, call_or_put: str):
         # Get the expiration that is today (0DTE). If not available, return None.
@@ -230,7 +236,7 @@ class IronCondor0DTE(Strategy):
 
         # Get current reference if not set
         if self.vars.vix_ref_price is None:
-            v = self.vix_helper.get_vix_value()
+            v = self._get_vix_price()
             if v is not None:
                 self.vars.vix_ref_price = float(v)
         if self.vars.underlying_ref_price is None:
@@ -240,7 +246,7 @@ class IronCondor0DTE(Strategy):
 
         # VIX filter
         if use_vix and self.vars.vix_ref_price is not None:
-            cur_v = self.vix_helper.get_vix_value()
+            cur_v = self._get_vix_price()
             if cur_v is not None and cur_v > 0:
                 vix_change = 100.0 * (float(cur_v) - self.vars.vix_ref_price) / self.vars.vix_ref_price
                 self.log_message(f"VIX change vs ref: {vix_change:.2f}%", color="white")
@@ -324,7 +330,7 @@ class IronCondor0DTE(Strategy):
             self.add_line("SPX", float(spx_price), color="black", width=2, detail_text="SPX Last Price")
 
         # Also plot VIX when available to understand regime changes
-        vix_val = self.vix_helper.get_vix_value()
+        vix_val = self._get_vix_price()
         if vix_val is not None:
             self.add_line("VIX", float(vix_val), color="orange", width=1, detail_text="VIX")
 

--- a/tests/backtest/test_ibkr_helper_stale_end_negative_cache.py
+++ b/tests/backtest/test_ibkr_helper_stale_end_negative_cache.py
@@ -91,9 +91,10 @@ def test_ibkr_stale_end_marks_missing_window_to_avoid_repeated_history_fetches(m
         )
         history_calls = [c for c in calls if "/ibkr/iserver/marketdata/history" in c["url"]]
         assert len(history_calls) == 1
-        # Underfilled windows now fail closed: the real bar remains in cache, but the returned
-        # frame is empty because the requested bound was not fully covered after refresh.
-        assert df1.empty
+        # Underfilled windows should not synthesize an empty dataset. Return the real cached bars;
+        # the downloader is responsible for rejecting non-cacheable/partial IBKR payloads.
+        assert not df1.empty
+        assert list(df1.index) == [start, last_bar]
         cached_mid = pd.read_parquet(cache_file)
         assert last_bar in cached_mid.index
         assert end in cached_mid.index
@@ -112,7 +113,8 @@ def test_ibkr_stale_end_marks_missing_window_to_avoid_repeated_history_fetches(m
         )
         history_calls = [c for c in calls if "/ibkr/iserver/marketdata/history" in c["url"]]
         assert len(history_calls) == 1
-        assert df2.empty
+        assert not df2.empty
+        assert list(df2.index) == [start, last_bar]
 
         cached = pd.read_parquet(cache_file)
         # Placeholder rows are used only to extend coverage; they must not replace the real bar.

--- a/tests/backtest/test_ibkr_local_repo_smokes_apitest.py
+++ b/tests/backtest/test_ibkr_local_repo_smokes_apitest.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+os.environ.setdefault("LUMIBOT_DISABLE_DOTENV", "1")
+
+import pytest
+import requests
+
+import lumibot
+from lumibot.backtesting.interactive_brokers_rest_backtesting import InteractiveBrokersRESTBacktesting
+from lumibot.entities import Asset
+from lumibot.entities.order import Order
+from lumibot.strategies.strategy import Strategy
+
+
+pytestmark = [pytest.mark.apitest, pytest.mark.downloader, pytest.mark.ibkr]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LUMIBOT_PACKAGE_ROOT = (REPO_ROOT / "lumibot").resolve()
+
+
+class _IbkrMultiTimestepSmoke(Strategy):
+    def initialize(self, parameters=None):
+        self.sleeptime = "1M"
+        self.include_cash_positions = True
+        self.fetch_counts: dict[str, int] = {}
+        self.fetch_last_close: dict[str, float] = {}
+        self.fetch_completed = False
+        self._entered = False
+
+    def _fetch_bars(self, asset: Asset, timestep: str, quote: Asset | None):
+        kwargs = {
+            "length": 2,
+            "timestep": timestep,
+        }
+        if quote is not None:
+            kwargs["quote"] = quote
+        bars = self.get_historical_prices(asset, **kwargs)
+        if bars is None or getattr(bars, "df", None) is None or bars.df.empty:
+            return None
+        return bars.df
+
+    def on_trading_iteration(self):
+        asset: Asset = self.parameters["asset"]
+        quote: Asset | None = self.parameters.get("quote")
+        place_order = bool(self.parameters.get("place_order"))
+
+        for timestep in ("minute", "hour", "day"):
+            df = self._fetch_bars(asset, timestep, quote)
+            if df is None:
+                return
+            self.fetch_counts[timestep] = len(df)
+            self.fetch_last_close[timestep] = float(df["close"].iloc[-1])
+
+        self.fetch_completed = True
+
+        if not place_order or self._entered:
+            return
+
+        if asset.asset_type == Asset.AssetType.CRYPTO:
+            last_price = self.fetch_last_close["minute"]
+            qty = Decimal(str((self.cash * 0.25) / last_price)).quantize(Decimal("0.0001"))
+            if qty <= 0:
+                return
+            order = self.create_order(
+                asset,
+                qty,
+                Order.OrderSide.BUY,
+                order_type=Order.OrderType.MARKET,
+                quote=quote,
+            )
+        else:
+            order = self.create_order(
+                asset,
+                1,
+                Order.OrderSide.BUY,
+                order_type=Order.OrderType.MARKET,
+            )
+
+        self.submit_order(order)
+        self._entered = True
+
+
+def _assert_repo_lumibot_import_path():
+    resolved = Path(lumibot.__file__).resolve()
+    assert resolved.is_relative_to(LUMIBOT_PACKAGE_ROOT), (
+        f"Expected repo LumiBot import under {LUMIBOT_PACKAGE_ROOT}, got {resolved}"
+    )
+
+
+def _require_prod_ibkr_downloader() -> tuple[str, str, str]:
+    base_url = (os.environ.get("DATADOWNLOADER_BASE_URL") or "").strip().rstrip("/")
+    api_key = (os.environ.get("DATADOWNLOADER_API_KEY") or "").strip()
+    api_key_header = (os.environ.get("DATADOWNLOADER_API_KEY_HEADER") or "X-Downloader-Key").strip()
+
+    if not base_url or not api_key:
+        pytest.skip("Missing DATADOWNLOADER_BASE_URL / DATADOWNLOADER_API_KEY")
+
+    if any(host in base_url for host in ("localhost", "127.0.0.1", "0.0.0.0")):
+        pytest.skip(f"Refusing local downloader base URL for this smoke: {base_url}")
+
+    try:
+        resp = requests.get(
+            f"{base_url}/healthz",
+            headers={api_key_header: api_key},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except Exception as exc:
+        pytest.skip(f"Production downloader not reachable/healthy: {exc}")
+
+    ibkr = payload.get("ibkr") if isinstance(payload, dict) else None
+    if not isinstance(ibkr, dict) or not ibkr.get("enabled"):
+        pytest.skip("Production downloader reachable but IBKR is not enabled")
+    if ibkr.get("authenticated") is not True:
+        pytest.skip("Production downloader reachable but IBKR is not authenticated")
+
+    return base_url, api_key, api_key_header
+
+
+def _run_smoke(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    asset: Asset,
+    market: str,
+    start: datetime,
+    end: datetime,
+    quote: Asset | None = None,
+    place_order: bool = False,
+):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    _assert_repo_lumibot_import_path()
+    _require_prod_ibkr_downloader()
+
+    monkeypatch.setenv("DATADOWNLOADER_SKIP_LOCAL_START", "true")
+    monkeypatch.setenv("LUMIBOT_DISABLE_DOTENV", "1")
+    monkeypatch.setenv("MARKET", market)
+    monkeypatch.setattr(ibkr_helper, "LUMIBOT_CACHE_FOLDER", tmp_path.as_posix())
+    if asset.asset_type == Asset.AssetType.CRYPTO:
+        monkeypatch.setenv("IBKR_CRYPTO_VENUE", "ZEROHASH")
+
+    run_kwargs = {
+        "datasource_class": InteractiveBrokersRESTBacktesting,
+        "backtesting_start": start,
+        "backtesting_end": end,
+        "market": market,
+        "analyze_backtest": False,
+        "show_plot": False,
+        "show_tearsheet": False,
+        "show_indicators": False,
+        "quiet_logs": True,
+        "name": f"IBKR_{asset.symbol}_LOCAL_REPO_SMOKE",
+        "budget": 100_000.0,
+        "benchmark_asset": asset,
+        "parameters": {
+            "asset": asset,
+            "quote": quote,
+            "place_order": place_order,
+        },
+    }
+    if quote is not None:
+        run_kwargs["quote_asset"] = quote
+
+    results, strategy = _IbkrMultiTimestepSmoke.run_backtest(**run_kwargs)
+
+    assert strategy is not None
+    assert strategy.broker is not None
+    assert strategy.broker.data_source.__class__.__name__ == "InteractiveBrokersRESTBacktesting"
+    assert strategy.fetch_completed, f"{asset.symbol} smoke never completed minute/hour/day fetches"
+    assert strategy.fetch_counts["minute"] >= 1
+    assert strategy.fetch_counts["hour"] >= 1
+    assert strategy.fetch_counts["day"] >= 1
+    assert strategy.fetch_last_close["minute"] > 0
+    assert strategy.fetch_last_close["hour"] > 0
+    assert strategy.fetch_last_close["day"] > 0
+
+    if place_order:
+        assert strategy.cash < 100_000.0, f"{asset.symbol} smoke never filled the buy order"
+
+    return results, strategy
+
+
+def test_local_repo_lumibot_ibkr_index_smoke(monkeypatch, tmp_path):
+    asset = Asset("SPX", asset_type=Asset.AssetType.INDEX)
+    start = datetime(2026, 4, 7, 13, 35, tzinfo=timezone.utc)
+    end = datetime(2026, 4, 9, 19, 55, tzinfo=timezone.utc)
+    _run_smoke(
+        monkeypatch,
+        tmp_path,
+        asset=asset,
+        market="NYSE",
+        start=start,
+        end=end,
+        place_order=False,
+    )
+
+
+def test_local_repo_lumibot_ibkr_stock_smoke(monkeypatch, tmp_path):
+    asset = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    start = datetime(2026, 4, 7, 13, 35, tzinfo=timezone.utc)
+    end = datetime(2026, 4, 9, 19, 55, tzinfo=timezone.utc)
+    _run_smoke(
+        monkeypatch,
+        tmp_path,
+        asset=asset,
+        market="NYSE",
+        start=start,
+        end=end,
+        place_order=True,
+    )
+
+
+def test_local_repo_lumibot_ibkr_crypto_smoke(monkeypatch, tmp_path):
+    asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    start = datetime(2026, 4, 7, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 4, 9, 0, 0, tzinfo=timezone.utc)
+    _run_smoke(
+        monkeypatch,
+        tmp_path,
+        asset=asset,
+        quote=quote,
+        market="24/7",
+        start=start,
+        end=end,
+        place_order=True,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,10 @@ if os.getcwd() != str(project_root):
     print(f"Changed working directory to: {project_root}")
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers", "ibkr: downloader-only IBKR tests that do not require Polygon or ThetaData credentials")
+
+
 def cleanup_all_schedulers():
     """Emergency cleanup for any remaining scheduler instances"""
     try:
@@ -274,8 +278,10 @@ def pytest_runtest_setup(item: pytest.Item):
       - downloader: tests that hit remote/downloader services
       - polygon: requires Polygon credentials
       - thetadata: requires ThetaData credentials
+      - ibkr: downloader-only IBKR tests; does not require Polygon/ThetaData creds
 
     Behavior:
+      - If a test is marked with ibkr, require neither Polygon nor ThetaData.
       - If a test is marked with polygon and/or thetadata, only those
         provider credentials are required.
       - If a test has apitest/downloader but no provider-specific markers,
@@ -289,9 +295,13 @@ def pytest_runtest_setup(item: pytest.Item):
 
     requires_polygon = item.get_closest_marker("polygon") is not None
     requires_theta = item.get_closest_marker("thetadata") is not None
+    requires_ibkr = item.get_closest_marker("ibkr") is not None
 
     # Determine which providers are required
-    if requires_polygon or requires_theta:
+    if requires_ibkr:
+        need_polygon = False
+        need_theta = False
+    elif requires_polygon or requires_theta:
         need_polygon = requires_polygon
         need_theta = requires_theta
     else:

--- a/tests/test_ibkr_helper_unit.py
+++ b/tests/test_ibkr_helper_unit.py
@@ -278,7 +278,7 @@ def test_ibkr_downloader_payload_contract_rejects_partial_or_uncacheable_history
         )
 
 
-def test_ibkr_get_price_data_fails_closed_when_cached_window_stays_underfilled_after_refresh_error(monkeypatch, tmp_path):
+def test_ibkr_get_price_data_returns_real_cached_bars_when_window_stays_underfilled_after_refresh_error(monkeypatch, tmp_path):
     import lumibot.tools.ibkr_helper as ibkr_helper
 
     monkeypatch.setattr(ibkr_helper, "LUMIBOT_CACHE_FOLDER", tmp_path.as_posix())
@@ -329,4 +329,6 @@ def test_ibkr_get_price_data_fails_closed_when_cached_window_stays_underfilled_a
         include_after_hours=True,
     )
 
-    assert df.empty
+    assert not df.empty
+    assert len(df) == len(stale)
+    assert df["close"].tolist() == stale["close"].tolist()

--- a/tests/test_ibkr_index_daily_last_price_unit.py
+++ b/tests/test_ibkr_index_daily_last_price_unit.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from lumibot.backtesting.interactive_brokers_rest_backtesting import InteractiveBrokersRESTBacktesting
+from lumibot.entities import Asset
+
+
+class _FakeDayData:
+    def __init__(self, price: float):
+        self._price = price
+
+    def get_last_price(self, now):
+        return self._price
+
+    def get_quote(self, now):
+        return {
+            "close": self._price,
+            "bid": self._price - 0.1,
+            "ask": self._price + 0.1,
+            "volume": 1000,
+            "bid_size": 10,
+            "ask_size": 12,
+        }
+
+
+def _make_data_source() -> InteractiveBrokersRESTBacktesting:
+    start = datetime(2026, 4, 9, 20, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 4, 10, 20, 0, tzinfo=timezone.utc)
+    data_source = InteractiveBrokersRESTBacktesting(
+        datetime_start=start,
+        datetime_end=end,
+        market="NYSE",
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    data_source.load_data()
+    data_source._update_datetime(end)
+    return data_source
+
+
+def test_ibkr_index_get_last_price_prefers_loaded_day_series(monkeypatch):
+    data_source = _make_data_source()
+    asset = Asset("VIX", asset_type=Asset.AssetType.INDEX)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    day_key = (asset, quote, "day", "AUTO")
+    data_source._data_store[day_key] = _FakeDayData(21.5)
+
+    def _unexpected_update(*args, **kwargs):
+        raise AssertionError("minute fetch should not run when day series is already loaded")
+
+    monkeypatch.setattr(data_source, "_update_pandas_data", _unexpected_update)
+
+    assert data_source.get_last_price(asset) == 21.5
+
+
+def test_ibkr_index_get_quote_prefers_loaded_day_series(monkeypatch):
+    data_source = _make_data_source()
+    asset = Asset("SPX", asset_type=Asset.AssetType.INDEX)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    day_key = (asset, quote, "day", "AUTO")
+    data_source._data_store[day_key] = _FakeDayData(5100.25)
+
+    def _unexpected_update(*args, **kwargs):
+        raise AssertionError("minute fetch should not run when day series is already loaded")
+
+    monkeypatch.setattr(data_source, "_update_pandas_data", _unexpected_update)
+
+    snapshot = data_source.get_quote(asset)
+    assert snapshot is not None
+    assert snapshot.price == 5100.25
+    assert snapshot.bid == 5100.15
+    assert snapshot.ask == 5100.35


### PR DESCRIPTION
## What

Ships the 4.4.62 release which includes a critical incident fix plus four prior commits on this branch.

**Critical fix (`backtesting_broker.py`):** The pandas fill path could silently fabricate fills by selecting a bar far in the future relative to simulation time. Observed in a production BotSpot backtest (Alpha Picks) where 72 of 84 stocks froze at the OPEN of 2026-04-10 for every fill across 2022-2024. The fix rejects future bars outside a narrow window, prefers the most recent bar at or before simulation time, and refuses to fabricate a fill when no bar exists within a reasonable window. A second layer sanity check hard-rejects any fill derived from a bar too far from the simulation clock.

## Why

This bug was producing silently-wrong backtest results for every customer running a diversified stock strategy through BotSpot. Trades showed plausible returns but fills were fabricated, making every customer-facing backtest invalid. Confirmed deterministic: across 36 frozen Alpha Picks symbols checked directly against prod S3 cache, every frozen fill price matched the `open` field of the `2026-04-10` row (the penultimate bar before backtest end). Provider-agnostic (any data source routed through the PANDAS fill path).

## Risk

- The new guard can skip a fill when no bar is available within the acceptable window. This is intentional and strictly safer than fabricating a price. Previous behavior silently filled at garbage prices; new behavior logs `[DIAG] No bar near ... refusing to fabricate fill` and the order retries on the next bar.
- The `max_fill_distance` check (7d daily / 1d intraday) hard-rejects distant bars and cancels the iteration. Strategies that relied on fills across large gaps might see fewer fills. Unlikely to be a real-world regression since distant-bar fills were always broken, just not loud.
- Normal cold-cache backtests verified locally - correct varied prices at 9 different simulation dates for AMR on daily cadence. 

## Tests run

Local sanity: ran a minimal repro against the prod data downloader that constructs a 2-row future-only `df_original` at simulation time 2022-07-01, confirmed the new logic refuses the fabrication (vs. old behavior that would have picked $186.10). Also verified the normal case (df_original near sim_ts) still resolves correctly.

## Other changes bundled in 4.4.62

- `5de1362a` IBKR helper fail-open behavior + daily-cadence preference for stock/index `get_last_price`/`get_quote` (April 14)
- `e3cb48fe` `Order.to_dict()` now emits `identifier` and `avg_fill_price` (April 15)
- `323b6488` Release readiness script verifies artifact file existence (April 12)
- `6944e22c` LumiBot matrix runner emits checkpoint state (April 12)
- `setup.py` bumped from 4.4.60 to 4.4.62 to match the branch name (closes prior version drift)
- CHANGELOG.md updated with the full commit range since v4.4.61

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core backtesting fill selection and IBKR history return semantics, which can materially alter simulated trade prices and execution timing. While aimed at correctness, the new guards can skip/reject fills when data is missing or distant, potentially changing backtest outcomes.
> 
> **Overview**
> Fixes a **critical backtesting correctness bug** where `BacktestingBroker._pandas_fill_path` could silently price fills from an unrelated bar far in the future, producing flat/constant prices; the new logic selects only bars near the simulation timestamp, falls back to the most recent bar at/before `self.datetime`, and hard-rejects fills derived from bars beyond a max distance threshold.
> 
> Improves IBKR backtesting behavior by **failing open** (returning real cached bars instead of an empty frame when refresh underfills the requested window) and by preferring already-loaded daily stock/index series for `get_last_price`/`get_quote` to avoid unnecessary intraday fetches.
> 
> Ensures order serialization stability by always emitting `identifier` and `avg_fill_price` in `Order.to_dict()`. Adds/updates tests (including IBKR smoke/unit coverage and a new `ibkr` pytest marker), refreshes related strategy/test usage of VIX via provider-backed index pricing, bumps version to `4.4.62`, and updates README/deployment docs + changelog for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d353cfa9642f2f797a79cfe708e1e5b8853c1faa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected backtesting fill behavior to avoid fabricated flat prices
  * IBKR history now returns available real bars when cache underfills requested window
  * Prefer daily data for certain last-price/quote queries
  * Order serialization now includes identifier and avg fill price

* **New Features**
  * Release readiness verification script
  * Matrix runner emits checkpoint files

* **Documentation**
  * README expanded (supported asset classes, onboarding paths, deploy options, stronger disclaimers)
  * Deployment guide split into managed and self-hosted paths

* **Tests**
  * Added IBKR end-to-end smoke test and related unit tests; added pytest marker for IBKR-only runs

* **Chores**
  * Bumped package version and updated changelog dates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->