### PR TITLE
v4.5.8 - Cash event polling and AI agent observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.8 - Unreleased
+
 ## 4.5.7 - 2026-04-29
 
 Deploy marker: c850cd66 (`deploy 4.5.7`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.8 - Unreleased
+## 4.5.8 - 2026-04-29
+
+Deploy marker: pending (`deploy 4.5.8`)
 
 ### Fixed
 - **Broker cash-event polling is hardened for real Alpaca and Tradier activity-history responses.** Alpaca cash-event polling now requests non-fill account-activity categories separately (`TRANS`, `DIV`, `MISC`) instead of paging through trade fills or letting dividend pages hide funding rows, safely handles wrapped/model/invalid activity rows, and was verified against real Alpaca live API-key/OAuth accounts with actual `CSD` deposits and `CSW` withdrawals. Tradier cash-event polling now parses the raw history response inside LumiBot so the published `lumiwealth_tradier` package's `"history": "null"` bug cannot emit live warnings like `string indices must be integers, not 'str'`; direct-request pagination, wrapper fallback, null-history payloads, the exact TypeError path, and real Tradier live transfer/wire/dividend history were verified.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.5.8 - 2026-04-29
 
-Deploy marker: pending (`deploy 4.5.8`)
+Deploy marker: eefe772f (`deploy 4.5.8`)
 
 ### Fixed
 - **Broker cash-event polling is hardened for real Alpaca and Tradier activity-history responses.** Alpaca cash-event polling now requests non-fill account-activity categories separately (`TRANS`, `DIV`, `MISC`) instead of paging through trade fills or letting dividend pages hide funding rows, safely handles wrapped/model/invalid activity rows, and was verified against real Alpaca live API-key/OAuth accounts with actual `CSD` deposits and `CSW` withdrawals. Tradier cash-event polling now parses the raw history response inside LumiBot so the published `lumiwealth_tradier` package's `"history": "null"` bug cannot emit live warnings like `string indices must be integers, not 'str'`; direct-request pagination, wrapper fallback, null-history payloads, the exact TypeError path, and real Tradier live transfer/wire/dividend history were verified.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.5.8 - Unreleased
 
+### Fixed
+- **Broker cash-event polling is hardened for real Alpaca and Tradier activity-history responses.** Alpaca cash-event polling now requests the non-fill account-activity categories (`TRANS,DIV,MISC`) instead of paging through trade fills, safely handles wrapped/model/invalid activity rows, and was verified against real Alpaca API-key and OAuth paper accounts. Tradier cash-event polling now parses the raw history response inside LumiBot so the published `lumiwealth_tradier` package's `"history": "null"` bug cannot emit live warnings like `string indices must be integers, not 'str'`; direct-request pagination, wrapper fallback, null-history payloads, and the exact TypeError path are covered by regression tests.
+
 ## 4.5.7 - 2026-04-29
 
 Deploy marker: c850cd66 (`deploy 4.5.7`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 4.5.8 - Unreleased
 
 ### Fixed
-- **Broker cash-event polling is hardened for real Alpaca and Tradier activity-history responses.** Alpaca cash-event polling now requests the non-fill account-activity categories (`TRANS,DIV,MISC`) instead of paging through trade fills, safely handles wrapped/model/invalid activity rows, and was verified against real Alpaca API-key and OAuth paper accounts. Tradier cash-event polling now parses the raw history response inside LumiBot so the published `lumiwealth_tradier` package's `"history": "null"` bug cannot emit live warnings like `string indices must be integers, not 'str'`; direct-request pagination, wrapper fallback, null-history payloads, and the exact TypeError path are covered by regression tests.
+- **Broker cash-event polling is hardened for real Alpaca and Tradier activity-history responses.** Alpaca cash-event polling now requests non-fill account-activity categories separately (`TRANS`, `DIV`, `MISC`) instead of paging through trade fills or letting dividend pages hide funding rows, safely handles wrapped/model/invalid activity rows, and was verified against real Alpaca live API-key/OAuth accounts with actual `CSD` deposits and `CSW` withdrawals. Tradier cash-event polling now parses the raw history response inside LumiBot so the published `lumiwealth_tradier` package's `"history": "null"` bug cannot emit live warnings like `string indices must be integers, not 'str'`; direct-request pagination, wrapper fallback, null-history payloads, the exact TypeError path, and real Tradier live transfer/wire/dividend history were verified.
+- **Cash-event warnings now identify the broker and sanitized fetch context.** Strategy warnings now include the broker name/class, and Alpaca/Tradier broker adapters log sanitized activity type, page/limit, pagination, and raw-type counts so future production warnings can be diagnosed without exposing API keys.
 
 ## 4.5.7 - 2026-04-29
 

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -1164,9 +1164,54 @@ class Alpaca(Broker):
             return "adjustment", False
         return "other_cash", normalized_raw_type in cls.EXTERNAL_CASH_ACTIVITY_TYPES
 
+    @staticmethod
+    def _coerce_activity_dict(activity) -> dict | None:
+        if isinstance(activity, dict):
+            return activity
+        for method_name in ("model_dump", "dict"):
+            method = getattr(activity, method_name, None)
+            if callable(method):
+                try:
+                    payload = method()
+                except Exception:
+                    continue
+                if isinstance(payload, dict):
+                    return payload
+        payload = getattr(activity, "__dict__", None)
+        if isinstance(payload, dict):
+            return payload
+        return None
+
+    @classmethod
+    def _coerce_activity_page(cls, raw_activities) -> list[dict]:
+        if raw_activities is None or isinstance(raw_activities, (str, bytes)):
+            return []
+
+        if isinstance(raw_activities, dict):
+            for key in ("activities", "activity"):
+                nested = raw_activities.get(key)
+                if nested:
+                    return cls._coerce_activity_page(nested)
+            else:
+                if "activity_type" in raw_activities:
+                    raw_activities = [raw_activities]
+                else:
+                    raw_activities = list(raw_activities.values())
+
+        if isinstance(raw_activities, (str, bytes)) or not isinstance(raw_activities, (list, tuple)):
+            return []
+
+        activities = []
+        for activity in raw_activities:
+            activity_dict = cls._coerce_activity_dict(activity)
+            if activity_dict is not None:
+                activities.append(activity_dict)
+        return activities
+
     @classmethod
     def _normalize_activity_to_cash_event(cls, activity: dict) -> CashEvent | None:
-        if not isinstance(activity, dict):
+        activity = cls._coerce_activity_dict(activity)
+        if activity is None:
             return None
 
         raw_type = str(activity.get("activity_type") or "").upper().strip()
@@ -1215,11 +1260,10 @@ class Alpaca(Broker):
         normalized_events = []
         seen_event_ids = set()
 
-        # Alpaca's account-activities endpoint has historically rejected some otherwise valid-looking
-        # activity-type filters (for example `INTPNL`) with 400 responses. Pull raw activity pages and
-        # normalize client-side, but paginate until we actually collect `limit` cash events instead of
-        # stopping after the first raw page.
+        # Ask Alpaca for non-fill activity categories so we do not page through thousands of trade fills
+        # just to find rare deposits, withdrawals, dividends, fees, or journals.
         request_fields = {
+            "activity_types": "TRANS,DIV,MISC",
             "direction": "desc",
             "page_size": page_size,
         }
@@ -1235,8 +1279,7 @@ class Alpaca(Broker):
                 request_fields.pop("page_token", None)
 
             raw_activities = self.api.get("/account/activities", request_fields)
-            if isinstance(raw_activities, dict):
-                raw_activities = raw_activities.get("activities") or raw_activities.get("activity") or []
+            raw_activities = self._coerce_activity_page(raw_activities)
 
             if not raw_activities:
                 break
@@ -1251,7 +1294,7 @@ class Alpaca(Broker):
                 break
 
             last_row = raw_activities[-1]
-            next_token = last_row.get("id") if isinstance(last_row, dict) else None
+            next_token = last_row.get("id")
             if not next_token or next_token == page_token:
                 break
             page_token = next_token

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -3,6 +3,7 @@ import datetime
 import time
 import traceback
 from asyncio import CancelledError
+from collections import Counter
 from datetime import timezone
 from decimal import Decimal
 
@@ -1260,49 +1261,81 @@ class Alpaca(Broker):
         normalized_events = []
         seen_event_ids = set()
 
-        # Ask Alpaca for non-fill activity categories so we do not page through thousands of trade fills
-        # just to find rare deposits, withdrawals, dividends, fees, or journals.
-        request_fields = {
-            "activity_types": "TRANS,DIV,MISC",
-            "direction": "desc",
-            "page_size": page_size,
-        }
-        if since is not None:
-            request_fields["after"] = CashEvent.coerce_datetime(since).isoformat()
-
-        page_token = None
+        # Query non-fill categories separately so real funding rows (TRANS/CSD/CSW) cannot be
+        # hidden behind a first page dominated by dividends or other non-trade activity.
+        activity_type_filters = ("TRANS", "DIV", "MISC")
         max_pages = 50
-        for _ in range(max_pages):
-            if page_token:
-                request_fields["page_token"] = page_token
-            else:
-                request_fields.pop("page_token", None)
+        raw_activity_count = 0
+        raw_activity_type_counts = Counter()
+        pages_read = 0
+        for activity_type_filter in activity_type_filters:
+            page_token = None
+            events_before_filter = len(normalized_events)
+            request_fields = {
+                "activity_types": activity_type_filter,
+                "direction": "desc",
+                "page_size": page_size,
+            }
+            if since is not None:
+                request_fields["after"] = CashEvent.coerce_datetime(since).isoformat()
 
-            raw_activities = self.api.get("/account/activities", request_fields)
-            raw_activities = self._coerce_activity_page(raw_activities)
+            for _ in range(max_pages):
+                if page_token:
+                    request_fields["page_token"] = page_token
+                else:
+                    request_fields.pop("page_token", None)
 
-            if not raw_activities:
-                break
+                try:
+                    raw_activities = self.api.get("/account/activities", request_fields)
+                except Exception as exc:
+                    logger.warning(
+                        "Alpaca cash-event fetch failed: %s (activity_types=%s, page_size=%s, "
+                        "page_token_present=%s, since_set=%s)",
+                        exc,
+                        request_fields.get("activity_types"),
+                        request_fields.get("page_size"),
+                        bool(request_fields.get("page_token")),
+                        since is not None,
+                    )
+                    raise
+                raw_activities = self._coerce_activity_page(raw_activities)
 
-            for activity in raw_activities:
-                event = self._normalize_activity_to_cash_event(activity)
-                if event is not None and event.event_id not in seen_event_ids:
-                    normalized_events.append(event)
-                    seen_event_ids.add(event.event_id)
+                if not raw_activities:
+                    break
+                pages_read += 1
+                raw_activity_count += len(raw_activities)
+                raw_activity_type_counts.update(
+                    str(activity.get("activity_type") or "").upper().strip()
+                    for activity in raw_activities
+                    if isinstance(activity, dict)
+                )
 
-            if len(normalized_events) >= normalized_limit:
-                break
+                for activity in raw_activities:
+                    event = self._normalize_activity_to_cash_event(activity)
+                    if event is not None and event.event_id not in seen_event_ids:
+                        normalized_events.append(event)
+                        seen_event_ids.add(event.event_id)
 
-            last_row = raw_activities[-1]
-            next_token = last_row.get("id")
-            if not next_token or next_token == page_token:
-                break
-            page_token = next_token
+                if len(normalized_events) - events_before_filter >= normalized_limit:
+                    break
+
+                last_row = raw_activities[-1]
+                next_token = last_row.get("id")
+                if not next_token or next_token == page_token:
+                    break
+                page_token = next_token
 
         normalized_events.sort(key=lambda event: (event.occurred_at, event.event_id))
         if len(normalized_events) > normalized_limit:
             normalized_events = normalized_events[-normalized_limit:]
-        logger.debug("Alpaca returned %s normalized cash events", len(normalized_events))
+        logger.debug(
+            "Alpaca returned %s normalized cash events from %s raw non-fill activities across %s pages "
+            "(raw_activity_types=%s)",
+            len(normalized_events),
+            raw_activity_count,
+            pages_read,
+            dict(raw_activity_type_counts),
+        )
         return normalized_events
 
     # =======Stream functions=========

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -878,6 +878,77 @@ class Tradier(Broker):
             is_external_cash_flow=is_external_cash_flow,
         )
 
+    @staticmethod
+    def _normalize_history_payload_to_df(data) -> pd.DataFrame:
+        if not isinstance(data, dict):
+            return pd.DataFrame()
+
+        history = data.get("history")
+        if not history or history == "null" or not isinstance(history, dict):
+            return pd.DataFrame()
+
+        events = history.get("event")
+        if not events or events == "null":
+            return pd.DataFrame()
+        if isinstance(events, dict):
+            events = [events]
+        if not isinstance(events, list):
+            return pd.DataFrame()
+
+        rows = [event for event in events if isinstance(event, dict)]
+        if not rows:
+            return pd.DataFrame()
+        return pd.json_normalize(rows)
+
+    def _get_tradier_history_page(
+        self,
+        *,
+        start_date: datetime.date | None,
+        end_date: datetime.date | None,
+        limit: int,
+        page: int,
+        activity_type: str,
+        supports_page: bool,
+    ) -> pd.DataFrame:
+        account = self.tradier.account
+        request = getattr(account, "request", None)
+        endpoint = getattr(account, "ACCOUNT_HISTORY_ENDPOINT", None)
+        if endpoint is None:
+            endpoint = f"v1/accounts/{getattr(self, '_tradier_account_number', '')}/history"
+
+        if callable(request):
+            params = {
+                "start": account.date2str(start_date),
+                "end": account.date2str(end_date),
+                "limit": limit,
+                "page": page,
+                "type": activity_type.lower(),
+            }
+            params = {key: value for key, value in params.items() if value is not None}
+            return self._normalize_history_payload_to_df(request(endpoint=endpoint, params=params))
+
+        # Compatibility fallback for alternate clients. Some published lumiwealth_tradier versions
+        # throw TypeError("string indices must be integers") when the API returns {"history": "null"}.
+        kwargs = {
+            "start_date": start_date,
+            "end_date": end_date,
+            "limit": limit,
+            "activity_type": activity_type,
+        }
+        if supports_page:
+            kwargs["page"] = page
+
+        try:
+            history_df = account.get_history(**kwargs)
+        except TypeError as exc:
+            if "string indices must be integers" in str(exc):
+                return pd.DataFrame()
+            raise
+
+        if isinstance(history_df, pd.DataFrame):
+            return history_df
+        return self._normalize_history_payload_to_df(history_df)
+
     def get_cash_events(
         self,
         *,
@@ -889,28 +960,31 @@ class Tradier(Broker):
         per_type_limit = max(int(limit or 100), 1)
         per_page_limit = min(per_type_limit, 1000)
         max_pages = max((per_type_limit - 1) // per_page_limit + 1, 1)
-        get_history = self.tradier.account.get_history
-        try:
-            signature = inspect.signature(get_history)
-            supports_page = "page" in signature.parameters or any(
-                parameter.kind is inspect.Parameter.VAR_KEYWORD
-                for parameter in signature.parameters.values()
-            )
-        except Exception:
-            supports_page = False
+        account = self.tradier.account
+        supports_page = callable(getattr(account, "request", None))
+        if not supports_page:
+            try:
+                signature = inspect.signature(account.get_history)
+                supports_page = "page" in signature.parameters or any(
+                    parameter.kind is inspect.Parameter.VAR_KEYWORD
+                    for parameter in signature.parameters.values()
+                )
+            except Exception:
+                supports_page = False
+        request_limit = per_page_limit if supports_page else per_type_limit
+        page_count = max_pages if supports_page else 1
 
         event_by_id: dict[str, CashEvent] = {}
         for activity_type in self.CASH_ACTIVITY_TYPES:
-            for page in range(1, max_pages + 1):
-                kwargs = {
-                    "start_date": start_date,
-                    "end_date": end_date,
-                    "limit": per_page_limit if supports_page else per_type_limit,
-                    "activity_type": activity_type,
-                }
-                if supports_page:
-                    kwargs["page"] = page
-                history_df = get_history(**kwargs)
+            for page in range(1, page_count + 1):
+                history_df = self._get_tradier_history_page(
+                    start_date=start_date,
+                    end_date=end_date,
+                    limit=request_limit,
+                    page=page,
+                    activity_type=activity_type,
+                    supports_page=supports_page,
+                )
 
                 if history_df is None or history_df.empty:
                     break
@@ -921,8 +995,6 @@ class Tradier(Broker):
                         event_by_id[event.event_id] = event
 
                 if len(history_df.index) < per_page_limit:
-                    break
-                if not supports_page:
                     break
 
         normalized_events = sorted(

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -7,6 +7,7 @@ import time
 import threading
 import datetime
 import inspect
+from collections import Counter
 from typing import Union
 
 import pandas as pd
@@ -925,7 +926,21 @@ class Tradier(Broker):
                 "type": activity_type.lower(),
             }
             params = {key: value for key, value in params.items() if value is not None}
-            return self._normalize_history_payload_to_df(request(endpoint=endpoint, params=params))
+            try:
+                data = request(endpoint=endpoint, params=params)
+            except Exception as exc:
+                logger.warning(
+                    "Tradier cash-event history fetch failed: %s (activity_type=%s, page=%s, "
+                    "limit=%s, endpoint=%s, since_set=%s)",
+                    exc,
+                    activity_type,
+                    page,
+                    limit,
+                    endpoint,
+                    start_date is not None,
+                )
+                raise
+            return self._normalize_history_payload_to_df(data)
 
         # Compatibility fallback for alternate clients. Some published lumiwealth_tradier versions
         # throw TypeError("string indices must be integers") when the API returns {"history": "null"}.
@@ -942,6 +957,13 @@ class Tradier(Broker):
             history_df = account.get_history(**kwargs)
         except TypeError as exc:
             if "string indices must be integers" in str(exc):
+                logger.debug(
+                    "Tradier cash-event history returned an empty/null payload through the wrapper "
+                    "(activity_type=%s, page=%s, limit=%s). Treating as empty.",
+                    activity_type,
+                    page,
+                    limit,
+                )
                 return pd.DataFrame()
             raise
 
@@ -975,6 +997,8 @@ class Tradier(Broker):
         page_count = max_pages if supports_page else 1
 
         event_by_id: dict[str, CashEvent] = {}
+        raw_row_count = 0
+        raw_type_counts = Counter()
         for activity_type in self.CASH_ACTIVITY_TYPES:
             for page in range(1, page_count + 1):
                 history_df = self._get_tradier_history_page(
@@ -989,6 +1013,12 @@ class Tradier(Broker):
                 if history_df is None or history_df.empty:
                     break
 
+                raw_row_count += len(history_df.index)
+                if "type" in history_df.columns:
+                    raw_type_counts.update(
+                        str(raw_type or "").lower().strip()
+                        for raw_type in history_df["type"].dropna().tolist()
+                    )
                 for row in history_df.to_dict(orient="records"):
                     event = self._normalize_history_row_to_cash_event(row)
                     if event is not None:
@@ -1001,7 +1031,14 @@ class Tradier(Broker):
             event_by_id.values(),
             key=lambda event: (event.occurred_at, event.event_id),
         )
-        logger.debug("Tradier returned %s normalized cash events", len(normalized_events))
+        logger.debug(
+            "Tradier returned %s normalized cash events from %s raw history rows "
+            "(supports_page=%s, raw_types=%s)",
+            len(normalized_events),
+            raw_row_count,
+            supports_page,
+            dict(raw_type_counts),
+        )
         return normalized_events
 
     def _pull_positions(self, strategy):

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -3124,7 +3124,11 @@ class _Strategy:
         try:
             fetched_events = get_cash_events(since=fetch_since, limit=fetch_limit)
         except Exception as exc:
-            self.logger.warning(f"Failed to load broker cash events: {exc}")
+            broker_name = getattr(broker, "name", None) or broker.__class__.__name__
+            self.logger.warning(
+                f"Failed to load broker cash events from {broker_name} "
+                f"({broker.__class__.__name__}): {exc}"
+            )
             self.logger.debug(traceback.format_exc())
             return []
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.7",
+    version="4.5.8",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_cash_events.py
+++ b/tests/test_cash_events.py
@@ -88,13 +88,14 @@ def test_alpaca_activity_normalization_maps_external_and_tax_events():
     assert tax_event.direction == "out"
 
 
-def test_alpaca_get_cash_events_fetches_unfiltered_activity_page_and_normalizes():
-    requested = {}
+def test_alpaca_get_cash_events_fetches_transfer_page_and_normalizes():
+    requests = []
 
     class _DummyAPI:
         def get(self, path, params):
-            requested["path"] = path
-            requested["params"] = dict(params)
+            requests.append({"path": path, "params": dict(params)})
+            if params.get("activity_types") != "TRANS" or params.get("page_token"):
+                return []
             return [
                 {
                     "id": "evt-deposit",
@@ -119,10 +120,10 @@ def test_alpaca_get_cash_events_fetches_unfiltered_activity_page_and_normalizes(
 
     events = broker.get_cash_events(limit=10)
 
-    assert requested["path"] == "/account/activities"
-    assert requested["params"]["page_size"] == 100
-    assert requested["params"]["direction"] == "desc"
-    assert requested["params"]["activity_types"] == "TRANS,DIV,MISC"
+    assert all(request["path"] == "/account/activities" for request in requests)
+    assert requests[0]["params"]["page_size"] == 100
+    assert requests[0]["params"]["direction"] == "desc"
+    assert [request["params"]["activity_types"] for request in requests] == ["TRANS", "TRANS", "DIV", "MISC"]
     assert len(events) == 1
     assert events[0].event_type == "deposit"
 
@@ -133,6 +134,8 @@ def test_alpaca_get_cash_events_paginates_until_it_finds_older_cash_events():
     class _DummyAPI:
         def get(self, path, params):
             requests.append(dict(params))
+            if params.get("activity_types") != "TRANS":
+                return []
             if "page_token" not in params:
                 return [
                     {
@@ -168,8 +171,9 @@ def test_alpaca_get_cash_events_paginates_until_it_finds_older_cash_events():
 
     events = broker.get_cash_events(limit=1)
 
-    assert len(requests) == 2
-    assert requests[1]["page_token"] == "evt-fill-2"
+    transfer_requests = [request for request in requests if request["activity_types"] == "TRANS"]
+    assert len(transfer_requests) == 2
+    assert transfer_requests[1]["page_token"] == "evt-fill-2"
     assert len(events) == 1
     assert events[0].event_type == "deposit"
 
@@ -551,6 +555,24 @@ class _Response:
         self.status_code = status_code
         self.text = text
         self.headers = {}
+
+
+def test_cash_event_fetch_warning_identifies_broker(caplog):
+    class _FailingBroker:
+        name = "tradier"
+
+        def get_cash_events(self, **_kwargs):
+            raise TypeError("string indices must be integers, not 'str'")
+
+    dummy = _cloud_update_dummy(lambda **_kwargs: [])
+    dummy.broker = _FailingBroker()
+
+    with caplog.at_level(logging.WARNING, logger="tests.cash_events.cloud"):
+        events = _Strategy._collect_cash_events_for_cloud(dummy)
+
+    assert events == []
+    assert "Failed to load broker cash events from tradier (_FailingBroker)" in caplog.text
+    assert "string indices must be integers" in caplog.text
 
 
 def test_send_update_to_cloud_includes_cash_events_and_dedupes_on_success(monkeypatch):

--- a/tests/test_cash_events.py
+++ b/tests/test_cash_events.py
@@ -122,7 +122,7 @@ def test_alpaca_get_cash_events_fetches_unfiltered_activity_page_and_normalizes(
     assert requested["path"] == "/account/activities"
     assert requested["params"]["page_size"] == 100
     assert requested["params"]["direction"] == "desc"
-    assert "activity_types" not in requested["params"]
+    assert requested["params"]["activity_types"] == "TRANS,DIV,MISC"
     assert len(events) == 1
     assert events[0].event_type == "deposit"
 
@@ -171,6 +171,38 @@ def test_alpaca_get_cash_events_paginates_until_it_finds_older_cash_events():
     assert len(requests) == 2
     assert requests[1]["page_token"] == "evt-fill-2"
     assert len(events) == 1
+    assert events[0].event_type == "deposit"
+
+
+def test_alpaca_cash_events_handles_wrapped_or_invalid_activity_pages():
+    class _DummyAPI:
+        def __init__(self):
+            self.calls = 0
+
+        def get(self, path, params):
+            self.calls += 1
+            if self.calls == 1:
+                return {
+                    "activities": {
+                        "evt-deposit": {
+                            "id": "evt-deposit",
+                            "activity_type": "CSD",
+                            "date": "2026-03-24",
+                            "net_amount": "1000.00",
+                            "description": "ACH deposit",
+                        },
+                        "evt-fill": "not a valid activity row",
+                    }
+                }
+            return "not a valid page"
+
+    broker = Alpaca.__new__(Alpaca)
+    broker.api = _DummyAPI()
+
+    events = broker.get_cash_events(limit=10)
+
+    assert len(events) == 1
+    assert events[0].raw_type == "CSD"
     assert events[0].event_type == "deposit"
 
 
@@ -290,6 +322,67 @@ def test_tradier_get_cash_events_paginates_per_activity_type():
     requests = []
 
     class _DummyAccount:
+        ACCOUNT_HISTORY_ENDPOINT = "v1/accounts/VA000001/history"
+
+        @staticmethod
+        def date2str(value):
+            return value.isoformat() if hasattr(value, "isoformat") else value
+
+        def request(self, endpoint, params):
+            requests.append({"endpoint": endpoint, "params": dict(params)})
+            if params["type"] != "ach":
+                return {"history": "null"}
+
+            if params.get("page") == 1:
+                return {
+                    "history": {
+                        "event": [
+                            {
+                                "id": f"tradier-deposit-{index}",
+                                "type": "ach",
+                                "date": "2026-03-24",
+                                "amount": "1000.00",
+                                "description": "Bank ACH",
+                            }
+                            for index in range(1000)
+                        ]
+                    }
+                }
+
+            if params.get("page") == 2:
+                return {
+                    "history": {
+                        "event": {
+                            "id": "tradier-deposit-last",
+                            "type": "ach",
+                            "date": "2026-03-23",
+                            "amount": "500.00",
+                            "description": "Bank ACH",
+                        }
+                    }
+                }
+
+            return {"history": "null"}
+
+    broker = Tradier.__new__(Tradier)
+    broker.tradier = SimpleNamespace(account=_DummyAccount())
+    broker._tradier_account_number = "VA000001"
+
+    events = broker.get_cash_events(limit=1500)
+
+    ach_requests = [req for req in requests if req["params"]["type"] == "ach"]
+    assert ach_requests[0]["endpoint"] == "v1/accounts/VA000001/history"
+    assert ach_requests[0]["params"]["limit"] == 1000
+    assert ach_requests[0]["params"]["page"] == 1
+    assert ach_requests[1]["params"]["page"] == 2
+    assert len(events) == 1001
+    assert events[0].event_type == "deposit"
+
+
+def test_tradier_get_cash_events_wrapper_fallback_paginates_per_activity_type():
+    requests = []
+
+    class _DummyAccount:
         def get_history(self, **kwargs):
             requests.append(dict(kwargs))
             if kwargs["activity_type"] != "ach":
@@ -337,6 +430,46 @@ def test_tradier_get_cash_events_paginates_per_activity_type():
     assert ach_requests[1]["page"] == 2
     assert len(events) == 1001
     assert events[0].event_type == "deposit"
+
+
+def test_tradier_empty_history_payload_normalizes_to_empty_dataframe():
+    empty_history = Tradier._normalize_history_payload_to_df({"history": "null"})
+    empty_event = Tradier._normalize_history_payload_to_df({"history": {"event": "null"}})
+    bad_payload = Tradier._normalize_history_payload_to_df("not a dict")
+
+    assert empty_history.empty
+    assert empty_event.empty
+    assert bad_payload.empty
+
+
+def test_tradier_get_cash_events_treats_wrapper_null_history_typeerror_as_empty():
+    requests = []
+
+    class _DummyAccount:
+        def get_history(self, start_date=None, end_date=None, limit=None, activity_type=None, symbol=None):
+            requests.append(
+                {
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "limit": limit,
+                    "activity_type": activity_type,
+                    "symbol": symbol,
+                }
+            )
+            if activity_type == "ach":
+                raise TypeError("string indices must be integers, not 'str'")
+
+            import pandas as pd
+
+            return pd.DataFrame()
+
+    broker = Tradier.__new__(Tradier)
+    broker.tradier = SimpleNamespace(account=_DummyAccount())
+
+    events = broker.get_cash_events(limit=100)
+
+    assert events == []
+    assert any(req["activity_type"] == "ach" for req in requests)
 
 
 def test_tradier_get_cash_events_omits_page_when_client_does_not_support_it():


### PR DESCRIPTION
## What / Why
Release branch for v4.5.8. This includes broker cash-event hardening for Alpaca/Tradier plus the AI-agent observability/news/prompt-cache work already staged in the 4.5.8 changelog.

The latest customer-facing fix is cash-event polling: production warnings were not actionable and Tradier wrapper parsing could emit `string indices must be integers, not 'str'` for empty/null history. The branch now parses raw Tradier history safely, fetches Alpaca account activity categories separately so `CSD`/`CSW` funding rows are not hidden behind dividends, and logs broker + sanitized request context when failures happen.

## Risk
- Broker cash-event polling now performs separate Alpaca non-fill category requests (`TRANS`, `DIV`, `MISC`). More requests, but only on the existing cash-event poll interval and bounded by page limits.
- Tradier now prefers raw account history parsing when available, bypassing fragile wrapper behavior for history payloads only.
- No order placement/trading behavior changed.

## Tests run
- `/opt/homebrew/bin/python3.12 -m pytest tests/test_cash_events.py -q` -> 19 passed.
- `/opt/homebrew/bin/python3.12 -m py_compile lumibot/brokers/alpaca.py lumibot/brokers/tradier.py lumibot/strategies/_strategy.py` -> passed.
- `git diff --check` -> passed.
- Real read-only Alpaca live API-key account probe: 108 normalized cash events, including 5 `CSD` deposits and 2 `CSW` withdrawals.
- Real read-only Alpaca live OAuth probe: same 108 normalized cash events, including 5 `CSD` deposits and 2 `CSW` withdrawals.
- Real read-only Tradier live probe: 37 normalized cash events, including wire/transfer/dividend history and external cash-flow rows.
- Paper/sandbox verification: Alpaca test key failed 401; Tradier sandbox returned 0 events, matching provider docs that account history is not presently available for sandbox/paper.

## Docs
- `CHANGELOG.md` updated under 4.5.8.
- Official provider docs checked: Alpaca Account Activities (`TRANS` includes `CSD`/`CSW`; pagination is `page_token`/`page_size`) and Tradier Account History (`type`, `limit`, `page`, `start`, `end`; sandbox history limitation noted).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release v4.5.8

* **Bug Fixes**
  * Improved broker cash-event fetching to correctly handle heterogeneous/malformed activity payloads and per-activity-type pagination, reducing false warnings and failures.
  * Enhanced error/warning output to include broker identity and sanitized fetch context for actionable diagnostics.

* **Tests**
  * Expanded cash-event tests covering pagination, wrapped/null/invalid payloads, and cloud-side logging of broker-identifying errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->