### PR TITLE
v4.5.7 - AI agent OpenAI temperature hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.5.7 - Unreleased
+## 4.5.7 - 2026-04-29
 
 ### Fixed
 - **AI agents no longer send unsupported `temperature=0` to LiteLLM-routed providers.** The ADK runtime had hardcoded `temperature=0.0` for every model. OpenAI GPT-5/reasoning-class models reject custom temperature values and only allow the provider default, causing backtests to fail before the first agent call. LumiBot now keeps explicit `temperature=0.0` only on the Gemini-native ADK path and omits temperature for OpenAI/xAI/Anthropic/etc. LiteLLM providers. Verified with a real `openai/gpt-5.4` agent call.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.5.7 - 2026-04-29
 
+Deploy marker: c850cd66 (`deploy 4.5.7`)
+
 ### Fixed
 - **AI agents no longer send unsupported `temperature=0` to LiteLLM-routed providers.** The ADK runtime had hardcoded `temperature=0.0` for every model. OpenAI GPT-5/reasoning-class models reject custom temperature values and only allow the provider default, causing backtests to fail before the first agent call. LumiBot now keeps explicit `temperature=0.0` only on the Gemini-native ADK path and omits temperature for OpenAI/xAI/Anthropic/etc. LiteLLM providers. Verified with a real `openai/gpt-5.4` agent call.
 - **Tradier live cash-event polling no longer passes unsupported `page=` to `Account.get_history()`.** The installed `lumiwealth-tradier` client supports `start_date`, `end_date`, `limit`, `activity_type`, and `symbol`, but not `page`. LumiBot now detects whether the client supports pagination and falls back to a single bounded per-activity request when it does not, preventing live warnings like `Account.get_history() got an unexpected keyword argument 'page'` and allowing broker cash events to load.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.5.7 - Unreleased
 
