### PR TITLE
resolve subscriber

### DIFF
--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -2230,6 +2230,13 @@ class Broker(ABC):
 
         return None
 
+    def _resolve_subscriber(self, strategy_name):
+        """Get subscriber by name, falling back to the sole registered subscriber when strategy_name is None."""
+        subscriber = self._get_subscriber(strategy_name)
+        if subscriber is None and strategy_name is None and len(self._subscribers) == 1:
+            subscriber = self._subscribers[0]
+        return subscriber
+
     def _on_new_order(self, order):
         """notify relevant subscriber/strategy about
         new order event"""
@@ -2238,7 +2245,7 @@ class Broker(ABC):
             self.logger.info(colored(f"New order was created: {order}", color="green"))
 
         payload = dict(order=order)
-        subscriber = self._get_subscriber(order.strategy)
+        subscriber = self._resolve_subscriber(order.strategy)
         if subscriber:
             # PERF: Many strategies do not override `Strategy.on_new_order()` (base impl is `pass`).
             # Avoid enqueueing/processing a no-op event in high-churn backtests.
@@ -2260,7 +2267,7 @@ class Broker(ABC):
             self.logger.info(colored(f"Order was canceled: {order}", color="green"))
 
         payload = dict(order=order)
-        subscriber = self._get_subscriber(order.strategy)
+        subscriber = self._resolve_subscriber(order.strategy)
         if subscriber:
             # PERF: Many strategies do not override `Strategy.on_canceled_order()` (base impl is `pass`).
             # Avoid enqueueing/processing a no-op event in high-churn backtests.
@@ -2288,7 +2295,7 @@ class Broker(ABC):
             quantity=quantity,
             multiplier=multiplier,
         )
-        subscriber = self._get_subscriber(order.strategy)
+        subscriber = self._resolve_subscriber(order.strategy)
         if subscriber:
             subscriber.add_event(subscriber.PARTIALLY_FILLED_ORDER, payload)
         else:
@@ -2308,7 +2315,7 @@ class Broker(ABC):
             quantity=quantity,
             multiplier=multiplier,
         )
-        subscriber = self._get_subscriber(order.strategy)
+        subscriber = self._resolve_subscriber(order.strategy)
         if subscriber:
             subscriber.add_event(subscriber.FILLED_ORDER, payload)
         else:
@@ -2458,7 +2465,7 @@ class Broker(ABC):
             elif type_event == self.ERROR_ORDER:
                 order = self._process_error_order(stored_order, error or LumibotBrokerAPIError("Unknown order error"))
                 if order:
-                    subscriber = self._get_subscriber(order.strategy)
+                    subscriber = self._resolve_subscriber(order.strategy)
                     if subscriber:
                         payload = dict(order=order, error=error)
                         subscriber.add_event(subscriber.ERROR_ORDER, payload)
@@ -2503,7 +2510,7 @@ class Broker(ABC):
                 order = self._process_error_order(stored_order, error or LumibotBrokerAPIError("Unknown order error"))
                 if order:
                     # Notify subscriber about the error event
-                    subscriber = self._get_subscriber(order.strategy)
+                    subscriber = self._resolve_subscriber(order.strategy)
                     if subscriber:
                         payload = dict(order=order, error=error)
                         subscriber.add_event(subscriber.ERROR_ORDER, payload)

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -2231,9 +2231,9 @@ class Broker(ABC):
         return None
 
     def _resolve_subscriber(self, strategy_name):
-        """Get subscriber by name, falling back to the sole registered subscriber when strategy_name is None."""
+        """Get subscriber by name, falling back to the sole registered subscriber when strategy_name is falsy."""
         subscriber = self._get_subscriber(strategy_name)
-        if subscriber is None and strategy_name is None and len(self._subscribers) == 1:
+        if subscriber is None and not strategy_name and len(self._subscribers) == 1:
             subscriber = self._subscribers[0]
         return subscriber
 

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -1337,6 +1337,21 @@ class Tradier(Broker):
                     # Always Update Quantity and Children. Children can change as they are assigned an identifier
                     # for the first time.
                     stored_order = stored_orders[order.identifier]
+
+                    # Repair missing strategy using tag field (mirrors fix in projectx.py).
+                    # Tradier stores the order tag as the strategy name with underscores replaced by hyphens.
+                    if not stored_order.strategy:
+                        tag = getattr(stored_order, 'tag', None) or getattr(order, 'tag', None)
+                        if tag and hasattr(self, '_subscribers') and self._subscribers:
+                            for sub in self._subscribers:
+                                sub_name = getattr(sub, 'name', '') or str(sub)
+                                if re.sub(r'[^a-zA-Z0-9-]', '-', sub_name) == tag or sub_name == tag:
+                                    stored_order.strategy = sub_name
+                                    break
+                        if not stored_order.strategy and hasattr(self, '_subscribers') and len(self._subscribers) == 1:
+                            only_sub = self._subscribers[0]
+                            stored_order.strategy = getattr(only_sub, 'name', '') or str(only_sub)
+
                     stored_order.quantity = order.quantity  # Update the quantity in case it has changed
                     stored_order.broker_create_date = order.broker_create_date
                     stored_order.broker_update_date = order.broker_update_date

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -1308,8 +1308,11 @@ class Tradier(Broker):
         except Exception:
             pass
         stored_orders = {x.identifier: x for x in self.get_all_orders()}
+        strategy_name = self._strategy_name
+        if not strategy_name and len(self._subscribers) == 1:
+            strategy_name = self._subscribers[0].name
         for order_row in raw_orders:
-            order = self._parse_broker_order_dict(order_row, strategy_name=self._strategy_name)
+            order = self._parse_broker_order_dict(order_row, strategy_name=strategy_name)
             # Process child orders first so they are tracked in the Lumi system before the parent order
             all_orders = [child for child in order.child_orders] + [order]
 


### PR DESCRIPTION
This makes a few fixes to prevent "subscriber not found" errors. The Tradier broker polls Tradier every 5 seconds. We can get into situations where we poll before the strategy's name is added as a subscriber. These fixes attempt to prevent that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of order and trade event handling when strategy information is unavailable or incomplete.
  * Enhanced order reconciliation with broker to better match orders with strategies, including handling of order identifiers with formatting variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->