### PR TITLE
v4.5.10 - Bitunix cancel-order fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 4.5.10 - Unreleased
+## 4.5.10 - 2026-04-30
+
+### Fixed
+- **Bitunix futures order cancellation now sends the exchange-required symbol with the order id.** `Bitunix.cancel_order()` now passes both `order_id` and `symbol` into the Bitunix REST client, and `BitUnixClient.cancel_order()` accepts either the broker's keyword shape or a Lumibot order object. This fixes cancellation failures caused by the client method expecting an order object while the broker passed only an identifier.
 
 ## 4.5.9 - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.10 - Unreleased
+
 ## 4.5.9 - 2026-04-30
 
 Deploy marker: b0da6a50 (`deploy 4.5.9`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.5.10 - 2026-04-30
 
+Deploy marker: 9e73736f (`deploy 4.5.10`)
+
 ### Fixed
 - **Bitunix futures order cancellation now sends the exchange-required symbol with the order id.** `Bitunix.cancel_order()` now passes both `order_id` and `symbol` into the Bitunix REST client, and `BitUnixClient.cancel_order()` accepts either the broker's keyword shape or a Lumibot order object. This fixes cancellation failures caused by the client method expecting an order object while the broker passed only an identifier.
 

--- a/lumibot/brokers/bitunix.py
+++ b/lumibot/brokers/bitunix.py
@@ -384,7 +384,10 @@ class Bitunix(Broker):
 
         try:
             # Retry up to 5 times on network error
-            response = self.api.cancel_order(order_id=order.identifier)
+            symbol = getattr(order, "symbol", None)
+            if not symbol and getattr(order, "asset", None) is not None:
+                symbol = getattr(order.asset, "symbol", None)
+            response = self.api.cancel_order(order_id=order.identifier, symbol=symbol)
 
             # Check response
             if response and response.get("code") == 0:

--- a/lumibot/tools/bitunix_helpers.py
+++ b/lumibot/tools/bitunix_helpers.py
@@ -194,14 +194,32 @@ class BitUnixClient:
             json_body=body,
         )
 
-    def cancel_order(self, order) -> Dict[str, Any]:
+    def cancel_order(
+        self,
+        order=None,
+        *,
+        order_id: Optional[str] = None,
+        symbol: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """
         Cancel a single FUTURES order.
         """
+        if order is not None:
+            order_id = order_id or getattr(order, "identifier", None) or getattr(order, "id", None)
+            symbol = symbol or getattr(order, "symbol", None)
+            asset = getattr(order, "asset", None)
+            if symbol is None and asset is not None:
+                symbol = getattr(asset, "symbol", None)
+
+        if not order_id:
+            raise ValueError("BitUnixClient.cancel_order requires an order identifier")
+        if not symbol:
+            raise ValueError("BitUnixClient.cancel_order requires a symbol")
+
         return self._request(
             method="POST",
             endpoint="/api/v1/futures/trade/cancel_orders",
-            json_body={"symbol": order.symbol, "orderList": [order.identifier]},
+            json_body={"symbol": symbol, "orderList": [str(order_id)]},
         )
 
     def adjust_position_margin(

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.9",
+    version="4.5.10",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_broker_bitunix.py
+++ b/tests/test_broker_bitunix.py
@@ -38,6 +38,55 @@ class TestBitunixBroker(unittest.TestCase):
         with self.assertRaises(ValueError):
             Bitunix({"TRADING_MODE": "FUTURES"})
 
+    def test_client_cancel_order_accepts_broker_keyword_shape(self):
+        client = BitUnixClient(api_key="test_api_key", secret_key="test_api_secret")
+        client._request = MagicMock(return_value={"code": 0})
+
+        response = client.cancel_order(order_id="2048802184602955776", symbol="BTCUSDT")
+
+        self.assertEqual(response, {"code": 0})
+        client._request.assert_called_once_with(
+            method="POST",
+            endpoint="/api/v1/futures/trade/cancel_orders",
+            json_body={"symbol": "BTCUSDT", "orderList": ["2048802184602955776"]},
+        )
+
+    def test_client_cancel_order_accepts_order_object(self):
+        client = BitUnixClient(api_key="test_api_key", secret_key="test_api_secret")
+        client._request = MagicMock(return_value={"code": 0})
+        order = SimpleNamespace(identifier="abc123", symbol="ETHUSDT")
+
+        response = client.cancel_order(order)
+
+        self.assertEqual(response, {"code": 0})
+        client._request.assert_called_once_with(
+            method="POST",
+            endpoint="/api/v1/futures/trade/cancel_orders",
+            json_body={"symbol": "ETHUSDT", "orderList": ["abc123"]},
+        )
+
+    @patch("lumibot.brokers.bitunix.BitUnixClient")
+    @patch("lumibot.brokers.bitunix.BitunixData")
+    def test_broker_cancel_order_passes_symbol_with_identifier(self, MockBitunixData, MockBitUnixClientInstance):
+        MockBitUnixClientInstance.return_value = self.mock_bitunix_client
+        self.mock_bitunix_client.cancel_order.return_value = {"code": 0}
+        mock_data_source = MockBitunixData.return_value
+        mock_data_source.client_symbols = set()
+
+        broker = Bitunix(self.config)
+        broker._process_trade_event = MagicMock()
+        asset = Asset("BTCUSDT", Asset.AssetType.CRYPTO_FUTURE)
+        order = Order("test_strategy", asset, Decimal("0.1"))
+        order.identifier = "2048802184602955776"
+
+        broker.cancel_order(order)
+
+        self.mock_bitunix_client.cancel_order.assert_called_once_with(
+            order_id="2048802184602955776",
+            symbol="BTCUSDT",
+        )
+        broker._process_trade_event.assert_called_once_with(order, broker.CANCELED_ORDER)
+
     @patch("lumibot.brokers.bitunix.BitUnixClient")
     @patch("lumibot.brokers.bitunix.BitunixData")
     def test_pull_positions_success(self, MockBitunixData, MockBitUnixClientInstance):


### PR DESCRIPTION
What / Why:
Release 4.5.10 fixes Bitunix futures order cancellation by sending the exchange-required symbol alongside the order id. This aligns the broker call shape with the REST client and keeps the client compatible with order-object calls.

Risk:
Low. Scope is limited to Bitunix cancel_order. Main risk is Bitunix API payload compatibility, covered by client and broker regression tests.

Tests run:
- env PYTHONPATH=/Users/robertgrzesik/Development/lumiwealth-tradier python3 -m pytest tests/test_broker_bitunix.py -q
- env PYTHONPATH=/Users/robertgrzesik/Development/lumiwealth-tradier python3 -m pytest -m "not apitest and not downloader" --tb=short -q --durations=30

Perf evidence:
Not applicable.

Docs:
CHANGELOG.md updated for 4.5.10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Bitunix futures order cancellation failures by ensuring all exchange-required parameters are now properly included in cancellation requests.

* **Tests**
  * Added comprehensive test coverage for cancel order operations at both client and broker layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->