+### Fixed
+- **AI agents no longer send unsupported `temperature=0` to LiteLLM-routed providers.** The ADK runtime had hardcoded `temperature=0.0` for every model. OpenAI GPT-5/reasoning-class models reject custom temperature values and only allow the provider default, causing backtests to fail before the first agent call. LumiBot now keeps explicit `temperature=0.0` only on the Gemini-native ADK path and omits temperature for OpenAI/xAI/Anthropic/etc. LiteLLM providers. Verified with a real `openai/gpt-5.4` agent call.
+- **Tradier live cash-event polling no longer passes unsupported `page=` to `Account.get_history()`.** The installed `lumiwealth-tradier` client supports `start_date`, `end_date`, `limit`, `activity_type`, and `symbol`, but not `page`. LumiBot now detects whether the client supports pagination and falls back to a single bounded per-activity request when it does not, preventing live warnings like `Account.get_history() got an unexpected keyword argument 'page'` and allowing broker cash events to load.
+
 ## 4.5.6 - 2026-04-29
 
 Deploy marker: 61b75f24 (`deploy 4.5.6`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.7 - Unreleased
+
 ## 4.5.6 - 2026-04-29
 
 Deploy marker: 61b75f24 (`deploy 4.5.6`)

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -6,6 +6,7 @@ import json
 import time
 import threading
 import datetime
+import inspect
 from typing import Union
 
 import pandas as pd
@@ -888,17 +889,28 @@ class Tradier(Broker):
         per_type_limit = max(int(limit or 100), 1)
         per_page_limit = min(per_type_limit, 1000)
         max_pages = max((per_type_limit - 1) // per_page_limit + 1, 1)
+        get_history = self.tradier.account.get_history
+        try:
+            signature = inspect.signature(get_history)
+            supports_page = "page" in signature.parameters or any(
+                parameter.kind is inspect.Parameter.VAR_KEYWORD
+                for parameter in signature.parameters.values()
+            )
+        except Exception:
+            supports_page = False
 
         event_by_id: dict[str, CashEvent] = {}
         for activity_type in self.CASH_ACTIVITY_TYPES:
             for page in range(1, max_pages + 1):
-                history_df = self.tradier.account.get_history(
-                    start_date=start_date,
-                    end_date=end_date,
-                    limit=per_page_limit,
-                    page=page,
-                    activity_type=activity_type,
-                )
+                kwargs = {
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "limit": per_page_limit if supports_page else per_type_limit,
+                    "activity_type": activity_type,
+                }
+                if supports_page:
+                    kwargs["page"] = page
+                history_df = get_history(**kwargs)
 
                 if history_df is None or history_df.empty:
                     break
@@ -909,6 +921,8 @@ class Tradier(Broker):
                         event_by_id[event.event_id] = event
 
                 if len(history_df.index) < per_page_limit:
+                    break
+                if not supports_page:
                     break
 
         normalized_events = sorted(

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -560,6 +560,22 @@ def _resolve_model_for_adk(model: Any, *, prompt_cache_key: str | None = None) -
     return LiteLlm(model=model, **kwargs)
 
 
+def _supports_explicit_temperature_for_adk_model(model: Any) -> bool:
+    """Return True only for ADK-native models known to accept temperature.
+
+    ADK's LiteLlm bridge forwards GenerateContentConfig fields to provider APIs.
+    OpenAI GPT-5/reasoning-class models reject custom temperature values and only
+    allow the provider default. Passing temperature=0.0 therefore breaks those
+    models before the agent can run. Keep deterministic temperature only on the
+    Gemini-native path; let LiteLLM providers use their provider defaults unless
+    a future explicit per-provider compatibility layer is added.
+    """
+    if not isinstance(model, str):
+        return False
+    lower = model.strip().lower()
+    return lower.startswith("gemini-") or lower.startswith("models/gemini")
+
+
 class GoogleADKRuntime:
     def __init__(self, mcp_servers: list[MCPServer] | None = None) -> None:
         self.mcp_servers = mcp_servers or []
@@ -660,9 +676,10 @@ class GoogleADKRuntime:
         tool_name_map = {_tool_function_name(tool.name): tool.name for tool in request.bound_tools}
         tools = [function_tool_type(_wrap_tool_callable(tool)) for tool in request.bound_tools]
         config_kwargs: dict[str, Any] = {
-            "temperature": 0.0,
             "max_output_tokens": 65535,
         }
+        if _supports_explicit_temperature_for_adk_model(request.model):
+            config_kwargs["temperature"] = 0.0
         planner = self._maybe_build_gemini_thinking_planner(request.model, genai_types)
         agent = LlmAgentType(
             name=request.agent_name,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.6",
+    version="4.5.7",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/backtest/backtest_performance_history.csv
+++ b/tests/backtest/backtest_performance_history.csv
@@ -7669,3 +7669,4 @@ timestamp,test_name,data_source,trading_days,execution_time_seconds,git_commit,l
 2026-04-28T23:07:38.636269,test_agent_runtime_invalid_asset_type_emits_observability_warning,unknown,,0.153,19cac24b,4.5.6,,,,,Auto-tracked from test_agent_runtime_backtest
 2026-04-28T23:07:39.029097,test_builtin_docs_search_returns_local_doc_snippets,unknown,,0.259,19cac24b,4.5.6,,,,,Auto-tracked from test_agent_runtime_backtest
 2026-04-28T23:10:51.198123,test_agent_runtime_injects_base_prompt_runtime_context_and_default_summary_log,unknown,,0.213,19cac24b,4.5.6,,,,,Auto-tracked from test_agent_runtime_backtest
+2026-04-29T00:53:37.946517,test_agent_runtime_injects_base_prompt_runtime_context_and_default_summary_log,unknown,,0.144,fea8b004,4.5.7,,,,,Auto-tracked from test_agent_runtime_backtest

--- a/tests/test_agent_runtime_provider_keys.py
+++ b/tests/test_agent_runtime_provider_keys.py
@@ -2,7 +2,12 @@ import os
 import sys
 import types
 
-from lumibot.components.agents.runtime import _resolve_model_for_adk, _sync_gemini_api_key_alias, _sync_xai_api_key_alias
+from lumibot.components.agents.runtime import (
+    _resolve_model_for_adk,
+    _supports_explicit_temperature_for_adk_model,
+    _sync_gemini_api_key_alias,
+    _sync_xai_api_key_alias,
+)
 
 
 def test_grok_api_key_alias_populates_xai_api_key(monkeypatch):
@@ -83,3 +88,15 @@ def test_gemini_native_path_uses_plain_model_id_for_implicit_or_adk_context_cach
     # only for LiteLLM providers; Gemini implicit caching and ADK explicit
     # ContextCacheConfig are configured outside the LiteLLM wrapper.
     assert _resolve_model_for_adk("gemini-3.1-pro-preview", prompt_cache_key="stable-prefix-key") == "gemini-3.1-pro-preview"
+
+
+def test_explicit_temperature_only_sent_to_gemini_native_models():
+    assert _supports_explicit_temperature_for_adk_model("gemini-3.1-pro-preview") is True
+    assert _supports_explicit_temperature_for_adk_model("models/gemini-3.1-pro-preview") is True
+
+    # GPT-5/reasoning-class OpenAI models reject custom temperature values; the
+    # provider default is the only accepted value.
+    assert _supports_explicit_temperature_for_adk_model("openai/gpt-5.4") is False
+    assert _supports_explicit_temperature_for_adk_model("openai/gpt-5.4-mini") is False
+    assert _supports_explicit_temperature_for_adk_model("xai/grok-4.20-0309-reasoning") is False
+    assert _supports_explicit_temperature_for_adk_model("anthropic/claude-opus-4-7") is False

--- a/tests/test_cash_events.py
+++ b/tests/test_cash_events.py
@@ -339,6 +339,56 @@ def test_tradier_get_cash_events_paginates_per_activity_type():
     assert events[0].event_type == "deposit"
 
 
+def test_tradier_get_cash_events_omits_page_when_client_does_not_support_it():
+    requests = []
+
+    class _DummyAccount:
+        def get_history(self, start_date=None, end_date=None, limit=None, activity_type=None, symbol=None):
+            requests.append(
+                {
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "limit": limit,
+                    "activity_type": activity_type,
+                    "symbol": symbol,
+                }
+            )
+            if activity_type != "ach":
+                return None
+
+            import pandas as pd
+
+            return pd.DataFrame(
+                [
+                    {
+                        "id": "tradier-deposit",
+                        "type": "ach",
+                        "date": "2026-03-24",
+                        "amount": "1000.00",
+                        "description": "Bank ACH",
+                    }
+                ]
+            )
+
+    broker = Tradier.__new__(Tradier)
+    broker.tradier = SimpleNamespace(account=_DummyAccount())
+
+    events = broker.get_cash_events(limit=1500)
+
+    ach_requests = [req for req in requests if req["activity_type"] == "ach"]
+    assert ach_requests == [
+        {
+            "start_date": None,
+            "end_date": ach_requests[0]["end_date"],
+            "limit": 1500,
+            "activity_type": "ach",
+            "symbol": None,
+        }
+    ]
+    assert len(events) == 1
+    assert events[0].event_type == "deposit"
+
+
 def _cloud_update_dummy(get_cash_events):
     return SimpleNamespace(
         is_backtesting=False,


### PR DESCRIPTION
## What
Fixes two release-blocking issues found after 4.5.6:

- AI agents no longer send explicit temperature=0.0 to LiteLLM-routed providers like OpenAI GPT-5.4, which reject non-default temperature.
- Tradier cash-event polling no longer passes page= to Account.get_history() when the installed client does not support it.

## Why
OpenAI GPT-5.4 backtests were failing before the first model response with Unsupported value: temperature. Separately, live Tradier strategies logged Failed to load broker cash events because Account.get_history() rejected page=.

## Tests run
- python3 -m py_compile lumibot/components/agents/runtime.py lumibot/brokers/tradier.py
- /opt/homebrew/bin/python3.12 -m pytest tests/test_agent_runtime_provider_keys.py tests/test_cash_events.py -q
- /opt/homebrew/bin/python3.12 -m pytest tests/test_agent_runtime_provider_keys.py tests/test_cash_events.py tests/backtest/test_agent_runtime_backtest.py::test_agent_runtime_injects_base_prompt_runtime_context_and_default_summary_log -q
- Real OpenAI proof: scripts/run_agent_prompt_cache_probe.py --model openai/gpt-5.4 --calls 1 --repetitions 1
- Real one-iteration PandasDataBacktesting strategy using openai/gpt-5.4 returned OPENAI_TEMP_HOTFIX_BACKTEST_OK

## Risk
Low. Temperature omission only applies to LiteLLM-routed providers; Gemini-native still gets temperature=0.0. Tradier fallback preserves pagination when supported and omits page only for clients that cannot accept it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved incompatible temperature parameter handling in AI agent requests, improving compatibility with multiple provider types
  * Fixed Tradier live cash-event polling to adapt dynamically to API pagination capabilities

* **Tests**
  * Added tests validating temperature parameter behavior across different AI model types
  * Added tests for cash-event polling with non-paginated account history responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->