### PR TITLE
Security: Path traversal/arbitrary file write risk in replay cache key handling

### DIFF
--- a/lumibot/components/agents/replay_cache.py
+++ b/lumibot/components/agents/replay_cache.py
@@ -4,6 +4,7 @@ import gzip
 import hashlib
 import json
 import os
+import re
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
@@ -49,6 +50,9 @@ def _cache_root() -> Path:
     return Path(os.environ.get("LUMIBOT_CACHE_FOLDER") or LUMIBOT_CACHE_FOLDER)
 
 
+_KEY_RE = re.compile(r"^[a-f0-9]{64}$")
+
+
 class AgentReplayCache:
     def __init__(self) -> None:
         self.root = _cache_root() / "agent_runtime" / "replay"
@@ -61,7 +65,16 @@ class AgentReplayCache:
         return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
     def _path_for(self, key: str) -> Path:
-        return self.root / key[:2] / f"{key}.json.gz"
+        if not _KEY_RE.fullmatch(key):
+            raise ValueError("Invalid replay cache key")
+        path = self.root / key[:2] / f"{key}.json.gz"
+        resolved_root = self.root.resolve()
+        resolved_path = path.resolve()
+        try:
+            resolved_path.relative_to(resolved_root)
+        except ValueError as exc:
+            raise ValueError("Invalid replay cache key") from exc
+        return resolved_path
 
     def load(self, key: str) -> dict[str, Any] | None:
         path = self._path_for(key)


### PR DESCRIPTION
## Summary

Security: Path traversal/arbitrary file write risk in replay cache key handling

## Problem

**Severity**: `High` | **File**: `lumibot/components/agents/replay_cache.py:L58`

`_path_for` builds file paths directly from `key` (`self.root / key[:2] / f"{key}.json.gz"`) without validating allowed characters. If `load()`/`save()` are called with attacker-controlled keys, `..` or path separators can escape the cache directory, enabling unintended file read/write locations and potential overwrite of arbitrary files.

## Solution

Validate `key` strictly (e.g., `^[a-f0-9]{64}$` for SHA-256 hex), reject any path separators/dots, and enforce a post-resolution check (`resolved_path.is_relative_to(self.root.resolve())`) before any file operation.

## Changes

- `lumibot/components/agents/replay_cache.py` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced replay cache validation to reject malformed cache keys and prevent unauthorized path access, improving system security and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->