### PR TITLE
Fix CI lint and IBKR futures order path

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -65,7 +65,7 @@ jobs:
           # tests this PR touches.
           ruff check --select F,I \
             lumibot/tools/thetadata_helper.py \
-            lumibot/tools/thetadata_queue_client.py \
+            lumibot/tools/data_downloader_queue_client.py \
             lumibot/backtesting/thetadata_backtesting_pandas.py \
             lumibot/components/options_helper.py \
             lumibot/strategies/_strategy.py \

--- a/lumibot/__init__.py
+++ b/lumibot/__init__.py
@@ -1,13 +1,8 @@
 import os
 import sys
 import warnings
-import importlib
-import re
-from pathlib import Path
-
-from lumibot.tools.lumibot_logger import get_logger
-
-logger = get_logger(__name__)
+import types
+from importlib.machinery import ModuleSpec
 
 
 def _read_version_from_setup_py() -> str | None:
@@ -18,15 +13,22 @@ def _read_version_from_setup_py() -> str | None:
     """
 
     try:
-        module_path = Path(__file__).resolve()
-        for parent in module_path.parents:
-            setup_py = parent / "setup.py"
-            if not setup_py.is_file():
-                continue
-            text = setup_py.read_text(encoding="utf-8", errors="ignore")
-            match = re.search(r"version\s*=\s*['\"]([^'\"]+)['\"]", text)
-            if match:
-                return match.group(1).strip()
+        current = os.path.dirname(os.path.abspath(__file__))
+        while True:
+            setup_py = os.path.join(current, "setup.py")
+            if os.path.isfile(setup_py):
+                with open(setup_py, encoding="utf-8", errors="ignore") as file:
+                    for line in file:
+                        if "version" not in line:
+                            continue
+                        _, _, value = line.partition("=")
+                        value = value.strip().strip(",")
+                        if len(value) >= 2 and value[0] in "'\"" and value[-1] == value[0]:
+                            return value[1:-1].strip()
+            parent = os.path.dirname(current)
+            if parent == current:
+                break
+            current = parent
     except Exception:
         pass
     return None
@@ -49,8 +51,6 @@ except ImportError:
 except:
     __version__ = "unknown"
 
-logger.info(f"LumiBot v{__version__} starting")
-
 # Get the major and minor Python version
 major, minor = sys.version_info[:2]
 
@@ -59,66 +59,187 @@ if (major, minor) < (3, 10):
     warnings.warn("Lumibot requires Python 3.10 or higher.", RuntimeWarning)
 
 # SOURCE PATH
-# Import constants from constants module (before importing submodules to avoid circular imports)
-from .constants import (
-    LUMIBOT_CACHE_FOLDER,
-    LUMIBOT_DEFAULT_PYTZ,
-    LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL,
-    LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE,
-    LUMIBOT_DEFAULT_TIMEZONE,
-    LUMIBOT_SOURCE_PATH,
-)
+LUMIBOT_SOURCE_PATH = os.path.dirname(os.path.abspath(__file__))
+LUMIBOT_DEFAULT_TIMEZONE = "America/New_York"
+LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL = "USD"
+LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE = "forex"
 
-# Import main submodules (after constants to avoid circular imports)
-from . import backtesting, brokers, data_sources, entities, strategies, traders
+
+def _default_cache_folder() -> str:
+    env_value = os.environ.get("LUMIBOT_CACHE_FOLDER")
+    if env_value:
+        return env_value
+    if sys.platform == "darwin":
+        return os.path.expanduser("~/Library/Caches/lumibot/1.0")
+    if os.name == "nt":
+        root = os.environ.get("LOCALAPPDATA") or os.path.expanduser("~\\AppData\\Local")
+        return os.path.join(root, "LumiWealth", "lumibot", "Cache", "1.0")
+    root = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return os.path.join(root, "lumibot", "1.0")
+
+
+LUMIBOT_CACHE_FOLDER = _default_cache_folder()
 
 # Ensure cache folder exists
 if not os.path.exists(LUMIBOT_CACHE_FOLDER):
     try:
         os.makedirs(LUMIBOT_CACHE_FOLDER)
     except Exception as e:
-        logger.critical(
+        warnings.warn(
             f"""Could not create cache folder because of the following error:
             {e}. Please fix the issue to use data caching."""
         )
 
-# === Backward Compatibility Aliases ===
-# Some older code and documentation may still refer to the top-level
-# package name `entities` (e.g. `entities.asset`) that existed in
-# earlier Lumibot versions.  To avoid breaking those references we
-# expose `lumibot.entities` and its sub-modules under the legacy name
-# when the library is imported.
+_SUBMODULE_EXPORTS = {
+    "strategies",
+    "brokers",
+    "backtesting",
+    "entities",
+    "data_sources",
+    "traders",
+    "tools",
+    "components",
+    "constants",
+    "credentials",
+    "trading_builtins",
+}
 
-# Map the root package alias.
-import lumibot.entities as _lb_entities
-sys.modules.setdefault("entities", _lb_entities)
 
-# Expose common sub-modules (asset, bars, data, order, position, trading_fee)
-# so that e.g. `import entities.asset` keeps working.
-for _sub in ("asset", "bars", "data", "order", "position", "trading_fee"):
-    _full = f"lumibot.entities.{_sub}"
-    _alias = f"entities.{_sub}"
-    try:
-        _mod = importlib.import_module(_full)
-        sys.modules[_alias] = _mod
-    except ModuleNotFoundError as e:
-        # If a particular sub-module was removed or fails to import (e.g., due to deeper issues like 'fp')
-        # log a warning and skip. Sphinx will simply not find this specific alias.
-        logger.warning(f"[lumibot/__init__.py] Could not create alias '{_alias}' for '{_full}': {e}")
-        # Ensure the problematic alias isn't lingering if it was partially set or if it's a mock
-        if _alias in sys.modules and isinstance(sys.modules[_alias], importlib.util.LazyLoader):
-            pass # Don't remove if it's a lazy loader that might resolve later or differently
-        elif _alias in sys.modules:
-            # If it's a real module or a simple mock that failed, best to remove its alias attempt
-            # to avoid Sphinx confusion with a potentially broken module object.
-            # However, if Sphinx/autodoc is running, it might be safer to leave mocks as they are.
-            # For now, we'll log and continue, letting Sphinx handle missing modules.
-            # Reconsidering removal: could interfere with Sphinx's own mock handling.
-            pass # Reconsidering removal: could interfere with Sphinx's own mock handling
-    except ImportError as e: # Catch other import-related errors
-        logger.warning(f"[lumibot/__init__.py] ImportError while creating alias '{_alias}' for '{_full}': {e}")
-    except Exception as e: # Catch any other unexpected errors during aliasing
-        logger.warning(f"[lumibot/__init__.py] Unexpected error creating alias '{_alias}' for '{_full}': {e}")
+class _EntitiesAliasLoader:
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        load = module.__dict__.get("_load")
+        if load is not None:
+            load()
+
+
+_ENTITIES_ALIAS_LOADER = _EntitiesAliasLoader()
+
+
+class _EntitiesAliasFinder:
+    _lumibot_entities_alias_finder = True
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname in _ENTITY_SUBMODULE_ALIAS_NAMES:
+            return ModuleSpec(fullname, _ENTITIES_ALIAS_LOADER, is_package=False)
+        if fullname == "entities":
+            spec = ModuleSpec(fullname, _ENTITIES_ALIAS_LOADER, is_package=True)
+            spec.submodule_search_locations = _EntitiesAlias.__path__
+            return spec
+        return None
+
+
+class _EntitiesAlias(types.ModuleType):
+    __path__ = [os.path.join(os.path.dirname(os.path.abspath(__file__)), "entities")]
+    __file__ = os.path.join(os.path.dirname(os.path.abspath(__file__)), "entities", "__init__.py")
+    __package__ = "entities"
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.__spec__ = ModuleSpec(name, _ENTITIES_ALIAS_LOADER, is_package=True)
+        self.__spec__.submodule_search_locations = self.__path__
+
+    def __getattr__(self, name):
+        import importlib
+
+        entities_module = importlib.import_module("lumibot.entities")
+        if name in getattr(entities_module, "__all__", ()):
+            value = getattr(entities_module, name)
+            setattr(self, name, value)
+            return value
+
+        alias = sys.modules.get(f"entities.{name}")
+        if alias is not None:
+            return alias
+
+        try:
+            module = importlib.import_module(f"lumibot.entities.{name}")
+            sys.modules[f"entities.{name}"] = module
+        except ModuleNotFoundError:
+            module = importlib.import_module(f"entities.{name}")
+        return module
+
+
+class _EntitiesSubmoduleAlias(types.ModuleType):
+    def __init__(self, alias_name: str, target_name: str):
+        super().__init__(alias_name)
+        self.__package__ = "entities"
+        self.__spec__ = ModuleSpec(alias_name, _ENTITIES_ALIAS_LOADER, is_package=False)
+        self._target_name = target_name
+        self._target_module = None
+
+    def _load(self):
+        import importlib
+
+        module = self._target_module
+        if module is None:
+            module = importlib.import_module(self._target_name)
+            self._target_module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __dir__(self):
+        return dir(self._load())
+
+
+_ENTITY_SUBMODULES = (
+    "asset",
+    "bar",
+    "bars",
+    "cash_event",
+    "chains",
+    "data",
+    "data_polars",
+    "dataline",
+    "order",
+    "position",
+    "quote",
+    "trading_fee",
+    "trading_slippage",
+    "smart_limit",
+)
+_ENTITY_SUBMODULE_ALIAS_NAMES = {f"entities.{_submodule}" for _submodule in _ENTITY_SUBMODULES}
+if not any(getattr(_finder, "_lumibot_entities_alias_finder", False) for _finder in sys.meta_path):
+    sys.meta_path.insert(0, _EntitiesAliasFinder())
+
+sys.modules.setdefault("entities", _EntitiesAlias("entities"))
+for _submodule in _ENTITY_SUBMODULES:
+    sys.modules.setdefault(
+        f"entities.{_submodule}",
+        _EntitiesSubmoduleAlias(f"entities.{_submodule}", f"lumibot.entities.{_submodule}"),
+    )
+
+
+def __getattr__(name):
+    if name == "LUMIBOT_DEFAULT_PYTZ":
+        from .constants import LUMIBOT_DEFAULT_PYTZ
+
+        globals()[name] = LUMIBOT_DEFAULT_PYTZ
+        return LUMIBOT_DEFAULT_PYTZ
+    if name in _SUBMODULE_EXPORTS:
+        import importlib
+
+        module = importlib.import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    if name == "get_logger":
+        from lumibot.tools.lumibot_logger import get_logger
+
+        globals()[name] = get_logger
+        return get_logger
+    if name == "logger":
+        logger = __getattr__("get_logger")(__name__)
+        globals()[name] = logger
+        return logger
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))
 
 # Export the default timezone constants so they can be imported by other modules
 __all__ = [
@@ -134,5 +255,12 @@ __all__ = [
     'backtesting',
     'entities',
     'data_sources',
-    'traders'
+    'traders',
+    'tools',
+    'components',
+    'constants',
+    'credentials',
+    'trading_builtins',
+    'get_logger',
+    'logger',
 ]

--- a/lumibot/backtesting/__init__.py
+++ b/lumibot/backtesting/__init__.py
@@ -1,32 +1,37 @@
-from .alpaca_backtesting import AlpacaBacktesting
-from .alpha_vantage_backtesting import AlphaVantageBacktesting
-from .backtesting_broker import BacktestingBroker
-from .ccxt_backtesting import CcxtBacktesting
-from .interactive_brokers_rest_backtesting import InteractiveBrokersRESTBacktesting
-from .pandas_backtesting import PandasDataBacktesting
-from .polygon_backtesting import PolygonDataBacktesting
-from .routed_backtesting import RoutedBacktestingPandas
-from .thetadata_backtesting import ThetaDataBacktesting
-from .thetadata_backtesting_pandas import ThetaDataBacktestingPandas
-from .yahoo_backtesting import YahooDataBacktesting
+"""Backtesting package exports without importing every backend."""
 
-from .databento_backtesting import DataBentoDataBacktesting
-from .databento_backtesting_pandas import DataBentoDataBacktestingPandas
-from .databento_backtesting_polars import DataBentoDataBacktestingPolars
+from importlib import import_module as _import_module
 
-__all__ = [
-    "AlpacaBacktesting",
-    "AlphaVantageBacktesting",
-    "BacktestingBroker",
-    "CcxtBacktesting",
-    "InteractiveBrokersRESTBacktesting",
-    "PandasDataBacktesting",
-    "PolygonDataBacktesting",
-    "RoutedBacktestingPandas",
-    "ThetaDataBacktesting",
-    "ThetaDataBacktestingPandas",
-    "YahooDataBacktesting",
-    "DataBentoDataBacktesting",
-    "DataBentoDataBacktestingPandas",
-    "DataBentoDataBacktestingPolars",
-]
+_NAME_TO_MODULE = {
+    "AlpacaBacktesting": "alpaca_backtesting",
+    "AlphaVantageBacktesting": "alpha_vantage_backtesting",
+    "BacktestingBroker": "backtesting_broker",
+    "CcxtBacktesting": "ccxt_backtesting",
+    "DataBentoDataBacktesting": "databento_backtesting",
+    "DataBentoDataBacktestingPandas": "databento_backtesting_pandas",
+    "DataBentoDataBacktestingPolars": "databento_backtesting_polars",
+    "InteractiveBrokersRESTBacktesting": "interactive_brokers_rest_backtesting",
+    "PandasDataBacktesting": "pandas_backtesting",
+    "PolygonDataBacktesting": "polygon_backtesting",
+    "RoutedBacktestingPandas": "routed_backtesting",
+    "ThetaDataBacktesting": "thetadata_backtesting",
+    "ThetaDataBacktestingPandas": "thetadata_backtesting_pandas",
+    "YahooDataBacktesting": "yahoo_backtesting",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/backtesting/alpaca_backtesting.py
+++ b/lumibot/backtesting/alpaca_backtesting.py
@@ -1,17 +1,20 @@
+from __future__ import annotations
+
 import os
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Optional
+from importlib import import_module
+from typing import TYPE_CHECKING, Optional
 
-import pandas as pd
 import pytz
-from alpaca.data.historical import CryptoHistoricalDataClient, StockHistoricalDataClient
-from alpaca.data.requests import CryptoBarsRequest, StockBarsRequest
-from alpaca.data.timeframe import TimeFrame
 
-from lumibot.constants import LUMIBOT_CACHE_FOLDER
-from lumibot.data_sources import AlpacaData, DataSourceBacktesting
-from lumibot.entities import Asset, Bars
+from lumibot.constants import (
+    LUMIBOT_CACHE_FOLDER,
+    LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL,
+    LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE,
+)
+from lumibot.data_sources import DataSourceBacktesting
+from lumibot.entities import Asset
 from lumibot.tools.helpers import (
     date_n_trading_days_from_date,
     get_decimals,
@@ -22,19 +25,83 @@ from lumibot.tools.helpers import (
 )
 from lumibot.tools.lumibot_logger import get_logger
 
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
+
 logger = get_logger(__name__)
 
-from lumibot.tools.alpaca_helpers import sanitize_base_and_quote_asset
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BARS_CLASS = None
+_ALPACA_DATA_CLASS = None
+_ALPACA_HELPERS = None
+
+
+def _alpaca_attr(module_name: str, attr_name: str):
+    return getattr(import_module(module_name), attr_name)
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _alpaca_data_class():
+    global _ALPACA_DATA_CLASS
+    if _ALPACA_DATA_CLASS is None:
+        from lumibot.data_sources import AlpacaData
+
+        _ALPACA_DATA_CLASS = AlpacaData
+    return _ALPACA_DATA_CLASS
+
+
+def _sanitize_base_and_quote_asset(*args, **kwargs):
+    global _ALPACA_HELPERS
+    if _ALPACA_HELPERS is None:
+        _ALPACA_HELPERS = import_module("lumibot.tools.alpaca_helpers")
+    return _ALPACA_HELPERS.sanitize_base_and_quote_asset(*args, **kwargs)
 
 
 class AlpacaBacktesting(DataSourceBacktesting):
     SOURCE = "ALPACA"
     MIN_TIMESTEP = "minute"
     TIMESTEP_MAPPING = [
-        {"timestep": "day", "representations": [TimeFrame.Day]},
-        {"timestep": "minute", "representations": [TimeFrame.Minute]},
+        {"timestep": "day", "representations": ["day"]},
+        {"timestep": "minute", "representations": ["minute"]},
     ]
-    LUMIBOT_DEFAULT_QUOTE_ASSET = AlpacaData.LUMIBOT_DEFAULT_QUOTE_ASSET
+    LUMIBOT_DEFAULT_QUOTE_ASSET = Asset(LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL, LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE)
+
+    def _parse_source_timestep(self, timestep, reverse=False):
+        if reverse:
+            normalized = self.get_timestep_from_string(timestep)
+            TimeFrame = _alpaca_attr("alpaca.data.timeframe", "TimeFrame")
+            if normalized == "day":
+                return TimeFrame.Day
+            if normalized == "minute":
+                return TimeFrame.Minute
+        return super()._parse_source_timestep(timestep, reverse=reverse)
 
     def __init__(
             self,
@@ -120,6 +187,8 @@ class AlpacaBacktesting(DataSourceBacktesting):
             raise ValueError("Backtesting is restricted to paper accounts. Pass in a paper account config.")
 
         # Initialize clients based on available authentication method
+        CryptoHistoricalDataClient = _alpaca_attr("alpaca.data.historical", "CryptoHistoricalDataClient")
+        StockHistoricalDataClient = _alpaca_attr("alpaca.data.historical", "StockHistoricalDataClient")
         oauth_token = config.get("OAUTH_TOKEN")
         api_key = config.get("API_KEY")
         api_secret = config.get("API_SECRET")
@@ -140,7 +209,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             raise ValueError("Either OAuth token or API key/secret must be provided for Alpaca authentication")
 
         # Create an AlpacaData instance for internal use
-        self._alpaca_data = AlpacaData(config)
+        self._alpaca_data = _alpaca_data_class()(config)
 
         # Ensure datetime_start and datetime_end have the same tzinfo
         if str(datetime_start.tzinfo) != str(datetime_end.tzinfo):
@@ -216,7 +285,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
         self._datetime = self.datetime_start
 
     def _sanitize_base_and_quote_asset(self, base_asset, quote_asset) -> tuple[Asset, Asset]:
-        asset, quote = sanitize_base_and_quote_asset(base_asset, quote_asset)
+        asset, quote = _sanitize_base_and_quote_asset(base_asset, quote_asset)
         return asset, quote
 
     def get_last_price(
@@ -374,7 +443,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
         else:
             result_df = df.iloc[max(0, current_index - length + 1): current_index + 1]
 
-        return Bars(
+        return _bars_class()(
             result_df,
             self.SOURCE,
             asset=asset,
@@ -512,6 +581,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
 
         if base_asset.asset_type == 'crypto':
             client = self._crypto_client
+            CryptoBarsRequest = _alpaca_attr("alpaca.data.requests", "CryptoBarsRequest")
 
             symbol = base_asset.symbol + '/' + quote_asset.symbol
 
@@ -524,6 +594,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             )
         else:
             client = self._stock_client
+            StockBarsRequest = _alpaca_attr("alpaca.data.requests", "StockBarsRequest")
             adjustment = 'all' if auto_adjust else 'split'
 
             # noinspection PyArgumentList
@@ -536,6 +607,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             )
 
         try:
+            CryptoBarsRequest = _alpaca_attr("alpaca.data.requests", "CryptoBarsRequest")
             if isinstance(request_params, CryptoBarsRequest):
                 bars = client.get_crypto_bars(request_params)
             else:

--- a/lumibot/backtesting/alpaca_backtesting.py
+++ b/lumibot/backtesting/alpaca_backtesting.py
@@ -77,6 +77,11 @@ def _alpaca_data_class():
     return _ALPACA_DATA_CLASS
 
 
+def _alpaca_timeframe_from_source_value(value):
+    module = import_module("lumibot.data_sources.alpaca_data")
+    return module._timeframe_from_source_value(value)
+
+
 def _sanitize_base_and_quote_asset(*args, **kwargs):
     global _ALPACA_HELPERS
     if _ALPACA_HELPERS is None:
@@ -94,8 +99,15 @@ class AlpacaBacktesting(DataSourceBacktesting):
     LUMIBOT_DEFAULT_QUOTE_ASSET = Asset(LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL, LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE)
 
     def _parse_source_timestep(self, timestep, reverse=False):
+        timestep_text = str(timestep)
+        for item in _alpaca_data_class().TIMESTEP_MAPPING:
+            if reverse and timestep_text == item["timestep"]:
+                return _alpaca_timeframe_from_source_value(item["representations"][0])
+            if not reverse and timestep_text in item["representations"]:
+                return item["timestep"]
+
         if reverse:
-            normalized = self.get_timestep_from_string(timestep)
+            normalized = super()._parse_source_timestep(timestep, reverse=False)
             TimeFrame = _alpaca_attr("alpaca.data.timeframe", "TimeFrame")
             if normalized == "day":
                 return TimeFrame.Day

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -2111,7 +2111,7 @@ class BacktestingBroker(Broker):
             new_cash = current_cash - trade_amount if is_buy_order else current_cash + trade_amount
             self._set_strategy_cash_fast(strategy, new_cash)
 
-        multiplier = getattr(order, "_simple_multiplier", None) or 1
+        multiplier = getattr(order, "_simple_multiplier", None) or getattr(order.asset, "multiplier", None) or 1
         try:
             if getattr(order, "_simple_backtest_order", False):
                 self._process_simple_market_filled_order(order, price, filled_quantity_f)

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import math
@@ -8,26 +10,75 @@ import threading
 from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta
 from decimal import Decimal
+from importlib import import_module
+from types import ModuleType
 from typing import Any, Optional, Union
 
-import numpy as np
-import pandas as pd
-import polars as pl
-import pytz
-
 from lumibot.brokers import Broker
-from lumibot.data_sources import DataSourceBacktesting
-from lumibot.entities import Asset, Order, Position, SmartLimitConfig, TradingFee
-from lumibot.tools.smart_limit_utils import build_price_ladder, compute_final_price, compute_mid, expected_fill_price, infer_tick_size, round_to_tick
+from lumibot.brokers.broker import _FAST_TRADE_EVENT_MARKER, _FAST_TRADE_PAIR_EVENT_MARKER
+from lumibot.entities import Asset, Order, Position, SmartLimitConfig
+from lumibot.tools.smart_limit_utils import compute_final_price, compute_mid, expected_fill_price, infer_tick_size, round_to_tick
 from lumibot.tools.lumibot_logger import get_logger
 from lumibot.trading_builtins import CustomStream
 
-try:
-    from lumibot.backtesting.thetadata_backtesting_pandas import ThetaDataBacktestingPandas
-except Exception:  # pragma: no cover - optional dependency
-    ThetaDataBacktestingPandas = None
+ThetaDataBacktestingPandas = None
+_THETADATA_BACKTESTING_PANDAS_IMPORT_ATTEMPTED = False
+_POLARS_MODULE = None
+_NO_SIMPLE_POSITION = object()
+DataSourceBacktesting = None
 
 logger = get_logger(__name__)
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+np = _LazyModule("numpy")
+pd = _LazyModule("pandas")
+
+
+def _get_thetadata_backtesting_pandas_cls():
+    """Load ThetaDataBacktestingPandas only when a Theta-specific branch needs it."""
+    global ThetaDataBacktestingPandas, _THETADATA_BACKTESTING_PANDAS_IMPORT_ATTEMPTED
+    if not _THETADATA_BACKTESTING_PANDAS_IMPORT_ATTEMPTED:
+        _THETADATA_BACKTESTING_PANDAS_IMPORT_ATTEMPTED = True
+        try:
+            from lumibot.backtesting.thetadata_backtesting_pandas import ThetaDataBacktestingPandas as cls
+        except Exception:  # pragma: no cover - optional dependency
+            cls = None
+        ThetaDataBacktestingPandas = cls
+    return ThetaDataBacktestingPandas
+
+
+def _get_polars_module():
+    global _POLARS_MODULE
+    if _POLARS_MODULE is None:
+        import polars as pl
+
+        _POLARS_MODULE = pl
+    return _POLARS_MODULE
+
+
+def _data_source_backtesting_class():
+    global DataSourceBacktesting
+    if DataSourceBacktesting is None:
+        from lumibot.data_sources import DataSourceBacktesting
+
+    return DataSourceBacktesting
 
 
 # Typical initial margin requirements for common futures contracts
@@ -157,7 +208,7 @@ class BacktestingBroker(Broker):
         # self._config = config
 
         # Check if data source is a backtesting data source
-        if not (isinstance(self.data_source, DataSourceBacktesting) or
+        if not (isinstance(self.data_source, _data_source_backtesting_class()) or
                 (hasattr(self.data_source, 'IS_BACKTESTING_DATA_SOURCE') and
                  self.data_source.IS_BACKTESTING_DATA_SOURCE)):
             raise ValueError("Must provide a backtesting data_source to run with a BacktestingBroker")
@@ -380,6 +431,7 @@ class BacktestingBroker(Broker):
         performance bottleneck, so this method sources active orders directly from the
         broker's active-order buckets.
         """
+        strategy_name = self._strategy_name_from_input(strategy)
         active_orders: list[Order] = []
         try:
             buckets = (
@@ -389,7 +441,7 @@ class BacktestingBroker(Broker):
             )
         except Exception:
             # Fallback to the slower path if internal buckets are unavailable.
-            orders = self.get_tracked_orders(strategy=strategy)
+            orders = self.get_tracked_orders(strategy=strategy_name)
             if not orders:
                 return []
             return [
@@ -397,9 +449,15 @@ class BacktestingBroker(Broker):
                 if o.is_active() and (asset is None or getattr(o, "asset", None) == asset)
             ]
 
+        simple_by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+        if simple_by_strategy:
+            for order in simple_by_strategy.get(strategy_name, ()):
+                if asset is None or getattr(order, "asset", None) == asset:
+                    active_orders.append(order)
+
         for bucket in buckets:
             for order in bucket:
-                if getattr(order, "strategy", None) != strategy:
+                if getattr(order, "strategy", None) != strategy_name:
                     continue
                 if asset is not None and getattr(order, "asset", None) != asset:
                     continue
@@ -429,26 +487,27 @@ class BacktestingBroker(Broker):
         orders : list, optional
             List of minimal order dicts from Order.to_minimal_dict()
         """
-        tz = self.datetime.tzinfo
-        is_pytz = isinstance(tz, (pytz.tzinfo.StaticTzInfo, pytz.tzinfo.DstTzInfo))
+        current_datetime = self.data_source.get_datetime()
+        tz = current_datetime.tzinfo
+        normalize_tz = getattr(tz, "normalize", None)
 
-        previous_datetime = self.datetime
+        previous_datetime = current_datetime
 
         if isinstance(update_dt, timedelta):
-            new_datetime = self.datetime + update_dt
+            new_datetime = current_datetime + update_dt
         elif isinstance(update_dt, int) or isinstance(update_dt, float):
-            new_datetime = self.datetime + timedelta(seconds=update_dt)
+            new_datetime = current_datetime + timedelta(seconds=update_dt)
         else:
             new_datetime = update_dt
 
         # This is needed to handle Daylight Savings Time changes
-        new_datetime = tz.normalize(new_datetime) if is_pytz else new_datetime
+        new_datetime = normalize_tz(new_datetime) if callable(normalize_tz) else new_datetime
 
         # Guard against non-advancing timestamps (e.g., DST ambiguity)
         if new_datetime <= previous_datetime:
             new_datetime = previous_datetime + timedelta(minutes=1)
-            if is_pytz:
-                new_datetime = tz.normalize(new_datetime)
+            if callable(normalize_tz):
+                new_datetime = normalize_tz(new_datetime)
 
         self.data_source._update_datetime(
             new_datetime,
@@ -1004,9 +1063,17 @@ class BacktestingBroker(Broker):
         # Currently perfect fill price in backtesting!
         order.avg_fill_price = price
 
-        position = super()._process_filled_order(order, price, quantity)
+        self._new_orders.remove(order.identifier, key="identifier")
+        self._unprocessed_orders.remove(order.identifier, key="identifier")
+        self._partially_filled_orders.remove(order.identifier, key="identifier")
+        order.add_transaction(price, quantity)
+        order.status = self.FILLED_ORDER
+        order.set_filled()
+        self._track_filled_order(order)
+
         if existing_position:
-            position.add_order(order, quantity)  # Add will update quantity, but not double count the order
+            position = existing_position
+            position.add_order(order, quantity)
             if position.quantity == 0:
                 logger.info(f"Position {position} liquidated")
                 self._filled_positions.remove(position)
@@ -1032,7 +1099,14 @@ class BacktestingBroker(Broker):
                         cancel_sides=cancel_sides,
                     )
         else:
+            position = order.to_position(quantity)
+            if position is None:
+                logger.error(f"Skipping filled order processing - could not create position from order {order.identifier}")
+                return
             self._filled_positions.append(position)  # New position, add it to the tracker
+
+        if order.asset and "crypto" == order.asset.asset_type and not getattr(order, "_simple_is_crypto_forex", False):
+            self._process_crypto_quote(order, quantity, price)
 
         # If this is a child order, update the parent order status if all children are filled or cancelled.
         if order.parent_identifier:
@@ -1058,6 +1132,24 @@ class BacktestingBroker(Broker):
             return
         filled_ids.add(identifier)
         self._filled_orders.append(order)
+
+    def _track_unique_simple_filled_order(self, order: Order) -> None:
+        """Record a monotonic-ID simple backtest order without a duplicate-id side set."""
+        self._filled_orders.append(order)
+
+    def _finalize_fast_trade_pair_row(self, order: Order, pair_row) -> None:
+        """Freeze a filled pair row and remove temporary private order references."""
+        try:
+            row_index = order._fast_trade_event_pair_row_index
+            if self._trade_event_log_rows[row_index] is pair_row:
+                self._trade_event_log_rows[row_index] = tuple(pair_row)
+            del order._fast_trade_event_pair_row
+            del order._fast_trade_event_pair_row_index
+            del order._fast_trade_event_static
+        except AttributeError:
+            return
+        except Exception:
+            return
 
     def _process_partially_filled_order(self, order, price, quantity):
         """
@@ -1124,15 +1216,19 @@ class BacktestingBroker(Broker):
             self._unprocessed_orders.remove(order.identifier, key="identifier")
             self._partially_filled_orders.remove(order.identifier, key="identifier")
 
-            self._track_filled_order(order)
+            self._track_unique_simple_filled_order(order)
 
     def _submit_order(self, order):
         """Submit an order for an asset"""
+        if getattr(order, "_simple_is_option", None):
+            self._backtest_has_option_lifecycle_exposure = True
+        elif self._is_option_asset(getattr(order, "asset", None)):
+            self._backtest_has_option_lifecycle_exposure = True
 
         # Optional audit trail (submission-time context).
         #
         # Invariant: audit collection must never break backtests; any errors must be swallowed.
-        audit_enabled = self._audit_enabled()
+        audit_enabled = getattr(self, "_backtest_audit_enabled", False)
         if audit_enabled:
             try:
                 self._audit_merge(order, self._audit_submit_fields(order), overwrite=False)
@@ -1144,12 +1240,93 @@ class BacktestingBroker(Broker):
         # submitted below. Bracket/OTO orders will be submitted here, but their child orders will not be submitted
         # until the parent order is filled
         if order.order_class is not Order.OrderClass.OCO:
-            order.update_raw(order)
-            self.stream.dispatch(
-                self.NEW_ORDER,
-                wait_until_complete=True,
-                order=order,
-            )
+            actions = getattr(getattr(self, "stream", None), "_actions_mapping", None)
+            default_action = getattr(self, "_default_new_order_stream_action", None)
+            if actions is not None and actions.get(self.NEW_ORDER) is default_action and not audit_enabled:
+                try:
+                    if getattr(order, "_simple_backtest_order", False):
+                        order._transmitted = True
+                        order._raw = order
+                        order._status = self.NEW_ORDER
+                        if order._new_event is not None:
+                            order._new_event.set()
+                        by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+                        if by_strategy is None:
+                            by_strategy = {}
+                            self._simple_new_orders_by_strategy = by_strategy
+                        by_strategy.setdefault(order.strategy, []).append(order)
+                        self._simple_new_orders_revision = getattr(self, "_simple_new_orders_revision", 0) + 1
+                        processed_order = order
+                    else:
+                        order.update_raw(order)
+                        processed_order = self._process_new_order(order)
+                    if processed_order and not (
+                        getattr(order, "_simple_backtest_order", False)
+                        and self._should_skip_default_new_callback(order)
+                    ):
+                        self._on_new_order(processed_order)
+                    if getattr(order, "_simple_backtest_order", False) and getattr(self, "_trade_event_log_enabled", True):
+                        static = getattr(order, "_fast_trade_event_static", None)
+                        if static is not None:
+                            (
+                                strategy_name,
+                                identifier,
+                                symbol,
+                                side,
+                                order_type,
+                                trade_slippage,
+                                time_in_force,
+                                asset_multiplier,
+                                asset_type,
+                            ) = static
+                        else:
+                            asset = order.asset
+                            strategy_name = order.strategy
+                            identifier = order._identifier
+                            symbol = order.symbol
+                            side = order.side
+                            order_type = order.order_type
+                            trade_slippage = getattr(order, "trade_slippage", None)
+                            time_in_force = order.time_in_force
+                            asset_multiplier = asset.multiplier if asset is not None else None
+                            asset_type = asset.asset_type if asset is not None else None
+                        pair_row = [
+                            _FAST_TRADE_PAIR_EVENT_MARKER,
+                            self.data_source.get_datetime(),
+                            None,
+                            strategy_name,
+                            identifier,
+                            symbol,
+                            side,
+                            order_type,
+                            order._status,
+                            None,
+                            None,
+                            None,
+                            1,
+                            None,
+                            trade_slippage,
+                            time_in_force,
+                            asset_multiplier,
+                            asset_type,
+                            None,
+                        ]
+                        order._fast_trade_event_pair_row = pair_row
+                        order._fast_trade_event_pair_row_index = len(self._trade_event_log_rows)
+                        self._trade_event_log_rows.append(pair_row)
+                        if self._trade_event_log_df_cache is not None:
+                            self._trade_event_log_df_cache = None
+                    else:
+                        self._record_fast_backtest_trade_event(order, None, None, 1)
+                except Exception:
+                    logger.error(traceback.format_exc())
+            else:
+                order.update_raw(order)
+                self.stream.dispatch(
+                    self.NEW_ORDER,
+                    wait_until_complete=True,
+                    order=order,
+                )
 
         # Only an OCO order submits the child orders immediately. Bracket/OTO child orders are not submitted until
         # the parent order is filled
@@ -1176,6 +1353,81 @@ class BacktestingBroker(Broker):
                     wait_until_complete=True,
                     order=child,
                 )
+
+        return order
+
+    def _submit_simple_backtest_order(self, order):
+        """Submit a validated simple backtest order without the general broker dispatch path."""
+        if getattr(order, "_simple_is_option", None):
+            self._backtest_has_option_lifecycle_exposure = True
+            return self._submit_order(order)
+
+        actions = getattr(getattr(self, "stream", None), "_actions_mapping", None)
+        default_action = getattr(self, "_default_new_order_stream_action", None)
+        if actions is None or actions.get(self.NEW_ORDER) is not default_action or getattr(self, "_backtest_audit_enabled", False):
+            return self._submit_order(order)
+
+        try:
+            order._transmitted = True
+            order._raw = order
+            order._status = self.NEW_ORDER
+            if order._new_event is not None:
+                order._new_event.set()
+
+            by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+            if by_strategy is None:
+                by_strategy = {}
+                self._simple_new_orders_by_strategy = by_strategy
+            by_strategy.setdefault(order.strategy, []).append(order)
+            self._simple_new_orders_revision = getattr(self, "_simple_new_orders_revision", 0) + 1
+
+            skip_new_cache = getattr(self, "_skip_default_new_callback_by_strategy", None)
+            skip_new_callback = None if skip_new_cache is None else skip_new_cache.get(order.strategy)
+            if skip_new_callback is None:
+                skip_new_callback = self._should_skip_default_new_callback(order)
+            if not skip_new_callback:
+                self._on_new_order(order)
+
+            if getattr(self, "_trade_event_log_enabled", True):
+                (
+                    strategy_name,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                ) = order._fast_trade_event_static
+                pair_row = [
+                    _FAST_TRADE_PAIR_EVENT_MARKER,
+                    getattr(order, "_date_created", None) or self.data_source.get_datetime(),
+                    None,
+                    strategy_name,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    order._status,
+                    None,
+                    None,
+                    None,
+                    1,
+                    None,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                    None,
+                ]
+                order._fast_trade_event_pair_row = pair_row
+                order._fast_trade_event_pair_row_index = len(self._trade_event_log_rows)
+                self._trade_event_log_rows.append(pair_row)
+                if self._trade_event_log_df_cache is not None:
+                    self._trade_event_log_df_cache = None
+        except Exception:
+            logger.error(traceback.format_exc())
 
         return order
 
@@ -1535,6 +1787,9 @@ class BacktestingBroker(Broker):
         return option_price
 
     def _run_backtest_option_lifecycle_tasks(self, strategy) -> None:
+        if not getattr(self, "_backtest_has_option_lifecycle_exposure", False):
+            return
+
         # Run conservative early-assignment checks near close.
         self.process_early_assignment_contracts(strategy)
 
@@ -1784,8 +2039,437 @@ class BacktestingBroker(Broker):
         if not trade_cost:
             return
 
-        current_cash = strategy.cash
+        current_cash = self._get_strategy_cash_fast(strategy)
         strategy._set_cash_position(current_cash - float(trade_cost))
+
+    @staticmethod
+    def _get_strategy_cash_fast(strategy) -> float:
+        cash_position = getattr(strategy, "_cash_position", None)
+        if cash_position is None:
+            get_cash_position = getattr(strategy, "_get_cash_position", None)
+            cash_position = get_cash_position() if callable(get_cash_position) else None
+
+        quantity = getattr(cash_position, "quantity", None) if cash_position is not None else None
+        if type(quantity) is Decimal:
+            return float(quantity)
+        if quantity is None:
+            cash_value = getattr(strategy, "cash", None)
+            if cash_value is not None:
+                try:
+                    return float(cash_value)
+                except Exception:
+                    pass
+            return 0.0
+        return quantity
+
+    @staticmethod
+    def _set_strategy_cash_fast(strategy, cash: float) -> None:
+        cash_position = getattr(strategy, "_cash_position", None)
+        if cash_position is not None:
+            try:
+                cash_f = float(cash)
+                cash_position._quantity_float = cash_f
+            except Exception:
+                cash_position.quantity = cash
+            return
+        strategy._set_cash_position(cash)
+
+    def _execute_simple_market_fast_fill(
+        self,
+        order: Order,
+        price: float,
+        filled_quantity: Decimal,
+        strategy,
+        price_source=None,
+    ) -> None:
+        """Direct fill for narrow zero-fee IBKR market orders with no user fill callback."""
+        order.trade_cost = 0.0
+        asset_type = getattr(order, "_simple_asset_type", None)
+        if asset_type is None:
+            asset_type = getattr(order.asset, "asset_type", None)
+        quote_asset_type = getattr(order, "_simple_quote_asset_type", None)
+        if quote_asset_type is None and getattr(order, "quote", None):
+            quote_asset_type = getattr(order.quote, "asset_type", None)
+
+        filled_quantity_f = getattr(order, "_simple_quantity_float", None)
+        if filled_quantity_f is None:
+            filled_quantity_f = filled_quantity
+        if filled_quantity_f is not None and type(filled_quantity_f) is not float:
+            filled_quantity_f = float(filled_quantity_f)
+
+        if asset_type in (Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE):
+            self._process_futures_fill(strategy, order, float(price), filled_quantity_f)
+        elif asset_type == Asset.AssetType.CRYPTO and quote_asset_type == Asset.AssetType.FOREX:
+            trade_amount = filled_quantity_f * price
+            multiplier = getattr(order, "_simple_multiplier", None)
+            if multiplier and multiplier != 1:
+                trade_amount *= multiplier
+            current_cash = self._get_strategy_cash_fast(strategy)
+            is_buy_order = getattr(order, "_simple_is_buy", None)
+            if is_buy_order is None:
+                is_buy_order = order.is_buy_order()
+            new_cash = current_cash - trade_amount if is_buy_order else current_cash + trade_amount
+            self._set_strategy_cash_fast(strategy, new_cash)
+
+        multiplier = getattr(order, "_simple_multiplier", None) or 1
+        try:
+            if getattr(order, "_simple_backtest_order", False):
+                self._process_simple_market_filled_order(order, price, filled_quantity_f)
+            else:
+                self._process_filled_order(order, price, filled_quantity_f)
+            self._record_fast_backtest_trade_event(
+                order,
+                price,
+                filled_quantity_f,
+                multiplier,
+                price_source=price_source,
+            )
+        except Exception:
+            logger.error(traceback.format_exc())
+
+    def _execute_simple_backtest_market_fast_fill(self, order: Order, price: float, strategy, price_source=None) -> None:
+        """Tighter direct fill for Order.simple_market_backtest orders."""
+        order.trade_cost = 0.0
+        quantity = order._simple_quantity_float
+
+        if order._simple_is_future:
+            self._process_futures_fill(strategy, order, float(price), quantity)
+        elif order._simple_is_crypto_forex:
+            trade_amount = quantity * price
+            multiplier = order._simple_multiplier
+            if multiplier != 1:
+                trade_amount *= multiplier
+            cash_delta = -trade_amount if order._simple_is_buy else trade_amount
+            cash_position = getattr(strategy, "_cash_position", None)
+            if cash_position is not None:
+                current_quantity = getattr(cash_position, "_quantity_float", None)
+                if current_quantity is None:
+                    current_quantity = getattr(cash_position, "quantity", None)
+                    if type(current_quantity) is Decimal:
+                        current_quantity = float(current_quantity)
+                new_cash = (current_quantity or 0.0) + cash_delta
+                try:
+                    cash_position._quantity_float = float(new_cash)
+                except Exception:
+                    cash_position.quantity = new_cash
+            else:
+                current_cash = self._get_strategy_cash_fast(strategy)
+                strategy._set_cash_position(current_cash + cash_delta)
+
+        try:
+            self._process_simple_market_filled_order(order, price, quantity)
+            self._record_fast_backtest_trade_event(
+                order,
+                price,
+                quantity,
+                order._simple_multiplier,
+                price_source=price_source,
+            )
+        except Exception:
+            logger.error(traceback.format_exc())
+
+    def _execute_simple_futures_backtest_fast_fill(
+        self,
+        order: Order,
+        price: float,
+        strategy,
+        price_source=None,
+        event_dt=None,
+    ) -> None:
+        """Direct fill for simple futures market orders."""
+        try:
+            order.trade_cost = 0.0
+            quantity = order._simple_quantity_float
+            price_f = float(price)
+
+            margin_per_contract = getattr(order.asset, "_lumibot_margin_requirement_cache", None)
+            if margin_per_contract is None:
+                margin_per_contract = get_futures_margin_requirement(order.asset)
+                try:
+                    setattr(order.asset, "_lumibot_margin_requirement_cache", margin_per_contract)
+                except Exception:
+                    pass
+            key = getattr(order, "_simple_futures_ledger_key", None)
+            if key is None:
+                key = self._get_futures_ledger_key(strategy, order.asset)
+            ledger = self._futures_lot_ledgers[key]
+            signed_fill_qty = quantity if order._simple_is_buy else -quantity
+            current_cash = self._get_strategy_cash_fast(strategy)
+            new_cash = current_cash
+
+            if not ledger:
+                ledger.append({"qty": signed_fill_qty, "price": price_f})
+                new_cash -= margin_per_contract * quantity
+            elif len(ledger) == 1:
+                lot = ledger[0]
+                lot_qty = lot["qty"]
+                if lot_qty and signed_fill_qty and lot_qty * signed_fill_qty < 0:
+                    closing_qty = min(abs(lot_qty), quantity)
+                    entry_price = lot["price"]
+                    multiplier = order._simple_multiplier
+                    if lot_qty > 0:
+                        realized_pnl = (price_f - entry_price) * closing_qty * multiplier
+                        lot["qty"] -= closing_qty
+                    else:
+                        realized_pnl = (entry_price - price_f) * closing_qty * multiplier
+                        lot["qty"] += closing_qty
+                    new_cash += margin_per_contract * closing_qty
+                    new_cash += realized_pnl
+                    if abs(lot["qty"]) < 1e-9:
+                        ledger.pop(0)
+                    opening_qty = quantity - closing_qty
+                    if opening_qty > 0:
+                        opening_sign = 1 if signed_fill_qty > 0 else -1
+                        ledger.append({"qty": opening_sign * opening_qty, "price": price_f})
+                        new_cash -= margin_per_contract * opening_qty
+                else:
+                    ledger.append({"qty": signed_fill_qty, "price": price_f})
+                    new_cash -= margin_per_contract * quantity
+            else:
+                self._process_futures_fill(strategy, order, price_f, quantity)
+                new_cash = None
+
+            if new_cash is not None:
+                if not ledger:
+                    self._futures_lot_ledgers.pop(key, None)
+                self._set_strategy_cash_fast(strategy, new_cash)
+
+            simple_positions = getattr(self, "_simple_positions_by_strategy_asset", None)
+            if simple_positions is None:
+                simple_positions = {}
+                self._simple_positions_by_strategy_asset = simple_positions
+            position_key = (order.strategy, id(order.asset))
+            existing_position = simple_positions.get(position_key)
+            if existing_position is _NO_SIMPLE_POSITION:
+                existing_position = None
+            elif existing_position is None:
+                existing_position = self.get_tracked_position(order.strategy, order.asset)
+                if existing_position is not None:
+                    simple_positions[position_key] = existing_position
+                else:
+                    simple_positions[position_key] = _NO_SIMPLE_POSITION
+
+            order._avg_fill_price = round(float(price), 2) if price is not None else None
+            order.transactions = [order.Transaction(quantity, price)]
+            order._status = self.FILLED_ORDER
+            filled_event = order._filled_event
+            if filled_event is not None:
+                filled_event.set()
+            closed_event = order._closed_event
+            if closed_event is not None:
+                closed_event.set()
+            self._track_unique_simple_filled_order(order)
+
+            qty_decimal = order._quantity
+            if existing_position:
+                new_qty = existing_position._quantity + (qty_decimal if order._simple_is_buy else -qty_decimal)
+                if new_qty == 0:
+                    self._filled_positions.remove(existing_position)
+                    simple_positions[position_key] = _NO_SIMPLE_POSITION
+                else:
+                    existing_position._quantity = new_qty
+                    existing_position._quantity_float = float(new_qty)
+                    existing_position.orders.append(order)
+            else:
+                position_qty = qty_decimal
+                if order._simple_is_sell:
+                    position_qty = -position_qty
+                position = Position.simple_backtest(
+                    order.strategy,
+                    order.asset,
+                    position_qty,
+                    order,
+                    avg_fill_price=order._avg_fill_price,
+                )
+                self._filled_positions.append(position)
+                simple_positions[position_key] = position
+
+            if getattr(self, "_trade_event_log_enabled", True):
+                pair_row = getattr(order, "_fast_trade_event_pair_row", None)
+                if pair_row is not None:
+                    pair_row[2] = event_dt if event_dt is not None else self.data_source.get_datetime()
+                    pair_row[9] = order._status
+                    pair_row[10] = price
+                    pair_row[11] = quantity
+                    pair_row[12] = order._simple_multiplier
+                    pair_row[13] = order.trade_cost
+                    pair_row[18] = price_source
+                    if self._trade_event_log_df_cache is not None:
+                        self._trade_event_log_df_cache = None
+                    self._finalize_fast_trade_pair_row(order, pair_row)
+                else:
+                    self._record_fast_backtest_trade_event(
+                        order,
+                        price,
+                        quantity,
+                        order._simple_multiplier,
+                        price_source=price_source,
+                    )
+        except Exception:
+            logger.error(traceback.format_exc())
+
+    def _execute_simple_crypto_forex_backtest_fast_fill(
+        self,
+        order: Order,
+        price: float,
+        strategy,
+        price_source=None,
+        event_dt=None,
+    ) -> None:
+        """Direct fill for simple crypto/forex market orders."""
+        try:
+            quantity = order._simple_quantity_float
+            order.trade_cost = 0.0
+
+            trade_amount = quantity * price
+            multiplier = order._simple_multiplier
+            if multiplier != 1:
+                trade_amount *= multiplier
+            cash_delta = -trade_amount if order._simple_is_buy else trade_amount
+            cash_position = getattr(strategy, "_cash_position", None)
+            if cash_position is not None:
+                current_quantity = getattr(cash_position, "_quantity_float", None)
+                if current_quantity is None:
+                    current_quantity = getattr(cash_position, "quantity", None)
+                    if type(current_quantity) is Decimal:
+                        current_quantity = float(current_quantity)
+                new_cash = (current_quantity or 0.0) + cash_delta
+                try:
+                    cash_position._quantity_float = float(new_cash)
+                except Exception:
+                    cash_position.quantity = new_cash
+            else:
+                current_cash = self._get_strategy_cash_fast(strategy)
+                strategy._set_cash_position(current_cash + cash_delta)
+
+            simple_positions = getattr(self, "_simple_positions_by_strategy_asset", None)
+            if simple_positions is None:
+                simple_positions = {}
+                self._simple_positions_by_strategy_asset = simple_positions
+            position_key = (order.strategy, id(order.asset))
+            existing_position = simple_positions.get(position_key)
+            if existing_position is _NO_SIMPLE_POSITION:
+                existing_position = None
+            elif existing_position is None:
+                existing_position = self.get_tracked_position(order.strategy, order.asset)
+                if existing_position is not None:
+                    simple_positions[position_key] = existing_position
+                else:
+                    simple_positions[position_key] = _NO_SIMPLE_POSITION
+
+            order._avg_fill_price = round(float(price), 2) if price is not None else None
+            order.transactions = [order.Transaction(quantity, price)]
+            order._status = self.FILLED_ORDER
+            filled_event = getattr(order, "_filled_event", None)
+            if filled_event is not None:
+                filled_event.set()
+            closed_event = getattr(order, "_closed_event", None)
+            if closed_event is not None:
+                closed_event.set()
+            self._track_unique_simple_filled_order(order)
+
+            qty_decimal = order._quantity
+            if existing_position:
+                new_qty = existing_position._quantity + (qty_decimal if order._simple_is_buy else -qty_decimal)
+                if new_qty == 0:
+                    self._filled_positions.remove(existing_position)
+                    simple_positions[position_key] = _NO_SIMPLE_POSITION
+                else:
+                    existing_position._quantity = new_qty
+                    existing_position._quantity_float = float(new_qty)
+                    existing_position.orders.append(order)
+            else:
+                if order._simple_is_sell:
+                    qty_decimal = -qty_decimal
+                position = Position.simple_backtest(
+                    order.strategy,
+                    order.asset,
+                    qty_decimal,
+                    order,
+                    avg_fill_price=order._avg_fill_price,
+                )
+                self._filled_positions.append(position)
+                simple_positions[position_key] = position
+
+            if getattr(self, "_trade_event_log_enabled", True):
+                pair_row = getattr(order, "_fast_trade_event_pair_row", None)
+                if pair_row is not None:
+                    pair_row[2] = event_dt if event_dt is not None else self.data_source.get_datetime()
+                    pair_row[9] = order._status
+                    pair_row[10] = price
+                    pair_row[11] = quantity
+                    pair_row[12] = order._simple_multiplier
+                    pair_row[13] = order.trade_cost
+                    pair_row[18] = price_source
+                    if self._trade_event_log_df_cache is not None:
+                        self._trade_event_log_df_cache = None
+                    self._finalize_fast_trade_pair_row(order, pair_row)
+                else:
+                    self._record_fast_backtest_trade_event(
+                        order,
+                        price,
+                        quantity,
+                        order._simple_multiplier,
+                        price_source=price_source,
+                    )
+        except Exception:
+            logger.error(traceback.format_exc())
+
+    def _process_simple_market_filled_order(self, order: Order, price, quantity):
+        """Minimal bookkeeping for simple direct market orders proven by the fast lane."""
+        simple_positions = getattr(self, "_simple_positions_by_strategy_asset", None)
+        if simple_positions is None:
+            simple_positions = {}
+            self._simple_positions_by_strategy_asset = simple_positions
+        position_key = (order.strategy, id(order.asset))
+        existing_position = simple_positions.get(position_key)
+        if existing_position is _NO_SIMPLE_POSITION:
+            existing_position = None
+        elif existing_position is None:
+            existing_position = self.get_tracked_position(order.strategy, order.asset)
+            if existing_position is not None:
+                simple_positions[position_key] = existing_position
+            else:
+                simple_positions[position_key] = _NO_SIMPLE_POSITION
+        order._avg_fill_price = round(float(price), 2) if price is not None else None
+
+        order.transactions = [order.Transaction(quantity, price)]
+        order._status = self.FILLED_ORDER
+        filled_event = order._filled_event
+        if filled_event is not None:
+            filled_event.set()
+        closed_event = order._closed_event
+        if closed_event is not None:
+            closed_event.set()
+        self._track_unique_simple_filled_order(order)
+
+        qty_decimal = order._quantity
+
+        if existing_position:
+            new_qty = existing_position._quantity + (qty_decimal if order._simple_is_buy else -qty_decimal)
+            if new_qty == 0:
+                self._filled_positions.remove(existing_position)
+                simple_positions[position_key] = _NO_SIMPLE_POSITION
+            else:
+                existing_position._quantity = new_qty
+                existing_position._quantity_float = float(new_qty)
+                existing_position.orders.append(order)
+        else:
+            position_qty = qty_decimal
+            if order._simple_is_sell:
+                position_qty = -position_qty
+            position = Position.simple_backtest(
+                order.strategy,
+                order.asset,
+                position_qty,
+                order,
+                avg_fill_price=order._avg_fill_price,
+            )
+            self._filled_positions.append(position)
+            simple_positions[position_key] = position
+
+        if not order._simple_is_crypto_forex and order._simple_asset_type_value == "crypto":
+            self._process_crypto_quote(order, quantity, price)
 
     def _execute_filled_order(
         self,
@@ -1835,7 +2519,7 @@ class BacktestingBroker(Broker):
             if hasattr(order.asset, 'multiplier') and order.asset.multiplier:
                 trade_amount *= order.asset.multiplier
 
-            current_cash = strategy.cash
+            current_cash = self._get_strategy_cash_fast(strategy)
 
             if order.is_buy_order():
                 # Deduct cash for buy orders (trade amount + fees)
@@ -1856,15 +2540,32 @@ class BacktestingBroker(Broker):
         if filled_quantity_f is not None and not isinstance(filled_quantity_f, float):
             filled_quantity_f = float(filled_quantity_f)
 
-        self.stream.dispatch(
-            self.FILLED_ORDER,
-            wait_until_complete=True,
-            order=order,
-            price=price,
-            filled_quantity=filled_quantity_f,
-            quantity=filled_quantity_f,
-            multiplier=multiplier,
-        )
+        # PERF: In backtests the FILLED_ORDER stream action is normally the broker's own
+        # `_process_trade_event()` wrapper. When that default action is still installed, call the
+        # filled-order work directly and skip the generic trade-event router/payload path.
+        actions = getattr(getattr(self, "stream", None), "_actions_mapping", None)
+        default_action = getattr(self, "_default_filled_order_stream_action", None)
+        audit_enabled = getattr(self, "_backtest_audit_enabled", None)
+        if audit_enabled is None:
+            audit_enabled = self._truthy_env(os.environ.get("LUMIBOT_BACKTEST_AUDIT"))
+        if actions is not None and actions.get(self.FILLED_ORDER) is default_action and not audit_enabled:
+            try:
+                position = self._process_filled_order(order, price, filled_quantity_f)
+                if position and not self._should_skip_default_filled_callback(order):
+                    self._on_filled_order(position, order, price, filled_quantity_f, multiplier)
+                self._record_fast_backtest_trade_event(order, price, filled_quantity_f, multiplier)
+            except Exception:
+                logger.error(traceback.format_exc())
+        else:
+            self.stream.dispatch(
+                self.FILLED_ORDER,
+                wait_until_complete=True,
+                order=order,
+                price=price,
+                filled_quantity=filled_quantity_f,
+                quantity=filled_quantity_f,
+                multiplier=multiplier,
+            )
 
         # Only apply trade cost if it's not crypto with forex quote (already handled above)
         if (
@@ -1886,6 +2587,176 @@ class BacktestingBroker(Broker):
                 parent_order.set_filled()
                 if parent_order not in self._filled_orders:
                     self._filled_orders.append(parent_order)
+
+    def _should_skip_default_new_callback(self, order: Order) -> bool:
+        strategy_name = getattr(order, "strategy", None)
+        cache = getattr(self, "_skip_default_new_callback_by_strategy", None)
+        if cache is None:
+            cache = {}
+            self._skip_default_new_callback_by_strategy = cache
+        if strategy_name in cache:
+            return cache[strategy_name]
+
+        subscriber = self._get_subscriber(strategy_name)
+        if not subscriber:
+            cache[strategy_name] = False
+            return False
+
+        try:
+            strategy_obj = getattr(subscriber, "strategy", None)
+            handler = getattr(strategy_obj, "on_new_order", None)
+            func = getattr(handler, "__func__", handler)
+            result = getattr(func, "__qualname__", "") == "Strategy.on_new_order"
+        except Exception:
+            result = False
+        cache[strategy_name] = result
+        return result
+
+    def _should_skip_default_filled_callback(self, order: Order) -> bool:
+        asset_type = getattr(getattr(order, "asset", None), "asset_type", None)
+        if asset_type not in (Asset.AssetType.CRYPTO, Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE):
+            return False
+
+        strategy_name = getattr(order, "strategy", None)
+        cache = getattr(self, "_skip_default_filled_callback_by_strategy", None)
+        if cache is None:
+            cache = {}
+            self._skip_default_filled_callback_by_strategy = cache
+        if strategy_name in cache:
+            return cache[strategy_name]
+
+        subscriber = self._get_subscriber(strategy_name)
+        if not subscriber:
+            cache[strategy_name] = False
+            return False
+
+        try:
+            strategy_obj = getattr(subscriber, "strategy", None)
+            handler = getattr(strategy_obj, "on_filled_order", None)
+            func = getattr(handler, "__func__", handler)
+            executor_handler = getattr(subscriber, "_on_filled_order", None)
+            executor_func = getattr(executor_handler, "__func__", executor_handler)
+            result = (
+                getattr(func, "__qualname__", "") == "Strategy.on_filled_order"
+                and getattr(executor_func, "__qualname__", "") == "StrategyExecutor._on_filled_order"
+                and not callable(getattr(strategy_obj, "_filled_order_callback", None))
+            )
+        except Exception:
+            result = False
+        cache[strategy_name] = result
+        return result
+
+    def _record_fast_backtest_trade_event(
+        self,
+        order: Order,
+        price,
+        filled_quantity,
+        multiplier=1,
+        price_source=None,
+    ):
+        """Append the non-audit trade log row for a direct backtest fill."""
+        if price_source is None:
+            price_source = getattr(order, "_price_source", None)
+        if getattr(self, "_trade_event_log_enabled", True):
+            static = getattr(order, "_fast_trade_event_static", None)
+            if static is not None:
+                (
+                    strategy_name,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                ) = static
+            else:
+                asset = order.asset
+                strategy_name = order.strategy
+                identifier = order._identifier
+                symbol = order.symbol
+                side = order.side
+                order_type = order.order_type
+                trade_slippage = getattr(order, "trade_slippage", None)
+                time_in_force = order.time_in_force
+                asset_multiplier = asset.multiplier if asset is not None else None
+                asset_type = asset.asset_type if asset is not None else None
+            pair_row = getattr(order, "_fast_trade_event_pair_row", None)
+            if pair_row is not None and price is not None:
+                pair_row[2] = self.data_source.get_datetime()
+                pair_row[9] = order._status
+                pair_row[10] = price
+                pair_row[11] = filled_quantity
+                pair_row[12] = multiplier
+                pair_row[13] = order.trade_cost
+                pair_row[18] = price_source
+                if self._trade_event_log_df_cache is not None:
+                    self._trade_event_log_df_cache = None
+                self._finalize_fast_trade_pair_row(order, pair_row)
+                return
+            if (
+                getattr(order, "_simple_backtest_order", False)
+                and price is None
+                and filled_quantity is None
+                and order._status == self.NEW_ORDER
+            ):
+                pair_row = [
+                    _FAST_TRADE_PAIR_EVENT_MARKER,
+                    self.data_source.get_datetime(),
+                    None,
+                    strategy_name,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    order._status,
+                    None,
+                    None,
+                    None,
+                    1,
+                    None,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                    None,
+                ]
+                order._fast_trade_event_pair_row = pair_row
+                order._fast_trade_event_pair_row_index = len(self._trade_event_log_rows)
+                self._trade_event_log_rows.append(pair_row)
+                if self._trade_event_log_df_cache is not None:
+                    self._trade_event_log_df_cache = None
+                return
+            self._trade_event_log_rows.append(
+                (
+                    _FAST_TRADE_EVENT_MARKER,
+                    self.data_source.get_datetime(),
+                    strategy_name,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    order._status,
+                    price,
+                    filled_quantity,
+                    multiplier,
+                    order.trade_cost,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                    price_source,
+                )
+            )
+            if self._trade_event_log_df_cache is not None:
+                self._trade_event_log_df_cache = None
+
+        if price_source and getattr(order, "_price_source", None) is not None:
+            try:
+                delattr(order, "_price_source")
+            except AttributeError:
+                pass
 
     def _process_crypto_quote(self, order, quantity, price):
         """Override to skip quote processing for assets that use direct cash updates or margin-based trading."""
@@ -1946,13 +2817,41 @@ class BacktestingBroker(Broker):
 
     def _process_futures_fill(self, strategy, order, price, filled_quantity):
         multiplier = getattr(order.asset, "multiplier", 1)
-        margin_per_contract = get_futures_margin_requirement(order.asset)
+        margin_per_contract = getattr(order.asset, "_lumibot_margin_requirement_cache", None)
+        if margin_per_contract is None:
+            margin_per_contract = get_futures_margin_requirement(order.asset)
+            try:
+                setattr(order.asset, "_lumibot_margin_requirement_cache", margin_per_contract)
+            except Exception:
+                pass
 
-        key = self._get_futures_ledger_key(strategy, order.asset)
+        key = getattr(order, "_simple_futures_ledger_key", None)
+        if key is None:
+            strategy_name = getattr(strategy, "_name", None) or getattr(strategy, "name", "unknown_strategy")
+            key_cache = getattr(order.asset, "_lumibot_futures_ledger_key_cache", None)
+            if key_cache is None:
+                key_cache = {}
+                try:
+                    setattr(order.asset, "_lumibot_futures_ledger_key_cache", key_cache)
+                except Exception:
+                    key_cache = None
+            key = key_cache.get(strategy_name) if key_cache is not None else None
+            if key is None:
+                key = self._get_futures_ledger_key(strategy, order.asset)
+                if key_cache is not None:
+                    key_cache[strategy_name] = key
         ledger = self._futures_lot_ledgers[key]
 
-        net_before = sum(lot["qty"] for lot in ledger)
-        signed_fill_qty = filled_quantity if order.is_buy_order() else -filled_quantity
+        if not ledger:
+            net_before = 0.0
+        elif len(ledger) == 1:
+            net_before = ledger[0]["qty"]
+        else:
+            net_before = sum(lot["qty"] for lot in ledger)
+        is_buy_order = getattr(order, "_simple_is_buy", None)
+        if is_buy_order is None:
+            is_buy_order = order.is_buy_order()
+        signed_fill_qty = filled_quantity if is_buy_order else -filled_quantity
 
         closing_qty = 0.0
         if net_before and signed_fill_qty and net_before * signed_fill_qty < 0:
@@ -1960,11 +2859,20 @@ class BacktestingBroker(Broker):
 
         opening_qty = filled_quantity - closing_qty
 
-        current_cash = strategy.cash or 0.0
+        current_cash = self._get_strategy_cash_fast(strategy)
         new_cash = current_cash
 
         if closing_qty > 0:
-            realized_pnl = self._realize_futures_pnl(ledger, closing_qty, price, multiplier)
+            if len(ledger) == 1 and abs(abs(ledger[0]["qty"]) - closing_qty) < 1e-9:
+                lot = ledger[0]
+                entry_price = lot["price"]
+                if lot["qty"] > 0:
+                    realized_pnl = (price - entry_price) * closing_qty * multiplier
+                else:
+                    realized_pnl = (entry_price - price) * closing_qty * multiplier
+                ledger.pop(0)
+            else:
+                realized_pnl = self._realize_futures_pnl(ledger, closing_qty, price, multiplier)
             new_cash += margin_per_contract * closing_qty
             new_cash += realized_pnl
 
@@ -1979,7 +2887,7 @@ class BacktestingBroker(Broker):
         if not ledger:
             self._futures_lot_ledgers.pop(key, None)
 
-        strategy._set_cash_position(new_cash)
+        self._set_strategy_cash_fast(strategy, new_cash)
 
     def calculate_trade_cost(self, order: Order, strategy, price: float):
         """Calculate the trade cost of an order for a given strategy"""
@@ -2014,7 +2922,7 @@ class BacktestingBroker(Broker):
                 trade_cost += Decimal(str(order.quantity)) * trading_fee.per_contract_fee
 
         return trade_cost
-        
+
 
     def process_pending_orders(self, strategy):
         """Used to evaluate and execute open orders in backtesting.
@@ -2031,40 +2939,289 @@ class BacktestingBroker(Broker):
 
         # This function is called once per bar (minute-level: ~100k/year). Avoid allocating lists
         # or copying buckets when there are no pending orders.
-        strategy_name = strategy.name
+        strategy_name = getattr(strategy, "_name", None)
+        if strategy_name is None:
+            strategy_name = strategy.name
 
         unprocessed_bucket = getattr(self, "_unprocessed_orders", None)
         new_bucket = getattr(self, "_new_orders", None)
-        if not unprocessed_bucket and not new_bucket:
-            self._run_backtest_option_lifecycle_tasks(strategy)
+        simple_by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+        if not unprocessed_bucket and not new_bucket and not simple_by_strategy:
+            if getattr(self, "_backtest_has_option_lifecycle_exposure", False):
+                self._run_backtest_option_lifecycle_tasks(strategy)
             return
 
-        def _iter_bucket(bucket):
-            if not bucket:
-                return ()
-            get_list = getattr(bucket, "get_list", None)
-            if callable(get_list):
-                return get_list()
-            return bucket
-
-        pending_orders: list[Order] = []
-        for order in _iter_bucket(unprocessed_bucket):
-            if getattr(order, "strategy", None) == strategy_name:
-                pending_orders.append(order)
-        for order in _iter_bucket(new_bucket):
-            if getattr(order, "strategy", None) == strategy_name:
-                pending_orders.append(order)
+        simple_pending = simple_by_strategy.pop(strategy_name, None) if simple_by_strategy else None
+        if simple_pending and not unprocessed_bucket and not new_bucket:
+            self._simple_new_orders_revision = getattr(self, "_simple_new_orders_revision", 0) + 1
+            pending_orders = simple_pending
+        else:
+            pending_orders: list[Order] = []
+            if simple_pending:
+                self._simple_new_orders_revision = getattr(self, "_simple_new_orders_revision", 0) + 1
+                pending_orders.extend(simple_pending)
+            if unprocessed_bucket:
+                get_list = getattr(unprocessed_bucket, "get_list", None)
+                for order in get_list() if callable(get_list) else unprocessed_bucket:
+                    if getattr(order, "strategy", None) == strategy_name:
+                        pending_orders.append(order)
+            if new_bucket:
+                get_list = getattr(new_bucket, "get_list", None)
+                for order in get_list() if callable(get_list) else new_bucket:
+                    if getattr(order, "strategy", None) == strategy_name:
+                        pending_orders.append(order)
 
         if not pending_orders:
-            self._run_backtest_option_lifecycle_tasks(strategy)
+            self._requeue_simple_pending(strategy_name, simple_pending)
+            if getattr(self, "_backtest_has_option_lifecycle_exposure", False):
+                self._run_backtest_option_lifecycle_tasks(strategy)
             return
 
-        # Prefetching: Track assets and schedule prefetch
-        current_dt = self.datetime
-        audit_enabled = self._audit_enabled()
+        audit_enabled = getattr(self, "_backtest_audit_enabled", False)
         # PERF: Used in multiple branches below; avoid recomputing per order.
-        data_source_name = str(getattr(self.data_source, "SOURCE", "") or "").upper()
+        data_source = self.data_source
+        data_source_source = getattr(data_source, "SOURCE", "") or ""
+        is_ibkr_rest_source = data_source_source in ("InteractiveBrokersREST", "INTERACTIVEBROKERSREST")
+        data_source_name = "INTERACTIVEBROKERSREST" if is_ibkr_rest_source else str(data_source_source).upper()
 
+        if (
+            not audit_enabled
+            and is_ibkr_rest_source
+            and not self.hybrid_prefetcher
+            and not self.prefetcher
+            and not (getattr(strategy, "buy_trading_fees", None) or getattr(strategy, "sell_trading_fees", None))
+        ):
+            actions = getattr(getattr(self, "stream", None), "_actions_mapping", None)
+            default_action = getattr(self, "_default_filled_order_stream_action", None)
+            can_use_direct_fill = actions is not None and actions.get(self.FILLED_ORDER) is default_action
+            if can_use_direct_fill:
+                first_order = pending_orders[0]
+                skip_filled_cache = getattr(self, "_skip_default_filled_callback_by_strategy", None)
+                skip_default_filled_callback = (
+                    None if skip_filled_cache is None else skip_filled_cache.get(getattr(first_order, "strategy", None))
+                )
+                if skip_default_filled_callback is None:
+                    skip_default_filled_callback = self._should_skip_default_filled_callback(first_order)
+            else:
+                skip_default_filled_callback = False
+            if can_use_direct_fill and skip_default_filled_callback and simple_pending and not unprocessed_bucket and not new_bucket:
+                all_simple_filled = True
+                fast_open_data_source = self.data_source
+                fast_open_now = getattr(fast_open_data_source, "_datetime", None)
+                if fast_open_now is None:
+                    fast_open_now = fast_open_data_source.get_datetime()
+                fast_open_exchange = getattr(fast_open_data_source, "exchange", None)
+                exchange_cache = getattr(self, "_fast_open_exchange_key_cache", None)
+                exchange_cache_key = (id(fast_open_data_source), fast_open_exchange)
+                if exchange_cache is not None and exchange_cache[0] == exchange_cache_key:
+                    fast_open_exchange_key = exchange_cache[1]
+                else:
+                    try:
+                        fast_open_exchange_key = fast_open_data_source._normalize_exchange_key(fast_open_exchange)
+                    except Exception:
+                        fast_open_exchange_key = (str(fast_open_exchange or "").strip().upper() or "AUTO")
+                    self._fast_open_exchange_key_cache = (exchange_cache_key, fast_open_exchange_key)
+                fast_open_cache = getattr(self, "_fast_market_open_data_cache", None)
+                if fast_open_cache is None:
+                    fast_open_cache = {}
+                    self._fast_market_open_data_cache = fast_open_cache
+                no_bid_ask = getattr(self, "_simple_no_bid_ask_fill_keys", None)
+                no_bid_open_cache = getattr(self, "_simple_no_bid_ask_open_cache", None)
+                if no_bid_open_cache is None:
+                    no_bid_open_cache = {}
+                    self._simple_no_bid_ask_open_cache = no_bid_open_cache
+                coerce_price = self._coerce_price
+                fast_open_cache_get = fast_open_cache.get
+                terminal_statuses = (self.FILLED_ORDER, self.CANCELED_ORDER, self.ERROR_ORDER)
+                for order in simple_pending:
+                    order_asset = order.asset
+                    is_buy_order = getattr(order, "_simple_is_buy", False)
+                    order_status = getattr(order, "_status", None)
+                    if (
+                        order_status in terminal_statuses
+                        or not getattr(order, "_simple_direct_fill_eligible", False)
+                    ):
+                        all_simple_filled = False
+                        break
+
+                    order_exchange = getattr(order, "exchange", None)
+                    order_quote = order.quote
+                    order_asset_id = id(order_asset)
+                    order_quote_id = id(order_quote)
+                    no_bid_ask_key = (order_asset_id, order_quote_id, order_exchange)
+                    price = None
+                    price_source = "quote"
+                    no_bid_ask_hit = no_bid_ask_key in no_bid_ask if no_bid_ask else False
+                    if no_bid_ask_hit and order_exchange is None:
+                        cached_open_entry = no_bid_open_cache.get(no_bid_ask_key)
+                        if cached_open_entry is not None and cached_open_entry[0] == fast_open_exchange_key:
+                            open_line = cached_open_entry[1]
+                            exact_i = cached_open_entry[2]
+                        else:
+                            cached_open = fast_open_cache_get((order_asset_id, order_quote_id, "minute", fast_open_exchange_key))
+                            if cached_open is not None:
+                                _, cached_open_line, exact_i = cached_open
+                                open_line = getattr(cached_open_line, "dataline", cached_open_line)
+                                no_bid_open_cache[no_bid_ask_key] = (fast_open_exchange_key, open_line, exact_i)
+                            else:
+                                open_line = None
+                                exact_i = None
+                        if open_line is not None:
+                            try:
+                                i = exact_i.get(fast_open_now) if exact_i is not None else None
+                                if i is not None:
+                                    price = float(open_line[int(i)])
+                                    price_source = "ohlc_fast_open"
+                            except Exception:
+                                price = None
+                    if not no_bid_ask_hit:
+                        fast_bid, fast_ask = self._fast_get_bid_ask_for_fill(order_asset, order_quote, order_exchange)
+                        fast_bid = coerce_price(fast_bid)
+                        fast_ask = coerce_price(fast_ask)
+                        price = fast_ask if is_buy_order else fast_bid
+                        if fast_bid is None and fast_ask is None:
+                            if no_bid_ask is None:
+                                no_bid_ask = set()
+                                self._simple_no_bid_ask_fill_keys = no_bid_ask
+                            no_bid_ask.add(no_bid_ask_key)
+                    if price is None or price <= 0 or price != price:
+                        price = None
+                        if order_exchange is None:
+                            cached_open_entry = no_bid_open_cache.get(no_bid_ask_key)
+                            if cached_open_entry is not None and cached_open_entry[0] == fast_open_exchange_key:
+                                open_line = cached_open_entry[1]
+                                exact_i = cached_open_entry[2]
+                            else:
+                                cached_open = fast_open_cache_get(
+                                    (order_asset_id, order_quote_id, "minute", fast_open_exchange_key)
+                                )
+                                if cached_open is not None:
+                                    _, cached_open_line, exact_i = cached_open
+                                    open_line = getattr(cached_open_line, "dataline", cached_open_line)
+                                    no_bid_open_cache[no_bid_ask_key] = (fast_open_exchange_key, open_line, exact_i)
+                                else:
+                                    open_line = None
+                                    exact_i = None
+                            if open_line is not None:
+                                try:
+                                    i = exact_i.get(fast_open_now) if exact_i is not None else None
+                                    if i is not None:
+                                        price = float(open_line[int(i)])
+                                except Exception:
+                                    price = None
+                        if price is None or price <= 0 or price != price:
+                            price = coerce_price(
+                                self._fast_get_market_open_for_fill(
+                                    order_asset,
+                                    order_quote,
+                                    order_exchange,
+                                    _data_source=fast_open_data_source,
+                                    _now=fast_open_now,
+                                    _cache=fast_open_cache,
+                                )
+                            )
+                        price_source = "ohlc_fast_open"
+                    if price is None or price <= 0 or price != price:
+                        all_simple_filled = False
+                        break
+
+                    if getattr(order, "_simple_is_crypto_forex", False):
+                        self._execute_simple_crypto_forex_backtest_fast_fill(
+                            order,
+                            price,
+                            strategy,
+                            price_source,
+                            event_dt=fast_open_now,
+                        )
+                    elif getattr(order, "_simple_is_future", False):
+                        self._execute_simple_futures_backtest_fast_fill(
+                            order,
+                            price,
+                            strategy,
+                            price_source,
+                            event_dt=fast_open_now,
+                        )
+                    else:
+                        self._execute_simple_backtest_market_fast_fill(order, price, strategy, price_source)
+                if all_simple_filled:
+                    if getattr(self, "_backtest_has_option_lifecycle_exposure", False):
+                        self._run_backtest_option_lifecycle_tasks(strategy)
+                    return
+
+            fast_fills = []
+            can_fast_fill_all = can_use_direct_fill
+            for order in pending_orders:
+                order_asset = order.asset
+                asset_type = getattr(order_asset, "asset_type", None)
+                is_market_order = order.order_type == Order.OrderType.MARKET
+                is_buy_order = getattr(order, "_simple_is_buy", None)
+                if is_buy_order is None:
+                    is_buy_order = order.is_buy_order()
+                is_sell_order = getattr(order, "_simple_is_sell", None)
+                if is_sell_order is None:
+                    is_sell_order = order.is_sell_order()
+                if (
+                    not order.is_active()
+                    or order.dependent_order_filled
+                    or getattr(order, "dependent_order", None) is not None
+                    or getattr(order, "parent_identifier", None) is not None
+                    or order.order_class is Order.OrderClass.OCO
+                    or order.order_class is Order.OrderClass.MULTILEG
+                    or getattr(order, "_smart_limit_managed_by_parent", False)
+                    or not is_market_order
+                    or not (is_buy_order or is_sell_order)
+                    or asset_type not in (Asset.AssetType.CRYPTO, Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE)
+                    or getattr(order, "_simple_is_option", None)
+                    or (not getattr(order, "_simple_backtest_order", False) and self._is_option_asset(order_asset))
+                    or self._should_force_day_fill_timestep(order)
+                    or not skip_default_filled_callback
+                ):
+                    can_fast_fill_all = False
+                    break
+
+                order_exchange = getattr(order, "exchange", None)
+                no_bid_ask_key = (id(order_asset), id(order.quote), order_exchange)
+                no_bid_ask = getattr(self, "_simple_no_bid_ask_fill_keys", None)
+                price = None
+                price_source = "quote"
+                if not (no_bid_ask and no_bid_ask_key in no_bid_ask):
+                    fast_bid, fast_ask = self._fast_get_bid_ask_for_fill(order_asset, order.quote, order_exchange)
+                    fast_bid = self._coerce_price(fast_bid)
+                    fast_ask = self._coerce_price(fast_ask)
+                    price = fast_ask if is_buy_order else fast_bid
+                    if fast_bid is None and fast_ask is None:
+                        if no_bid_ask is None:
+                            no_bid_ask = set()
+                            self._simple_no_bid_ask_fill_keys = no_bid_ask
+                        no_bid_ask.add(no_bid_ask_key)
+                if price is None or self._is_invalid_price(price):
+                    price = self._coerce_price(
+                        self._fast_get_market_open_for_fill(
+                            order_asset,
+                            order.quote,
+                            order_exchange,
+                        )
+                    )
+                    price_source = "ohlc_fast_open"
+                if price is None or self._is_invalid_price(price):
+                    can_fast_fill_all = False
+                    break
+                fast_fills.append((order, price, price_source))
+
+            if can_fast_fill_all and fast_fills:
+                for order, price, price_source in fast_fills:
+                    self._execute_simple_market_fast_fill(
+                        order=order,
+                        price=price,
+                        filled_quantity=order.quantity,
+                        strategy=strategy,
+                        price_source=price_source,
+                    )
+                if getattr(self, "_backtest_has_option_lifecycle_exposure", False):
+                    self._run_backtest_option_lifecycle_tasks(strategy)
+                return
+
+        current_dt = self.datetime
         if self.hybrid_prefetcher:
             # Use advanced hybrid prefetcher
             try:
@@ -2209,18 +3366,24 @@ class BacktestingBroker(Broker):
             fast_bid = None
             fast_ask = None
             force_day_fill_timestep = self._should_force_day_fill_timestep(order)
+            order_asset = order.asset
+            is_buy_order = order.is_buy_order()
+            is_sell_order = order.is_sell_order()
+            is_buy_or_sell = is_buy_order or is_sell_order
+            is_option_order = self._is_option_asset(order_asset)
+            is_market_order = order.order_type == Order.OrderType.MARKET
 
             # PERF: MARKET orders dominate many warm-cache backtests (minute strategies, speed-burner).
             # When bid/ask are already present in the cached Data series, we can fill immediately
             # without constructing a `Quote` object or running the full quote normalization stack.
             if (
                 not audit_enabled
-                and order.order_type == Order.OrderType.MARKET
-                and (order.is_buy_order() or order.is_sell_order())
-                and not self._is_option_asset(getattr(order, "asset", None))
+                and is_market_order
+                and is_buy_or_sell
+                and not is_option_order
             ):
                 fast_bid, fast_ask = self._fast_get_bid_ask_for_fill(
-                    order.asset,
+                    order_asset,
                     order.quote,
                     getattr(order, "exchange", None),
                 )
@@ -2231,7 +3394,7 @@ class BacktestingBroker(Broker):
                 if fast_ask is not None and self._is_invalid_price(fast_ask):
                     fast_ask = None
 
-                required_price = fast_ask if order.is_buy_order() else fast_bid
+                required_price = fast_ask if is_buy_order else fast_bid
                 if required_price is not None and not self._is_invalid_price(required_price):
                     setattr(order, "_price_source", "quote")
                     self._execute_filled_order(
@@ -2248,9 +3411,9 @@ class BacktestingBroker(Broker):
             skip_quote_fills = (
                 (not audit_enabled)
                 and data_source_name in {"INTERACTIVEBROKERSREST"}
-                and order.order_type == Order.OrderType.MARKET
-                and (order.is_buy_order() or order.is_sell_order())
-                and not self._is_option_asset(getattr(order, "asset", None))
+                and is_market_order
+                and is_buy_or_sell
+                and not is_option_order
                 and fast_bid is None
                 and fast_ask is None
             )
@@ -2258,27 +3421,51 @@ class BacktestingBroker(Broker):
                 not skip_quote_fills
                 and not audit_enabled
                 and force_day_fill_timestep
-                and order.order_type == Order.OrderType.MARKET
-                and (order.is_buy_order() or order.is_sell_order())
+                and is_market_order
+                and is_buy_or_sell
             ):
                 skip_quote_fills = True
+
+            if (
+                skip_quote_fills
+                and not audit_enabled
+                and is_market_order
+                and is_buy_or_sell
+                and not force_day_fill_timestep
+                and not is_option_order
+            ):
+                fast_open = self._fast_get_market_open_for_fill(
+                    order_asset,
+                    order.quote,
+                    getattr(order, "exchange", None),
+                )
+                fast_open = self._coerce_price(fast_open)
+                if fast_open is not None and not self._is_invalid_price(fast_open):
+                    setattr(order, "_price_source", "ohlc_fast_open")
+                    self._execute_filled_order(
+                        order=order,
+                        price=fast_open,
+                        filled_quantity=filled_quantity,
+                        strategy=strategy,
+                    )
+                    continue
 
             # PERFORMANCE: Prefer quote-based fills when bid/ask are present so we avoid
             # fetching trade-only OHLC bars (which can be sparse/missing, especially for
             # options). When bid/ask are unavailable we fall back to the OHLC-based model.
             should_try_quote_first = not (
-                force_day_fill_timestep and order.order_type == Order.OrderType.MARKET
+                force_day_fill_timestep and is_market_order
             )
             if (
                 should_try_quote_first
                 and
                 order.order_type in (Order.OrderType.MARKET, Order.OrderType.LIMIT)
-                and (order.is_buy_order() or order.is_sell_order())
+                and is_buy_or_sell
             ):
                 quote = None
                 if not skip_quote_fills:
                     try:
-                        quote = self.get_quote(order.asset, quote=order.quote)
+                        quote = self.get_quote(order_asset, quote=order.quote)
                     except Exception:
                         quote = None
 
@@ -2296,12 +3483,12 @@ class BacktestingBroker(Broker):
                 # to sparse trade-only OHLC (which can leave orders unfilled and canceled at EOD).
                 if (
                     (bid is None or ask is None)
-                    and getattr(order.asset, "asset_type", None) == Asset.AssetType.OPTION
+                    and getattr(order_asset, "asset_type", None) == Asset.AssetType.OPTION
                     and self.data_source is not None
                     and self.data_source.__class__.__name__ == "ThetaDataBacktestingPandas"
                 ):
                     try:
-                        snap = self.data_source.get_quote(order.asset, quote=order.quote, snapshot_only=True)
+                        snap = self.data_source.get_quote(order_asset, quote=order.quote, snapshot_only=True)
                     except TypeError:
                         snap = None
                     except Exception:
@@ -2314,10 +3501,8 @@ class BacktestingBroker(Broker):
                         if ask is None and snap_ask is not None and not self._is_invalid_price(snap_ask):
                             ask = snap_ask
 
-                is_buy = order.is_buy_order()
-
                 if order.order_type == Order.OrderType.MARKET:
-                    required_price = ask if is_buy else bid
+                    required_price = ask if is_buy_order else bid
                     if required_price is not None and not self._is_invalid_price(required_price):
                         if audit_enabled:
                             payload: dict[str, Any] = {
@@ -2346,7 +3531,7 @@ class BacktestingBroker(Broker):
                     limit_price = self._coerce_price(order.limit_price)
                     crossed = False
                     if limit_price is not None:
-                        if is_buy:
+                        if is_buy_order:
                             if limit_price >= ask:
                                 fill_price = ask
                                 crossed = True
@@ -2360,7 +3545,7 @@ class BacktestingBroker(Broker):
                                 fill_price = limit_price
 
                     if fill_price is not None and not self._is_invalid_price(fill_price):
-                        spread_key = "max_spread_buy_pct" if is_buy else "max_spread_sell_pct"
+                        spread_key = "max_spread_buy_pct" if is_buy_order else "max_spread_sell_pct"
                         spread_limit = self._get_spread_limit(strategy, spread_key)
                         if spread_limit is None:
                             spread_limit = self._get_spread_limit(strategy, "max_spread_pct")
@@ -2609,6 +3794,7 @@ class BacktestingBroker(Broker):
                             if df_check is not None and hasattr(df_check, "index"):
                                 last_dt = df_check.index.max()
                             elif df_check is not None and hasattr(df_check, "columns"):
+                                pl = _get_polars_module()
                                 dt_col = None
                                 for col in df_check.columns:
                                     try:
@@ -2805,6 +3991,7 @@ class BacktestingBroker(Broker):
 
                 # Handle both pandas and polars DataFrames
                 if hasattr(df_original, 'select'):  # Polars DataFrame
+                    pl = _get_polars_module()
                     # Find datetime column
                     dt_col = None
                     for col in df_original.columns:
@@ -3140,7 +4327,25 @@ class BacktestingBroker(Broker):
                     )
                 continue
 
-        self._run_backtest_option_lifecycle_tasks(strategy)
+        self._requeue_simple_pending(strategy_name, simple_pending)
+        if getattr(self, "_backtest_has_option_lifecycle_exposure", False):
+            self._run_backtest_option_lifecycle_tasks(strategy)
+
+    def _requeue_simple_pending(self, strategy_name, simple_pending) -> None:
+        if not simple_pending:
+            return
+        active_simple = [order for order in simple_pending if order.is_active()]
+        if not active_simple:
+            return
+        by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+        if by_strategy is None:
+            by_strategy = {}
+            self._simple_new_orders_by_strategy = by_strategy
+        existing = by_strategy.get(strategy_name)
+        if existing:
+            active_simple.extend(existing)
+        by_strategy[strategy_name] = active_simple
+        self._simple_new_orders_revision = getattr(self, "_simple_new_orders_revision", 0) + 1
 
     def _coerce_price(self, value):
         """Convert numeric inputs to float when possible for safe comparisons."""
@@ -3215,7 +4420,7 @@ class BacktestingBroker(Broker):
         if data_source is None or data_source.__class__.__name__ != "InteractiveBrokersRESTBacktesting":
             return None, None
 
-        now = getattr(self, "datetime", None)
+        now = data_source.get_datetime()
         if now is None:
             return None, None
 
@@ -3301,6 +4506,122 @@ class BacktestingBroker(Broker):
 
         return bid, ask
 
+    def _fast_get_market_open_for_fill(
+        self,
+        asset: Asset,
+        quote: Optional[Asset],
+        exchange: Optional[str] = None,
+        *,
+        _data_source=None,
+        _now=None,
+        _cache=None,
+    ) -> Optional[float]:
+        """Fast exact-bar MARKET fill from loaded IBKR OHLC data.
+
+        This is intentionally narrow: if the current simulation timestamp is not an exact bar
+        timestamp in the cached Data object, return None and let the canonical OHLC path enforce
+        its broader gap/fabrication guards.
+        """
+        data_source = _data_source if _data_source is not None else getattr(self, "data_source", None)
+        if data_source is None or data_source.__class__.__name__ != "InteractiveBrokersRESTBacktesting":
+            return None
+
+        now = _now if _now is not None else data_source.get_datetime()
+        if now is None:
+            return None
+
+        timestep = getattr(data_source, "_timestep", None) or "minute"
+        if str(timestep) != "minute":
+            return None
+
+        cache = _cache if _cache is not None else getattr(self, "_fast_market_open_data_cache", None)
+        if cache is None:
+            cache = {}
+            setattr(self, "_fast_market_open_data_cache", cache)
+
+        effective_exchange = exchange if exchange is not None else getattr(data_source, "exchange", None)
+        try:
+            exchange_key = data_source._normalize_exchange_key(effective_exchange)  # type: ignore[attr-defined]
+        except Exception:
+            exchange_key = (str(effective_exchange or "").strip().upper() or "AUTO")
+
+        cache_key = (id(asset), id(quote), str(timestep), exchange_key)
+        if cache_key in cache:
+            cached = cache[cache_key]
+            if len(cached) == 3:
+                data_obj, open_line, exact_i = cached
+            else:
+                data_obj, open_line = cached
+                exact_i = getattr(data_obj, "iter_index_dict", None) if data_obj is not None else None
+        else:
+            quote_asset = quote if quote is not None else Asset("USD", asset_type=Asset.AssetType.FOREX)
+            data_obj = None
+            open_line = None
+            exact_i = None
+            store = getattr(data_source, "_data_store", None)
+            if isinstance(store, dict):
+                try:
+                    canonical_key, legacy_key = data_source._build_dataset_keys(  # type: ignore[attr-defined]
+                        asset,
+                        quote_asset,
+                        str(timestep),
+                        effective_exchange,
+                    )
+                except Exception:
+                    canonical_key = (asset, quote_asset, str(timestep), exchange_key)
+                    legacy_key = (asset, quote_asset, exchange_key)
+
+                data_obj = store.get(canonical_key)
+                if data_obj is None:
+                    data_obj = store.get(legacy_key)
+
+            if data_obj is not None:
+                try:
+                    open_line_obj = getattr(data_obj, "datalines", {}).get("open")
+                    open_line = getattr(open_line_obj, "dataline", None) if open_line_obj is not None else getattr(data_obj, "open", None)
+                    exact_i = getattr(data_obj, "iter_index_dict", None)
+                    if exact_i is None:
+                        data_obj.repair_times_and_fill(data_obj.df.index)
+                        exact_i = getattr(data_obj, "iter_index_dict", None)
+                except Exception:
+                    open_line = None
+                    exact_i = None
+
+            cache[cache_key] = (data_obj, open_line, exact_i)
+
+        if data_obj is None or open_line is None:
+            return None
+
+        if exact_i is not None:
+            i = exact_i.get(now)
+            if i is not None:
+                try:
+                    return open_line[int(i)]
+                except Exception:
+                    return None
+
+        try:
+            now_ts = pd.Timestamp(now)
+            index = getattr(getattr(data_obj, "df", None), "index", None)
+            if index is None or len(index) == 0:
+                return None
+            i = data_obj.get_iter_count(now)
+            if int(i) < 0 or int(i) >= len(index):
+                return None
+            selected_ts = pd.Timestamp(index[int(i)])
+            if getattr(selected_ts, "tz", None) is not None:
+                if now_ts.tz is None:
+                    now_ts = now_ts.tz_localize(selected_ts.tz)
+                else:
+                    now_ts = now_ts.tz_convert(selected_ts.tz)
+            elif now_ts.tz is not None:
+                now_ts = now_ts.tz_localize(None)
+            if selected_ts != now_ts:
+                return None
+            return open_line[int(i)]
+        except Exception:
+            return None
+
     def _resolve_provider_key_for_asset(self, asset: Asset) -> Optional[str]:
         """Resolve a routing provider key for an asset when exposed by the data source."""
         if asset is None:
@@ -3329,6 +4650,9 @@ class BacktestingBroker(Broker):
     def _should_force_day_fill_timestep(self, order: Order) -> bool:
         """Whether market fills should bypass minute quote paths and use daily bars."""
         if order is None:
+            return False
+
+        if getattr(order, "_simple_backtest_order", False) and not getattr(order, "_simple_is_option", False):
             return False
 
         asset = getattr(order, "asset", None)
@@ -3379,9 +4703,12 @@ class BacktestingBroker(Broker):
         return timestep == "day"
 
     def _is_thetadata_source(self) -> bool:
-        if ThetaDataBacktestingPandas is None:
+        if self.data_source.__class__.__name__ != "ThetaDataBacktestingPandas":
             return False
-        return isinstance(self.data_source, ThetaDataBacktestingPandas)
+        theta_cls = _get_thetadata_backtesting_pandas_cls()
+        if theta_cls is None:
+            return False
+        return isinstance(self.data_source, theta_cls)
 
     def _get_spread_limit(self, strategy, key: str) -> Optional[float]:
         if strategy is None or not key:
@@ -4313,6 +5640,8 @@ class BacktestingBroker(Broker):
             except:
                 logger.error(traceback.format_exc())
 
+        broker._default_new_order_stream_action = on_trade_event
+
         @broker.stream.add_action(broker.PLACEHOLDER_ORDER)
         def on_trade_event(order):
             try:
@@ -4337,6 +5666,8 @@ class BacktestingBroker(Broker):
                 return True
             except:
                 logger.error(traceback.format_exc())
+
+        broker._default_filled_order_stream_action = on_trade_event
 
         @broker.stream.add_action(broker.CANCELED_ORDER)
         def on_trade_event(order, **payload):

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -3170,6 +3170,10 @@ class BacktestingBroker(Broker):
                     or getattr(order, "_smart_limit_managed_by_parent", False)
                     or not is_market_order
                     or not (is_buy_order or is_sell_order)
+                    or (
+                        asset_type in (Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE)
+                        and not getattr(order, "_simple_backtest_order", False)
+                    )
                     or asset_type not in (Asset.AssetType.CRYPTO, Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE)
                     or getattr(order, "_simple_is_option", None)
                     or (not getattr(order, "_simple_backtest_order", False) and self._is_option_asset(order_asset))

--- a/lumibot/backtesting/databento_backtesting_pandas.py
+++ b/lumibot/backtesting/databento_backtesting_pandas.py
@@ -1,13 +1,12 @@
+from __future__ import annotations
+
 import traceback
 from datetime import datetime, timedelta
-
-import pandas as pd
+from importlib import import_module
 
 from lumibot import LUMIBOT_DEFAULT_PYTZ
 from lumibot.data_sources import PandasData
-from lumibot.entities import Asset, Data
-from lumibot.tools import databento_helper
-from lumibot.tools.databento_helper import DataBentoAuthenticationError
+from lumibot.entities import Asset
 from lumibot.tools.helpers import to_datetime_aware
 from termcolor import colored
 
@@ -15,6 +14,57 @@ from lumibot.tools.lumibot_logger import get_logger
 logger = get_logger(__name__)
 
 START_BUFFER = timedelta(days=5)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+databento_helper = _LazyModule("lumibot.tools.databento_helper")
+_DATA_CLASS = None
+_DATABENTO_AUTH_ERROR_CLASS = None
+
+
+def _data_class():
+    global _DATA_CLASS
+    if _DATA_CLASS is None:
+        from lumibot.entities import Data
+
+        _DATA_CLASS = Data
+    return _DATA_CLASS
+
+
+def _databento_auth_error_class():
+    global _DATABENTO_AUTH_ERROR_CLASS
+    if _DATABENTO_AUTH_ERROR_CLASS is None:
+        from lumibot.tools.databento_helper import DataBentoAuthenticationError
+
+        _DATABENTO_AUTH_ERROR_CLASS = DataBentoAuthenticationError
+    return _DATABENTO_AUTH_ERROR_CLASS
 
 
 class DataBentoDataBacktestingPandas(PandasData):
@@ -161,7 +211,7 @@ class DataBentoDataBacktestingPandas(PandasData):
 
             logger.debug(f"Successfully set multiplier for {asset.symbol}: {asset.multiplier}")
 
-        except DataBentoAuthenticationError as e:
+        except _databento_auth_error_class() as e:
             logger.error(colored(f"DataBento authentication failed while fetching multiplier for {asset.symbol}: {e}", "red"))
             raise
         except Exception as e:
@@ -217,7 +267,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                     # Create an empty DatetimeIndex with proper timezone
                     empty_df.index = pd.DatetimeIndex([], tz=LUMIBOT_DEFAULT_PYTZ, name='datetime')
                     
-                    data_obj = Data(
+                    data_obj = _data_class()(
                         asset,
                         df=empty_df,
                         timestep=timestep,
@@ -229,7 +279,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                     self.pandas_data[search_asset] = data_obj
                 else:
                     # Create Data object and store
-                    data_obj = Data(
+                    data_obj = _data_class()(
                         asset,
                         df=df,
                         timestep=timestep,
@@ -241,7 +291,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                 # Mark as prefetched
                 self._prefetched_assets.add(search_asset)
                 
-            except DataBentoAuthenticationError as e:
+            except _databento_auth_error_class() as e:
                 logger.error(colored(f"DataBento authentication failed while prefetching {asset.symbol}: {e}", "red"))
                 raise
             except Exception as e:
@@ -354,7 +404,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                 # Create an empty DatetimeIndex with proper timezone
                 empty_df.index = pd.DatetimeIndex([], tz=LUMIBOT_DEFAULT_PYTZ, name='datetime')
                 
-                data_obj = Data(
+                data_obj = _data_class()(
                     asset_separated,
                     df=empty_df,
                     timestep=ts_unit,
@@ -372,7 +422,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                 return
 
             # Create Data object and store in pandas_data
-            data_obj = Data(
+            data_obj = _data_class()(
                 asset_separated,
                 df=df,
                 timestep=ts_unit,
@@ -381,7 +431,7 @@ class DataBentoDataBacktestingPandas(PandasData):
             
             self.pandas_data[search_asset] = data_obj
 
-        except DataBentoAuthenticationError as e:
+        except _databento_auth_error_class() as e:
             logger.error(colored(f"DataBento authentication failed for {asset_separated.symbol}: {e}", "red"))
             raise
         except Exception as e:
@@ -494,7 +544,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                 reference_date=current_dt_aware
             )
             
-        except DataBentoAuthenticationError as e:
+        except _databento_auth_error_class() as e:
             logger.error(colored(f"DataBento authentication failed while getting last price for {asset.symbol}: {e}", "red"))
             raise
         except Exception as e:
@@ -594,7 +644,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                     logger.warning(f"No data found for {asset.symbol}")
                     result[asset] = None
                     
-            except DataBentoAuthenticationError as e:
+            except _databento_auth_error_class() as e:
                 logger.error(colored(f"DataBento authentication failed while getting bars for {asset}: {e}", "red"))
                 raise
             except Exception as e:

--- a/lumibot/backtesting/databento_backtesting_polars.py
+++ b/lumibot/backtesting/databento_backtesting_polars.py
@@ -1,16 +1,12 @@
+from __future__ import annotations
+
 import traceback
 from datetime import datetime, timedelta
-
-import pandas as pd
-import polars as pl
-import numpy as np
+from importlib import import_module
 
 from lumibot import LUMIBOT_DEFAULT_PYTZ
 from lumibot.data_sources import PolarsData
-from lumibot.entities import Asset, Data, Quote
-from lumibot.entities.data_polars import DataPolars
-from lumibot.tools import databento_helper_polars as databento_helper
-from lumibot.tools.databento_helper_polars import DataBentoAuthenticationError
+from lumibot.entities import Asset, Quote
 from lumibot.tools.helpers import to_datetime_aware
 from termcolor import colored
 
@@ -23,6 +19,69 @@ def _log_conversion(operation, from_type, to_type, location):
     logger.debug(f"[CONVERSION] {operation} | {from_type} → {to_type} | {location}")
 
 START_BUFFER = timedelta(days=5)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+pl = _LazyModule("polars")
+np = _LazyModule("numpy")
+databento_helper = _LazyModule("lumibot.tools.databento_helper_polars")
+_DATA_CLASS = None
+_DATA_POLARS_CLASS = None
+_DATABENTO_AUTH_ERROR_CLASS = None
+
+
+def _data_class():
+    global _DATA_CLASS
+    if _DATA_CLASS is None:
+        from lumibot.entities import Data
+
+        _DATA_CLASS = Data
+    return _DATA_CLASS
+
+
+def _data_polars_class():
+    global _DATA_POLARS_CLASS
+    if _DATA_POLARS_CLASS is None:
+        from lumibot.entities.data_polars import DataPolars
+
+        _DATA_POLARS_CLASS = DataPolars
+    return _DATA_POLARS_CLASS
+
+
+def _databento_auth_error_class():
+    global _DATABENTO_AUTH_ERROR_CLASS
+    if _DATABENTO_AUTH_ERROR_CLASS is None:
+        from lumibot.tools.databento_helper_polars import DataBentoAuthenticationError
+
+        _DATABENTO_AUTH_ERROR_CLASS = DataBentoAuthenticationError
+    return _DATABENTO_AUTH_ERROR_CLASS
 
 
 class DataBentoDataBacktestingPolars(PolarsData):
@@ -174,7 +233,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
 
             logger.debug(f"Successfully set multiplier for {asset.symbol}: {asset.multiplier}")
 
-        except DataBentoAuthenticationError as e:
+        except _databento_auth_error_class() as e:
             logger.error(colored(f"DataBento authentication failed while fetching multiplier for {asset.symbol}: {e}", "red"))
             raise
         except Exception as e:
@@ -238,7 +297,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                     # Create an empty DatetimeIndex with proper timezone
                     empty_df.index = pd.DatetimeIndex([], tz=LUMIBOT_DEFAULT_PYTZ, name='datetime')
                     
-                    data_obj = Data(
+                    data_obj = _data_class()(
                         asset,
                         df=empty_df,
                         timestep=timestep,
@@ -252,7 +311,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                 else:
                     pandas_df = df.to_pandas() if hasattr(df, "to_pandas") else df
                     # Create Data object and store
-                    data_obj = Data(
+                    data_obj = _data_class()(
                         asset,
                         df=pandas_df,
                         timestep=timestep,
@@ -266,7 +325,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                 # Mark as prefetched
                 self._prefetched_assets.add(search_asset)
                 
-            except DataBentoAuthenticationError as e:
+            except _databento_auth_error_class() as e:
                 logger.error(colored(f"DataBento authentication failed while prefetching {asset.symbol}: {e}", "red"))
                 raise
             except Exception as e:
@@ -317,7 +376,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
             asset_data = self.pandas_data[search_asset]
 
             # OPTIMIZATION: For DataPolars, check polars_df directly without converting to pandas
-            if isinstance(asset_data, DataPolars):
+            if isinstance(asset_data, _data_polars_class()):
                 # Avoid conversion overhead by reading DataPolars.polars_df directly
                 polars_df = asset_data.polars_df
                 if polars_df.height > 0:
@@ -443,7 +502,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                 # Create an empty DatetimeIndex with proper timezone
                 empty_df.index = pd.DatetimeIndex([], tz=LUMIBOT_DEFAULT_PYTZ, name='datetime')
                 
-                data_obj = Data(
+                data_obj = _data_class()(
                     asset_separated,
                     df=empty_df,
                     timestep=ts_unit,
@@ -461,7 +520,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                 _log_conversion("STORE", "polars", "DataPolars", "_update_pandas_data")
                 logger.debug(f"[POLARS] Storing polars DataFrame for {asset_separated.symbol}: {df.height} rows")
                 # Create DataPolars object with polars DataFrame (keeps polars end-to-end)
-                data_obj = DataPolars(
+                data_obj = _data_polars_class()(
                     asset_separated,
                     df=df,
                     timestep=ts_unit,
@@ -473,7 +532,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                     logger.error(f"DataBento data for {asset_separated.symbol} doesn't have datetime index")
                     return
                 # Create Data object with pandas DataFrame
-                data_obj = Data(
+                data_obj = _data_class()(
                     asset_separated,
                     df=df,
                     timestep=ts_unit,
@@ -486,7 +545,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
             self.pandas_data[search_asset] = data_obj
             self._cache_datetime_series(search_asset, data_obj)
 
-        except DataBentoAuthenticationError as e:
+        except _databento_auth_error_class() as e:
             logger.error(colored(f"DataBento authentication failed for {asset_separated.symbol}: {e}", "red"))
             raise
         except Exception as e:
@@ -501,7 +560,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
             timestep = getattr(data_obj, "timestep", "minute")
             cache_key = (search_asset, timestep)
 
-            if isinstance(data_obj, DataPolars):
+            if isinstance(data_obj, _data_polars_class()):
                 dt_series = data_obj.polars_df["datetime"]
                 if dt_series.dtype.time_zone:
                     dt_series = dt_series.dt.convert_time_zone("UTC")
@@ -587,7 +646,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                     datetime_ns = self._datetime_ns_cache.get(datetime_key)
 
                 # OPTIMIZATION: If asset_data is DataPolars, work with polars directly to avoid conversion
-                if isinstance(asset_data, DataPolars):
+                if isinstance(asset_data, _data_polars_class()):
                     polars_df = asset_data.polars_df
 
                     if polars_df.height > 0 and 'close' in polars_df.columns and datetime_ns is not None and len(datetime_ns) > 0:
@@ -654,7 +713,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                 venue=exchange
             )
             
-        except DataBentoAuthenticationError as e:
+        except _databento_auth_error_class() as e:
             logger.error(colored(f"DataBento authentication failed while getting last price for {asset.symbol}: {e}", "red"))
             raise
         except Exception as e:
@@ -688,7 +747,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
             search_asset = asset if isinstance(asset, tuple) else (asset, Asset("USD", "forex"))
             asset_data = self.pandas_data.get(search_asset)
             df = None
-            if isinstance(asset_data, DataPolars):
+            if isinstance(asset_data, _data_polars_class()):
                 df = asset_data.polars_df
             elif asset_data is not None:
                 df = asset_data.polars_df if hasattr(asset_data, "polars_df") else asset_data.df
@@ -721,7 +780,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
             )
             quote_obj.source = "polars"
             return quote_obj
-        except DataBentoAuthenticationError as exc:
+        except _databento_auth_error_class() as exc:
             logger.error(colored(f"DataBento authentication failed while getting quote for {asset}: {exc}", "red"))
             raise
         except Exception as exc:
@@ -800,7 +859,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                     logger.warning(f"No data found for {asset.symbol}")
                     result[asset] = None
                     
-            except DataBentoAuthenticationError as e:
+            except _databento_auth_error_class() as e:
                 logger.error(colored(f"DataBento authentication failed while getting bars for {asset}: {e}", "red"))
                 raise
             except Exception as e:
@@ -863,7 +922,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
             asset_data = self.pandas_data[search_asset]
 
             # OPTIMIZATION: If asset_data is DataPolars, work with polars directly to avoid conversion
-            if isinstance(asset_data, DataPolars):
+            if isinstance(asset_data, _data_polars_class()):
                 polars_df = asset_data.polars_df
 
                 if polars_df.height > 0:

--- a/lumibot/backtesting/interactive_brokers_rest_backtesting.py
+++ b/lumibot/backtesting/interactive_brokers_rest_backtesting.py
@@ -1,19 +1,79 @@
+from __future__ import annotations
+
 import logging
 import uuid
 from datetime import datetime, timedelta
+from functools import lru_cache
+from importlib import import_module
 from typing import Optional
 
-import pandas as pd
-
 from lumibot.data_sources import PandasData
-from lumibot.entities import Asset, Data
-import lumibot.tools.ibkr_helper as ibkr_helper
-from lumibot.tools.helpers import parse_timestep_qty_and_unit
-from lumibot.tools.data_downloader_queue_client import set_queue_client_id
+from lumibot.entities import Asset
 
 logger = logging.getLogger(__name__)
 
 _USD_FOREX = Asset("USD", "forex")
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+ibkr_helper = _LazyModule("lumibot.tools.ibkr_helper")
+_DATA_CLASS = None
+_BARS_CLASS = None
+_PARSE_TIMESTEP_QTY_AND_UNIT = None
+
+
+def _data_class():
+    global _DATA_CLASS
+    if _DATA_CLASS is None:
+        from lumibot.entities import Data
+
+        _DATA_CLASS = Data
+    return _DATA_CLASS
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities.bars import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _parse_timestep_qty_and_unit(*args, **kwargs):
+    global _PARSE_TIMESTEP_QTY_AND_UNIT
+    if _PARSE_TIMESTEP_QTY_AND_UNIT is None:
+        from lumibot.tools.helpers import parse_timestep_qty_and_unit
+
+        _PARSE_TIMESTEP_QTY_AND_UNIT = parse_timestep_qty_and_unit
+    return _PARSE_TIMESTEP_QTY_AND_UNIT(*args, **kwargs)
 
 
 class InteractiveBrokersRESTBacktesting(PandasData):
@@ -44,10 +104,13 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         self._timestep = self.MIN_TIMESTEP
         self.exchange = exchange
         self.history_source = history_source
+        self.market = kwargs.get("market")
 
         unique_id = uuid.uuid4().hex[:8]
         strategy_name = kwargs.get("name", "Backtest")
         client_id = f"{strategy_name}_{unique_id}"
+        from lumibot.tools.data_downloader_queue_client import set_queue_client_id
+
         set_queue_client_id(client_id)
         logger.info("[IBKR][QUEUE] Set client_id for queue fairness: %s", client_id)
 
@@ -101,14 +164,89 @@ class InteractiveBrokersRESTBacktesting(PandasData):
           not collide with "minute".
         - Keeps the `Data.timestep` base unit as "minute"/"day" for compatibility.
         """
-        qty, unit = parse_timestep_qty_and_unit(timestep)
+        if timestep in {"minute", "day", "hour"}:
+            return timestep
+        qty, unit = _parse_timestep_qty_and_unit(timestep)
         qty = int(qty)
         unit = str(unit)
         if qty == 1:
             return unit
         return f"{qty}{unit}"
 
+    def get_historical_prices(
+        self,
+        asset: Asset,
+        length: int,
+        timestep: str = None,
+        timeshift: int = None,
+        quote: Asset = None,
+        exchange: str = None,
+        include_after_hours: bool = True,
+        return_polars: bool = False,
+    ):
+        """Get bars for a given asset, with a hot path for fully prefetched IBKR series."""
+        if isinstance(asset, str):
+            asset = Asset(symbol=asset)
+
+        if not timestep:
+            timestep = self.get_timestep()
+
+        asset_separated = asset
+        quote_asset = quote
+        if isinstance(asset_separated, tuple):
+            asset_separated, quote_asset = asset_separated
+
+        quote_key = quote_asset if quote_asset is not None else _USD_FOREX
+        effective_exchange = exchange if exchange is not None else self.exchange
+        timestep_key = timestep if isinstance(timestep, str) else str(timestep)
+        hot_cache = getattr(self, "_fully_loaded_hot_data_cache", None)
+        if hot_cache is not None:
+            data = hot_cache.get((id(asset_separated), id(quote_key), timestep_key, effective_exchange))
+            if data is not None:
+                try:
+                    if timeshift is None and timestep in {"minute", "day"}:
+                        response = data.get_native_bars_fast(self._datetime, length=length, timestep=timestep)
+                    else:
+                        response = data.get_bars(self._datetime, length=length, timestep=timestep, timeshift=timeshift)
+                except ValueError:
+                    return None
+                if isinstance(response, float) or response is None:
+                    return response
+                if (
+                    not return_polars
+                    and isinstance(response, pd.DataFrame)
+                    and response.attrs.get("_lumibot_skip_timezone", False)
+                    and "return" in response.columns
+                    and "dividend" not in response.columns
+                ):
+                    return _bars_class().from_pandas_fast(
+                        response,
+                        self.SOURCE,
+                        asset_separated,
+                        quote=quote_asset,
+                        raw=response,
+                    )
+                return self._parse_source_symbol_bars(
+                    response,
+                    asset,
+                    quote=quote,
+                    length=length,
+                    return_polars=return_polars,
+                )
+
+        return super().get_historical_prices(
+            asset,
+            length,
+            timestep=timestep,
+            timeshift=timeshift,
+            quote=quote,
+            exchange=exchange,
+            include_after_hours=include_after_hours,
+            return_polars=return_polars,
+        )
+
     @staticmethod
+    @lru_cache(maxsize=256)
     def _previous_us_futures_session_open(dt_value: datetime) -> Optional[datetime]:
         """Return the most recent `us_futures` session open at or before `dt_value`.
 
@@ -161,8 +299,12 @@ class InteractiveBrokersRESTBacktesting(PandasData):
 
         effective_exchange = exchange if exchange is not None else self.exchange
 
-        asset_type = self._normalize_asset_type(getattr(base_asset, "asset_type", ""))
-        now = self.get_datetime()
+        raw_asset_type = getattr(base_asset, "asset_type", "")
+        if raw_asset_type in {"crypto", "future", "cont_future", "stock", "index"}:
+            asset_type = raw_asset_type
+        else:
+            asset_type = self._normalize_asset_type(raw_asset_type)
+        now = self._datetime
         # Futures backtests should not look ahead into the current (incomplete) bar. Interpret
         # "last price at dt" as the last completed bar's close by nudging dt slightly earlier.
         #
@@ -193,6 +335,9 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             day_data = self._data_store.get(day_key)
             if day_data is not None:
                 try:
+                    get_last_price_fast = getattr(day_data, "get_last_price_fast", None)
+                    if callable(get_last_price_fast):
+                        return get_last_price_fast(now)
                     return day_data.get_last_price(now)
                 except Exception:
                     pass
@@ -205,6 +350,9 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             day_data = self._data_store.get(day_key)
             if day_data is not None:
                 try:
+                    get_last_price_fast = getattr(day_data, "get_last_price_fast", None)
+                    if callable(get_last_price_fast):
+                        return get_last_price_fast(now)
                     return day_data.get_last_price(now)
                 except Exception:
                     pass
@@ -226,8 +374,13 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             self._fully_loaded_series.add(minute_key)
         data = self._data_store.get(minute_key)
         if data is not None:
+            hot_cache = getattr(self, "_fully_loaded_hot_data_cache", None)
+            if hot_cache is None:
+                hot_cache = {}
+                self._fully_loaded_hot_data_cache = hot_cache
+            hot_cache[(id(base_asset), id(quote_asset), "minute", effective_exchange)] = data
             try:
-                return data.get_last_price(now)
+                return data.get_last_price_fast(now)
             except Exception:
                 pass
         return None
@@ -390,10 +543,21 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         # `Data` supports only base units ("minute"/"day"). Store multi-minute datasets under a
         # separate key (e.g., "15minute") and annotate the instance so it can fast-path slices
         # without resampling on every call.
-        qty, unit = parse_timestep_qty_and_unit(dataset_key)
+        qty, unit = _parse_timestep_qty_and_unit(dataset_key)
         unit = str(unit)
         data_timestep = unit if unit in {"minute", "day"} else "minute"
-        data = Data(asset, merged, timestep=data_timestep, quote=quote)
+        assume_clean = bool(
+            isinstance(merged, pd.DataFrame)
+            and isinstance(merged.index, pd.DatetimeIndex)
+            and merged.index.tz is not None
+            and merged.index.is_monotonic_increasing
+            and all(col in merged.columns for col in ("open", "high", "low", "close", "volume"))
+        )
+        data = _data_class()(asset, merged, timestep=data_timestep, quote=quote, assume_clean=assume_clean)
+        if dataset_key in {"minute", "day"}:
+            data._defer_clean_returns = True
+        if dataset_key == "day":
+            data._skip_clean_datalines = True
         data._native_timestep_quantity = int(qty)  # type: ignore[attr-defined]
         data._native_timestep_unit = unit  # type: ignore[attr-defined]
         # CRITICAL: Pandas backtesting expects each Data object to have `iter_index`/datalines
@@ -409,7 +573,8 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         # See: docs/BACKTESTING_SESSION_GAPS_AND_DATA_GAPS.md
         try:
             if isinstance(merged.index, pd.DatetimeIndex) and len(merged.index) > 0:
-                data.repair_times_and_fill(merged.index)
+                if not data._initialize_clean_repaired_state():
+                    data.repair_times_and_fill(merged.index)
         except Exception:
             # Fallback: if repair fails, leave data as-is (callers will treat as missing).
             pass
@@ -438,26 +603,54 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         if timestep is None:
             timestep = self.get_timestep()
 
-        dataset_key = self._normalize_timestep_key(timestep)
-        end_dt = self.get_datetime()
+        end_dt = self._datetime
 
         # PERF: warm-cache minute backtests call `_pull_source_symbol_bars()` in tight loops. Once a
         # (asset, quote, timestep) series has been prefetched for the full backtest window, we can
         # skip start/end datetime calculations and downloader bookkeeping and slice immediately.
         quote_key = quote_asset if quote_asset is not None else _USD_FOREX
         effective_exchange = exchange if exchange is not None else self.exchange
+        timestep_key = timestep if isinstance(timestep, str) else str(timestep)
+        hot_cache_key = (id(asset_separated), id(quote_key), timestep_key, effective_exchange)
+        hot_cache = getattr(self, "_fully_loaded_hot_data_cache", None)
+        if hot_cache is not None:
+            data = hot_cache.get(hot_cache_key)
+            if data is not None:
+                try:
+                    return data.get_bars(end_dt, length=length, timestep=timestep, timeshift=timeshift)
+                except ValueError:
+                    return None
+        dataset_key = self._normalize_timestep_key(timestep)
         exchange_key = self._normalize_exchange_key(effective_exchange)
         fully_loaded_key = (asset_separated, quote_key, dataset_key, exchange_key)
         if fully_loaded_key in self._fully_loaded_series:
-            canonical_key, legacy_key = self._build_dataset_keys(asset_separated, quote_asset, dataset_key, effective_exchange)
-            data = self._data_store.get(canonical_key)
-            if data is None and dataset_key == "minute":
-                data = self._data_store.get(legacy_key)
+            data_cache = getattr(self, "_fully_loaded_data_cache", None)
+            if data_cache is None:
+                data_cache = {}
+                self._fully_loaded_data_cache = data_cache
+
+            data = data_cache.get(fully_loaded_key)
+            if data is None:
+                canonical_key, legacy_key = self._build_dataset_keys(
+                    asset_separated,
+                    quote_asset,
+                    dataset_key,
+                    effective_exchange,
+                )
+                data = self._data_store.get(canonical_key)
+                if data is None and dataset_key == "minute":
+                    data = self._data_store.get(legacy_key)
+                if data is not None:
+                    data_cache[fully_loaded_key] = data
+                    hot_cache = getattr(self, "_fully_loaded_hot_data_cache", None)
+                    if hot_cache is None:
+                        hot_cache = {}
+                        self._fully_loaded_hot_data_cache = hot_cache
+                    hot_cache[hot_cache_key] = data
             if data is None:
                 return None
-            now = self.get_datetime()
             try:
-                return data.get_bars(now, length=length, timestep=timestep, timeshift=timeshift)
+                return data.get_bars(end_dt, length=length, timestep=timestep, timeshift=timeshift)
             except ValueError:
                 return None
 
@@ -478,7 +671,7 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             quote_key = quote_asset if quote_asset is not None else _USD_FOREX
             key = (asset_separated, quote_key, dataset_key, exchange_key)
             if key not in self._fully_loaded_series:
-                prev_open = self._previous_us_futures_session_open(self.datetime_start)
+                prev_open = None if self.market == "24/7" else self._previous_us_futures_session_open(self.datetime_start)
                 if prev_open is not None:
                     prefetch_start = min(start_dt, prev_open)
                 else:
@@ -608,6 +801,12 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             data = self._data_store.get(legacy_key)
         if data is None:
             return None
+        if fully_loaded_key in self._fully_loaded_series:
+            hot_cache = getattr(self, "_fully_loaded_hot_data_cache", None)
+            if hot_cache is None:
+                hot_cache = {}
+                self._fully_loaded_hot_data_cache = hot_cache
+            hot_cache[hot_cache_key] = data
 
         now = self.get_datetime()
         try:
@@ -636,7 +835,7 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             return None
 
         dataset_key = self._normalize_timestep_key(timestep)
-        qty, unit = parse_timestep_qty_and_unit(dataset_key)
+        qty, unit = _parse_timestep_qty_and_unit(dataset_key)
         unit = str(unit or "").strip().lower()
         asset_type = self._normalize_asset_type(getattr(asset_separated, "asset_type", ""))
         include_after_hours = self._ibkr_include_after_hours(asset_type, unit)

--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -1,20 +1,81 @@
+from __future__ import annotations
+
 import traceback
 from collections import OrderedDict
 from datetime import timedelta
 from decimal import Decimal
+from importlib import import_module
 from typing import Union
 
-from polygon.exceptions import BadResponse
 from termcolor import colored
 
 from lumibot.tools.lumibot_logger import get_logger
 from lumibot.data_sources import PandasData
-from lumibot.entities import Asset, Data
-from lumibot.tools import polygon_helper
-from lumibot.tools.polygon_helper import PolygonClient
+from lumibot.entities import Asset
 
 logger = get_logger(__name__)
 START_BUFFER = timedelta(days=5)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+polygon_helper = _LazyModule("lumibot.tools.polygon_helper")
+_POLYGON_CLIENT_CLASS = None
+_BAD_RESPONSE_CLASS = None
+_DATA_CLASS = None
+
+
+def _polygon_client_class():
+    global _POLYGON_CLIENT_CLASS
+    if _POLYGON_CLIENT_CLASS is None:
+        from lumibot.tools.polygon_helper import PolygonClient
+
+        _POLYGON_CLIENT_CLASS = PolygonClient
+    return _POLYGON_CLIENT_CLASS
+
+
+def _bad_response_class():
+    global _BAD_RESPONSE_CLASS
+    if _BAD_RESPONSE_CLASS is None:
+        from polygon.exceptions import BadResponse
+
+        _BAD_RESPONSE_CLASS = BadResponse
+    return _BAD_RESPONSE_CLASS
+
+
+def _data_class():
+    global _DATA_CLASS
+    if _DATA_CLASS is None:
+        from lumibot.entities import Data
+
+        _DATA_CLASS = Data
+    return _DATA_CLASS
+
 
 class PolygonDataBacktesting(PandasData):
     """
@@ -43,7 +104,7 @@ class PolygonDataBacktesting(PandasData):
         # Store errors CSV path for use in data retrieval
 
         # RESTClient API for Polygon.io polygon-api-client
-        self.polygon_client = PolygonClient.create(api_key=api_key)
+        self.polygon_client = _polygon_client_class().create(api_key=api_key)
 
     def _enforce_storage_limit(pandas_data: OrderedDict):
         storage_used = sum(data.df.memory_usage().sum() for data in pandas_data.values())
@@ -138,7 +199,7 @@ class PolygonDataBacktesting(PandasData):
                 timespan=ts_unit,
                 quote_asset=quote_asset
             )
-        except BadResponse as e:
+        except _bad_response_class() as e:
             # Assuming e.message or similar attribute contains the error message
             formatted_start_datetime = start_datetime.strftime("%Y-%m-%d")
             formatted_end_datetime = self.datetime_end.strftime("%Y-%m-%d")
@@ -180,7 +241,7 @@ class PolygonDataBacktesting(PandasData):
 
         if (df is None) or df.empty:
             return
-        data = Data(asset_separated, df, timestep=ts_unit, quote=quote_asset)
+        data = _data_class()(asset_separated, df, timestep=ts_unit, quote=quote_asset)
         pandas_data_update = self._set_pandas_data_keys([data])
         # Add the keys to the self.pandas_data dictionary
         self.pandas_data.update(pandas_data_update)

--- a/lumibot/backtesting/routed_backtesting.py
+++ b/lumibot/backtesting/routed_backtesting.py
@@ -5,21 +5,65 @@ import os
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from importlib import import_module
 from typing import Any, Dict, Optional
-
-import pandas as pd
 
 from lumibot.backtesting.thetadata_backtesting_pandas import ThetaDataBacktestingPandas
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
-from lumibot.credentials import ALPACA_CONFIG, COINBASE_CONFIG, KRAKEN_CONFIG, POLYGON_API_KEY
-from lumibot.entities import Asset, Data
-from lumibot.tools import ibkr_helper
-from lumibot.tools import polygon_helper
+from lumibot.entities import Asset
 from lumibot.tools.helpers import parse_timestep_qty_and_unit
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_QUOTE_ASSET = Asset("USD", "forex")
+_DATA_CLASS = None
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+ibkr_helper = _LazyModule("lumibot.tools.ibkr_helper")
+polygon_helper = _LazyModule("lumibot.tools.polygon_helper")
+
+
+def _credential(name: str):
+    import lumibot.credentials as credentials
+
+    return getattr(credentials, name)
+
+
+def _data_class():
+    global _DATA_CLASS
+    if _DATA_CLASS is None:
+        from lumibot.entities import Data
+
+        _DATA_CLASS = Data
+    return _DATA_CLASS
 
 
 class RoutingProviderError(ValueError):
@@ -82,9 +126,9 @@ def _infer_default_ccxt_exchange_id() -> str:
         if resolved:
             return resolved
 
-    if (COINBASE_CONFIG.get("apiKey") or "").strip():
+    if (_credential("COINBASE_CONFIG").get("apiKey") or "").strip():
         return "coinbase"
-    if (KRAKEN_CONFIG.get("apiKey") or "").strip():
+    if (_credential("KRAKEN_CONFIG").get("apiKey") or "").strip():
         return "kraken"
     return "binance"
 
@@ -280,7 +324,7 @@ class _DataFrameRoutingAdapter(_RoutingAdapter):
         else:
             merged = df
 
-        data = Data(asset, merged, timestep=ts_unit, quote=quote_asset)
+        data = _data_class()(asset, merged, timestep=ts_unit, quote=quote_asset)
         self._router._data_store[canonical_key] = data
         if legacy_key not in self._router._data_store:
             self._router._data_store[legacy_key] = data
@@ -575,7 +619,7 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
         # a separate key (e.g., "60minute") and annotate the instance so `Data.get_bars()` can
         # slice directly without resampling each iteration.
         data_timestep = unit if unit in {"minute", "hour", "day"} else "minute"
-        data = Data(asset, merged, timestep=data_timestep, quote=quote_asset)
+        data = _data_class()(asset, merged, timestep=data_timestep, quote=quote_asset)
         data._native_timestep_quantity = int(qty)  # type: ignore[attr-defined]
         data._native_timestep_unit = unit  # type: ignore[attr-defined]
         try:
@@ -720,7 +764,7 @@ class _PolygonRoutingAdapter(_DataFrameRoutingAdapter):
         require_quote_data: bool,
         require_ohlc_data: bool,
     ) -> pd.DataFrame | None:
-        polygon_key = (os.environ.get("POLYGON_API_KEY") or POLYGON_API_KEY or "").strip()
+        polygon_key = (os.environ.get("POLYGON_API_KEY") or _credential("POLYGON_API_KEY") or "").strip()
         if not polygon_key:
             raise RoutingProviderError("Routing selected Polygon but POLYGON_API_KEY is not configured.")
 
@@ -797,9 +841,10 @@ class _AlpacaRoutingAdapter(_DataFrameRoutingAdapter):
         require_ohlc_data: bool,
     ) -> pd.DataFrame | None:
         if self._source is None:
+            alpaca_config = _credential("ALPACA_CONFIG")
             if not (
-                ALPACA_CONFIG.get("OAUTH_TOKEN")
-                or (ALPACA_CONFIG.get("API_KEY") and ALPACA_CONFIG.get("API_SECRET"))
+                alpaca_config.get("OAUTH_TOKEN")
+                or (alpaca_config.get("API_KEY") and alpaca_config.get("API_SECRET"))
             ):
                 raise RoutingProviderError(
                     "Routing selected Alpaca but Alpaca credentials are not configured. "
@@ -810,7 +855,7 @@ class _AlpacaRoutingAdapter(_DataFrameRoutingAdapter):
             self._source = AlpacaBacktesting(
                 datetime_start=self._router.datetime_start,
                 datetime_end=self._router.datetime_end,
-                config=ALPACA_CONFIG,
+                config=alpaca_config,
                 show_progress_bar=False,
             )
 

--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import math
@@ -5,17 +7,65 @@ import os
 import subprocess
 from datetime import date, datetime, timedelta
 from decimal import Decimal
-from typing import Dict, List, Optional, Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-import pandas as pd
 import pytz
 
-from lumibot.credentials import THETADATA_CONFIG
 from lumibot.data_sources import PandasData
-from lumibot.entities import Asset, AssetsMapping, Data
-from lumibot.tools import thetadata_helper
+from lumibot.entities import Asset, AssetsMapping
+
+if TYPE_CHECKING:
+    from lumibot.entities import Data
 
 logger = logging.getLogger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+thetadata_helper = _LazyModule("lumibot.tools.thetadata_helper")
+_DATA_CLASS = None
+
+
+def _thetadata_config():
+    from lumibot.credentials import THETADATA_CONFIG
+
+    return THETADATA_CONFIG
+
+
+def _data_class():
+    global _DATA_CLASS
+    if _DATA_CLASS is None:
+        from lumibot.entities import Data
+
+        _DATA_CLASS = Data
+    return _DATA_CLASS
 
 
 def _parity_log(message: str, *args) -> None:
@@ -132,10 +182,11 @@ class ThetaDataBacktestingPandas(PandasData):
         self._cadence_last_dt = None
         self._observed_intraday_cadence = False
 
+        config = _thetadata_config()
         if username is None:
-            username = THETADATA_CONFIG.get("THETADATA_USERNAME")
+            username = config.get("THETADATA_USERNAME")
         if password is None:
-            password = THETADATA_CONFIG.get("THETADATA_PASSWORD")
+            password = config.get("THETADATA_PASSWORD")
         if username is None or password is None:
             logger.warning("ThetaData credentials are not configured; ThetaTerminal may fail to authenticate.")
 
@@ -2261,7 +2312,7 @@ class ThetaDataBacktestingPandas(PandasData):
                     data_start_candidate,
                     data_end_candidate,
                 ) = _process_frame(merged_df)
-        data = Data(asset_separated, cleaned_df, timestep=ts_unit, quote=quote_asset)
+        data = _data_class()(asset_separated, cleaned_df, timestep=ts_unit, quote=quote_asset)
         # For minute data we want strict cache boundary enforcement so missing bars force a refresh.
         # For daily data, the backtester queries intraday timestamps (09:30/16:00) while the latest
         # completed daily bar represents the prior session; allow Data.check_data's tolerance window.

--- a/lumibot/brokers/__init__.py
+++ b/lumibot/brokers/__init__.py
@@ -1,11 +1,35 @@
-from .alpaca import Alpaca
-from .bitunix import Bitunix
-from .broker import Broker, LumibotBrokerAPIError
-from .ccxt import Ccxt
-from .example_broker import ExampleBroker
-from .interactive_brokers import InteractiveBrokers
-from .interactive_brokers_rest import InteractiveBrokersREST
-from .projectx import ProjectX
-from .schwab import Schwab
-from .tradier import Tradier
-from .tradovate import Tradovate
+"""Broker package exports without importing every broker backend."""
+
+from importlib import import_module as _import_module
+
+_NAME_TO_MODULE = {
+    "Alpaca": "alpaca",
+    "Bitunix": "bitunix",
+    "Broker": "broker",
+    "LumibotBrokerAPIError": "broker",
+    "Ccxt": "ccxt",
+    "ExampleBroker": "example_broker",
+    "InteractiveBrokers": "interactive_brokers",
+    "InteractiveBrokersREST": "interactive_brokers_rest",
+    "ProjectX": "projectx",
+    "Schwab": "schwab",
+    "Tradier": "tradier",
+    "Tradovate": "tradovate",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -1,29 +1,73 @@
-import asyncio
+from __future__ import annotations
+
 import datetime
 import time
 import traceback
-from asyncio import CancelledError
 from collections import Counter
 from datetime import timezone
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
-import pandas_market_calendars as mcal
-from alpaca.trading.client import TradingClient
-from alpaca.trading.enums import ActivityType, QueryOrderStatus, PositionSide
-from alpaca.trading.requests import GetOrdersRequest, ReplaceOrderRequest
-from alpaca.trading.stream import TradingStream
-from dateutil import tz
-from termcolor import colored
-
-from lumibot.data_sources import AlpacaData
-from lumibot.entities import Asset, CashEvent, Order, Position, Quote
-from lumibot.tools.helpers import has_more_than_n_decimal_places
+from lumibot.entities import Asset, Order
 from lumibot.tools.lumibot_logger import get_logger
-from lumibot.trading_builtins import PollingStream
 
 from .broker import Broker
 
+if TYPE_CHECKING:
+    from lumibot.entities import CashEvent, Quote
+
 logger = get_logger(__name__)
+
+TradingClient = None
+TradingStream = None
+_HAS_MORE_THAN_N_DECIMAL_PLACES = None
+_CASH_EVENT_CLASS = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _cash_event_class():
+    global _CASH_EVENT_CLASS
+    if _CASH_EVENT_CLASS is None:
+        from lumibot.entities import CashEvent
+
+        _CASH_EVENT_CLASS = CashEvent
+    return _CASH_EVENT_CLASS
+
+
+def _has_more_than_n_decimal_places(*args, **kwargs):
+    global _HAS_MORE_THAN_N_DECIMAL_PLACES
+    if _HAS_MORE_THAN_N_DECIMAL_PLACES is None:
+        from lumibot.tools.helpers import has_more_than_n_decimal_places
+
+        _HAS_MORE_THAN_N_DECIMAL_PLACES = has_more_than_n_decimal_places
+    return _HAS_MORE_THAN_N_DECIMAL_PLACES(*args, **kwargs)
+
+
+def _get_trading_client_class():
+    global TradingClient
+    if TradingClient is None:
+        from alpaca.trading.client import TradingClient as _TradingClient
+
+        TradingClient = _TradingClient
+    return TradingClient
+
+
+def _get_trading_stream_class():
+    global TradingStream
+    if TradingStream is None:
+        from alpaca.trading.stream import TradingStream as _TradingStream
+
+        TradingStream = _TradingStream
+    return TradingStream
 
 
 # Create our own OrderData class to pass to the API because this is easier to work with
@@ -114,7 +158,12 @@ class Alpaca(Broker):
         forex=[],
         crypto=["crypto", "CRYPTO"],  # Added support for crypto asset class names
     )
-    CASH_ACTIVITY_TYPES = tuple(activity.value for activity in ActivityType if activity != ActivityType.FILL)
+    CASH_ACTIVITY_TYPES = (
+        "ACATC", "ACATS", "CFEE", "CIL", "CSD", "CSW", "DIV", "DIVCGL", "DIVCGS", "DIVNRA",
+        "DIVROC", "DIVTXEX", "DIVWH", "EXTRD", "FEE", "FXTRD", "INT", "INTPNL", "JNLC", "JNLS",
+        "MA", "MEM", "NC", "OCT", "OPASN", "OPCSH", "OPEXC", "OPEXP", "OPTRD", "PTC", "REORG",
+        "SPIN", "SPLIT", "SWP", "VOF", "WH",
+    )
     DIVIDEND_ACTIVITY_TYPES = {
         "DIV",
         "DIVCGL",
@@ -167,6 +216,8 @@ class Alpaca(Broker):
         logger.debug(f"Alpaca Broker Init: is_oauth_only={self.is_oauth_only}")
 
         if not data_source:
+            from lumibot.data_sources import AlpacaData
+
             data_source = AlpacaData(config, max_workers=max_workers, chunk_size=chunk_size)
 
         super().__init__(
@@ -179,10 +230,12 @@ class Alpaca(Broker):
 
         # Initialize TradingClient based on available authentication method (API keys have precedence)
         try:
+            trading_client_class = _get_trading_client_class()
+
             if self.api_key and self.api_secret:
-                self.api = TradingClient(self.api_key, self.api_secret, paper=self.is_paper)
+                self.api = trading_client_class(self.api_key, self.api_secret, paper=self.is_paper)
             elif self.oauth_token:
-                self.api = TradingClient(oauth_token=self.oauth_token, paper=self.is_paper)
+                self.api = trading_client_class(oauth_token=self.oauth_token, paper=self.is_paper)
             else:
                 raise ValueError("Either OAuth token or API key/secret must be provided for Alpaca authentication")
         except Exception as e:
@@ -299,9 +352,11 @@ class Alpaca(Broker):
 
             open_time = self.utc_to_local(self.market_hours(close=False))
             close_time = self.utc_to_local(self.market_hours(close=True))
-            current_time = datetime.datetime.now().astimezone(tz=tz.tzlocal())
+            current_time = datetime.datetime.now().astimezone()
 
             # Check if it is a holiday or weekend using pandas_market_calendars
+            import pandas_market_calendars as mcal
+
             market_cal = mcal.get_calendar(self.market)
             schedule = market_cal.schedule(start_date=open_time, end_date=close_time)
             if schedule.empty:
@@ -437,10 +492,14 @@ class Alpaca(Broker):
         except (ValueError, TypeError):
             avg_fill_price = None
 
+        from lumibot.entities import Position
+
         position = Position(strategy, asset, quantity, orders=orders, avg_fill_price=avg_fill_price)
 
         position.pnl = float(broker_position.unrealized_pl) if broker_position.unrealized_pl else None
         position.current_price = float(broker_position.current_price) if broker_position.current_price else None
+        from alpaca.trading.enums import PositionSide
+
         position.side = Position.PositionSide.LONG if broker_position.side == PositionSide.LONG else Position.PositionSide.SHORT
         position.market_value = float(broker_position.market_value) if broker_position.market_value else None
         
@@ -656,6 +715,9 @@ class Alpaca(Broker):
         """Get the broker orders"""
         # Use GetOrdersRequest with status="all" to get both open and filled orders
         # This is crucial for OAuth polling since orders can be filled quickly
+        from alpaca.trading.enums import QueryOrderStatus
+        from alpaca.trading.requests import GetOrdersRequest
+
         request = GetOrdersRequest(status=QueryOrderStatus.ALL, limit=100)
         return self.api.get_orders(filter=request)
 
@@ -943,7 +1005,7 @@ class Alpaca(Broker):
                 if order.is_stop_order() and order.stop_price is not None:
                     orig_stop = order.stop_price
                     conformed = False
-                    if has_more_than_n_decimal_places(order.stop_price, 2):
+                    if _has_more_than_n_decimal_places(order.stop_price, 2):
                         order.stop_price = round(order.stop_price, 2)
                         conformed = True
                     if conformed:
@@ -958,7 +1020,7 @@ class Alpaca(Broker):
                 if order.order_type == Order.OrderType.STOP_LIMIT and order.stop_limit_price is not None:
                     orig_stop_limit = order.stop_limit_price
                     conformed = False
-                    if has_more_than_n_decimal_places(order.stop_limit_price, 2):
+                    if _has_more_than_n_decimal_places(order.stop_limit_price, 2):
                         order.stop_limit_price = round(order.stop_limit_price, 2)
                         conformed = True
                     if conformed:
@@ -1025,10 +1087,10 @@ class Alpaca(Broker):
             """
             orig_price = order.limit_price
             conformed = False
-            if order.limit_price >= 1.0 and has_more_than_n_decimal_places(order.limit_price, 2):
+            if order.limit_price >= 1.0 and _has_more_than_n_decimal_places(order.limit_price, 2):
                     order.limit_price = round(order.limit_price, 2)
                     conformed = True
-            elif order.limit_price < 1.0 and has_more_than_n_decimal_places(order.limit_price, 4):
+            elif order.limit_price < 1.0 and _has_more_than_n_decimal_places(order.limit_price, 4):
                 order.limit_price = round(order.limit_price, 4)
                 conformed = True
 
@@ -1095,6 +1157,8 @@ class Alpaca(Broker):
                 return
 
             # Build the replace request
+            from alpaca.trading.requests import ReplaceOrderRequest
+
             replace_req = ReplaceOrderRequest(**update_kwargs)
 
             # Try to replace the order on Alpaca, handle APIError for accepted status
@@ -1211,12 +1275,14 @@ class Alpaca(Broker):
 
     @classmethod
     def _normalize_activity_to_cash_event(cls, activity: dict) -> CashEvent | None:
+        CashEvent = _cash_event_class()
+
         activity = cls._coerce_activity_dict(activity)
         if activity is None:
             return None
 
         raw_type = str(activity.get("activity_type") or "").upper().strip()
-        if not raw_type or raw_type == ActivityType.FILL.value or raw_type in cls.TRADE_LIKE_ACTIVITY_TYPES:
+        if not raw_type or raw_type == "FILL" or raw_type in cls.TRADE_LIKE_ACTIVITY_TYPES:
             return None
 
         amount = CashEvent.coerce_amount(activity.get("net_amount"))
@@ -1256,6 +1322,8 @@ class Alpaca(Broker):
         since: datetime.datetime | None = None,
         limit: int | None = 100,
     ) -> list[CashEvent]:
+        CashEvent = _cash_event_class()
+
         normalized_limit = max(int(limit or 100), 1)
         page_size = min(max(normalized_limit * 10, normalized_limit), 100)
         normalized_events = []
@@ -1347,12 +1415,15 @@ class Alpaca(Broker):
         """
         if self.is_oauth_only:
             # OAuth-only configurations use polling since TradingStream doesn't support OAuth tokens
+            from lumibot.trading_builtins import PollingStream
+
             logger.debug("Alpaca Stream: Using PollingStream for OAuth-only configuration")
             return PollingStream(self.polling_interval)
         elif self.api_key and self.api_secret:
             # Traditional API key/secret authentication
             logger.debug("Alpaca Stream: Using TradingStream for API key/secret authentication")
-            return TradingStream(self.api_key, self.api_secret, paper=self.is_paper)
+            trading_stream_class = _get_trading_stream_class()
+            return trading_stream_class(self.api_key, self.api_secret, paper=self.is_paper)
         else:
             raise ValueError("Either OAuth token or API key/secret must be provided for Alpaca authentication")
 
@@ -1364,7 +1435,7 @@ class Alpaca(Broker):
             logger.debug("Alpaca Stream: Registering OAuth polling events")
             broker = self
 
-            @broker.stream.add_action(PollingStream.POLL_EVENT)
+            @broker.stream.add_action("poll")
             def on_trade_event_poll():
                 logger.debug("Alpaca Stream: Polling event triggered, calling do_polling()")
                 self.do_polling()
@@ -1651,6 +1722,9 @@ class Alpaca(Broker):
                     return True
                 except ValueError:
                     logger.error(traceback.format_exc())
+
+            import asyncio
+            from asyncio import CancelledError
 
             self.stream.loop = asyncio.new_event_loop()
             loop = self.stream.loop

--- a/lumibot/brokers/bitunix.py
+++ b/lumibot/brokers/bitunix.py
@@ -1,19 +1,62 @@
+from __future__ import annotations
+
 import os
 import time
 import traceback
 from decimal import Decimal
-from typing import Any, Dict, List, Optional, Tuple
-
-import pandas as pd
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from .broker import Broker, LumibotBrokerAPIError
-from lumibot.data_sources.bitunix_data import BitunixData
-from lumibot.entities import Asset, Order, Position
-from lumibot.tools.bitunix_helpers import BitUnixClient
+from lumibot.entities import Asset, Order
 from lumibot.tools.lumibot_logger import get_logger
-from lumibot.trading_builtins import PollingStream
+
+if TYPE_CHECKING:
+    from lumibot.entities import Position
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+BitUnixClient = None
+BitunixData = None
+
+
+def _bitunix_client_class():
+    global BitUnixClient
+    if BitUnixClient is None:
+        from lumibot.tools.bitunix_helpers import BitUnixClient as _BitUnixClient
+
+        BitUnixClient = _BitUnixClient
+    return BitUnixClient
+
+
+def _bitunix_data_class():
+    global BitunixData
+    if BitunixData is None:
+        from lumibot.data_sources.bitunix_data import BitunixData as _BitunixData
+
+        BitunixData = _BitunixData
+    return BitunixData
+
 
 class Bitunix(Broker):
     """
@@ -75,7 +118,7 @@ class Bitunix(Broker):
             raise ValueError("API_KEY and API_SECRET must be provided in config")
 
         # Initialize API client and WS attributes BEFORE calling super().__init__
-        self.api = BitUnixClient(api_key=api_key, secret_key=api_secret)
+        self.api = _bitunix_client_class()(api_key=api_key, secret_key=api_secret)
         self.api_secret = api_secret  # needed for signing
         # Private-channel URL per BitUnix docs (used for authenticated account streams)
         self.ws_url = "wss://fapi.bitunix.com/private/"
@@ -98,7 +141,7 @@ class Bitunix(Broker):
             logger.debug(traceback.format_exc())
 
         if not data_source:
-            data_source = BitunixData(config, max_workers=max_workers, chunk_size=chunk_size)
+            data_source = _bitunix_data_class()(config, max_workers=max_workers, chunk_size=chunk_size)
             # Share the client instance with the data source if it was just created
             data_source.client = self.api
             # Share the client_symbols set with the broker for WebSocket subscriptions
@@ -194,6 +237,8 @@ class Bitunix(Broker):
                     # entry price is avgOpenPrice (fallback to entryValue)
                     entry = Decimal(str(p.get("avgOpenPrice", p.get("entryValue", "0"))))
                     if qty != 0 and sym:
+                        from lumibot.entities import Position
+
                         asset = Asset(sym, Asset.AssetType.CRYPTO_FUTURE)
                         pos = Position(strategy_name, asset, qty)
                         pos.avg_fill_price = entry
@@ -606,13 +651,15 @@ class Bitunix(Broker):
 
     def _get_stream_object(self):
         """Returns the polling stream object."""
+        from lumibot.trading_builtins import PollingStream
+
         return PollingStream(self.poll_interval)
 
     def _register_stream_events(self):
         """Register polling event for Bitunix."""
         broker = self
 
-        @broker.stream.add_action(PollingStream.POLL_EVENT)
+        @broker.stream.add_action("poll")
         def on_trade_event_poll():
             self.do_polling()
 

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import json
 import os
@@ -5,33 +7,75 @@ import time
 import threading
 from collections import deque
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from queue import Queue
+from importlib import import_module
 from threading import RLock, Thread
-from typing import Union
-
-import pandas as pd
-import pandas_market_calendars as mcal
-from dateutil import tz
-from termcolor import colored
+from typing import TYPE_CHECKING, Union
 
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
 
 from lumibot.tools.lumibot_logger import get_logger, get_strategy_logger
-from lumibot.tools.parquet_utils import (
-    coerce_object_columns_to_json_strings,
-    is_parquet_required,
-    write_parquet_with_logging,
-)
 from lumibot.tools.symbol_normalization import normalize_symbol_for_broker, normalize_symbol_for_internal
-from ..data_sources import DataSource
-from ..entities import Asset, CashEvent, Order, Position, Quote
+from ..entities import Asset, Order
 from ..entities.chains import normalize_option_chains
 from ..trading_builtins import SafeList, SafeOrderDict
+
+if TYPE_CHECKING:
+    from ..data_sources import DataSource
+    from ..entities import CashEvent, Position, Quote
+    from ..strategies.strategy import Strategy
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_PARQUET_UTILS = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _get_parquet_utils():
+    global _PARQUET_UTILS
+    if _PARQUET_UTILS is None:
+        from lumibot.tools.parquet_utils import (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+
+        _PARQUET_UTILS = (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+    return _PARQUET_UTILS
 
 DEFAULT_CLEANUP_CONFIG = {
     "enabled": True,
@@ -99,6 +143,8 @@ TRADE_EVENT_LOG_COLUMNS = (
     "cash_event_broker_name",
     "cash_event_broker_event_id",
 )
+_FAST_TRADE_EVENT_MARKER = "__fast_trade__"
+_FAST_TRADE_PAIR_EVENT_MARKER = "__fast_trade_pair__"
 
 # Consolidate errors from different brokers into a single class that can be easily caught even
 # if the user decides to switch brokers.
@@ -169,6 +215,8 @@ class Broker(ABC):
         the existing trade-event stream so downstream artifacts can render them without requiring a
         separate cash-event file.
         """
+        from ..entities import CashEvent
+
         if not getattr(self, "_trade_event_log_enabled", True):
             return
         if not isinstance(cash_event, CashEvent):
@@ -302,7 +350,7 @@ class Broker(ABC):
         self._trade_event_log_rows = (
             deque(maxlen=self._trade_event_log_max_rows) if self._trade_event_log_max_rows else []
         )
-        self._trade_event_log_df_cache = pd.DataFrame()
+        self._trade_event_log_df_cache = None
         self._trade_event_log_columns = TRADE_EVENT_LOG_COLUMNS
         self._hold_trade_events = False
         self._held_trades = []
@@ -351,6 +399,8 @@ class Broker(ABC):
 
         # setting the orders queue and threads
         if not self.IS_BACKTESTING_BROKER:
+            from queue import Queue
+
             self._orders_queue = Queue()
             self._orders_thread = None
             self._start_orders_thread()
@@ -942,6 +992,7 @@ class Broker(ABC):
             getattr(self._error_orders, "revision", 0),
             getattr(self._canceled_orders, "revision", 0),
             getattr(self._placeholder_orders, "revision", 0),
+            getattr(self, "_simple_new_orders_revision", 0),
         )
         if self._tracked_orders_cache_key == cache_key:
             return self._tracked_orders_cache_value
@@ -949,6 +1000,10 @@ class Broker(ABC):
         orders: list[Order] = []
         orders.extend(self._unprocessed_orders.get_list())
         orders.extend(self._new_orders.get_list())
+        simple_by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+        if simple_by_strategy:
+            for strategy_orders in simple_by_strategy.values():
+                orders.extend(strategy_orders)
         orders.extend(self._partially_filled_orders.get_list())
         orders.extend(self._filled_orders.get_list())
         orders.extend(self._error_orders.get_list())
@@ -1390,6 +1445,41 @@ class Broker(ABC):
     def _process_new_order(self, order):
         # Don't duplicate orders in the new orders tracker. Check if an order with the same identifier already exists
         # in the tracked orders.
+        if self.IS_BACKTESTING_BROKER:
+            order_identifier = order.identifier
+
+            def _find_in_bucket(bucket):
+                if order_identifier not in bucket:
+                    return None
+                getter = getattr(bucket, "get", None)
+                if getter is not None:
+                    existing = getter(order_identifier)
+                    if existing is not None:
+                        return existing
+                for existing in bucket.get_list():
+                    if getattr(existing, "_identifier", getattr(existing, "identifier", None)) == order_identifier:
+                        return existing
+                return None
+
+            existing_order = _find_in_bucket(self._new_orders)
+            if existing_order is not None:
+                return existing_order
+
+            existing_order = _find_in_bucket(self._unprocessed_orders)
+            if existing_order is not None:
+                order = existing_order
+            else:
+                for bucket in (self._partially_filled_orders, self._placeholder_orders):
+                    existing_order = _find_in_bucket(bucket)
+                    if existing_order is not None:
+                        return existing_order
+
+            self._unprocessed_orders.remove(order_identifier, key="identifier")
+            order.status = self.NEW_ORDER
+            order.set_new()
+            self._new_orders.append(order)
+            return order
+
         existing_order = self.get_tracked_order(order.identifier)
         if existing_order:
             # Check if this order already exists in self._new_orders based on the identifier - Do nothing
@@ -1580,6 +1670,8 @@ class Broker(ABC):
             quote_quantity = -quote_quantity
         position = self.get_tracked_position(order.strategy, order.quote)
         if position is None:
+            from ..entities import Position
+
             position = Position(
                 order.strategy,
                 order.quote,
@@ -1592,7 +1684,7 @@ class Broker(ABC):
     # =========Clock functions=====================
 
     def utc_to_local(self, utc_dt):
-        return utc_dt.replace(tzinfo=timezone.utc).astimezone(tz=tz.tzlocal())
+        return utc_dt.replace(tzinfo=timezone.utc).astimezone()
 
     def market_hours(self, market="NASDAQ", close=True, next=False, date=None):
         """[summary]
@@ -1616,6 +1708,8 @@ class Broker(ABC):
         """
 
         market = self.market if self.market is not None else market
+        import pandas_market_calendars as mcal
+
         mkt_cal = mcal.get_calendar(market)
 
         # Get the current datetime in UTC (because the market hours are in UTC)
@@ -1739,7 +1833,7 @@ class Broker(ABC):
             
             return True
             
-        current_time = datetime.now().astimezone(tz=tz.tzlocal())
+        current_time = datetime.now().astimezone()
 
         # For ANY market, check both today's and tomorrow's sessions since trading sessions 
         # can span multiple calendar days (futures: 6pm Thu -> 6pm Fri, forex: Sun 5pm -> Fri 5pm, 
@@ -1773,7 +1867,7 @@ class Broker(ABC):
         open_time_next_day = self.utc_to_local(self.market_hours(close=False, next=True))
         now = self.utc_to_local(datetime.now())
         open_time = open_time_this_day if open_time_this_day > now else open_time_next_day
-        current_time = datetime.now().astimezone(tz=tz.tzlocal())
+        current_time = datetime.now().astimezone()
         if self.is_market_open():
             return 0
         else:
@@ -1784,7 +1878,7 @@ class Broker(ABC):
         """Return the remaining time for the market to close in seconds"""
         market_hours = self.market_hours(close=True)
         close_time = self.utc_to_local(market_hours)
-        current_time = datetime.now().astimezone(tz=tz.tzlocal())
+        current_time = datetime.now().astimezone()
         if self.is_market_open():
             result = close_time.timestamp() - current_time.timestamp()
             return result
@@ -1832,7 +1926,10 @@ class Broker(ABC):
             return cached
 
         for position in self._filled_positions:
-            if position.asset == asset and (strategy_name is None or position.strategy == strategy_name):
+            position_asset = position.asset
+            if (position_asset is asset or position_asset == asset) and (
+                strategy_name is None or position.strategy == strategy_name
+            ):
                 self._cache_result(self._tracked_position_cache, cache_key, position)
                 return position
         self._cache_result(self._tracked_position_cache, cache_key, None)
@@ -1895,6 +1992,7 @@ class Broker(ABC):
             getattr(self._new_orders, "revision", 0),
             getattr(self._partially_filled_orders, "revision", 0),
             getattr(self._placeholder_orders, "revision", 0),
+            getattr(self, "_simple_new_orders_revision", 0),
             strategy_name,
             asset,
         )
@@ -1913,6 +2011,19 @@ class Broker(ABC):
                 if not order.is_active():
                     continue
                 if strategy_name is not None and order.strategy != strategy_name:
+                    continue
+                if asset is not None and order.asset != asset:
+                    continue
+                result.append(order)
+        simple_by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+        if simple_by_strategy:
+            strategy_orders = (
+                simple_by_strategy.get(strategy_name, ())
+                if strategy_name is not None
+                else (order for orders in simple_by_strategy.values() for order in orders)
+            )
+            for order in strategy_orders:
+                if not order.is_active():
                     continue
                 if asset is not None and order.asset != asset:
                     continue
@@ -2050,6 +2161,8 @@ class Broker(ABC):
             if kwargs.get('is_multileg') and kwargs.get('order_type') == Order.OrderType.LIMIT:
                 raise NotImplementedError("Multileg limit orders are not supported by this broker")
 
+            from concurrent.futures import ThreadPoolExecutor, as_completed
+
             with ThreadPoolExecutor(
                 max_workers=self.max_workers,
                 thread_name_prefix=f"{self.name}_submitting_orders",
@@ -2083,6 +2196,8 @@ class Broker(ABC):
 
     def cancel_orders(self, orders):
         """cancel orders"""
+        from concurrent.futures import ThreadPoolExecutor
+
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             tasks = []
             for order in orders:
@@ -2310,6 +2425,24 @@ class Broker(ABC):
         )
         subscriber = self._get_subscriber(order.strategy)
         if subscriber:
+            # Futures/crypto cash and position effects are handled before the strategy executor
+            # event. If the user did not override the callback, avoid enqueueing a no-op.
+            try:
+                asset_type = getattr(getattr(order, "asset", None), "asset_type", None)
+                if asset_type in (Asset.AssetType.CRYPTO, Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE):
+                    strategy_obj = getattr(subscriber, "strategy", None)
+                    handler = getattr(strategy_obj, "on_filled_order", None)
+                    func = getattr(handler, "__func__", handler)
+                    executor_handler = getattr(subscriber, "_on_filled_order", None)
+                    executor_func = getattr(executor_handler, "__func__", executor_handler)
+                    if (
+                        getattr(func, "__qualname__", "") == "Strategy.on_filled_order"
+                        and getattr(executor_func, "__qualname__", "") == "StrategyExecutor._on_filled_order"
+                        and not callable(getattr(strategy_obj, "_filled_order_callback", None))
+                    ):
+                        return
+            except Exception:
+                pass
             subscriber.add_event(subscriber.FILLED_ORDER, payload)
         else:
             self.logger.error(colored(f"Subscriber {order.strategy} not found", color="red"))
@@ -2336,9 +2469,180 @@ class Broker(ABC):
                     cache = pd.DataFrame(list(rows))
                 else:
                     cols = getattr(self, "_trade_event_log_columns", None) or None
-                    cache = pd.DataFrame(list(rows), columns=list(cols) if cols else None)
+                    normalized_rows = self._expand_trade_event_rows(rows)
+                    cache = pd.DataFrame(normalized_rows, columns=list(cols) if cols else None)
             self._trade_event_log_df_cache = cache
         return cache
+
+    def _expand_trade_event_rows(self, rows):
+        expanded = []
+        for row in rows:
+            if (
+                isinstance(row, (tuple, list))
+                and len(row) == 19
+                and row[0] == _FAST_TRADE_PAIR_EVENT_MARKER
+            ):
+                (
+                    _marker,
+                    new_time,
+                    fill_time,
+                    strategy,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    new_status,
+                    fill_status,
+                    price,
+                    filled_quantity,
+                    multiplier,
+                    trade_cost,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                    price_source,
+                ) = row
+
+                expanded.append(
+                    (
+                        new_time,
+                        strategy,
+                        None,
+                        identifier,
+                        symbol,
+                        side,
+                        order_type,
+                        new_status,
+                        None,
+                        None,
+                        1,
+                        None,
+                        trade_slippage,
+                        time_in_force,
+                        None,
+                        None,
+                        asset_multiplier,
+                        None,
+                        asset_type,
+                        None,
+                        "trade",
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
+                )
+                if fill_time is not None:
+                    expanded.append(
+                        (
+                            fill_time,
+                            strategy,
+                            None,
+                            identifier,
+                            symbol,
+                            side,
+                            order_type,
+                            fill_status,
+                            price,
+                            filled_quantity,
+                            multiplier,
+                            trade_cost,
+                            trade_slippage,
+                            time_in_force,
+                            None,
+                            None,
+                            asset_multiplier,
+                            None,
+                            asset_type,
+                            price_source,
+                            "trade",
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
+                    )
+            elif (
+                isinstance(row, tuple)
+                and len(row) == 17
+                and row[0] == _FAST_TRADE_EVENT_MARKER
+            ):
+                (
+                    _marker,
+                    event_time,
+                    strategy,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    status,
+                    price,
+                    filled_quantity,
+                    multiplier,
+                    trade_cost,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                    price_source,
+                ) = row
+                expanded.append(
+                    (
+                        event_time,
+                        strategy,
+                        None,
+                        identifier,
+                        symbol,
+                        side,
+                        order_type,
+                        status,
+                        price,
+                        filled_quantity,
+                        multiplier,
+                        trade_cost,
+                        trade_slippage,
+                        time_in_force,
+                        None,
+                        None,
+                        asset_multiplier,
+                        None,
+                        asset_type,
+                        price_source,
+                        "trade",
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
+                )
+            else:
+                expanded.append(row)
+        return expanded
 
     @_trade_event_log_df.setter
     def _trade_event_log_df(self, value) -> None:
@@ -2539,7 +2843,7 @@ class Broker(ABC):
         # method call overhead in the hot-path trade-event logger, but fall back to `get_datetime()`
         # for stubbed sources used in unit tests.
         if is_backtesting:
-            current_dt = getattr(self.data_source, "_datetime", None) or self.data_source.get_datetime()
+            current_dt = self.datetime
         else:
             current_dt = self.data_source.get_datetime()
         # Cache the audit-enabled flag when available (BacktestingBroker sets this in __init__).
@@ -2723,6 +3027,11 @@ class Broker(ABC):
         parquet_filename = (
             filename[:-4] + ".parquet" if str(filename).lower().endswith(".csv") else str(filename) + ".parquet"
         )
+        (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        ) = _get_parquet_utils()
         required = bool(self.IS_BACKTESTING_BROKER) and is_parquet_required()
         write_parquet_with_logging(
             df=df,

--- a/lumibot/brokers/ccxt.py
+++ b/lumibot/brokers/ccxt.py
@@ -1,17 +1,36 @@
+from __future__ import annotations
+
 import datetime
 import os
 from decimal import ROUND_DOWN, Decimal, getcontext
 from typing import Union
 
-from termcolor import colored
-
-from lumibot.data_sources import CcxtData
-from lumibot.entities import Asset, Order, Position
+from lumibot.entities import Asset, Order
 from lumibot.tools.lumibot_logger import get_logger
 
 from .broker import Broker
 
 logger = get_logger(__name__)
+_CCXT_DATA_CLASS = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _ccxt_data_class():
+    global _CCXT_DATA_CLASS
+    if _CCXT_DATA_CLASS is None:
+        from lumibot.data_sources import CcxtData
+
+        _CCXT_DATA_CLASS = CcxtData
+    return _CCXT_DATA_CLASS
 
 
 class Ccxt(Broker):
@@ -19,7 +38,8 @@ class Ccxt(Broker):
     Crypto broker using CCXT.
     """
 
-    def __init__(self, config, data_source: CcxtData = None, max_workers=20, chunk_size=100, **kwargs):
+    def __init__(self, config, data_source=None, max_workers=20, chunk_size=100, **kwargs):
+        CcxtData = _ccxt_data_class()
         if data_source is None:
             data_source = CcxtData(config, max_workers=max_workers, chunk_size=chunk_size)
         super().__init__(name="ccxt", config=config, data_source=data_source, max_workers=max_workers, **kwargs)
@@ -200,6 +220,8 @@ class Ccxt(Broker):
             asset_type="crypto",
             precision=precision,
         )
+
+        from lumibot.entities import Position
 
         position_return = Position(strategy, asset, quantity, hold=hold, available=available, orders=orders)
         return position_return

--- a/lumibot/brokers/example_broker.py
+++ b/lumibot/brokers/example_broker.py
@@ -1,13 +1,25 @@
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from termcolor import colored
 
 from .broker import Broker
-from lumibot.data_sources import ExampleBrokerData
 from lumibot.entities import Asset, Order, Position
 from lumibot.tools.lumibot_logger import get_logger
 
+if TYPE_CHECKING:
+    from lumibot.strategies.strategy import Strategy
+
 logger = get_logger(__name__)
+_EXAMPLE_BROKER_DATA_CLASS = None
+
+
+def _example_broker_data_class():
+    global _EXAMPLE_BROKER_DATA_CLASS
+    if _EXAMPLE_BROKER_DATA_CLASS is None:
+        from lumibot.data_sources import ExampleBrokerData
+
+        _EXAMPLE_BROKER_DATA_CLASS = ExampleBrokerData
+    return _EXAMPLE_BROKER_DATA_CLASS
 
 class ExampleBroker(Broker):
     """
@@ -20,10 +32,10 @@ class ExampleBroker(Broker):
             self,
             config=None,
             data_source=None,
-    ):
+        ):
         # Check if the user has provided a data source, if not, create one
         if data_source is None:
-            data_source = ExampleBrokerData()
+            data_source = _example_broker_data_class()()
 
         super().__init__(
             name=self.NAME,

--- a/lumibot/brokers/interactive_brokers.py
+++ b/lumibot/brokers/interactive_brokers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import math
 import os
@@ -10,21 +12,38 @@ from sys import exit
 from threading import Thread
 from typing import Union
 
-from dateutil import tz
 from ibapi.client import *
 from ibapi.contract import *
 from ibapi.order import *
 from ibapi.wrapper import *
-from termcolor import colored
 
-from lumibot.data_sources import InteractiveBrokersData
 from lumibot.tools.lumibot_logger import get_logger
 from lumibot.tools.symbol_normalization import normalize_symbol_for_broker
 
 logger = get_logger(__name__)
+_INTERACTIVE_BROKERS_DATA_CLASS = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _interactive_brokers_data_class():
+    global _INTERACTIVE_BROKERS_DATA_CLASS
+    if _INTERACTIVE_BROKERS_DATA_CLASS is None:
+        from lumibot.data_sources import InteractiveBrokersData
+
+        _INTERACTIVE_BROKERS_DATA_CLASS = InteractiveBrokersData
+    return _INTERACTIVE_BROKERS_DATA_CLASS
 
 # Naming conflict on Order between IB and Lumibot.
-from lumibot.entities import Asset, Position
+from lumibot.entities import Asset
 from lumibot.entities import Order as OrderLum
 
 from .broker import Broker
@@ -58,7 +77,7 @@ class InteractiveBrokers(Broker):
 
     def __init__(self, config, max_workers=20, chunk_size=100, data_source=None, **kwargs):
         if data_source is None:
-            data_source = InteractiveBrokersData(config, max_workers=max_workers, chunk_size=chunk_size)
+            data_source = _interactive_brokers_data_class()(config, max_workers=max_workers, chunk_size=chunk_size)
 
         super().__init__(
             name="interactive_brokers",
@@ -115,7 +134,7 @@ class InteractiveBrokers(Broker):
         if not self.ib:
             self.ib = IBApp(ip_address=self.ip, socket_port=self.socket_port, client_id=self.client_id, subaccount=self.subaccount, ib_broker=self)
 
-        if isinstance(self.data_source, InteractiveBrokersData):
+        if isinstance(self.data_source, _interactive_brokers_data_class()):
             if not self.data_source.ib:
                 self.data_source.ib = self.ib
 
@@ -168,6 +187,8 @@ class InteractiveBrokers(Broker):
             )
 
         quantity = broker_position["position"]
+        from lumibot.entities import Position
+
         position = Position(strategy, asset, quantity, orders=orders)
         return position
 
@@ -825,7 +846,7 @@ class IBWrapper(EWrapper):
         if not hasattr(self, "realtimeBar"):
             self.init_realtimeBar()
         rtb = dict(
-            datetime=datetime.datetime.fromtimestamp(time).astimezone(tz=tz.tzlocal()),
+            datetime=datetime.datetime.fromtimestamp(time).astimezone(),
             open=open_,
             high=high,
             low=low,

--- a/lumibot/brokers/interactive_brokers_rest.py
+++ b/lumibot/brokers/interactive_brokers_rest.py
@@ -1,21 +1,42 @@
+from __future__ import annotations
+
 import datetime
 import os
 import re
 import traceback
 from decimal import Decimal
 from math import gcd
-from typing import Union
-
-from termcolor import colored
+from typing import TYPE_CHECKING, Union
 
 from lumibot.tools.lumibot_logger import get_logger
 
 from ..brokers import Broker
-from ..data_sources import InteractiveBrokersRESTData
-from ..entities import Asset, Order, Position
-from ..trading_builtins import PollingStream
+from ..entities import Asset, Order
+
+if TYPE_CHECKING:
+    from ..entities import Position
 
 logger = get_logger(__name__)
+_INTERACTIVE_BROKERS_REST_DATA_CLASS = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _interactive_brokers_rest_data_class():
+    global _INTERACTIVE_BROKERS_REST_DATA_CLASS
+    if _INTERACTIVE_BROKERS_REST_DATA_CLASS is None:
+        from ..data_sources import InteractiveBrokersRESTData
+
+        _INTERACTIVE_BROKERS_REST_DATA_CLASS = InteractiveBrokersRESTData
+    return _INTERACTIVE_BROKERS_REST_DATA_CLASS
 
 TYPE_MAP = dict(
     stock="STK",
@@ -68,7 +89,7 @@ class InteractiveBrokersREST(Broker):
     Broker that connects to the Interactive Brokers REST API.
     """
 
-    POLL_EVENT = PollingStream.POLL_EVENT
+    POLL_EVENT = "poll"
     NAME = "InteractiveBrokersREST"
 
     def __init__(self, config, data_source=None, poll_interval=5.0):
@@ -76,7 +97,7 @@ class InteractiveBrokersREST(Broker):
         self.polling_interval = poll_interval
 
         if data_source is None:
-            data_source = InteractiveBrokersRESTData(config)
+            data_source = _interactive_brokers_rest_data_class()(config)
 
         super().__init__(
             name=self.NAME,
@@ -139,6 +160,8 @@ class InteractiveBrokersREST(Broker):
                 quantity = balances["cashbalance"]
 
                 if quantity != 0:
+                    from ..entities import Position
+
                     position = Position(
                         strategy=strategy_name,
                         asset=asset,
@@ -381,6 +404,8 @@ class InteractiveBrokersREST(Broker):
             )
 
         quantity = broker_position["position"]
+        from ..entities import Position
+
         position = Position(strategy, asset, quantity, orders=orders)
         return position
 
@@ -399,6 +424,8 @@ class InteractiveBrokersREST(Broker):
         for pos in result:
             if pos.asset == asset:
                 return pos
+        from ..entities import Position
+
         return Position(strategy, asset, 0)
 
     def _pull_broker_positions(self, strategy=None):
@@ -562,6 +589,8 @@ class InteractiveBrokersREST(Broker):
                 continue
 
             # Create the Position object
+            from ..entities import Position
+
             position_obj = Position(
                 strategy=strategy,
                 asset=asset,
@@ -1149,6 +1178,8 @@ class InteractiveBrokersREST(Broker):
 
     def _get_stream_object(self):
         """Create polling stream"""
+        from ..trading_builtins import PollingStream
+
         return PollingStream(self.polling_interval)
 
     def _close_connection(self):

--- a/lumibot/brokers/projectx.py
+++ b/lumibot/brokers/projectx.py
@@ -5,38 +5,105 @@ Provides futures trading functionality through ProjectX broker integration.
 Supports multiple underlying brokers (TSX, TOPONE, etc.) via ProjectX gateway.
 """
 
+from __future__ import annotations
+
 import threading
 from datetime import datetime, timedelta
-from typing import Dict, List
-
-import pandas as pd
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict, List
 
 from lumibot.brokers.broker import Broker
-from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
-from lumibot.data_sources import DataSource
-from lumibot.entities import Asset, Order, Position
+from lumibot.entities import Asset, Order
 from lumibot.tools.lumibot_logger import get_logger
-from lumibot.tools.projectx_helpers import (
-    ProjectXClient,
-    create_bracket_meta,
-    normalize_bracket_entry_tag,
-    build_unique_order_tag,
-    select_effective_prices,
-    bracket_child_tag,
-    derive_base_tag,
-    early_store_bracket_meta,
-    restore_bracket_meta_if_needed,
-    should_spawn_bracket_children,
-    build_bracket_child_spec,
-)
-from termcolor import colored
 # PollingStream usage was removed to align with centralized lifecycle in core Broker
-import traceback
+
+if TYPE_CHECKING:
+    from lumibot.entities import Position
 
 # Import moved to avoid circular dependency
 # from lumibot.credentials import PROJECTX_CONFIG
 
 logger = get_logger(__name__)
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_projectx_helpers = _LazyModule("lumibot.tools.projectx_helpers")
+ProjectXClient = None
+
+
+def _projectx_client_class():
+    global ProjectXClient
+    if ProjectXClient is None:
+        ProjectXClient = _projectx_helpers.ProjectXClient
+    return ProjectXClient
+
+
+def create_bracket_meta(*args, **kwargs):
+    return _projectx_helpers.create_bracket_meta(*args, **kwargs)
+
+
+def normalize_bracket_entry_tag(*args, **kwargs):
+    return _projectx_helpers.normalize_bracket_entry_tag(*args, **kwargs)
+
+
+def build_unique_order_tag(*args, **kwargs):
+    return _projectx_helpers.build_unique_order_tag(*args, **kwargs)
+
+
+def select_effective_prices(*args, **kwargs):
+    return _projectx_helpers.select_effective_prices(*args, **kwargs)
+
+
+def bracket_child_tag(*args, **kwargs):
+    return _projectx_helpers.bracket_child_tag(*args, **kwargs)
+
+
+def derive_base_tag(*args, **kwargs):
+    return _projectx_helpers.derive_base_tag(*args, **kwargs)
+
+
+def early_store_bracket_meta(*args, **kwargs):
+    return _projectx_helpers.early_store_bracket_meta(*args, **kwargs)
+
+
+def restore_bracket_meta_if_needed(*args, **kwargs):
+    return _projectx_helpers.restore_bracket_meta_if_needed(*args, **kwargs)
+
+
+def should_spawn_bracket_children(*args, **kwargs):
+    return _projectx_helpers.should_spawn_bracket_children(*args, **kwargs)
+
+
+def build_bracket_child_spec(*args, **kwargs):
+    return _projectx_helpers.build_bracket_child_spec(*args, **kwargs)
 
 
 class ProjectX(Broker):
@@ -101,7 +168,7 @@ class ProjectX(Broker):
         2: "short",
     }
 
-    def __init__(self, config: dict = None, data_source: DataSource = None,
+    def __init__(self, config: dict = None, data_source = None,
                  connect_stream: bool = True, max_workers: int = 20, firm: str = None):
         """
         Initialize ProjectX broker.
@@ -142,7 +209,7 @@ class ProjectX(Broker):
         self.firm = config.get("firm")
 
         # Initialize ProjectX client
-        self.client = ProjectXClient(config)
+        self.client = _projectx_client_class()(config)
 
         # Account management
         self.account_id = None
@@ -600,6 +667,8 @@ class ProjectX(Broker):
 
             # Get orders from last 30 days to catch filled/cancelled orders
             # Note: Orders may disappear quickly after being filled
+            from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
+
             end_date = datetime.now(LUMIBOT_DEFAULT_PYTZ).replace(hour=23, minute=59, second=59)
             start_date = end_date.replace(hour=0, minute=0, second=0) - timedelta(days=self.order_lookback_days)
 
@@ -762,6 +831,8 @@ class ProjectX(Broker):
         """Get all orders from broker, including recently filled ones via trades."""
         try:
             # Get all orders from today to catch any recent activity
+            from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
+
             end_date = datetime.now(LUMIBOT_DEFAULT_PYTZ).replace(hour=23, minute=59, second=59)
             start_date = end_date.replace(hour=0, minute=0, second=0)
 
@@ -1071,6 +1142,8 @@ class ProjectX(Broker):
 
             # Try both field names: avgPrice and averagePrice
             avg_price = broker_position.get("avgPrice") or broker_position.get("averagePrice", 0.0)
+
+            from lumibot.entities import Position
 
             position = Position(
                 strategy="",  # Will be set by strategy

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import json
 import os
@@ -5,33 +7,55 @@ import re
 import traceback
 from datetime import datetime, timedelta
 from threading import Thread
-from typing import List, Optional, Union
-
-import dotenv
-from pytz import timezone
-
-# Import Schwab specific libraries
-from schwab.client import Client
-from schwab.streaming import StreamClient
-from termcolor import colored
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from .broker import Broker
-from lumibot.data_sources import SchwabData  # Import YahooData
-from lumibot.entities import Asset, Order, Position
+from lumibot.entities import Asset, Order
 from lumibot.tools.lumibot_logger import get_logger
+
+if TYPE_CHECKING:
+    from lumibot.entities import Position
+    from lumibot.strategies.strategy import Strategy
 
 logger = get_logger(__name__)
 
-# Import PollingStream class
 import time
 from pathlib import Path
-
-from lumibot.tools import SchwabHelper
-from lumibot.trading_builtins import PollingStream
 
 # ---- Lumiwealth default Schwab app configuration ----
 LUMI_DEFAULT_APP_KEY = "RfUVxotUc8p6CbeCwFmophgNZSat0TLv"
 LUMI_DEFAULT_CALLBACK = "https://api.botspot.trade/broker_oauth/schwab"
+_SCHWAB_DATA_CLASS = None
+SchwabHelper = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _schwab_data_class():
+    global _SCHWAB_DATA_CLASS
+    if _SCHWAB_DATA_CLASS is None:
+        from lumibot.data_sources import SchwabData
+
+        _SCHWAB_DATA_CLASS = SchwabData
+    return _SCHWAB_DATA_CLASS
+
+
+def _schwab_helper():
+    global SchwabHelper
+    if SchwabHelper is None:
+        from lumibot.tools import SchwabHelper as _helper
+
+        SchwabHelper = _helper
+    return SchwabHelper
+
 
 class Schwab(Broker):
     """
@@ -46,7 +70,7 @@ class Schwab(Broker):
     """
 
     NAME = "Schwab"
-    POLL_EVENT = PollingStream.POLL_EVENT
+    POLL_EVENT = "poll"
 
     def __init__(
             self,
@@ -60,6 +84,7 @@ class Schwab(Broker):
 
         # === Prepare Data Source ===
         # Determine if SchwabData is intended or if a specific one was passed
+        SchwabData = _schwab_data_class()
         is_schwab_data_intended = data_source is None or isinstance(data_source, SchwabData)
         final_data_source = data_source
 
@@ -106,6 +131,8 @@ class Schwab(Broker):
         self.market = (config.get("MARKET") if config else None) or os.environ.get("MARKET") or "NASDAQ"
 
         # Load environment variables (still useful for fallback if config is missing keys)
+        import dotenv
+
         dotenv.load_dotenv()
         logger.warning("==== [DEBUG] Schwab Broker Initialization (New OAuth Flow) ====")
         config = config or {}
@@ -173,10 +200,10 @@ class Schwab(Broker):
         if token_payload_env:
             logger.info("[Schwab] SCHWAB_TOKEN environment variable found. Processing it.")
             try:
-                SchwabHelper._save_payload_str_to_token_file(token_payload_env, token_path)
-                if SchwabHelper._is_token_valid_for_schwab_py(token_path):
-                    SchwabHelper._ensure_token_metadata(token_path)
-                    if SchwabHelper._is_token_valid_for_schwab_py(token_path):
+                _schwab_helper()._save_payload_str_to_token_file(token_payload_env, token_path)
+                if _schwab_helper()._is_token_valid_for_schwab_py(token_path):
+                    _schwab_helper()._ensure_token_metadata(token_path)
+                    if _schwab_helper()._is_token_valid_for_schwab_py(token_path):
                         token_available_and_valid = True
                         logger.info(f"[Schwab] Token from SCHWAB_TOKEN env var processed, validated, and saved to {token_path}")
                     else:
@@ -192,8 +219,8 @@ class Schwab(Broker):
         if not token_available_and_valid and token_path.exists() and token_path.stat().st_size > 0:
             logger.info(f"[Schwab] Existing token file found at {token_path}. Validating...")
             try:
-                SchwabHelper._ensure_token_metadata(token_path)
-                if SchwabHelper._is_token_valid_for_schwab_py(token_path):
+                _schwab_helper()._ensure_token_metadata(token_path)
+                if _schwab_helper()._is_token_valid_for_schwab_py(token_path):
                     token_available_and_valid = True
                     logger.info(f"[Schwab] Existing token file {token_path} is valid after metadata check.")
                 else:
@@ -205,7 +232,7 @@ class Schwab(Broker):
 
         if not token_available_and_valid:
             logger.info("[Schwab] No valid token found. Initiating user authorization flow to obtain token payload.")
-            auth_success = SchwabHelper._initiate_schwab_auth_and_get_token_payload(api_key, schwab_backend_redirect_uri, token_path)
+            auth_success = _schwab_helper()._initiate_schwab_auth_and_get_token_payload(api_key, schwab_backend_redirect_uri, token_path)
             if not auth_success:
                 self.schwab_authorization_error = True
                 raise ConnectionError(
@@ -213,9 +240,9 @@ class Schwab(Broker):
                     "Please check logs, ensure SCHWAB_APP_KEY and SCHWAB_BACKEND_CALLBACK_URL are correct, "
                     "and that the backend OAuth flow is functioning. Restart to try again."
                 )
-            if SchwabHelper._is_token_valid_for_schwab_py(token_path):
-                SchwabHelper._ensure_token_metadata(token_path)
-                if SchwabHelper._is_token_valid_for_schwab_py(token_path):
+            if _schwab_helper()._is_token_valid_for_schwab_py(token_path):
+                _schwab_helper()._ensure_token_metadata(token_path)
+                if _schwab_helper()._is_token_valid_for_schwab_py(token_path):
                     token_available_and_valid = True
                 else:
                     logger.error(f"[Schwab] Token became invalid after SchwabHelper._ensure_token_metadata post-auth. Deleting {token_path}.")
@@ -285,6 +312,8 @@ class Schwab(Broker):
             # Passing it raises: TypeError: BaseClient.__init__() got an unexpected keyword argument 'app_secret'.
             # The secret is only needed when REFRESHING a token via the auth helpers, not when we already
             # have a full token dict and build the OAuth2Session ourselves, so we can safely omit it here.
+            from schwab.client import Client
+
             self.client = Client(api_key=api_key, session=oauth_session)
             logger.info(f"[Schwab] Successfully initialized Schwab client from {token_path} (app_secret not used).")
             # Check if SCHWAB_APP_SECRET is available for auto-refresh warning
@@ -478,7 +507,7 @@ class Schwab(Broker):
                 elif asset_type == 'OPTION':
                     # Parse option details
                     option_symbol = instrument.get('symbol')
-                    option_parts = SchwabHelper._parse_option_symbol(option_symbol)
+                    option_parts = _schwab_helper()._parse_option_symbol(option_symbol)
 
                     if option_parts is None:
                         logger.error(colored(f"Failed to parse option symbol: {option_symbol}", "red"))
@@ -561,6 +590,8 @@ class Schwab(Broker):
                             existing_position.market_value += market_value
                     else:
                         # Create a new Position object
+                        from lumibot.entities import Position
+
                         pos_dict[key] = Position(
                             strategy_name,
                             asset=asset,
@@ -658,6 +689,8 @@ class Schwab(Broker):
 
         try:
             # Get orders from last 7 days
+            from pytz import timezone
+
             seek_start = datetime.now(timezone('UTC')) - timedelta(days=7)
 
             response = self.client.get_orders_for_account(
@@ -964,7 +997,7 @@ class Schwab(Broker):
                     )
                 elif asset_type == Asset.AssetType.OPTION:
                     option_symbol = instrument.get("symbol", "")
-                    option_parts = SchwabHelper._parse_option_symbol(option_symbol)
+                    option_parts = _schwab_helper()._parse_option_symbol(option_symbol)
 
                     if not option_parts:
                         logger.error(colored(f"Failed to parse option symbol: {option_symbol} for order ID: {order_id}", "red"))
@@ -1025,6 +1058,8 @@ class Schwab(Broker):
         # Only create stream client if client exists
         if self.client:
             try:
+                from schwab.streaming import StreamClient
+
                 self.stream_client = StreamClient(self.client, account_id=account_number)
             except Exception as e:
                 logger.error(colored(f"Failed to create Schwab StreamClient: {e}", "red"))
@@ -1036,7 +1071,7 @@ class Schwab(Broker):
         # === Configure Data Source Client ===
         # The data_source passed here is the one set in self.data_source by super().__init__
         # self.data_source should already be the correct instance (either passed in or created in __init__)
-        if self._is_schwab_data_intended and isinstance(self.data_source, SchwabData):
+        if self._is_schwab_data_intended and isinstance(self.data_source, _schwab_data_class()):
             if self.client:
                 # Set the client on the existing SchwabData instance
                 if not hasattr(self.data_source, 'client') or self.data_source.client is None:
@@ -1070,6 +1105,8 @@ class Schwab(Broker):
     # Unimplemented methods with stubs
     def _get_stream_object(self):
         """Get the broker stream connection"""
+        from lumibot.trading_builtins import PollingStream
+
         stream = PollingStream(5.0)  # 5 seconds polling interval
         return stream
 
@@ -1198,7 +1235,7 @@ class Schwab(Broker):
 
             # Import Schwab order templates
             try:
-                from schwab.orders.common import Duration, OrderType, Session
+                from schwab.orders.common import Duration, Session
                 from schwab.orders.equities import (
                     equity_buy_limit,
                     equity_buy_market,

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import traceback
@@ -8,23 +10,121 @@ import threading
 import datetime
 import inspect
 from collections import Counter
-from typing import Union
-
-import pandas as pd
-import requests
-from lumiwealth_tradier import Tradier as _Tradier
-from lumiwealth_tradier.base import TradierApiError
-from lumiwealth_tradier.orders import OrderLeg
-from termcolor import colored
+from importlib import import_module
+from typing import TYPE_CHECKING, Union
 
 from .broker import Broker, LumibotBrokerAPIError
-from lumibot.data_sources.tradier_data import TradierData
-from lumibot.entities import Asset, CashEvent, Order, Position
-from lumibot.tools.helpers import create_options_symbol
+from lumibot.entities import Asset, Order
 from lumibot.tools.lumibot_logger import get_logger
-from lumibot.trading_builtins import PollingStream
+
+if TYPE_CHECKING:
+    from lumibot.entities import CashEvent
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        if name in {"_module_name", "_module"}:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+requests = _LazyModule("requests")
+_TRADIER_CLASS = None
+_TRADIER_API_ERROR_CLASS = None
+_ORDER_LEG_CLASS = None
+_TRADIER_DATA_CLASS = None
+_CREATE_OPTIONS_SYMBOL = None
+_CASH_EVENT_CLASS = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _cash_event_class():
+    global _CASH_EVENT_CLASS
+    if _CASH_EVENT_CLASS is None:
+        from lumibot.entities import CashEvent
+
+        _CASH_EVENT_CLASS = CashEvent
+    return _CASH_EVENT_CLASS
+
+
+def _tradier_class():
+    global _TRADIER_CLASS
+    if _TRADIER_CLASS is None:
+        from lumiwealth_tradier import Tradier
+
+        _TRADIER_CLASS = Tradier
+    return _TRADIER_CLASS
+
+
+def _tradier_api_error_class():
+    global _TRADIER_API_ERROR_CLASS
+    if _TRADIER_API_ERROR_CLASS is None:
+        from lumiwealth_tradier.base import TradierApiError
+
+        _TRADIER_API_ERROR_CLASS = TradierApiError
+    return _TRADIER_API_ERROR_CLASS
+
+
+def _order_leg_class():
+    global _ORDER_LEG_CLASS
+    if _ORDER_LEG_CLASS is None:
+        from lumiwealth_tradier.orders import OrderLeg
+
+        _ORDER_LEG_CLASS = OrderLeg
+    return _ORDER_LEG_CLASS
+
+
+def _tradier_data_class():
+    global _TRADIER_DATA_CLASS
+    if _TRADIER_DATA_CLASS is None:
+        from lumibot.data_sources.tradier_data import TradierData
+
+        _TRADIER_DATA_CLASS = TradierData
+    return _TRADIER_DATA_CLASS
+
+
+def _create_options_symbol(*args, **kwargs):
+    global _CREATE_OPTIONS_SYMBOL
+    if _CREATE_OPTIONS_SYMBOL is None:
+        from lumibot.tools.helpers import create_options_symbol
+
+        _CREATE_OPTIONS_SYMBOL = create_options_symbol
+    return _CREATE_OPTIONS_SYMBOL(*args, **kwargs)
 
 
 class Tradier(Broker):
@@ -39,7 +139,7 @@ class Tradier(Broker):
     ***Note: Tradier does not support Trailing StopLoss orders.
     """
 
-    POLL_EVENT = PollingStream.POLL_EVENT
+    POLL_EVENT = "poll"
     CASH_ACTIVITY_TYPES = (
         "ach",
         "wire",
@@ -216,7 +316,7 @@ class Tradier(Broker):
                 self._refresh_oauth_token(force=False)
                 try:
                     return orig_request(*args, **kwargs)
-                except TradierApiError as e:
+                except _tradier_api_error_class() as e:
                     # Retry once on auth errors after forcing a refresh.
                     if self._is_auth_error(e) and self._refresh_oauth_token(force=True):
                         return orig_request(*args, **kwargs)
@@ -336,11 +436,11 @@ class Tradier(Broker):
         self._refresh_oauth_token(force=False)
 
         # Create the Tradier object
-        self.tradier = _Tradier(account_number, self._tradier_access_token, paper)
+        self.tradier = _tradier_class()(account_number, self._tradier_access_token, paper)
 
         # Check if the user has provided a data source, if not, create one
         if data_source is None:
-            data_source = TradierData(
+            data_source = _tradier_data_class()(
                 account_number=account_number,
                 access_token=self._tradier_access_token,
                 paper=paper,
@@ -422,7 +522,7 @@ class Tradier(Broker):
                 limit_price=limit_price,
                 stop_price=stop_price,
             )
-        except TradierApiError as e:
+        except _tradier_api_error_class() as e:
             raise LumibotBrokerAPIError(f"Unable to modify order at broker. {e}") from e
 
     def _submit_orders(self, orders, is_multileg=False, order_type=None, duration="day", price=None):
@@ -525,12 +625,12 @@ class Tradier(Broker):
         legs = []
         for order in orders:
             # Create the options symbol
-            option_symbol = create_options_symbol(
+            option_symbol = _create_options_symbol(
                 order.asset.symbol, order.asset.expiration, order.asset.right, order.asset.strike
             )
 
             # Example leg: leg1 = OrderLeg(option_symbol=option_symbol_1, quantity=1, side='buy_to_open')
-            leg = OrderLeg(
+            leg = _order_leg_class()(
                 option_symbol=option_symbol,
                 quantity=int(order.quantity), # Quantity for Tradier must be a positive integer
                 side=self._lumi_side2tradier(order),
@@ -602,14 +702,14 @@ class Tradier(Broker):
                 legs = []
                 if order.order_class != Order.OrderClass.OCO:
                     # Create the stock/options symbol
-                    parent_option_symbol = create_options_symbol(
+                    parent_option_symbol = _create_options_symbol(
                         order.asset.symbol, order.asset.expiration, order.asset.right, order.asset.strike
                     ) if order.asset.asset_type == Asset.AssetType.OPTION else None
                     parent_stock_symbol = self._normalize_symbol_for_broker(order.asset.symbol, asset_type=order.asset.asset_type) \
                         if order.asset.asset_type != Asset.AssetType.OPTION else None
 
                     # Add the parent order to the legs list
-                    legs.append(OrderLeg(
+                    legs.append(_order_leg_class()(
                         stock_symbol=parent_stock_symbol,  # None if option order
                         option_symbol=parent_option_symbol,  # None if stock order
                         quantity=int(order.quantity),
@@ -630,14 +730,14 @@ class Tradier(Broker):
                         if child_order.order_type != Order.OrderType.STOP_LIMIT else child_order.stop_limit_price
 
                     # Create the stock/options symbol
-                    child_option_symbol = create_options_symbol(
+                    child_option_symbol = _create_options_symbol(
                         order.asset.symbol, order.asset.expiration, order.asset.right, order.asset.strike
                     ) if child_order.asset.asset_type == Asset.AssetType.OPTION else None
                     child_stock_symbol = self._normalize_symbol_for_broker(order.asset.symbol, asset_type=order.asset.asset_type) \
                         if child_order.asset.asset_type != Asset.AssetType.OPTION else None
 
                     # Create the leg
-                    leg = OrderLeg(
+                    leg = _order_leg_class()(
                         stock_symbol=child_stock_symbol,  # None if option order
                         option_symbol=child_option_symbol,  # None if stock order
                         quantity=int(child_order.quantity),
@@ -658,7 +758,7 @@ class Tradier(Broker):
                         legs=legs,
                         tag=tag,
                     )
-                except TradierApiError as e:
+                except _tradier_api_error_class() as e:
                     msg = colored(f"Error submitting order {order}: {e}", color="red")
                     self._safe_stream_dispatch(self.ERROR_ORDER, order=order, error_msg=msg)
                     return None
@@ -681,7 +781,7 @@ class Tradier(Broker):
             elif order.asset is not None and order.asset.asset_type == Asset.AssetType.OPTION:
                 tradier_side = self._lumi_side2tradier(order)
                 stock_symbol = self._normalize_symbol_for_broker(order.asset.symbol, asset_type=order.asset.asset_type)
-                option_symbol = create_options_symbol(
+                option_symbol = _create_options_symbol(
                     order.asset.symbol, order.asset.expiration, order.asset.right, order.asset.strike
                 )
 
@@ -711,7 +811,7 @@ class Tradier(Broker):
             self._unprocessed_orders.append(order)
             self._safe_stream_dispatch(self.NEW_ORDER, order=order)
 
-        except TradierApiError as e:
+        except _tradier_api_error_class() as e:
             msg = colored(f"Error submitting order {order}: {e}", color="red")
             self._safe_stream_dispatch(self.ERROR_ORDER, order=order, error_msg=msg)
 
@@ -720,7 +820,7 @@ class Tradier(Broker):
     def _get_balances_at_broker(self, quote_asset: Asset, strategy):
         try:
             df = self.tradier.account.get_account_balance()
-        except TradierApiError as e:
+        except _tradier_api_error_class() as e:
             # Check if the error is a 401 or 403, if so, the access token is invalid
             error = str(e)
             if "401" in error or "403" in error:
@@ -761,6 +861,8 @@ class Tradier(Broker):
 
     @staticmethod
     def _extract_history_amount(row: dict) -> float:
+        CashEvent = _cash_event_class()
+
         for key in ("amount", "net_amount", "total", "cash", "value"):
             if key in row and row.get(key) not in (None, ""):
                 return CashEvent.coerce_amount(row.get(key))
@@ -833,6 +935,8 @@ class Tradier(Broker):
 
     @classmethod
     def _normalize_history_row_to_cash_event(cls, row: dict) -> CashEvent | None:
+        CashEvent = _cash_event_class()
+
         if not isinstance(row, dict):
             return None
 
@@ -977,6 +1081,8 @@ class Tradier(Broker):
         since: datetime.datetime | None = None,
         limit: int | None = 100,
     ) -> list[CashEvent]:
+        CashEvent = _cash_event_class()
+
         start_date = CashEvent.coerce_datetime(since).date() if since is not None else None
         end_date = datetime.datetime.now(datetime.timezone.utc).date()
         per_type_limit = max(int(limit or 100), 1)
@@ -1044,7 +1150,7 @@ class Tradier(Broker):
     def _pull_positions(self, strategy):
         try:
             positions_df = self.tradier.account.get_positions()
-        except TradierApiError as e:
+        except _tradier_api_error_class() as e:
             # Check if the error is a 401 or 403, if so, the access token is invalid
             error = str(e)
             if "401" in error or "403" in error:
@@ -1079,6 +1185,8 @@ class Tradier(Broker):
             asset = Asset.symbol2asset(symbol)  # Parse the symbol. Handles 'stock' and 'option' types
 
             # Create the position
+            from lumibot.entities import Position
+
             position = Position(
                 strategy=strategy_name,
                 asset=asset,
@@ -1562,6 +1670,8 @@ class Tradier(Broker):
 
     def _get_stream_object(self):
         """get the broker stream connection"""
+        from lumibot.trading_builtins import PollingStream
+
         stream = PollingStream(self.polling_interval)
         return stream
 
@@ -1664,7 +1774,7 @@ class Tradier(Broker):
         # Try to run the stream
         try:
             self.stream._run()
-        except TradierApiError as e:
+        except _tradier_api_error_class() as e:
             # Check if the error is a 401 or 403, if so, the access token is invalid
             error = str(e)
             if "401" in error or "403" in error:

--- a/lumibot/brokers/tradovate.py
+++ b/lumibot/brokers/tradovate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import re
 import threading
@@ -5,20 +7,56 @@ import time
 import traceback
 from collections import deque
 from datetime import datetime, timezone
-from typing import Optional, Union
-
-import requests
-from termcolor import colored
+from importlib import import_module
+from typing import TYPE_CHECKING, Optional, Union
 
 from .broker import Broker
-from lumibot.data_sources import TradovateData
-from lumibot.entities import Asset, Order, Position
-from lumibot.trading_builtins import PollingStream
+from lumibot.entities import Asset, Order
+
+if TYPE_CHECKING:
+    from lumibot.entities import Position
 
 # Set up module-specific logger for enhanced logging
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+requests = _LazyModule("requests")
+
+
+def _tradovate_data_class():
+    from lumibot.data_sources import TradovateData
+
+    return TradovateData
 
 class TradovateAPIError(Exception):
     """Exception raised for errors in the Tradovate API."""
@@ -33,7 +71,7 @@ class Tradovate(Broker):
     Tradovate broker that implements connection to the Tradovate API.
     """
     NAME = "Tradovate"
-    POLL_EVENT = PollingStream.POLL_EVENT
+    POLL_EVENT = "poll"
 
     def __init__(self, config=None, data_source=None):
         if config is None:
@@ -84,7 +122,7 @@ class Tradovate(Broker):
                 # Update config with API URLs for consistency
                 config["TRADING_API_URL"] = self.trading_api_url
                 config["MD_URL"] = self.market_data_url
-                data_source = TradovateData(
+                data_source = _tradovate_data_class()(
                     config=config,
                     trading_token=self.trading_token,
                     market_token=self.market_token
@@ -530,6 +568,8 @@ class Tradovate(Broker):
 
     def _get_stream_object(self):
         """Return a polling stream to monitor Tradovate orders."""
+        from lumibot.trading_builtins import PollingStream
+
         return PollingStream(self.polling_interval)
 
     def check_token_expiry(self):
@@ -695,6 +735,8 @@ class Tradovate(Broker):
                 net_price = pos.get("netPrice", 0)
                 hold = 0
                 available = 0
+                from lumibot.entities import Position
+
                 position_obj = Position(
                     strategy,
                     asset,

--- a/lumibot/components/__init__.py
+++ b/lumibot/components/__init__.py
@@ -1,9 +1,26 @@
-from .agents import AgentManager, AgentRunResult, BuiltinTools, MCPServer, agent_tool
+"""Lazy exports for optional component packages."""
 
-__all__ = [
+from importlib import import_module as _import_module
+
+_AGENT_EXPORTS = {
     "AgentManager",
     "AgentRunResult",
     "BuiltinTools",
     "MCPServer",
     "agent_tool",
-]
+}
+
+__all__ = sorted(_AGENT_EXPORTS)
+
+
+def __getattr__(name):
+    if name in _AGENT_EXPORTS:
+        agents = _import_module(f"{__name__}.agents")
+        value = getattr(agents, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/components/agents/__init__.py
+++ b/lumibot/components/agents/__init__.py
@@ -1,17 +1,31 @@
-from .builtins import BuiltinTools
-from .manager import AgentHandle, AgentManager
-from .runtime import GoogleADKRuntime, StubAgentRuntime
-from .schemas import AgentRunResult, AgentTraceEvent, MCPServer
-from .tools import agent_tool
+"""Lazy exports for agent runtime components."""
 
-__all__ = [
-    "AgentHandle",
-    "AgentManager",
-    "AgentRunResult",
-    "AgentTraceEvent",
-    "BuiltinTools",
-    "GoogleADKRuntime",
-    "MCPServer",
-    "StubAgentRuntime",
-    "agent_tool",
-]
+from importlib import import_module as _import_module
+
+_NAME_TO_MODULE = {
+    "AgentHandle": "manager",
+    "AgentManager": "manager",
+    "AgentRunResult": "schemas",
+    "AgentTraceEvent": "schemas",
+    "BuiltinTools": "builtins",
+    "GoogleADKRuntime": "runtime",
+    "MCPServer": "schemas",
+    "StubAgentRuntime": "runtime",
+    "agent_tool": "tools",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/components/agents/builtins.py
+++ b/lumibot/components/agents/builtins.py
@@ -1,11 +1,8 @@
 import math
 import os
 from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
 from typing import Any, Literal
-
-import requests
-
-from lumibot.entities import Order
 
 from .docs_tools import search_lumibot_docs
 from .asset_resolution import resolve_asset_and_quote
@@ -17,6 +14,43 @@ OrderSideArg = Literal["buy", "sell", "buy_to_open", "sell_to_close", "sell_shor
 OrderTypeArg = Literal["market", "limit", "stop", "stop_limit", "trailing_stop", "smart_limit"]
 TimeInForceArg = Literal["day", "gtc", "gtd"]
 NewsSortArg = Literal["asc", "desc"]
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        if name in {"_module_name", "_module"}:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+requests = _LazyModule("requests")
+
+
+def _requests():
+    return requests
 
 
 def _parse_datetime_value(value: Any) -> datetime | None:
@@ -395,7 +429,7 @@ def _bind_alpaca_news(strategy: Any, manager: Any) -> BoundTool:
         if page_token:
             params["page_token"] = page_token
 
-        response = requests.get(
+        response = _requests().get(
             "https://data.alpaca.markets/v1beta1/news",
             headers={
                 "APCA-API-KEY-ID": api_key,

--- a/lumibot/components/agents/duckdb_tools.py
+++ b/lumibot/components/agents/duckdb_tools.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 import hashlib
 import re
 import time
 from collections import defaultdict
+from importlib import import_module
 from typing import Any
-
-import duckdb
-import pandas as pd
 
 from lumibot.tools.helpers import parse_timestep_qty_and_unit
 
@@ -13,6 +13,28 @@ from .asset_resolution import resolve_asset_and_quote
 
 
 _READ_ONLY_SQL_RE = re.compile(r"^\s*(select|with|show|describe|pragma|explain)\b", re.IGNORECASE)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+duckdb = _LazyModule("duckdb")
+pd = _LazyModule("pandas")
 
 
 class DuckDBQueryLayer:

--- a/lumibot/components/agents/manager.py
+++ b/lumibot/components/agents/manager.py
@@ -8,19 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-import pandas as pd
+from lumibot import LUMIBOT_CACHE_FOLDER
 
-from lumibot.constants import LUMIBOT_CACHE_FOLDER
-from lumibot.tools.parquet_utils import (
-    coerce_object_columns_to_json_strings,
-    is_parquet_required,
-    write_parquet_with_logging,
-)
-
-from .builtins import _order_to_dict, _position_to_dict
-from .duckdb_tools import DuckDBQueryLayer
-from .replay_cache import AgentReplayCache, _normalize_json
-from .runtime import GoogleADKRuntime, RuntimeRequest, StubAgentRuntime, call_mcp_tool
 from .schemas import AgentRunResult, AgentTraceEvent, BoundTool, MCPServer, ToolDefinition
 from .tools import bind_callable_tool
 
@@ -29,6 +18,78 @@ _TIMESTAMP_HINT_RE = re.compile(
     r"(time|date|datetime|published|updated|created|accepted|released|release|as_of|realtime)",
     re.IGNORECASE,
 )
+_PANDAS_MODULE = None
+_REPLAY_IMPORTS = None
+_DUCKDB_QUERY_LAYER = None
+_RUNTIME_IMPORTS = None
+_PARQUET_UTILS = None
+_BUILTIN_SERIALIZERS = None
+
+
+def _get_pandas():
+    global _PANDAS_MODULE
+    if _PANDAS_MODULE is None:
+        import pandas as pd
+
+        _PANDAS_MODULE = pd
+    return _PANDAS_MODULE
+
+
+def _get_replay_imports():
+    global _REPLAY_IMPORTS
+    if _REPLAY_IMPORTS is None:
+        from .replay_cache import AgentReplayCache, _normalize_json as normalize_json
+
+        _REPLAY_IMPORTS = (AgentReplayCache, normalize_json)
+    return _REPLAY_IMPORTS
+
+
+def _normalize_json(value: Any) -> Any:
+    return _get_replay_imports()[1](value)
+
+
+def _get_duckdb_query_layer_class():
+    global _DUCKDB_QUERY_LAYER
+    if _DUCKDB_QUERY_LAYER is None:
+        from .duckdb_tools import DuckDBQueryLayer
+
+        _DUCKDB_QUERY_LAYER = DuckDBQueryLayer
+    return _DUCKDB_QUERY_LAYER
+
+
+def _get_runtime_imports():
+    global _RUNTIME_IMPORTS
+    if _RUNTIME_IMPORTS is None:
+        from .runtime import GoogleADKRuntime, RuntimeRequest, StubAgentRuntime, call_mcp_tool
+
+        _RUNTIME_IMPORTS = (GoogleADKRuntime, RuntimeRequest, StubAgentRuntime, call_mcp_tool)
+    return _RUNTIME_IMPORTS
+
+
+def _get_parquet_utils():
+    global _PARQUET_UTILS
+    if _PARQUET_UTILS is None:
+        from lumibot.tools.parquet_utils import (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+
+        _PARQUET_UTILS = (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+    return _PARQUET_UTILS
+
+
+def _get_builtin_serializers():
+    global _BUILTIN_SERIALIZERS
+    if _BUILTIN_SERIALIZERS is None:
+        from .builtins import _order_to_dict, _position_to_dict
+
+        _BUILTIN_SERIALIZERS = (_order_to_dict, _position_to_dict)
+    return _BUILTIN_SERIALIZERS
 
 
 def _safe_call(func, default=None):
@@ -76,6 +137,9 @@ def _strategy_timezone_name(strategy: Any, current_dt: Any) -> str | None:
 def _serialize_recent_trade_events(strategy: Any, limit: int = 10) -> list[dict[str, Any]]:
     broker = getattr(strategy, "broker", None)
     rows = list(getattr(broker, "_trade_event_log_rows", []) or [])
+    expand_rows = getattr(broker, "_expand_trade_event_rows", None)
+    if callable(expand_rows):
+        rows = expand_rows(rows)
     columns = list(getattr(broker, "_trade_event_log_columns", []) or [])
     serialized: list[dict[str, Any]] = []
     for row in rows[-limit:]:
@@ -502,7 +566,8 @@ class AgentHandle:
             # Always include built-in tools, plus any custom tools the user added
             self._tool_inputs = builtin_tools + list(tools)
         self._mcp_servers = mcp_servers or []
-        self._runtime = runtime or GoogleADKRuntime(mcp_servers=self._mcp_servers)
+        google_runtime, _RuntimeRequest, _StubAgentRuntime, _call_mcp_tool = _get_runtime_imports()
+        self._runtime = runtime or google_runtime(mcp_servers=self._mcp_servers)
         self._bound_tools: list[BoundTool] | None = None
 
     def _state_bucket(self) -> dict[str, Any]:
@@ -543,6 +608,7 @@ class AgentHandle:
         if not hasattr(self.manager.strategy, "get_positions"):
             return []
         positions = _safe_call(lambda: self.manager.strategy.get_positions(include_cash_positions=True), default=[]) or []
+        _order_to_dict, _position_to_dict = _get_builtin_serializers()
         return [_position_to_dict(position) for position in positions]
 
     def _serialize_account_state(self) -> dict[str, Any]:
@@ -557,6 +623,7 @@ class AgentHandle:
         if not hasattr(self.manager.strategy, "get_orders"):
             return []
         orders = _safe_call(self.manager.strategy.get_orders, default=[]) or []
+        _order_to_dict, _position_to_dict = _get_builtin_serializers()
         return [_order_to_dict(order) for order in orders[-limit:]]
 
     def _runtime_mode(self) -> str:
@@ -718,6 +785,7 @@ class AgentHandle:
                                     color="yellow",
                                 )
                             self.manager._warned_backtest_mcp_tools.add(warning_key)
+                        _GoogleADKRuntime, _RuntimeRequest, _StubAgentRuntime, call_mcp_tool = _get_runtime_imports()
                         return call_mcp_tool(_server, _tool_name, payload)
 
                     return remote_tool
@@ -1131,7 +1199,8 @@ class AgentHandle:
                 self._log_run_summary(result, runtime_context)
                 return result
 
-        request = RuntimeRequest(
+        _GoogleADKRuntime, runtime_request_class, _StubAgentRuntime, _call_mcp_tool = _get_runtime_imports()
+        request = runtime_request_class(
             agent_name=self.name,
             model=model_name,
             system_prompt=effective_system_prompt,
@@ -1336,8 +1405,9 @@ class AgentManager:
         self.strategy = strategy
         self._agents: dict[str, AgentHandle] = {}
         self._warned_backtest_mcp_tools: set[tuple[str, str]] = set()
-        self.replay_cache = AgentReplayCache()
-        self.duckdb = DuckDBQueryLayer(strategy)
+        agent_replay_cache_class, _normalize_json_func = _get_replay_imports()
+        self.replay_cache = agent_replay_cache_class()
+        self.duckdb = _get_duckdb_query_layer_class()(strategy)
         self._observability_totals: dict[str, dict[str, int]] = {}
         self._observability_call_index: dict[str, int] = {}
         self._observability_rows: dict[str, list[dict[str, Any]]] = {}
@@ -1483,7 +1553,12 @@ class AgentManager:
             )
         agent_rows = self._observability_rows.setdefault(handle.name, [])
         agent_rows.extend(rows)
-        detail_df = pd.DataFrame(agent_rows, columns=_AGENT_DETAIL_COLUMNS)
+        detail_df = _get_pandas().DataFrame(agent_rows, columns=_AGENT_DETAIL_COLUMNS)
+        (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        ) = _get_parquet_utils()
         write_parquet_with_logging(
             df=detail_df,
             path=str(detail_path),

--- a/lumibot/components/agents/replay_cache.py
+++ b/lumibot/components/agents/replay_cache.py
@@ -11,7 +11,17 @@ from pathlib import Path
 from typing import Any
 
 from lumibot.constants import LUMIBOT_CACHE_FOLDER
-from lumibot.tools.backtest_cache import get_backtest_cache
+
+_BACKTEST_CACHE_GETTER = None
+
+
+def get_backtest_cache():
+    global _BACKTEST_CACHE_GETTER
+    if _BACKTEST_CACHE_GETTER is None:
+        from lumibot.tools.backtest_cache import get_backtest_cache as _get_backtest_cache
+
+        _BACKTEST_CACHE_GETTER = _get_backtest_cache
+    return _BACKTEST_CACHE_GETTER()
 
 
 def _normalize_json(value: Any) -> Any:

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -1,4 +1,5 @@
-import asyncio
+from __future__ import annotations
+
 import contextlib
 import hashlib
 import importlib
@@ -17,17 +18,31 @@ from datetime import date, datetime, timezone
 from typing import Any
 from uuid import uuid4
 
-import httpx
-from anyio import run as anyio_run
-from anyio.from_thread import start_blocking_portal
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
-
 from .schemas import AgentRunResult, AgentTraceEvent, BoundTool, MCPServer
 
 
 _GOOGLE_SDK_NOISE_FILTERS_CONFIGURED = False
+ClientSession = None
+StdioServerParameters = None
+stdio_client = None
+streamablehttp_client = None
+
+
+def _ensure_mcp_client_imports():
+    global ClientSession, StdioServerParameters, stdio_client, streamablehttp_client
+    if ClientSession is None or StdioServerParameters is None:
+        from mcp import ClientSession as _ClientSession, StdioServerParameters as _StdioServerParameters
+
+        ClientSession = _ClientSession
+        StdioServerParameters = _StdioServerParameters
+    if stdio_client is None:
+        from mcp.client.stdio import stdio_client as _stdio_client
+
+        stdio_client = _stdio_client
+    if streamablehttp_client is None:
+        from mcp.client.streamable_http import streamablehttp_client as _streamablehttp_client
+
+        streamablehttp_client = _streamablehttp_client
 
 
 class _GoogleGenAITypesNoiseFilter(logging.Filter):
@@ -776,6 +791,8 @@ class GoogleADKRuntime:
         last_exc: BaseException | None = None
         for attempt in range(1, self._MAX_RUN_ATTEMPTS + 1):
             try:
+                import asyncio
+
                 return asyncio.run(self._run_async(request))
             except (KeyboardInterrupt, SystemExit):
                 raise
@@ -894,6 +911,7 @@ def _jsonable(value: Any) -> Any:
 
 
 async def _with_mcp_session(server: MCPServer, callback):
+    _ensure_mcp_client_imports()
     transport = (server.transport or "http").lower().replace("-", "_")
     if transport == "stdio":
         parameters = StdioServerParameters(
@@ -924,10 +942,16 @@ async def _with_mcp_session(server: MCPServer, callback):
 
 
 def _run_mcp_sync(async_fn, *args):
+    import asyncio
+
     try:
         asyncio.get_running_loop()
     except RuntimeError:
+        from anyio import run as anyio_run
+
         return anyio_run(async_fn, *args)
+    from anyio.from_thread import start_blocking_portal
+
     with start_blocking_portal() as portal:
         return portal.call(async_fn, *args)
 
@@ -966,6 +990,8 @@ async def _call_mcp_tool_async(server: MCPServer, name: str, arguments: dict[str
 
 
 async def _legacy_http_list_tools(server: MCPServer) -> list[dict[str, Any]]:
+    import httpx
+
     payload = {
         "jsonrpc": "2.0",
         "id": "tools-list",
@@ -982,6 +1008,8 @@ async def _legacy_http_list_tools(server: MCPServer) -> list[dict[str, Any]]:
 
 
 async def _legacy_http_call_tool(server: MCPServer, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    import httpx
+
     payload = {
         "jsonrpc": "2.0",
         "id": f"{name}-call",

--- a/lumibot/components/drift_rebalancer_logic.py
+++ b/lumibot/components/drift_rebalancer_logic.py
@@ -1,13 +1,46 @@
+from __future__ import annotations
+
 import time
 from decimal import ROUND_DOWN, ROUND_UP, Decimal
-from typing import Any, Dict, List
-
-import pandas as pd
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from lumibot.entities import Asset, TradingFee
 from lumibot.entities.order import Order
-from lumibot.strategies.strategy import Strategy
-from lumibot.tools.pandas import prettify_dataframe_with_decimals
+
+if TYPE_CHECKING:
+    from lumibot.strategies.strategy import Strategy
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_PRETTIFY_DATAFRAME_WITH_DECIMALS = None
+
+
+def _prettify_dataframe_with_decimals(*args, **kwargs):
+    global _PRETTIFY_DATAFRAME_WITH_DECIMALS
+    if _PRETTIFY_DATAFRAME_WITH_DECIMALS is None:
+        from lumibot.tools.pandas import prettify_dataframe_with_decimals
+
+        _PRETTIFY_DATAFRAME_WITH_DECIMALS = prettify_dataframe_with_decimals
+    return _PRETTIFY_DATAFRAME_WITH_DECIMALS(*args, **kwargs)
 
 
 class DriftType:
@@ -364,7 +397,7 @@ class DriftOrderLogic:
 
         # Just print the drift_df to the log but sort it by symbol column
         drift_df = drift_df.sort_values(by='symbol')
-        self.strategy.logger.info(f"drift_df:\n{prettify_dataframe_with_decimals(df=drift_df)}")
+        self.strategy.logger.info(f"drift_df:\n{_prettify_dataframe_with_decimals(df=drift_df)}")
 
         rebalance_needed = self._check_if_rebalance_needed(drift_df)
         if rebalance_needed:

--- a/lumibot/components/grok_helper.py
+++ b/lumibot/components/grok_helper.py
@@ -2,11 +2,15 @@ import json
 import re
 import time
 
-from openai import OpenAI
-
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _openai_client_class():
+    from openai import OpenAI
+
+    return OpenAI
 
 class GrokHelper:
     """
@@ -39,7 +43,7 @@ class GrokHelper:
                 raise ValueError("API key is required for GrokHelper. Set it as GROK_API_KEY or XAI_API_KEY in your environment or pass it directly.")
 
         self.api_key = api_key
-        self.client = OpenAI(
+        self.client = _openai_client_class()(
             api_key=self.api_key,
             base_url="https://api.x.ai/v1",
         )

--- a/lumibot/components/perplexity_helper.py
+++ b/lumibot/components/perplexity_helper.py
@@ -2,11 +2,15 @@ import json
 import re
 import time
 
-from openai import OpenAI
-
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _openai_client_class():
+    from openai import OpenAI
+
+    return OpenAI
 
 # --- constants ---------------------------------------------------------------
 _MODEL_LIMITS = {
@@ -126,7 +130,7 @@ class PerplexityHelper:
                 raise ValueError("API key is required for PerplexityHelper. Set it as PERPLEXITY_API_KEY in your environment or your secrets")
 
         self.api_key = api_key
-        self.client = OpenAI(
+        self.client = _openai_client_class()(
             api_key=self.api_key,
             base_url="https://api.perplexity.ai",  # Correct base URL
         )

--- a/lumibot/components/vix_helper.py
+++ b/lumibot/components/vix_helper.py
@@ -1,23 +1,9 @@
+from __future__ import annotations
+
 import datetime
 import traceback
 from datetime import timedelta
-
-import pandas as pd
-import yfinance as yf
-from scipy import stats
-import traceback
-import datetime
-
-# Fix for NumPy 2.0+ compatibility with pandas_ta
-import numpy as np
-
-# pandas_ta 0.3.14b uses numpy.NaN which was removed in NumPy 2.0
-# Create alias for backward compatibility if needed
-if not hasattr(np, 'NaN'):
-    np.NaN = np.nan
-
-# Import pandas-ta-classic
-import pandas_ta_classic as ta
+from importlib import import_module
 
 """ 
     Description
@@ -26,6 +12,49 @@ import pandas_ta_classic as ta
     This is a general component for working with the VIX. It can be used to check the 
     VIX, VIX 1D, VIX RSI, VIX percentile values and more.
 """
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+yf = _LazyModule("yfinance")
+stats = _LazyModule("scipy.stats")
+_TA_MODULE = None
+
+
+def _get_ta_module():
+    global _TA_MODULE
+    if _TA_MODULE is None:
+        np = import_module("numpy")
+        if not hasattr(np, "NaN"):
+            np.NaN = np.nan
+        _TA_MODULE = import_module("pandas_ta_classic")
+    return _TA_MODULE
 
 class VixHelper:
     def __init__(self, strategy) -> None:
@@ -420,7 +449,7 @@ class VixHelper:
         vix_df = pd.DataFrame(vix_values, columns=['VIX'])
 
         # Calculate the RSI
-        vix_df['RSI'] = ta.rsi(vix_df['VIX'], length=window)
+        vix_df['RSI'] = _get_ta_module().rsi(vix_df['VIX'], length=window)
 
         # Get the last VIX RSI value
         vix_rsi = vix_df['RSI'].iloc[-1]
@@ -1103,7 +1132,7 @@ class VixHelper:
         gvz_df = pd.DataFrame(gvz_values, columns=['GVZ'])
 
         # Calculate the RSI
-        gvz_df['RSI'] = ta.rsi(gvz_df['GVZ'], length=window)
+        gvz_df['RSI'] = _get_ta_module().rsi(gvz_df['GVZ'], length=window)
 
         # Get the last GVZ RSI value
         gvz_rsi = gvz_df['RSI'].iloc[-1]
@@ -1482,7 +1511,7 @@ class VixHelper:
         vix_df = pd.DataFrame(vix_values, columns=['VIX'])
 
         # Calculate the RSI
-        vix_df['RSI'] = ta.rsi(vix_df['VIX'], length=window)
+        vix_df['RSI'] = _get_ta_module().rsi(vix_df['VIX'], length=window)
 
         # Get the last VIX RSI value
         vix_rsi = vix_df['RSI'].iloc[-1]

--- a/lumibot/credentials.py
+++ b/lumibot/credentials.py
@@ -9,14 +9,58 @@
 import os
 import sys
 
-from .brokers import Alpaca, Ccxt, InteractiveBrokers, InteractiveBrokersREST, Tradier, Tradovate, Schwab, Bitunix, ProjectX
-from dotenv import load_dotenv
 import termcolor
-from dateutil import parser
 
 # Configure logging
 from lumibot.tools.lumibot_logger import get_logger
 logger = get_logger(__name__)
+_LOAD_DOTENV = None
+_DATEUTIL_PARSER = None
+
+
+def _load_dotenv(dotenv_path, *, override=False):
+    global _LOAD_DOTENV
+    if _LOAD_DOTENV is None:
+        from dotenv import load_dotenv
+
+        _LOAD_DOTENV = load_dotenv
+    return _LOAD_DOTENV(dotenv_path, override=override)
+
+
+def _parse_datetime(value):
+    global _DATEUTIL_PARSER
+    if _DATEUTIL_PARSER is None:
+        from dateutil import parser
+
+        _DATEUTIL_PARSER = parser
+    return _DATEUTIL_PARSER.parse(value)
+
+
+def _broker_class(name: str):
+    from . import brokers
+
+    return getattr(brokers, name)
+
+
+_BROKER_CLASS_NAMES = {
+    "Alpaca",
+    "Ccxt",
+    "InteractiveBrokers",
+    "InteractiveBrokersREST",
+    "Tradier",
+    "Tradovate",
+    "Schwab",
+    "Bitunix",
+    "ProjectX",
+}
+
+
+def __getattr__(name: str):
+    if name in _BROKER_CLASS_NAMES:
+        cls = _broker_class(name)
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _quiet_backtest_logs_requested() -> bool:
@@ -24,13 +68,16 @@ def _quiet_backtest_logs_requested() -> bool:
 
 
 def find_and_load_dotenv(base_dir) -> bool:
-    for root, dirs, files in os.walk(base_dir):
-        logger.debug(f"Checking {root} for .env file")
-        if '.env' in files:
-            dotenv_path = os.path.join(root, '.env')
-            load_dotenv(dotenv_path)
+    current = os.path.abspath(base_dir)
+    if os.path.isfile(current):
+        current = os.path.dirname(current)
 
-            # Create a colored message for the log using termcolor
+    while True:
+        logger.debug(f"Checking {current} for .env file")
+        dotenv_path = os.path.join(current, ".env")
+        if os.path.isfile(dotenv_path):
+            _load_dotenv(dotenv_path)
+
             colored_message = termcolor.colored(f".env file loaded from: {dotenv_path}", "green")
             if _quiet_backtest_logs_requested():
                 logger.debug(colored_message)
@@ -40,9 +87,9 @@ def find_and_load_dotenv(base_dir) -> bool:
             # Optional local override file. This is intentionally loaded *after* `.env` so it can
             # override settings without requiring edits to the primary file (which may contain
             # shared or sensitive values).
-            dotenv_local_path = os.path.join(root, ".env.local")
-            if os.path.exists(dotenv_local_path):
-                load_dotenv(dotenv_local_path, override=True)
+            dotenv_local_path = os.path.join(current, ".env.local")
+            if os.path.isfile(dotenv_local_path):
+                _load_dotenv(dotenv_local_path, override=True)
                 colored_message = termcolor.colored(f".env.local file loaded from: {dotenv_local_path}", "green")
                 if _quiet_backtest_logs_requested():
                     logger.debug(colored_message)
@@ -50,6 +97,10 @@ def find_and_load_dotenv(base_dir) -> bool:
                     logger.info(colored_message)
             return True
 
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
     return False
 
 
@@ -104,10 +155,10 @@ backtesting_end = os.environ.get("BACKTESTING_END")
 # Check if the dates are not None and not empty strings before parsing
 BACKTESTING_START = None
 if backtesting_start:
-    BACKTESTING_START = parser.parse(backtesting_start)
+    BACKTESTING_START = _parse_datetime(backtesting_start)
 BACKTESTING_END = None
 if backtesting_end:
-    BACKTESTING_END = parser.parse(backtesting_end)
+    BACKTESTING_END = _parse_datetime(backtesting_end)
 
 # Get the backtesting data source
 BACKTESTING_DATA_SOURCE = os.environ.get("BACKTESTING_DATA_SOURCE", "ThetaData")
@@ -490,27 +541,27 @@ if not is_backtesting or is_backtesting.lower() == "false":
     if trading_broker_name:
         # Create broker instance based on explicitly specified name
         if trading_broker_name.lower() == "alpaca":
-            broker = Alpaca(ALPACA_CONFIG)
+            broker = _broker_class("Alpaca")(ALPACA_CONFIG)
         elif trading_broker_name.lower() == "tradier":
-            broker = Tradier(TRADIER_CONFIG)
+            broker = _broker_class("Tradier")(TRADIER_CONFIG)
         elif trading_broker_name.lower() == "ccxt":
-            broker = Ccxt(COINBASE_CONFIG)
+            broker = _broker_class("Ccxt")(COINBASE_CONFIG)
         elif trading_broker_name.lower() == "coinbase":
-            broker = Ccxt(COINBASE_CONFIG)
+            broker = _broker_class("Ccxt")(COINBASE_CONFIG)
         elif trading_broker_name.lower() == "kraken":
-            broker = Ccxt(KRAKEN_CONFIG)
+            broker = _broker_class("Ccxt")(KRAKEN_CONFIG)
         elif trading_broker_name.lower() == "weex":
-            broker = Ccxt(WEEX_CONFIG)
+            broker = _broker_class("Ccxt")(WEEX_CONFIG)
         elif trading_broker_name.lower() == "ib" or trading_broker_name.lower() == "interactivebrokers":
-            broker = InteractiveBrokers(INTERACTIVE_BROKERS_CONFIG)
+            broker = _broker_class("InteractiveBrokers")(INTERACTIVE_BROKERS_CONFIG)
         elif trading_broker_name.lower() == "ibrest" or trading_broker_name.lower() == "interactivebrokersrest":
-            broker = InteractiveBrokersREST(INTERACTIVE_BROKERS_REST_CONFIG)
+            broker = _broker_class("InteractiveBrokersREST")(INTERACTIVE_BROKERS_REST_CONFIG)
         elif trading_broker_name.lower() == "tradovate":
-            broker = Tradovate(TRADOVATE_CONFIG)
+            broker = _broker_class("Tradovate")(TRADOVATE_CONFIG)
         elif trading_broker_name.lower() == "schwab":
-            broker = Schwab(SCHWAB_CONFIG)
+            broker = _broker_class("Schwab")(SCHWAB_CONFIG)
         elif trading_broker_name.lower() == "bitunix":
-            broker = Bitunix(BITUNIX_CONFIG)
+            broker = _broker_class("Bitunix")(BITUNIX_CONFIG)
         elif trading_broker_name.lower() == "projectx":
             try:
                 # Get specified firm or use auto-detection
@@ -522,7 +573,7 @@ if not is_backtesting or is_backtesting.lower() == "false":
                 
                 from .data_sources import ProjectXData
                 data_source = ProjectXData(config)
-                broker = ProjectX(config, data_source=data_source)
+                broker = _broker_class("ProjectX")(config, data_source=data_source)
             except Exception as e:
                 colored_message = termcolor.colored(f"Failed to initialize ProjectX broker: {e}", "red")
                 logger.error(colored_message)
@@ -568,7 +619,7 @@ if not is_backtesting or is_backtesting.lower() == "false":
                 
                 from .data_sources import ProjectXData
                 data_source = ProjectXData(config)
-                broker = ProjectX(config, data_source=data_source)
+                broker = _broker_class("ProjectX")(config, data_source=data_source)
             except Exception as e:
                 colored_message = termcolor.colored(f"Failed to initialize ProjectX broker {trading_broker_name}: {e}", "red")
                 logger.error(colored_message)
@@ -579,7 +630,7 @@ if not is_backtesting or is_backtesting.lower() == "false":
         # Auto-detect broker based on available credentials if not explicitly specified
         if ALPACA_CONFIG["API_KEY"] or ALPACA_CONFIG["OAUTH_TOKEN"]:
             try:
-                broker = Alpaca(ALPACA_CONFIG)
+                broker = _broker_class("Alpaca")(ALPACA_CONFIG)
             except ValueError as e:
                 # If Alpaca initialization fails due to missing credentials, skip it
                 if "Either OAuth token or API key/secret must be provided" in str(e):
@@ -587,14 +638,14 @@ if not is_backtesting or is_backtesting.lower() == "false":
                 else:
                     raise e
         elif TRADIER_CONFIG["ACCESS_TOKEN"]:
-            broker = Tradier(TRADIER_CONFIG)
+            broker = _broker_class("Tradier")(TRADIER_CONFIG)
         elif INTERACTIVE_BROKERS_CONFIG["CLIENT_ID"]:
-            broker = InteractiveBrokers(INTERACTIVE_BROKERS_CONFIG)
+            broker = _broker_class("InteractiveBrokers")(INTERACTIVE_BROKERS_CONFIG)
         elif INTERACTIVE_BROKERS_REST_CONFIG["IB_USERNAME"]:
-            broker = InteractiveBrokersREST(INTERACTIVE_BROKERS_REST_CONFIG)
+            broker = _broker_class("InteractiveBrokersREST")(INTERACTIVE_BROKERS_REST_CONFIG)
         elif TRADOVATE_CONFIG["USERNAME"]:
             try:
-                broker = Tradovate(TRADOVATE_CONFIG)
+                broker = _broker_class("Tradovate")(TRADOVATE_CONFIG)
             except Exception as e:
                 # Handle rate limiting and other connection errors gracefully
                 error_str = str(e)
@@ -610,15 +661,15 @@ if not is_backtesting or is_backtesting.lower() == "false":
                     raise
         # Only check for SCHWAB_ACCOUNT_NUMBER to select Schwab
         elif SCHWAB_CONFIG.get("SCHWAB_ACCOUNT_NUMBER"):
-            broker = Schwab(SCHWAB_CONFIG)
+            broker = _broker_class("Schwab")(SCHWAB_CONFIG)
         elif COINBASE_CONFIG["apiKey"]:
-            broker = Ccxt(COINBASE_CONFIG)
+            broker = _broker_class("Ccxt")(COINBASE_CONFIG)
         elif KRAKEN_CONFIG["apiKey"]:
-            broker = Ccxt(KRAKEN_CONFIG)
+            broker = _broker_class("Ccxt")(KRAKEN_CONFIG)
         elif WEEX_CONFIG["apiKey"] and WEEX_CONFIG["secret"] and WEEX_CONFIG["password"]:
-            broker = Ccxt(WEEX_CONFIG)
+            broker = _broker_class("Ccxt")(WEEX_CONFIG)
         elif BITUNIX_CONFIG["API_KEY"] and BITUNIX_CONFIG["API_SECRET"]:
-            broker = Bitunix(BITUNIX_CONFIG)
+            broker = _broker_class("Bitunix")(BITUNIX_CONFIG)
         elif get_available_projectx_firms():
             try:
                 # Use first available ProjectX firm
@@ -628,7 +679,7 @@ if not is_backtesting or is_backtesting.lower() == "false":
                 if config.get("api_key") and config.get("username"):
                     from .data_sources import ProjectXData
                     data_source = ProjectXData(config)
-                    broker = ProjectX(config, data_source=data_source)
+                    broker = _broker_class("ProjectX")(config, data_source=data_source)
             except Exception as e:
                 colored_message = termcolor.colored(f"Failed to initialize ProjectX broker: {e}", "red")
                 logger.error(colored_message)

--- a/lumibot/data_sources/__init__.py
+++ b/lumibot/data_sources/__init__.py
@@ -1,22 +1,51 @@
-from .alpaca_data import AlpacaData
-from .alpha_vantage_data import AlphaVantageData
-from .ccxt_data import CcxtData
-from .data_source import DataSource
-from .data_source_backtesting import DataSourceBacktesting
-from .exceptions import NoDataFound, UnavailabeTimestep
-from .interactive_brokers_data import InteractiveBrokersData
-from .pandas_data import PandasData
-from .polars_data import PolarsData
-from .tradier_data import TradierData
-from .bitunix_data import BitunixData
-from .ccxt_backtesting_data import CcxtBacktestingData
-from .example_broker_data import ExampleBrokerData
-from .interactive_brokers_rest_data import InteractiveBrokersRESTData
-from .schwab_data import SchwabData
-from .tradovate_data import TradovateData
-from .yahoo_data import YahooData
+"""Data source package exports without importing every provider backend."""
 
-from .databento_data import DataBentoData, DataBentoDataPandas, DataBentoDataPolars
-from .projectx_data import ProjectXData
+from importlib import import_module as _import_module
 
-from ..backtesting.polygon_backtesting import PolygonDataBacktesting
+_NAME_TO_MODULE = {
+    "AlpacaData": "alpaca_data",
+    "AlphaVantageData": "alpha_vantage_data",
+    "BitunixData": "bitunix_data",
+    "CcxtBacktestingData": "ccxt_backtesting_data",
+    "CcxtData": "ccxt_data",
+    "DataBentoData": "databento_data",
+    "DataBentoDataPandas": "databento_data",
+    "DataBentoDataPolars": "databento_data",
+    "DataSource": "data_source",
+    "DataSourceBacktesting": "data_source_backtesting",
+    "ExampleBrokerData": "example_broker_data",
+    "InteractiveBrokersData": "interactive_brokers_data",
+    "InteractiveBrokersRESTData": "interactive_brokers_rest_data",
+    "NoDataFound": "exceptions",
+    "PandasData": "pandas_data",
+    "PolarsData": "polars_data",
+    "PolygonDataBacktesting": "polygon_backtesting",
+    "ProjectXData": "projectx_data",
+    "SchwabData": "schwab_data",
+    "TradierData": "tradier_data",
+    "TradovateData": "tradovate_data",
+    "UnavailabeTimestep": "exceptions",
+    "YahooData": "yahoo_data",
+}
+
+_EXTERNAL_MODULES = {
+    "polygon_backtesting": "lumibot.backtesting.polygon_backtesting",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import_name = _EXTERNAL_MODULES.get(module_name, f"{__name__}.{module_name}")
+    module = _import_module(import_name)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/data_sources/alpaca_data.py
+++ b/lumibot/data_sources/alpaca_data.py
@@ -1,34 +1,117 @@
+from __future__ import annotations
+
 import datetime as dt
 import os
 from decimal import Decimal
-from typing import Optional, Union, List, Dict
-import os
-import datetime as dt
-import pandas as pd
-import pytz
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-import pandas as pd
 import pytz
-from alpaca.data.enums import Adjustment
-from alpaca.data.historical import CryptoHistoricalDataClient, OptionHistoricalDataClient, StockHistoricalDataClient
-from alpaca.data.requests import (
-    CryptoBarsRequest,
-    OptionBarsRequest,
-    OptionChainRequest,
-    OptionSnapshotRequest,
-    StockBarsRequest,
-)
-from alpaca.data.timeframe import TimeFrame
 
 from lumibot.constants import LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL, LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE
-from lumibot.entities import Asset, Bars, Quote
+from lumibot.entities import Asset, Quote
 from lumibot.tools.alpaca_helpers import sanitize_base_and_quote_asset
-from lumibot.tools.helpers import date_n_trading_days_from_date
 from lumibot.tools.lumibot_logger import get_logger
 
 from .data_source import DataSource
 
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
+
 logger = get_logger(__name__)
+
+Adjustment = None
+CryptoHistoricalDataClient = None
+OptionHistoricalDataClient = None
+StockHistoricalDataClient = None
+CryptoBarsRequest = None
+OptionBarsRequest = None
+OptionChainRequest = None
+OptionSnapshotRequest = None
+StockBarsRequest = None
+TimeFrame = None
+TimeFrameUnit = None
+_DATE_N_TRADING_DAYS_FROM_DATE = None
+_BARS_CLASS = None
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+
+
+_ALPACA_ATTR_MODULES = {
+    "Adjustment": "alpaca.data.enums",
+    "CryptoHistoricalDataClient": "alpaca.data.historical",
+    "OptionHistoricalDataClient": "alpaca.data.historical",
+    "StockHistoricalDataClient": "alpaca.data.historical",
+    "CryptoBarsRequest": "alpaca.data.requests",
+    "OptionBarsRequest": "alpaca.data.requests",
+    "OptionChainRequest": "alpaca.data.requests",
+    "OptionSnapshotRequest": "alpaca.data.requests",
+    "StockBarsRequest": "alpaca.data.requests",
+    "TimeFrame": "alpaca.data.timeframe",
+    "TimeFrameUnit": "alpaca.data.timeframe",
+}
+
+
+def _get_alpaca_attr(name):
+    value = globals().get(name)
+    if value is None:
+        module = import_module(_ALPACA_ATTR_MODULES[name])
+        value = getattr(module, name)
+        globals()[name] = value
+    return value
+
+
+def _date_n_trading_days_from_date(*args, **kwargs):
+    global _DATE_N_TRADING_DAYS_FROM_DATE
+    if _DATE_N_TRADING_DAYS_FROM_DATE is None:
+        from lumibot.tools.helpers import date_n_trading_days_from_date
+
+        _DATE_N_TRADING_DAYS_FROM_DATE = date_n_trading_days_from_date
+    return _DATE_N_TRADING_DAYS_FROM_DATE(*args, **kwargs)
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _timeframe_from_source_value(value):
+    text = str(value)
+    amount_text = "".join(ch for ch in text if ch.isdigit()) or "1"
+    unit_text = text[len(amount_text):]
+    amount = int(amount_text)
+    timeframe = _get_alpaca_attr("TimeFrame")
+    unit_enum = _get_alpaca_attr("TimeFrameUnit")
+    if unit_text == "Min":
+        return timeframe.Minute if amount == 1 else timeframe(amount, unit_enum.Minute)
+    if unit_text == "Hour":
+        return timeframe.Hour if amount == 1 else timeframe(amount, unit_enum.Hour)
+    if unit_text == "Day":
+        return timeframe.Day if amount == 1 else timeframe(amount, unit_enum.Day)
+    return value
 
 
 class AlpacaData(DataSource):
@@ -37,59 +120,59 @@ class AlpacaData(DataSource):
     TIMESTEP_MAPPING = [
         {
             "timestep": "minute",
-            "representations": [TimeFrame.Minute, "minute"],
+            "representations": ["1Min", "minute"],
         },
         {
             "timestep": "5 minutes",
             "representations": [
-                [f"5{TimeFrame.Minute}", "minute"],
+                "5Min",
             ],
         },
         {
             "timestep": "10 minutes",
             "representations": [
-                [f"10{TimeFrame.Minute}", "minute"],
+                "10Min",
             ],
         },
         {
             "timestep": "15 minutes",
             "representations": [
-                [f"15{TimeFrame.Minute}", "minute"],
+                "15Min",
             ],
         },
         {
             "timestep": "30 minutes",
             "representations": [
-                [f"30{TimeFrame.Minute}", "minute"],
+                "30Min",
             ],
         },
         {
             "timestep": "hour",
             "representations": [
-                [f"{TimeFrame.Hour}", "hour"],
+                "1Hour",
             ],
         },
         {
             "timestep": "1 hour",
             "representations": [
-                [f"{TimeFrame.Hour}", "hour"],
+                "1Hour",
             ],
         },
         {
             "timestep": "2 hours",
             "representations": [
-                [f"2{TimeFrame.Hour}", "hour"],
+                "2Hour",
             ],
         },
         {
             "timestep": "4 hours",
             "representations": [
-                [f"4{TimeFrame.Hour}", "hour"],
+                "4Hour",
             ],
         },
         {
             "timestep": "day",
-            "representations": [TimeFrame.Day, "day"],
+            "representations": ["1Day", "day"],
         },
     ]
     LUMIBOT_DEFAULT_QUOTE_ASSET = Asset(LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL, LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE)
@@ -99,6 +182,10 @@ class AlpacaData(DataSource):
     @staticmethod
     def _format_datetime(dt):
         return pd.Timestamp(dt).isoformat()
+
+    def _parse_source_timestep(self, timestep, reverse=False):
+        parsed = super()._parse_source_timestep(str(timestep), reverse=reverse)
+        return _timeframe_from_source_value(parsed) if reverse else parsed
 
     def _handle_auth_error(self, e, operation="data request"):
         """
@@ -160,10 +247,11 @@ class AlpacaData(DataSource):
         """Lazily initialize and return the stock client."""
         if self._stock_client is None:
             try:
+                stock_client_class = _get_alpaca_attr("StockHistoricalDataClient")
                 if self.oauth_token:
-                    self._stock_client = StockHistoricalDataClient(oauth_token=self.oauth_token)
+                    self._stock_client = stock_client_class(oauth_token=self.oauth_token)
                 else:
-                    self._stock_client = StockHistoricalDataClient(self.api_key, self.api_secret)
+                    self._stock_client = stock_client_class(self.api_key, self.api_secret)
             except Exception as e:
                 # Check if this is specifically an authentication error
                 error_message = str(e).lower()
@@ -182,10 +270,11 @@ class AlpacaData(DataSource):
         """Lazily initialize and return the crypto client."""
         if self._crypto_client is None:
             try:
+                crypto_client_class = _get_alpaca_attr("CryptoHistoricalDataClient")
                 if self.oauth_token:
-                    self._crypto_client = CryptoHistoricalDataClient(oauth_token=self.oauth_token)
+                    self._crypto_client = crypto_client_class(oauth_token=self.oauth_token)
                 else:
-                    self._crypto_client = CryptoHistoricalDataClient(self.api_key, self.api_secret)
+                    self._crypto_client = crypto_client_class(self.api_key, self.api_secret)
             except Exception as e:
                 # Check if this is specifically an authentication error
                 error_message = str(e).lower()
@@ -204,10 +293,11 @@ class AlpacaData(DataSource):
         """Lazily initialize and return the option client."""
         if self._option_client is None:
             try:
+                option_client_class = _get_alpaca_attr("OptionHistoricalDataClient")
                 if self.oauth_token:
-                    self._option_client = OptionHistoricalDataClient(oauth_token=self.oauth_token)
+                    self._option_client = option_client_class(oauth_token=self.oauth_token)
                 else:
-                    self._option_client = OptionHistoricalDataClient(self.api_key, self.api_secret)
+                    self._option_client = option_client_class(self.api_key, self.api_secret)
             except Exception as e:
                 # Log the actual error without going through auth error handler immediately
                 logger.error(f"Error initializing option client: {e}")
@@ -388,7 +478,8 @@ class AlpacaData(DataSource):
             client = self._get_option_client()
 
             # Use OptionChainRequest with underlying_symbol for stock assets
-            req = OptionChainRequest(
+            option_chain_request = _get_alpaca_attr("OptionChainRequest")
+            req = option_chain_request(
                 underlying_symbol=asset.symbol,
             )
 
@@ -596,7 +687,7 @@ class AlpacaData(DataSource):
         else:
             minutes_per_day = 390
             days_needed = (length // minutes_per_day) + 2  # + buffer
-        start_date = date_n_trading_days_from_date(
+        start_date = _date_n_trading_days_from_date(
             n_days=days_needed,
             start_datetime=end_dt,
             market="NYSE",
@@ -655,14 +746,16 @@ class AlpacaData(DataSource):
                 yield lst[i : i + size]
 
         # Adjustment setting
-        adjustment = Adjustment.ALL if getattr(self, "_auto_adjust", True) else Adjustment.RAW
+        adjustment_enum = _get_alpaca_attr("Adjustment")
+        adjustment = adjustment_enum.ALL if getattr(self, "_auto_adjust", True) else adjustment_enum.RAW
 
         # Stocks batching
         if stock_assets:
             client = self._get_stock_client()
             for chunk in _chunks(stock_assets, chunk_size):
                 syms = [a.symbol for a in chunk]
-                params = StockBarsRequest(
+                stock_bars_request = _get_alpaca_attr("StockBarsRequest")
+                params = stock_bars_request(
                     symbol_or_symbols=syms,
                     timeframe=timeframe,
                     start=start_dt,
@@ -684,7 +777,7 @@ class AlpacaData(DataSource):
                                 cleaned = _clean_df(df_sym, sym)
                                 if cleaned is not None:
                                     asset_obj = next(a for a in chunk if a.symbol == sym)
-                                    result[asset_obj] = Bars(
+                                    result[asset_obj] = _bars_class()(
                                         cleaned,
                                         self.SOURCE,
                                         asset_obj,
@@ -696,7 +789,7 @@ class AlpacaData(DataSource):
                         cleaned = _clean_df(df_multi, sym)
                         if cleaned is not None:
                             asset_obj = chunk[0]
-                            result[asset_obj] = Bars(
+                            result[asset_obj] = _bars_class()(
                                 cleaned,
                                 self.SOURCE,
                                 asset_obj,
@@ -711,7 +804,8 @@ class AlpacaData(DataSource):
             client = self._get_option_client()
             for chunk in _chunks(option_assets, chunk_size):
                 syms = [_option_symbol(a) for a in chunk]
-                params = OptionBarsRequest(
+                option_bars_request = _get_alpaca_attr("OptionBarsRequest")
+                params = option_bars_request(
                     symbol_or_symbols=syms,
                     timeframe=timeframe,
                     start=start_dt,
@@ -732,7 +826,7 @@ class AlpacaData(DataSource):
                                 continue
                             cleaned = _clean_df(df_sym, sym)
                             if cleaned is not None:
-                                result[a] = Bars(
+                                result[a] = _bars_class()(
                                     cleaned,
                                     self.SOURCE,
                                     a,
@@ -743,7 +837,7 @@ class AlpacaData(DataSource):
                         sym = syms[0]
                         cleaned = _clean_df(df_multi, sym)
                         if cleaned is not None:
-                            result[chunk[0]] = Bars(
+                            result[chunk[0]] = _bars_class()(
                                 cleaned,
                                 self.SOURCE,
                                 chunk[0],
@@ -765,7 +859,8 @@ class AlpacaData(DataSource):
                     symbol_fmt = f"{base_asset.symbol}/{quote_asset.symbol}"
                     syms.append(symbol_fmt)
                     asset_map[symbol_fmt] = a
-                params = CryptoBarsRequest(
+                crypto_bars_request = _get_alpaca_attr("CryptoBarsRequest")
+                params = crypto_bars_request(
                     symbol_or_symbols=syms,
                     timeframe=timeframe,
                     start=start_dt,
@@ -787,7 +882,7 @@ class AlpacaData(DataSource):
                             cleaned = _clean_df(df_sym, sym)
                             if cleaned is not None:
                                 a = asset_map[sym]
-                                result[a] = Bars(
+                                result[a] = _bars_class()(
                                     cleaned,
                                     self.SOURCE,
                                     a,
@@ -799,7 +894,7 @@ class AlpacaData(DataSource):
                         cleaned = _clean_df(df_multi, sym)
                         if cleaned is not None:
                             a = asset_map[sym]
-                            result[a] = Bars(
+                            result[a] = _bars_class()(
                                 cleaned,
                                 self.SOURCE,
                                 a,
@@ -884,7 +979,7 @@ class AlpacaData(DataSource):
             minutes_per_day = 390  # ~6.5 hours of trading per day
             days_needed = (length // minutes_per_day) + 1
 
-        start_date = date_n_trading_days_from_date(
+        start_date = _date_n_trading_days_from_date(
             n_days=days_needed,
             start_datetime=end_dt,
             # TODO: pass market into DataSource
@@ -900,7 +995,8 @@ class AlpacaData(DataSource):
                 client = self._get_crypto_client()
 
                 # noinspection PyArgumentList
-                params = CryptoBarsRequest(
+                crypto_bars_request = _get_alpaca_attr("CryptoBarsRequest")
+                params = crypto_bars_request(
                     symbol_or_symbols=symbol,
                     timeframe=timeframe,
                     start=start_dt,
@@ -915,7 +1011,8 @@ class AlpacaData(DataSource):
                 client = self._get_option_client()
 
                 # noinspection PyArgumentList
-                params = OptionBarsRequest(
+                option_bars_request = _get_alpaca_attr("OptionBarsRequest")
+                params = option_bars_request(
                     symbol_or_symbols=symbol,
                     timeframe=timeframe,
                     start=start_dt,
@@ -928,12 +1025,14 @@ class AlpacaData(DataSource):
                 client = self._get_stock_client()
 
                 # noinspection PyArgumentList
-                params = StockBarsRequest(
+                stock_bars_request = _get_alpaca_attr("StockBarsRequest")
+                adjustment_enum = _get_alpaca_attr("Adjustment")
+                params = stock_bars_request(
                     symbol_or_symbols=symbol,
                     timeframe=timeframe,
                     start=start_dt,
                     end=end_dt,
-                    adjustment=Adjustment.ALL if self._auto_adjust else Adjustment.RAW
+                    adjustment=adjustment_enum.ALL if self._auto_adjust else adjustment_enum.RAW
                 )
                 barset = client.get_stock_bars(params)
 
@@ -985,7 +1084,7 @@ class AlpacaData(DataSource):
         return df
 
     def _parse_source_symbol_bars(self, response, asset, quote=None, length=None):
-        bars = Bars(
+        bars = _bars_class()(
             response,
             self.SOURCE,
             asset,
@@ -1125,11 +1224,13 @@ class AlpacaData(DataSource):
         option_symbol = f"{asset.symbol}{date}{asset.right[0]}{strike_formatted}"
 
         # Initialize the historical data client
+        option_client_class = _get_alpaca_attr("OptionHistoricalDataClient")
         if self.oauth_token:
-            client = OptionHistoricalDataClient(oauth_token=self.oauth_token)
+            client = option_client_class(oauth_token=self.oauth_token)
         else:
-            client = OptionHistoricalDataClient(self.api_key, self.api_secret)
-        request = OptionSnapshotRequest(symbol_or_symbols=option_symbol)
+            client = option_client_class(self.api_key, self.api_secret)
+        option_snapshot_request = _get_alpaca_attr("OptionSnapshotRequest")
+        request = option_snapshot_request(symbol_or_symbols=option_symbol)
         try:
             snapshots = client.get_option_snapshot(request)
             snapshot = snapshots.get(option_symbol)

--- a/lumibot/data_sources/alpha_vantage_data.py
+++ b/lumibot/data_sources/alpha_vantage_data.py
@@ -1,16 +1,48 @@
+from __future__ import annotations
+
 import os.path
 import time
 from datetime import datetime, timedelta
-
-import pandas as pd
+from importlib import import_module
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
-from lumibot.entities import Asset, Bars
+from lumibot.entities import Asset
 from lumibot.tools.lumibot_logger import get_logger
 
 from .data_source import DataSource
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BARS_CLASS = None
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class AlphaVantageData(DataSource):
@@ -141,5 +173,5 @@ class AlphaVantageData(DataSource):
         return result
 
     def _parse_source_symbol_bars(self, response, asset, quote=None, length=None):
-        bars = Bars(response, self.SOURCE, asset, raw=response, quote=quote)
+        bars = _bars_class()(response, self.SOURCE, asset, raw=response, quote=quote)
         return bars

--- a/lumibot/data_sources/bitunix_data.py
+++ b/lumibot/data_sources/bitunix_data.py
@@ -1,11 +1,56 @@
-from typing import Optional
+from __future__ import annotations
 
-import pandas as pd
+from importlib import import_module
+from typing import TYPE_CHECKING, Optional
+
 import pytz
 
 from lumibot.data_sources.data_source import DataSource
-from lumibot.entities import Asset, Bars
-from lumibot.tools.bitunix_helpers import BitUnixClient
+from lumibot.entities import Asset
+
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+BitUnixClient = None
+_BARS_CLASS = None
+
+
+def _bitunix_client_class():
+    global BitUnixClient
+    if BitUnixClient is None:
+        from lumibot.tools.bitunix_helpers import BitUnixClient as _BitUnixClient
+
+        BitUnixClient = _BitUnixClient
+    return BitUnixClient
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class BitunixData(DataSource):
@@ -42,7 +87,7 @@ class BitunixData(DataSource):
             self.api_secret = getattr(config, "API_SECRET", None)
             if not self.api_key or not self.api_secret:
                 raise ValueError("API_KEY and API_SECRET must be provided in config")
-        self.client = BitUnixClient(self.api_key, self.api_secret)
+        self.client = _bitunix_client_class()(self.api_key, self.api_secret)
         # Track symbols we're interested in for WebSocket subscriptions
         self.client_symbols = set()
 
@@ -206,7 +251,7 @@ class BitunixData(DataSource):
         """
         Wraps the raw DataFrame into a Bars entity with source metadata.
         """
-        return Bars(df, self.SOURCE, asset, raw=df, quote=quote)
+        return _bars_class()(df, self.SOURCE, asset, raw=df, quote=quote)
 
     def get_chains(self, asset: Asset, quote: Asset = None, exchange: str = None, strike_count: int = 100) -> dict:
         """Option chains not supported by BitUnix."""

--- a/lumibot/data_sources/ccxt_backtesting_data.py
+++ b/lumibot/data_sources/ccxt_backtesting_data.py
@@ -1,18 +1,63 @@
+from __future__ import annotations
+
 import logging
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any, Dict, Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Dict, Union
 
-import numpy as np
 import pytz
-from pandas import DataFrame
 
 logger = logging.getLogger(__name__)
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.data_sources import DataSourceBacktesting
-from lumibot.entities import Asset, Bars
-from lumibot.tools import CcxtCacheDB
+from lumibot.entities import Asset
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
+    from lumibot.entities import Bars
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+np = _LazyModule("numpy")
+_CCXT_CACHE_DB_CLASS = None
+_BARS_CLASS = None
+
+
+def _ccxt_cache_db_class():
+    global _CCXT_CACHE_DB_CLASS
+    if _CCXT_CACHE_DB_CLASS is None:
+        from lumibot.tools import CcxtCacheDB
+
+        _CCXT_CACHE_DB_CLASS = CcxtCacheDB
+    return _CCXT_CACHE_DB_CLASS
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class CcxtBacktestingData(DataSourceBacktesting):
@@ -43,7 +88,7 @@ class CcxtBacktestingData(DataSourceBacktesting):
         # The number of historical data is downloaded earlier than the start date when downloading historical data.
         self._download_start_dt_prebuffer = 300
 
-        self.cache_db = CcxtCacheDB(self.name,max_download_limit=download_limit)
+        self.cache_db = _ccxt_cache_db_class()(self.name,max_download_limit=download_limit)
 
 
     def _to_utc_timezone(self, dt:datetime)->datetime:
@@ -235,7 +280,7 @@ class CcxtBacktestingData(DataSourceBacktesting):
     def _parse_source_symbol_bars(self, response:DataFrame, asset:tuple[Asset,Asset],
                                   quote:Asset=None, length:int=None)->Bars:
         # Parse the dataframe returned from CCXT.
-        bars = Bars(response, self.SOURCE, asset, quote=quote, raw=response)
+        bars = _bars_class()(response, self.SOURCE, asset, quote=quote, raw=response)
         return bars
 
     def get_last_price(self, asset, timestep=None, quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:

--- a/lumibot/data_sources/ccxt_data.py
+++ b/lumibot/data_sources/ccxt_data.py
@@ -1,17 +1,48 @@
+from __future__ import annotations
+
 import datetime
 import time
 from decimal import Decimal
+from importlib import import_module
 from typing import Union
 
-import ccxt
-import pandas as pd
-
-from lumibot.entities import Asset, Bars
+from lumibot.entities import Asset
 from lumibot.tools.lumibot_logger import get_logger
 
 from .data_source import DataSource
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BARS_CLASS = None
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class CcxtData(DataSource):
@@ -38,6 +69,8 @@ class CcxtData(DataSource):
         # if there is too many assets, the best thing to do would
         # be to split it into chunks and request data for each chunk
         self.chunk_size = min(chunk_size, 100)
+
+        import ccxt
 
         try:
             exchange_class = getattr(ccxt, config["exchange_id"])
@@ -225,7 +258,7 @@ class CcxtData(DataSource):
 
     def _parse_source_symbol_bars(self, response, asset, quote=None, length=None):
         # Parse the dataframe returned from CCXT.
-        bars = Bars(response, self.SOURCE, asset, quote=quote, raw=response)
+        bars = _bars_class()(response, self.SOURCE, asset, quote=quote, raw=response)
         return bars
 
     def get_last_price(self, asset, quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:

--- a/lumibot/data_sources/data_source.py
+++ b/lumibot/data_sources/data_source.py
@@ -1,23 +1,75 @@
+from __future__ import annotations
+
 import os
 import time
 import traceback
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime, timedelta
 from decimal import Decimal
-from typing import Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Union
 
-import pandas as pd
 import pytz
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ, LUMIBOT_DEFAULT_TIMEZONE
-from lumibot.entities import Asset, AssetsMapping, Bars, Quote
-from lumibot.tools import black_scholes, create_options_symbol
-from lumibot.tools.lumibot_logger import get_logger
+from lumibot.entities import Asset, AssetsMapping, Quote
+from lumibot.tools import black_scholes
 
 from .exceptions import UnavailabeTimestep
 
-logger = get_logger(__name__)
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_CREATE_OPTIONS_SYMBOL = None
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        self._logger = None
+
+    def _load(self):
+        if self._logger is None:
+            from lumibot.tools.lumibot_logger import get_logger
+
+            self._logger = get_logger(__name__)
+        return self._logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
+
+
+def _create_options_symbol(*args, **kwargs):
+    global _CREATE_OPTIONS_SYMBOL
+    if _CREATE_OPTIONS_SYMBOL is None:
+        from lumibot.tools import create_options_symbol
+
+        _CREATE_OPTIONS_SYMBOL = create_options_symbol
+    return _CREATE_OPTIONS_SYMBOL(*args, **kwargs)
 
 
 class DataSource(ABC):
@@ -435,6 +487,8 @@ class DataSource(ABC):
 
         results = {}
         # Reuse thread pool to avoid creation/destruction overhead
+        from concurrent.futures import as_completed
+
         executor = self._get_or_create_thread_pool()
         futures = [executor.submit(process_chunk, chunk) for chunk in chunks]
         for future in as_completed(futures):
@@ -629,7 +683,7 @@ class DataSource(ABC):
                     right=right,
                 )
                 query_t = time.perf_counter()
-                option_symbol = create_options_symbol(opt_asset.symbol, expiry_dt, right, strike)
+                option_symbol = _create_options_symbol(opt_asset.symbol, expiry_dt, right, strike)
                 opt_price = self.get_last_price(opt_asset)
                 greeks = self.calculate_greeks(opt_asset, opt_price, underlying_price, risk_free_rate)
                 query_total += time.perf_counter() - query_t

--- a/lumibot/data_sources/data_source_backtesting.py
+++ b/lumibot/data_sources/data_source_backtesting.py
@@ -7,8 +7,18 @@ from collections import deque
 from datetime import datetime, timedelta
 
 from lumibot.data_sources import DataSource
-from lumibot.tools import print_progress_bar, to_datetime_aware
-from lumibot.tools.helpers import get_timezone_from_datetime
+
+_HELPER_FUNCS = {}
+
+
+def _helper_func(name):
+    func = _HELPER_FUNCS.get(name)
+    if func is None:
+        from lumibot import tools
+
+        func = getattr(tools, name)
+        _HELPER_FUNCS[name] = func
+    return func
 
 
 class DataSourceBacktesting(DataSource, ABC):
@@ -65,13 +75,13 @@ class DataSourceBacktesting(DataSource, ABC):
         else:
             _backtesting_started = backtesting_started
 
-        self.datetime_start = to_datetime_aware(datetime_start)
-        self.datetime_end = to_datetime_aware(datetime_end)
+        self.datetime_start = _helper_func("to_datetime_aware")(datetime_start)
+        self.datetime_end = _helper_func("to_datetime_aware")(datetime_end)
         self._datetime = self.datetime_start
         self._iter_count = None
         self.backtesting_started = _backtesting_started
         self.log_backtest_progress_to_file = log_backtest_progress_to_file
-        self.tzinfo = get_timezone_from_datetime(self.datetime_start)
+        self.tzinfo = _helper_func("get_timezone_from_datetime")(self.datetime_start)
         self._eta_history = deque()
         self._eta_window_seconds = 30
         self._eta_calibration_seconds = 25
@@ -330,6 +340,10 @@ class DataSourceBacktesting(DataSource, ABC):
         import json
 
         self._datetime = new_datetime
+        try:
+            self._datetime_minus_microsecond = new_datetime - timedelta(microseconds=1)
+        except Exception:
+            self._datetime_minus_microsecond = None
 
         if not self._show_progress_bar and not self.log_backtest_progress_to_file:
             return
@@ -371,7 +385,7 @@ class DataSourceBacktesting(DataSource, ABC):
 
         if should_print_progress_bar:
             self._last_progress_bar_update = now_wall
-            print_progress_bar(
+            _helper_func("print_progress_bar")(
                 new_datetime,
                 self.datetime_start,
                 self.datetime_end,

--- a/lumibot/data_sources/databento_data.py
+++ b/lumibot/data_sources/databento_data.py
@@ -1,7 +1,26 @@
 """Canonical DataBento data source aliasing the Polars implementation."""
 
-from .databento_data_polars import DataBentoDataPolars as DataBentoData
-from .databento_data_pandas import DataBentoDataPandas
-from .databento_data_polars import DataBentoDataPolars
+from importlib import import_module
 
 __all__ = ["DataBentoData", "DataBentoDataPandas", "DataBentoDataPolars"]
+
+_NAME_TO_IMPORT = {
+    "DataBentoData": ("lumibot.data_sources.databento_data_polars", "DataBentoDataPolars"),
+    "DataBentoDataPolars": ("lumibot.data_sources.databento_data_polars", "DataBentoDataPolars"),
+    "DataBentoDataPandas": ("lumibot.data_sources.databento_data_pandas", "DataBentoDataPandas"),
+}
+
+
+def __getattr__(name):
+    try:
+        module_name, attr_name = _NAME_TO_IMPORT[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    value = getattr(import_module(module_name), attr_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/data_sources/databento_data_pandas.py
+++ b/lumibot/data_sources/databento_data_pandas.py
@@ -1,21 +1,75 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Union, Optional
-
-import pandas as pd
-import polars as pl
+from importlib import import_module
+from typing import TYPE_CHECKING, Optional, Union
 
 from .data_source import DataSource
-from lumibot.entities import Asset, Bars, Quote
-from lumibot.tools import databento_helper, databento_helper_polars
+from lumibot.entities import Asset, Quote
 from lumibot.tools.lumibot_logger import get_logger
 
-try:
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
     from .databento_data_polars import DataBentoDataPolars
-except Exception:  # pragma: no cover - optional dependency path
-    DataBentoDataPolars = None
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+pl = _LazyModule("polars")
+databento_helper = _LazyModule("lumibot.tools.databento_helper")
+databento_helper_polars = _LazyModule("lumibot.tools.databento_helper_polars")
+_BARS_CLASS = None
+_DATABENTO_DATA_POLARS_CLASS = None
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _databento_data_polars_class():
+    global _DATABENTO_DATA_POLARS_CLASS
+    if _DATABENTO_DATA_POLARS_CLASS is None:
+        try:
+            from .databento_data_polars import DataBentoDataPolars
+        except Exception:  # pragma: no cover - optional dependency path
+            return None
+
+        _DATABENTO_DATA_POLARS_CLASS = DataBentoDataPolars
+    return _DATABENTO_DATA_POLARS_CLASS
 
 
 class DataBentoDataPandas(DataSource):
@@ -247,7 +301,7 @@ class DataBentoDataPandas(DataSource):
             return None
 
         # Create and return Bars object
-        bars = Bars(
+        bars = _bars_class()(
             df=df_result,
             source=self.SOURCE,
             asset=asset,
@@ -376,12 +430,13 @@ class DataBentoDataPandas(DataSource):
     def _ensure_live_delegate(self) -> Optional['DataBentoDataPolars']:
         if not self.enable_live_stream:
             return None
-        if DataBentoDataPolars is None or self.is_backtesting_mode:
+        databento_data_polars_class = _databento_data_polars_class()
+        if databento_data_polars_class is None or self.is_backtesting_mode:
             return None
 
         if self._live_delegate is None:
             try:
-                self._live_delegate = DataBentoDataPolars(
+                self._live_delegate = databento_data_polars_class(
                     api_key=self._api_key,
                     has_paid_subscription=True,
                     enable_cache=False,
@@ -425,7 +480,7 @@ class DataBentoDataPandas(DataSource):
                 return None
 
             # Create Bars object
-            bars = Bars(
+            bars = _bars_class()(
                 df=response,
                 source=self.SOURCE,
                 asset=asset,

--- a/lumibot/data_sources/databento_data_polars.py
+++ b/lumibot/data_sources/databento_data_polars.py
@@ -7,36 +7,100 @@ This implementation uses:
 - Correct price conversion from fixed-point format
 """
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
-from typing import Dict, Optional, Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict, Optional
 import time
 import threading
 import queue
 from collections import defaultdict
 
-import polars as pl
-try:
-    import databento as db
-except ImportError:  # pragma: no cover - optional dependency
-    db = None
-
 from .data_source import DataSource
-from .polars_mixin import PolarsMixin
-from lumibot.entities import Asset, Bars, Quote
-from lumibot.tools import databento_helper_polars, futures_roll
-from lumibot.tools.databento_helper_polars import (
-    _ensure_polars_datetime_timezone as _ensure_polars_tz,
-    _ensure_polars_datetime_precision as _ensure_polars_precision,
-    _format_futures_symbol_for_databento,
-    _generate_databento_symbol_alternatives,
-)
+from lumibot.entities import Asset, Quote
 from lumibot.tools.lumibot_logger import get_logger
+
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
 
 logger = get_logger(__name__)
 
 
-class DataBentoDataPolars(PolarsMixin, DataSource):
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pl = _LazyModule("polars")
+databento_helper_polars = _LazyModule("lumibot.tools.databento_helper_polars")
+futures_roll = _LazyModule("lumibot.tools.futures_roll")
+db = None
+_DATABENTO_MODULE = None
+_BARS_CLASS = None
+
+
+def _databento_module():
+    global _DATABENTO_MODULE, db
+    if db is not None:
+        return db
+    if _DATABENTO_MODULE is None:
+        try:
+            _DATABENTO_MODULE = import_module("databento")
+        except ImportError:  # pragma: no cover - optional dependency
+            return None
+    db = _DATABENTO_MODULE
+    return _DATABENTO_MODULE
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _ensure_polars_tz(*args, **kwargs):
+    return databento_helper_polars._ensure_polars_datetime_timezone(*args, **kwargs)
+
+
+def _ensure_polars_precision(*args, **kwargs):
+    return databento_helper_polars._ensure_polars_datetime_precision(*args, **kwargs)
+
+
+def _format_futures_symbol_for_databento(*args, **kwargs):
+    return databento_helper_polars._format_futures_symbol_for_databento(*args, **kwargs)
+
+
+def _generate_databento_symbol_alternatives(*args, **kwargs):
+    return databento_helper_polars._generate_databento_symbol_alternatives(*args, **kwargs)
+
+
+class DataBentoDataPolars(DataSource):
     """
     DataBento data source optimized with Polars and proper Live API usage.
 
@@ -65,7 +129,7 @@ class DataBentoDataPolars(PolarsMixin, DataSource):
         """Initialize DataBento data source with Live API support"""
         super().__init__(api_key=api_key, has_paid_subscription=has_paid_subscription)
 
-        if db is None:
+        if _databento_module() is None:
             raise ImportError("DataBento package not available. Please install with: pip install databento")
 
         # Core configuration
@@ -159,7 +223,7 @@ class DataBentoDataPolars(PolarsMixin, DataSource):
         while not self._stop_streaming and reconnect_attempts < max_reconnect_attempts:
             try:
                 # Create a new client for this producer
-                client = db.Live(key=self._api_key)
+                client = _databento_module().Live(key=self._api_key)
                 
                 logger.debug(f"[DATABENTO][PRODUCER] Subscribing to {symbol} from {start_time.isoformat()}")
                 
@@ -682,7 +746,7 @@ class DataBentoDataPolars(PolarsMixin, DataSource):
             df = df.tail(length)
             df = _ensure_polars_tz(df)
             df = _ensure_polars_precision(df)
-            return Bars(
+            return _bars_class()(
                 df=df,
                 source=self.SOURCE,
                 asset=asset,

--- a/lumibot/data_sources/interactive_brokers_data.py
+++ b/lumibot/data_sources/interactive_brokers_data.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 import datetime
 import math
 from decimal import Decimal
+from importlib import import_module
 from typing import Union
 
-import pandas as pd
-
-from lumibot.entities import Asset, Bars, Quote
+from lumibot.entities import Asset, Quote
 
 from .data_source import DataSource
 
@@ -17,6 +18,37 @@ TYPE_MAP = dict(
     index="IND",
     multileg="BAG",
 )
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BARS_CLASS = None
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class InteractiveBrokersData(DataSource):
@@ -259,7 +291,7 @@ class InteractiveBrokersData(DataSource):
     def _parse_source_symbol_bars(self, response, asset, quote=None, length=None):
         # Catch empty dataframe.
         if isinstance(response, float) or response.empty:
-            bars = Bars(response, self.SOURCE, asset, raw=response)
+            bars = _bars_class()(response, self.SOURCE, asset, raw=response)
             return bars
         df = response.copy()
         # df["date"] = pd.to_datetime(df["date"], unit='s')
@@ -286,7 +318,7 @@ class InteractiveBrokersData(DataSource):
             ]
         ]
 
-        bars = Bars(df, self.SOURCE, asset, raw=response, quote=quote)
+        bars = _bars_class()(df, self.SOURCE, asset, raw=response, quote=quote)
         return bars
 
     def _start_realtime_bars(self, asset, keep_bars=12):

--- a/lumibot/data_sources/interactive_brokers_rest_data.py
+++ b/lumibot/data_sources/interactive_brokers_rest_data.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import os
 import subprocess
 import time
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Union
 
-import requests
-import urllib3
 from termcolor import colored
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
@@ -16,16 +17,15 @@ from lumibot.tools.ibkr_secdef import (
     select_futures_exchange_from_secdef_search_payload,
 )
 
-from ..entities import Asset, Bars
+from ..entities import Asset
 from .data_source import DataSource
+
+if TYPE_CHECKING:
+    from ..entities import Bars
 
 logger = get_logger(__name__)
 import importlib.resources  # Added
 import tempfile  # Added
-
-import pandas as pd
-
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 TYPE_MAP = dict(
     stock="STK",
@@ -35,6 +35,47 @@ TYPE_MAP = dict(
     index="IND",
     multileg="BAG",
 )
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+requests = _LazyModule("requests")
+urllib3 = _LazyModule("urllib3")
+_BARS_CLASS = None
+_URLLIB3_WARNINGS_DISABLED = False
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _disable_urllib3_warnings():
+    global _URLLIB3_WARNINGS_DISABLED
+    if not _URLLIB3_WARNINGS_DISABLED:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        _URLLIB3_WARNINGS_DISABLED = True
 
 
 class InteractiveBrokersRESTData(DataSource):
@@ -442,6 +483,7 @@ class InteractiveBrokersRESTData(DataSource):
 
         while retrying or not allow_fail:
             try:
+                _disable_urllib3_warnings()
                 response = requests.get(url, verify=False)
             except requests.exceptions.RequestException as e:
                 response = requests.Response()
@@ -469,6 +511,7 @@ class InteractiveBrokersRESTData(DataSource):
 
         while retrying or not allow_fail:
             try:
+                _disable_urllib3_warnings()
                 response = requests.post(url, json=json, verify=False)
             except requests.exceptions.RequestException as e:
                 response = requests.Response()
@@ -491,6 +534,7 @@ class InteractiveBrokersRESTData(DataSource):
 
         while retrying or not allow_fail:
             try:
+                _disable_urllib3_warnings()
                 response = requests.delete(url, verify=False)
             except requests.exceptions.RequestException as e:
                 response = requests.Response()
@@ -776,6 +820,7 @@ class InteractiveBrokersRESTData(DataSource):
         exchange_val = str(exchange or "").strip().upper() or self._resolve_futures_exchange(symbol)
         params = {"symbols": symbol, "secType": "CONTFUT", "exchange": exchange_val}
         try:
+            _disable_urllib3_warnings()
             response = requests.get(url, params=params, verify=False)
             if response.status_code != 200:
                 logger.error(colored(f"Failed to retrieve security definition for {symbol}: {response.text}", "red"))
@@ -933,7 +978,7 @@ class InteractiveBrokersRESTData(DataSource):
             timestep = f"{timestep_value}y"
         else:
             logger.error(colored(f"Unsupported timestep: {timestep}", "red"))
-            return Bars(
+            return _bars_class()(
                 pd.DataFrame(
                     columns=["timestamp", "open", "high", "low", "close", "volume"]
                 ),
@@ -957,7 +1002,7 @@ class InteractiveBrokersRESTData(DataSource):
             logger.error(
                 colored(f"Error getting historical prices: {result['error']}", "red")
             )
-            return Bars(
+            return _bars_class()(
                 pd.DataFrame(
                     columns=["timestamp", "open", "high", "low", "close", "volume"]
                 ),
@@ -976,7 +1021,7 @@ class InteractiveBrokersRESTData(DataSource):
                     "red",
                 )
             )
-            return Bars(
+            return _bars_class()(
                 pd.DataFrame(
                     columns=["timestamp", "open", "high", "low", "close", "volume"]
                 ),
@@ -1017,7 +1062,7 @@ class InteractiveBrokersRESTData(DataSource):
         df['stock_splits'] = 0.0
         """
 
-        bars = Bars(df, self.SOURCE, asset, raw=df, quote=quote)
+        bars = _bars_class()(df, self.SOURCE, asset, raw=df, quote=quote)
 
         return bars
 

--- a/lumibot/data_sources/pandas_data.py
+++ b/lumibot/data_sources/pandas_data.py
@@ -1,16 +1,75 @@
+from __future__ import annotations
+
 from collections import OrderedDict, defaultdict
 from datetime import timedelta
 from decimal import Decimal
+from importlib import import_module
 from typing import Union
 
-import pandas as pd
-
 from lumibot.data_sources import DataSourceBacktesting
-from lumibot.entities import Asset, Bars, Quote
-from lumibot.tools.helpers import parse_timestep_qty_and_unit
-from lumibot.tools.lumibot_logger import get_logger
+from lumibot.entities import Asset, Quote
 
-logger = get_logger(__name__)
+_BARS_CLASS = None
+_PARSE_TIMESTEP_QTY_AND_UNIT = None
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        self._logger = None
+
+    def _load(self):
+        if self._logger is None:
+            from lumibot.tools.lumibot_logger import get_logger
+
+            self._logger = get_logger(__name__)
+        return self._logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _parse_timestep_qty_and_unit(*args, **kwargs):
+    global _PARSE_TIMESTEP_QTY_AND_UNIT
+    if _PARSE_TIMESTEP_QTY_AND_UNIT is None:
+        from lumibot.tools.helpers import parse_timestep_qty_and_unit
+
+        _PARSE_TIMESTEP_QTY_AND_UNIT = parse_timestep_qty_and_unit
+    return _PARSE_TIMESTEP_QTY_AND_UNIT(*args, **kwargs)
 
 # PERF: `find_asset_in_data_store()` is called in tight loops (often 200K+ times per backtest). It
 # constructs `Asset("USD", "forex")` as the default quote on every call, which shows up as ~3s of
@@ -412,7 +471,7 @@ class PandasData(DataSourceBacktesting):
             requested_asset_type = requested_asset_type.split(".")[-1]
         if timestep is not None:
             try:
-                qty, requested_unit = parse_timestep_qty_and_unit(str(timestep))
+                qty, requested_unit = _parse_timestep_qty_and_unit(str(timestep))
             except Exception:
                 qty, requested_unit = 1, str(timestep)
                 requested_unit = str(timestep)
@@ -615,7 +674,27 @@ class PandasData(DataSourceBacktesting):
         asset2 = quote
         if isinstance(asset, tuple):
             asset1, asset2 = asset
-        bars = Bars(response, self.SOURCE, asset1, quote=asset2, raw=response, return_polars=return_polars)
+        skip_timezone = bool(getattr(response, "attrs", {}).get("_lumibot_skip_timezone", False))
+        if not skip_timezone and getattr(self, "IS_BACKTESTING_DATA_SOURCE", False):
+            response_index = getattr(response, "index", None)
+            skip_timezone = bool(hasattr(response_index, "tz") and response_index.tz is not None)
+        if (
+            skip_timezone
+            and not return_polars
+            and isinstance(response, pd.DataFrame)
+            and "return" in response.columns
+            and "dividend" not in response.columns
+        ):
+            return _bars_class().from_pandas_fast(response, self.SOURCE, asset1, quote=asset2, raw=response)
+        bars = _bars_class()(
+            response,
+            self.SOURCE,
+            asset1,
+            quote=asset2,
+            raw=response,
+            return_polars=return_polars,
+            skip_timezone=skip_timezone,
+        )
         return bars
 
     def get_yesterday_dividend(self, asset, quote=None):

--- a/lumibot/data_sources/polars_data.py
+++ b/lumibot/data_sources/polars_data.py
@@ -1,16 +1,51 @@
+from __future__ import annotations
+
 from collections import OrderedDict, defaultdict
 from datetime import timedelta
 from decimal import Decimal
-from typing import Union
-
-import pandas as pd
+from importlib import import_module
+from typing import TYPE_CHECKING, Union
 
 from lumibot.data_sources import DataSourceBacktesting
-from lumibot.entities import Asset, Bars, Quote
+from lumibot.entities import Asset
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.tools.lumibot_logger import get_logger
 
+if TYPE_CHECKING:
+    from lumibot.entities import Quote
+
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BARS_CLASS = None
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class PolarsData(DataSourceBacktesting):
@@ -751,7 +786,6 @@ class PolarsData(DataSourceBacktesting):
                 # CRITICAL: Integer timeshift represents BAR offsets, not minute deltas!
                 # Must calculate adjustment based on the actual timestep being requested.
                 if timeshift:
-                    from datetime import timedelta
                     if isinstance(timeshift, int):
                         # Calculate timedelta for one bar of this timestep
                         timestep_delta, _ = self.convert_timestep_str_to_timedelta(timestep)
@@ -886,7 +920,7 @@ class PolarsData(DataSourceBacktesting):
         asset2 = quote
         if isinstance(asset, tuple):
             asset1, asset2 = asset
-        bars = Bars(response, self.SOURCE, asset1, quote=asset2, raw=response, return_polars=return_polars)
+        bars = _bars_class()(response, self.SOURCE, asset1, quote=asset2, raw=response, return_polars=return_polars)
         return bars
 
     def get_yesterday_dividend(self, asset, quote=None):

--- a/lumibot/data_sources/polars_mixin.py
+++ b/lumibot/data_sources/polars_mixin.py
@@ -3,15 +3,32 @@
 This mixin provides common polars operations without disrupting inheritance.
 """
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
-
-import polars as pl
 
 from lumibot.entities import Asset, Bars
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+
+
+class _LazyPolars:
+    _module = None
+
+    def _load(self):
+        if self._module is None:
+            import polars as pl
+
+            self._module = pl
+        return self._module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pl = _LazyPolars()
 
 # DEBUG-LOG: Always-on debug logging (will be removed after debugging is complete)
 _THETA_PARITY_DEBUG = False

--- a/lumibot/data_sources/projectx_data.py
+++ b/lumibot/data_sources/projectx_data.py
@@ -5,20 +5,65 @@ Provides market data functionality through ProjectX data feed.
 Supports historical data retrieval for futures contracts.
 """
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta
-import pandas as pd
-from typing import Dict, List
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict, List
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.data_sources.data_source import DataSource
-from lumibot.entities import Asset, Bars, Quote
+from lumibot.entities import Asset, Quote
 from lumibot.tools.lumibot_logger import get_logger
-from lumibot.tools.projectx_helpers import ProjectXClient
+
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
 
 # Import moved to avoid circular dependency
 # from lumibot.credentials import PROJECTX_CONFIG
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+ProjectXClient = None
+_BARS_CLASS = None
+
+
+def _projectx_client_class():
+    global ProjectXClient
+    if ProjectXClient is None:
+        from lumibot.tools.projectx_helpers import ProjectXClient as _ProjectXClient
+
+        ProjectXClient = _ProjectXClient
+    return ProjectXClient
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class ProjectXData(DataSource):
@@ -79,7 +124,7 @@ class ProjectXData(DataSource):
             )
 
         # Initialize ProjectX client
-        self.client = ProjectXClient(config)
+        self.client = _projectx_client_class()(config)
 
         # Setup logging
         self.logger = get_logger(f"ProjectXData_{self.firm}")
@@ -312,7 +357,7 @@ class ProjectXData(DataSource):
                 logger.debug(debug_msg)
             except Exception as log_exc:
                 self.logger.debug(f"Datetime normalization debug failed for {asset.symbol}: {log_exc}")
-            return Bars(df=df, source=self.SOURCE, asset=asset, raw=df.to_dict())
+            return _bars_class()(df=df, source=self.SOURCE, asset=asset, raw=df.to_dict())
         except Exception as e:
             self.logger.error(f"Error fetching bars for {getattr(asset, 'symbol', asset)}: {e}")
             return None
@@ -576,7 +621,7 @@ class ProjectXData(DataSource):
                 return None
 
             # Create Bars object
-            bars = Bars(
+            bars = _bars_class()(
                 df=df,
                 source=self.SOURCE,
                 asset=asset,

--- a/lumibot/data_sources/schwab_data.py
+++ b/lumibot/data_sources/schwab_data.py
@@ -1,19 +1,75 @@
+from __future__ import annotations
+
 import datetime
 import os
 from datetime import timedelta
 from decimal import Decimal
-from typing import Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Union
 
-import pandas as pd
 from termcolor import colored
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ, LUMIBOT_DEFAULT_TIMEZONE
 from lumibot.data_sources import DataSource
-from lumibot.entities import Asset, Bars, Chains, Quote
-from lumibot.tools import get_trading_days, parse_timestep_qty_and_unit
+from lumibot.entities import Asset, Chains, Quote
 from lumibot.tools.lumibot_logger import get_logger
 
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
+
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BARS_CLASS = None
+_GET_TRADING_DAYS = None
+_PARSE_TIMESTEP_QTY_AND_UNIT = None
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _get_trading_days(*args, **kwargs):
+    global _GET_TRADING_DAYS
+    if _GET_TRADING_DAYS is None:
+        from lumibot.tools import get_trading_days
+
+        _GET_TRADING_DAYS = get_trading_days
+    return _GET_TRADING_DAYS(*args, **kwargs)
+
+
+def _parse_timestep_qty_and_unit(*args, **kwargs):
+    global _PARSE_TIMESTEP_QTY_AND_UNIT
+    if _PARSE_TIMESTEP_QTY_AND_UNIT is None:
+        from lumibot.tools import parse_timestep_qty_and_unit
+
+        _PARSE_TIMESTEP_QTY_AND_UNIT = parse_timestep_qty_and_unit
+    return _PARSE_TIMESTEP_QTY_AND_UNIT(*args, **kwargs)
+
 
 class SchwabData(DataSource):
     """
@@ -280,7 +336,7 @@ class SchwabData(DataSource):
         Returns:
             tuple: (timedelta object, timestep_unit string)
         """
-        qty, unit = parse_timestep_qty_and_unit(timestep_str)
+        qty, unit = _parse_timestep_qty_and_unit(timestep_str)
 
         if unit == "minute":
             return timedelta(minutes=qty), unit
@@ -339,7 +395,7 @@ class SchwabData(DataSource):
         timestep = timestep if timestep else self.MIN_TIMESTEP
 
         # Parse the timestep
-        timestep_qty, timestep_unit = parse_timestep_qty_and_unit(timestep)
+        timestep_qty, timestep_unit = _parse_timestep_qty_and_unit(timestep)
 
         # Calculate end date in Eastern time
         end_date = datetime.datetime.now()
@@ -361,7 +417,7 @@ class SchwabData(DataSource):
             tcal_start_date = end_date - (td * length * 2 + timedelta(days=3))
 
             try:
-                trading_days = get_trading_days(market='NYSE', start_date=tcal_start_date, end_date=end_date)
+                trading_days = _get_trading_days(market='NYSE', start_date=tcal_start_date, end_date=end_date)
                 # Filter out trading days when the market_open is after the end_date
                 trading_days = trading_days[trading_days['market_open'] < end_date]
                 # Now, start_date is the length bars before the last trading day
@@ -488,7 +544,7 @@ class SchwabData(DataSource):
                 df.index = df.index.tz_convert(LUMIBOT_DEFAULT_TIMEZONE)
 
             # Create and return the Bars object
-            bars = Bars(df, self.SOURCE, asset, raw=df, quote=quote)
+            bars = _bars_class()(df, self.SOURCE, asset, raw=df, quote=quote)
             return bars
 
         except Exception as e:

--- a/lumibot/data_sources/tradier_data.py
+++ b/lumibot/data_sources/tradier_data.py
@@ -1,21 +1,92 @@
+from __future__ import annotations
+
 import datetime as dt
 from collections import defaultdict
 from decimal import Decimal
+from importlib import import_module
 from typing import Union
 
-import pandas as pd
 import pytz
-from lumiwealth_tradier import Tradier
 
 from lumibot.constants import LUMIBOT_DEFAULT_TIMEZONE
-from lumibot.entities import Asset, Bars, Quote
+from lumibot.entities import Asset, Quote
 from lumibot.tools import black_scholes
-from lumibot.tools.helpers import create_options_symbol, date_n_trading_days_from_date, parse_timestep_qty_and_unit
 from lumibot.tools.lumibot_logger import get_logger
 
 from .data_source import DataSource
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_TRADIER_CLASS = None
+_BARS_CLASS = None
+_CREATE_OPTIONS_SYMBOL = None
+_DATE_N_TRADING_DAYS_FROM_DATE = None
+_PARSE_TIMESTEP_QTY_AND_UNIT = None
+
+
+def _tradier_class():
+    global _TRADIER_CLASS
+    if _TRADIER_CLASS is None:
+        from lumiwealth_tradier import Tradier
+
+        _TRADIER_CLASS = Tradier
+    return _TRADIER_CLASS
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _create_options_symbol(*args, **kwargs):
+    global _CREATE_OPTIONS_SYMBOL
+    if _CREATE_OPTIONS_SYMBOL is None:
+        from lumibot.tools.helpers import create_options_symbol
+
+        _CREATE_OPTIONS_SYMBOL = create_options_symbol
+    return _CREATE_OPTIONS_SYMBOL(*args, **kwargs)
+
+
+def _date_n_trading_days_from_date(*args, **kwargs):
+    global _DATE_N_TRADING_DAYS_FROM_DATE
+    if _DATE_N_TRADING_DAYS_FROM_DATE is None:
+        from lumibot.tools.helpers import date_n_trading_days_from_date
+
+        _DATE_N_TRADING_DAYS_FROM_DATE = date_n_trading_days_from_date
+    return _DATE_N_TRADING_DAYS_FROM_DATE(*args, **kwargs)
+
+
+def _parse_timestep_qty_and_unit(*args, **kwargs):
+    global _PARSE_TIMESTEP_QTY_AND_UNIT
+    if _PARSE_TIMESTEP_QTY_AND_UNIT is None:
+        from lumibot.tools.helpers import parse_timestep_qty_and_unit
+
+        _PARSE_TIMESTEP_QTY_AND_UNIT = parse_timestep_qty_and_unit
+    return _PARSE_TIMESTEP_QTY_AND_UNIT(*args, **kwargs)
 
 
 class TradierAPIError(Exception):
@@ -98,7 +169,7 @@ class TradierData(DataSource):
         self._account_number = account_number
         self._paper = paper
         self.max_workers = min(max_workers, 50)
-        self.tradier = Tradier(account_number, access_token, paper)
+        self.tradier = _tradier_class()(account_number, access_token, paper)
         self._remove_incomplete_current_bar = remove_incomplete_current_bar
 
     def _sanitize_base_and_quote_asset(self, base_asset, quote_asset) -> tuple[Asset, Asset]:
@@ -234,12 +305,12 @@ class TradierData(DataSource):
         timestep = timestep if timestep else self.MIN_TIMESTEP
 
         # Parse the timestep
-        timestep_qty, timestep_unit = parse_timestep_qty_and_unit(timestep)
+        timestep_qty, timestep_unit = _parse_timestep_qty_and_unit(timestep)
 
         parsed_timestep_unit = self._parse_source_timestep(timestep_unit, reverse=True)
 
         if asset.asset_type == "option":
-            symbol = create_options_symbol(
+            symbol = _create_options_symbol(
                 asset.symbol,
                 asset.expiration,
                 asset.right,
@@ -268,7 +339,7 @@ class TradierData(DataSource):
             minutes_per_day = 24 * 60 / timestep_qty  # Need to include premarket and after hours
             days_needed = int(length // minutes_per_day) + 1
 
-        start_date = date_n_trading_days_from_date(
+        start_date = _date_n_trading_days_from_date(
             n_days=days_needed,
             start_datetime=end_dt,
             # TODO: pass market into DataSource
@@ -331,7 +402,7 @@ class TradierData(DataSource):
             df = df.iloc[-length:]
 
         # Convert the dataframe to a Bars object
-        bars = Bars(df, self.SOURCE, asset, raw=df, quote=quote)
+        bars = _bars_class()(df, self.SOURCE, asset, raw=df, quote=quote)
 
         return bars
 
@@ -357,7 +428,7 @@ class TradierData(DataSource):
         symbol = None
         try:
             if asset.asset_type == "option":
-                symbol = create_options_symbol(
+                symbol = _create_options_symbol(
                     asset.symbol,
                     asset.expiration,
                     asset.right,
@@ -396,7 +467,7 @@ class TradierData(DataSource):
         asset, quote = self._sanitize_base_and_quote_asset(asset, quote)
 
         if asset.asset_type == "option":
-            symbol = create_options_symbol(
+            symbol = _create_options_symbol(
                 asset.symbol,
                 asset.expiration,
                 asset.right,
@@ -446,7 +517,7 @@ class TradierData(DataSource):
         greeks = {}
         stock_symbol = asset.symbol
         expiration = asset.expiration
-        option_symbol = create_options_symbol(stock_symbol, expiration, asset.right, asset.strike)
+        option_symbol = _create_options_symbol(stock_symbol, expiration, asset.right, asset.strike)
         df_chains = self.tradier.market.get_option_chains(stock_symbol, expiration, greeks=True)
         df = df_chains[df_chains["symbol"] == option_symbol]
         if df.empty:

--- a/lumibot/data_sources/tradovate_data.py
+++ b/lumibot/data_sources/tradovate_data.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 from decimal import Decimal
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from termcolor import colored
 
 from lumibot.data_sources import DataSource
-from lumibot.entities import Asset, Bars
+from lumibot.entities import Asset
 from lumibot.tools.lumibot_logger import get_logger
+
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
 
 logger = get_logger(__name__)
 

--- a/lumibot/data_sources/yahoo_data.py
+++ b/lumibot/data_sources/yahoo_data.py
@@ -1,16 +1,57 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from decimal import Decimal
+from importlib import import_module
 from typing import Union
 
-import numpy
-import pandas as pd
-
 from lumibot.data_sources import DataSourceBacktesting
-from lumibot.entities import Asset, Bars
-from lumibot.tools import YahooHelper
+from lumibot.entities import Asset
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+_BARS_CLASS = None
+_YAHOO_HELPER = None
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+numpy = _LazyModule("numpy")
+pd = _LazyModule("pandas")
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _yahoo_helper():
+    global _YAHOO_HELPER
+    if _YAHOO_HELPER is None:
+        from lumibot.tools import YahooHelper
+
+        _YAHOO_HELPER = YahooHelper
+    return _YAHOO_HELPER
 
 
 class YahooData(DataSourceBacktesting):
@@ -254,7 +295,7 @@ class YahooData(DataSourceBacktesting):
         for sym in symbols_to_try:
             logger.info("Attempting to fetch data for symbol: %s", sym)
             try:
-                data = YahooHelper.get_symbol_data(
+                data = _yahoo_helper().get_symbol_data(
                     sym,
                     interval=interval,
                     auto_adjust=self.auto_adjust,
@@ -336,7 +377,7 @@ class YahooData(DataSourceBacktesting):
 
         if missing_assets:
             # Fetch data using the helper without restricting dates here
-            dfs = YahooHelper.get_symbols_data(
+            dfs = _yahoo_helper().get_symbols_data(
                 missing_assets,
                 interval=interval,
                 auto_adjust=self.auto_adjust
@@ -363,7 +404,7 @@ class YahooData(DataSourceBacktesting):
         if quote is not None:
             logger.warning(f"quote is not implemented for YahooData, but {quote} was passed as the quote")
 
-        bars = Bars(response, self.SOURCE, asset, raw=response)
+        bars = _bars_class()(response, self.SOURCE, asset, raw=response)
         return bars
 
     def get_last_price(self, asset, timestep=None, quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:

--- a/lumibot/entities/__init__.py
+++ b/lumibot/entities/__init__.py
@@ -1,38 +1,39 @@
-from .asset import Asset, AssetsMapping
-from .bar import Bar
+"""Compatibility exports for entity classes without importing every entity."""
 
-# Import base implementations
-from .bars import Bars as _BarsBase
-from .cash_event import CashEvent
-from .chains import Chains
-from .data import Data as _DataBase
-from .data_polars import DataPolars
-from .dataline import Dataline
-from .order import Order
-from .position import Position
-from .quote import Quote
-from .trading_fee import TradingFee
-from .trading_slippage import TradingSlippage
-from .smart_limit import SmartLimitConfig, SmartLimitPreset
+from importlib import import_module as _import_module
 
-# Use base implementations directly
-Bars = _BarsBase
-Data = _DataBase
-__all__ = [
-    "Asset",
-    "AssetsMapping",
-    "Bar",
-    "Bars",
-    "CashEvent",
-    "Chains",
-    "Data",
-    "DataPolars",
-    "Dataline",
-    "Order",
-    "Position",
-    "Quote",
-    "TradingFee",
-    "TradingSlippage",
-    "SmartLimitConfig",
-    "SmartLimitPreset",
-]
+_NAME_TO_MODULE = {
+    "Asset": "asset",
+    "AssetsMapping": "asset",
+    "Bar": "bar",
+    "Bars": "bars",
+    "CashEvent": "cash_event",
+    "Chains": "chains",
+    "Data": "data",
+    "DataPolars": "data_polars",
+    "Dataline": "dataline",
+    "Order": "order",
+    "Position": "position",
+    "Quote": "quote",
+    "TradingFee": "trading_fee",
+    "TradingSlippage": "trading_slippage",
+    "SmartLimitConfig": "smart_limit",
+    "SmartLimitPreset": "smart_limit",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/entities/asset.py
+++ b/lumibot/entities/asset.py
@@ -2,7 +2,7 @@ from collections import UserDict
 from datetime import date, datetime
 from enum import Enum
 
-from lumibot.tools import parse_symbol
+from lumibot.tools.symbol_parser import parse_symbol
 
 
 FUTURES_MONTH_CODES = {

--- a/lumibot/entities/bars.py
+++ b/lumibot/entities/bars.py
@@ -1,14 +1,14 @@
-from datetime import datetime, timedelta
+from __future__ import annotations
+
+from datetime import datetime
+from importlib import import_module
 import re
 import weakref
 from decimal import Decimal
+from types import ModuleType
 from typing import Union, Set
-import warnings
 import atexit
 
-import numpy as np
-import pandas as pd
-import polars as pl
 import pytz
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
@@ -22,6 +22,44 @@ logger = get_logger(__name__)
 # share the same `df.columns` object; cache column presence flags to avoid repeated
 # `Index.__contains__` probes in tight loops.
 _PANDAS_COLUMNS_FLAGS_CACHE: dict[int, tuple[weakref.ReferenceType, tuple[bool, bool, bool, bool]]] = {}
+_POLARS_MODULE = None
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+np = _LazyModule("numpy")
+pd = _LazyModule("pandas")
+
+
+def _get_polars_module():
+    global _POLARS_MODULE
+    if _POLARS_MODULE is None:
+        import polars as _pl
+
+        _POLARS_MODULE = _pl
+    return _POLARS_MODULE
+
+
+def _is_polars_df(value) -> bool:
+    if value.__class__.__name__ != "DataFrame":
+        return False
+    module = getattr(value.__class__, "__module__", "")
+    return module == "polars" or module.startswith("polars.")
 
 
 class PolarsConversionTracker:
@@ -166,7 +204,27 @@ class Bars:
     >>> self.log_message(df["close"][-1])
     """
 
-    def __init__(self, df, source, asset, quote=None, raw=None, return_polars=False, tzinfo=None):
+    @classmethod
+    def from_pandas_fast(cls, df, source, asset, quote=None, raw=None):
+        """Build a pandas-backed Bars object for pre-normalized backtesting slices."""
+        obj = cls.__new__(cls)
+        obj.source = str(source).upper()
+        obj.asset = asset
+        if isinstance(asset, tuple):
+            obj.symbol = f"{asset[0].symbol}/{asset[1].symbol}".upper()
+        else:
+            obj.symbol = asset.symbol.upper()
+        obj.quote = quote
+        obj._raw = raw if raw is not None else df
+        obj._return_polars = False
+        obj._polars_cache = None
+        obj._pandas_cache = None
+        obj._tzinfo = None
+        obj._df = df
+        obj._df_is_pandas = True
+        return obj
+
+    def __init__(self, df, source, asset, quote=None, raw=None, return_polars=False, tzinfo=None, skip_timezone=False):
         """
         df columns: open, high, low, close, volume, dividend, stock_splits
         datetime column for polars DataFrames
@@ -185,13 +243,26 @@ class Bars:
         self._polars_cache = None
         self._pandas_cache = None
         self._tzinfo = self._normalize_tzinfo(tzinfo)
+        self._df_is_pandas = isinstance(df, pd.DataFrame)
+
+        if (
+            skip_timezone
+            and not return_polars
+            and isinstance(df, pd.DataFrame)
+            and "return" in df.columns
+            and "dividend" not in df.columns
+        ):
+            self._df = df
+            return
         
         # Check if empty
-        if (isinstance(df, pl.DataFrame) and df.shape[0] == 0) or \
+        is_polars_df = _is_polars_df(df)
+        if (is_polars_df and df.shape[0] == 0) or \
            (isinstance(df, pd.DataFrame) and df.shape[0] == 0):
             logger.warning(f"Unable to get bar data for {asset} {source}")
         
-        if isinstance(df, pl.DataFrame):
+        if is_polars_df:
+            pl = _get_polars_module()
             # Already polars, process it
             columns = df.columns
             
@@ -324,16 +395,22 @@ class Bars:
                         returns[1:] = (curr - prev) / prev
                 self._df["return"] = returns
 
-            self._apply_timezone()
+            if not skip_timezone:
+                self._apply_timezone()
             if self._return_polars:
                 self._pandas_cache = self._df
                 self._df = self._convert_pandas_to_polars(self._df)
                 self._polars_cache = None
+                self._df_is_pandas = False
 
     @property
     def df(self):
         """Return the active DataFrame representation based on return_polars flag."""
-        return self.polars_df if self._return_polars else self.pandas_df
+        if self._return_polars:
+            return self.polars_df
+        if self._df_is_pandas:
+            return self._df
+        return self.pandas_df
 
     @df.setter
     def df(self, value):
@@ -341,13 +418,14 @@ class Bars:
         self._df = value
         self._polars_cache = None
         self._pandas_cache = None
+        self._df_is_pandas = isinstance(value, pd.DataFrame)
 
         if isinstance(value, pd.DataFrame):
             self._apply_timezone()
             if self._return_polars:
                 self._pandas_cache = value
                 self._df = self._convert_pandas_to_polars(value)
-        elif isinstance(value, pl.DataFrame) and not self._return_polars:
+        elif _is_polars_df(value) and not self._return_polars:
             tracker = PolarsConversionTracker()
             tracker.track_conversion(self.asset.symbol if hasattr(self.asset, 'symbol') else str(self.asset))
             pandas_df = value.to_pandas()
@@ -361,7 +439,7 @@ class Bars:
     @property
     def polars_df(self):
         """Return as Polars DataFrame if needed"""
-        if isinstance(self._df, pl.DataFrame):
+        if _is_polars_df(self._df):
             return self._df
         else:
             # Convert pandas to polars once and cache
@@ -398,17 +476,17 @@ class Bars:
 
     def __len__(self):
         """Return the number of bars (rows) in the DataFrame"""
-        if isinstance(self._df, pl.DataFrame):
+        if _is_polars_df(self._df):
             return self._df.height
         if isinstance(self._df, pd.DataFrame):
             return len(self._df)
         df = self.df
-        return df.height if isinstance(df, pl.DataFrame) else len(df)
+        return df.height if _is_polars_df(df) else len(df)
 
     @property
     def empty(self):
         """Check if the DataFrame is empty (compatible with both pandas and polars)"""
-        if isinstance(self._df, pl.DataFrame):
+        if _is_polars_df(self._df):
             return self._df.is_empty()
         else:
             return self._df.empty
@@ -456,8 +534,9 @@ class Bars:
             self._df = target_df
         return target_df
 
-    def _convert_pandas_to_polars(self, pandas_df: pd.DataFrame) -> pl.DataFrame:
+    def _convert_pandas_to_polars(self, pandas_df: pd.DataFrame):
         """Convert a pandas DataFrame (possibly with datetime index) to Polars."""
+        pl = _get_polars_module()
         df_to_convert = pandas_df.copy()
         if isinstance(df_to_convert.index, pd.DatetimeIndex):
             df_to_convert = df_to_convert.reset_index()
@@ -468,6 +547,7 @@ class Bars:
 
     @classmethod
     def parse_bar_list(cls, bar_list, source, asset):
+        pl = _get_polars_module()
         raw = []
         for bar in bar_list:
             raw.append(bar)
@@ -502,7 +582,8 @@ class Bars:
         """
         result = []
         # Use appropriate DataFrame for iteration
-        if isinstance(self._df, pl.DataFrame):
+        pl = _get_polars_module()
+        if _is_polars_df(self._df):
             underlying_df = self._df
         else:
             underlying_df = pl.from_pandas(self._df.reset_index() if hasattr(self._df, 'index') else self._df)
@@ -586,6 +667,7 @@ class Bars:
         Bars object
         """
         # Get polars DataFrame for operations
+        pl = _get_polars_module()
         df_copy = self.polars_df
         # Find datetime column
         dt_col = None
@@ -659,6 +741,7 @@ class Bars:
         Ensures the datetime column is a proper polars Datetime, coercing from integer epoch seconds
         (or milliseconds) and common string formats.
         """
+        pl = _get_polars_module()
         underlying_df = self.polars_df
 
         # Identify datetime column
@@ -690,13 +773,13 @@ class Bars:
                 .drop(dt_col)
                 .rename({tmp_name: dt_col})
             )
-            if isinstance(self._df, pl.DataFrame):
+            if _is_polars_df(self._df):
                 self._df = underlying_df
         elif early_dtype == pl.Utf8:
             underlying_df = underlying_df.with_columns(
                 pl.col(dt_col).str.strptime(pl.Datetime, strict=False, format=None).alias(dt_col)
             )
-            if isinstance(self._df, pl.DataFrame):
+            if _is_polars_df(self._df):
                 self._df = underlying_df
 
         # Frequency normalization

--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -1,13 +1,9 @@
 import datetime
 from decimal import Decimal
+from importlib import import_module
+from types import ModuleType
 from typing import Optional, Union
 
-import numpy as np
-
-import pandas as pd
-
-from lumibot.constants import LUMIBOT_DEFAULT_PYTZ as DEFAULT_PYTZ
-from lumibot.tools.helpers import parse_timestep_qty_and_unit, to_datetime_aware
 from lumibot.tools.lumibot_logger import get_logger
 
 from .asset import Asset
@@ -45,13 +41,179 @@ _DATA_QUOTE_FIELDS = {
 
 # PERF: module-level sentinel used to avoid eager-evaluating fallbacks in `getattr()` hot paths.
 _MISSING = object()
+_LAZY_PANDAS_SLICE_FRAME_CLASS = None
+_DEFAULT_PYTZ = None
+_PARSE_TIMESTEP_QTY_AND_UNIT = None
+_TO_DATETIME_AWARE = None
 
-# Set the option to raise an error if downcasting is not possible (if available in this pandas version)
-try:
-    pd.set_option('future.no_silent_downcasting', True)
-except (pd._config.config.OptionError, AttributeError):
-    # Option not available in this pandas version, skip it
-    pass
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module_name = self._module_name
+            module = import_module(module_name)
+            if module_name == "pandas":
+                try:
+                    module.set_option('future.no_silent_downcasting', True)
+                except (module._config.config.OptionError, AttributeError):
+                    pass
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+np = _LazyModule("numpy")
+pd = _LazyModule("pandas")
+
+
+def _default_pytz():
+    global _DEFAULT_PYTZ
+    if _DEFAULT_PYTZ is None:
+        from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
+
+        _DEFAULT_PYTZ = LUMIBOT_DEFAULT_PYTZ
+    return _DEFAULT_PYTZ
+
+
+def parse_timestep_qty_and_unit(*args, **kwargs):
+    global _PARSE_TIMESTEP_QTY_AND_UNIT
+    if _PARSE_TIMESTEP_QTY_AND_UNIT is None:
+        from lumibot.tools.helpers import parse_timestep_qty_and_unit as _parse_timestep_qty_and_unit
+
+        _PARSE_TIMESTEP_QTY_AND_UNIT = _parse_timestep_qty_and_unit
+    return _PARSE_TIMESTEP_QTY_AND_UNIT(*args, **kwargs)
+
+
+def to_datetime_aware(*args, **kwargs):
+    global _TO_DATETIME_AWARE
+    if _TO_DATETIME_AWARE is None:
+        from lumibot.tools.helpers import to_datetime_aware as _to_datetime_aware
+
+        _TO_DATETIME_AWARE = _to_datetime_aware
+    return _TO_DATETIME_AWARE(*args, **kwargs)
+
+
+def _lazy_pandas_slice_frame_class():
+    global _LAZY_PANDAS_SLICE_FRAME_CLASS
+    if _LAZY_PANDAS_SLICE_FRAME_CLASS is not None:
+        return _LAZY_PANDAS_SLICE_FRAME_CLASS
+
+    class _LazyPandasSliceFrame(pd.DataFrame):
+        """Pandas-compatible lazy row slice for hot backtesting bars.
+
+        It is still a ``pd.DataFrame`` instance for compatibility, but defers the
+        expensive BlockManager slice until strategy code actually uses DataFrame
+        operations. This keeps no-op historical-price calls cheap without changing
+        the public ``bars.df`` surface.
+        """
+
+        _metadata = [
+            "_lumibot_source_df",
+            "_lumibot_slice",
+            "_lumibot_len",
+            "_lumibot_real_df",
+            "_lumibot_virtual_return",
+        ]
+
+        def __init__(self, source_df, slice_obj, length, virtual_return=False):
+            object.__setattr__(self, "_lumibot_source_df", source_df)
+            object.__setattr__(self, "_lumibot_slice", slice_obj)
+            object.__setattr__(self, "_lumibot_len", int(length))
+            object.__setattr__(self, "_lumibot_real_df", None)
+            object.__setattr__(self, "_lumibot_virtual_return", bool(virtual_return))
+
+        def _lumibot_return_values(self):
+            source_df = object.__getattribute__(self, "_lumibot_source_df")
+            slice_obj = object.__getattribute__(self, "_lumibot_slice")
+            start = 0 if slice_obj.start is None else int(slice_obj.start)
+            stop = len(source_df.index) if slice_obj.stop is None else int(slice_obj.stop)
+            close = source_df["close"].to_numpy(dtype="float64", copy=False)
+            values = np.empty(max(0, stop - start), dtype="float64")
+            values[:] = np.nan
+            if len(values) == 0:
+                return values
+            prev_start = max(0, start - 1)
+            window = close[prev_start:stop]
+            if start > 0 and len(window) > 1:
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    values[:] = (window[1:] - window[:-1]) / window[:-1]
+            elif len(window) > 1:
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    values[1:] = (window[1:] - window[:-1]) / window[:-1]
+            return values
+
+        def _lumibot_materialize(self):
+            df = object.__getattribute__(self, "_lumibot_real_df")
+            if df is None:
+                source_df = object.__getattribute__(self, "_lumibot_source_df")
+                slice_obj = object.__getattribute__(self, "_lumibot_slice")
+                try:
+                    mgr = source_df._mgr.get_slice(slice_obj, axis=1)
+                    df = source_df._constructor_from_mgr(mgr, axes=mgr.axes)
+                except Exception:
+                    df = source_df._slice(slice_obj)
+                if object.__getattribute__(self, "_lumibot_virtual_return") and "return" not in df.columns:
+                    df = df.copy(deep=False)
+                    df["return"] = self._lumibot_return_values()
+                object.__setattr__(self, "_lumibot_real_df", df)
+            return df
+
+        @property
+        def _mgr(self):
+            return self._lumibot_materialize()._mgr
+
+        @_mgr.setter
+        def _mgr(self, value):
+            object.__setattr__(self, "_lumibot_real_df", pd.DataFrame._from_mgr(value, axes=value.axes))
+
+        @property
+        def _constructor(self):
+            return pd.DataFrame
+
+        def __len__(self):
+            return object.__getattribute__(self, "_lumibot_len")
+
+        @property
+        def empty(self):
+            return object.__getattribute__(self, "_lumibot_len") == 0
+
+        @property
+        def columns(self):
+            columns = object.__getattribute__(self, "_lumibot_source_df").columns
+            if object.__getattribute__(self, "_lumibot_virtual_return") and "return" not in columns:
+                return columns.append(pd.Index(["return"]))
+            return columns
+
+        @property
+        def index(self):
+            return self._lumibot_materialize().index
+
+        @property
+        def attrs(self):
+            return self._lumibot_materialize().attrs
+
+        def __getitem__(self, key):
+            if isinstance(key, str) and key == "return" and object.__getattribute__(self, "_lumibot_virtual_return"):
+                index = self._lumibot_materialize().index
+                return pd.Series(self._lumibot_return_values(), index=index, name="return")
+            return self._lumibot_materialize().__getitem__(key)
+
+        def __getattr__(self, name):
+            return getattr(self._lumibot_materialize(), name)
+
+        def __repr__(self):
+            return repr(self._lumibot_materialize())
+
+    _LAZY_PANDAS_SLICE_FRAME_CLASS = _LazyPandasSliceFrame
+    return _LAZY_PANDAS_SLICE_FRAME_CLASS
 
 
 class Data:
@@ -162,6 +324,7 @@ class Data:
         timestep="minute",
         quote=None,
         timezone=None,
+        assume_clean=False,
     ):
         self.asset = asset
         self.symbol = self.asset.symbol
@@ -188,6 +351,9 @@ class Data:
             )
 
         self.timestep = timestep
+
+        if assume_clean and self._initialize_clean_constructor_state(df, date_start, date_end, trading_hours_start, trading_hours_end):
+            return
 
         self.df = self.columns(df)
 
@@ -281,6 +447,54 @@ class Data:
         self._bars_has_dividend = "dividend" in self._bars_cols
         self._bars_required_cols = [c for c in ("open", "high", "low", "close") if c in self._bars_cols]
 
+    def _initialize_clean_constructor_state(
+        self,
+        df,
+        date_start=None,
+        date_end=None,
+        trading_hours_start=datetime.time(0, 0),
+        trading_hours_end=datetime.time(23, 59),
+    ) -> bool:
+        if not isinstance(df, pd.DataFrame):
+            return False
+        idx = df.index
+        if not isinstance(idx, pd.DatetimeIndex) or idx.tz is None:
+            return False
+        if not idx.is_monotonic_increasing:
+            return False
+        required = ("open", "high", "low", "close", "volume")
+        if any(col not in df.columns for col in required):
+            return False
+
+        self.df = df
+        if self.df.index.name != "datetime":
+            self.df.index.name = "datetime"
+        self._index_is_unique = bool(getattr(self.df.index, "is_unique", False))
+        self.trading_hours_start, self.trading_hours_end = self.set_times(trading_hours_start, trading_hours_end)
+        self.date_start, self.date_end = self.set_dates(date_start, date_end)
+        try:
+            self._data_len = int(len(self.df.index))
+        except Exception:
+            self._data_len = None
+
+        start_ts = self.df.index[0]
+        end_ts = self.df.index[-1]
+        self.datetime_start = start_ts.to_pydatetime() if isinstance(start_ts, pd.Timestamp) else start_ts
+        self.datetime_end = end_ts.to_pydatetime() if isinstance(end_ts, pd.Timestamp) else end_ts
+
+        self._ohlc_has_nan = False
+        self._volume_has_nan = False
+        self._dividend_has_nan = "dividend" in self.df.columns
+        bars_cols = ["open", "high", "low", "close", "volume"]
+        if "dividend" in self.df.columns:
+            bars_cols.append("dividend")
+        self._bars_cols = [c for c in bars_cols if c in self.df.columns]
+        self._bars_df = None
+        self._bars_has_volume = True
+        self._bars_has_dividend = "dividend" in self._bars_cols
+        self._bars_required_cols = ["open", "high", "low", "close"]
+        return True
+
     def set_times(self, trading_hours_start, trading_hours_end):
         """Set the start and end times for the data. The default is 0001 hrs to 2359 hrs.
 
@@ -321,9 +535,9 @@ class Data:
         df.index.name = "datetime"
         df.index = pd.to_datetime(df.index)
         if not df.index.tzinfo:
-            df.index = pd.to_datetime(df.index).tz_localize(DEFAULT_PYTZ)
-        elif df.index.tzinfo != DEFAULT_PYTZ:
-            df.index = df.index.tz_convert(DEFAULT_PYTZ)
+            df.index = pd.to_datetime(df.index).tz_localize(_default_pytz())
+        elif df.index.tzinfo != _default_pytz():
+            df.index = df.index.tz_convert(_default_pytz())
         return df
 
     def set_dates(self, date_start, date_end):
@@ -379,11 +593,17 @@ class Data:
         idx = idx[start_pos:end_pos]
 
         # OPTIMIZATION: More efficient duplicate removal
-        if self.df.index.has_duplicates:
+        has_duplicates = bool(self.df.index.has_duplicates)
+        if has_duplicates:
             self.df = self.df[~self.df.index.duplicated(keep='first')]
 
-        # Reindex the DataFrame with the new index and forward-fill missing values.
-        df = self.df.reindex(idx, method="ffill")
+        # Reindex the DataFrame with the new index and forward-fill missing values. Lazy-loaded
+        # backtesting data frequently passes its existing clean index here; avoid an identical
+        # reindex/copy and keep the downstream normalization work unchanged.
+        if (not has_duplicates) and len(idx) == len(self.df.index) and idx.equals(self.df.index):
+            df = self.df.copy(deep=False)
+        else:
+            df = self.df.reindex(idx, method="ffill")
 
         # Check if we have a volume column, if not then add it and fill with 0 or NaN.
         if "volume" in df.columns:
@@ -525,14 +745,15 @@ class Data:
             self._data_len = None
 
         # Set up iter_index and iter_index_dict for later use.
-        iter_index = pd.Series(df.index)
-        self.iter_index = pd.Series(iter_index.index, index=iter_index)
+        idx_values = df.index
+        self.iter_index = None
         # PERF: `to_dict()` produces keys as `pd.Timestamp`, which do not hash-equal to
         # `datetime.datetime` objects. Many hot paths pass python datetimes, causing dictionary
         # misses and forcing an expensive `Series.asof()` fallback.
         #
         # Store a second mapping keyed by python datetimes so `dt in iter_index_dict` is fast.
-        self.iter_index_dict = {ts.to_pydatetime(): int(pos) for ts, pos in self.iter_index.items()}
+        self.iter_index_dict = dict(zip(idx_values.to_pydatetime(), range(len(idx_values))))
+        self._iter_index_dict_get = self.iter_index_dict.get
 
         # PERF: Precompute an integer nanoseconds view of the datetime index so `get_iter_count()`
         # can use NumPy search/forward cursors without triggering pandas datetime scalar validation.
@@ -598,6 +819,86 @@ class Data:
         except Exception:
             self._bars_df = None
 
+    def _initialize_clean_repaired_state(self) -> bool:
+        """Initialize datalines/caches for already-clean OHLCV data without full repair."""
+        df = self.df
+        required = ("open", "high", "low", "close", "volume")
+        if any(col not in df.columns for col in required):
+            return False
+        if any(col in df.columns for col in ("bid", "ask", "bid_size", "ask_size")):
+            return False
+        if bool(getattr(df.index, "has_duplicates", False)):
+            return False
+        if getattr(self, "_ohlc_has_nan", True) or getattr(self, "_volume_has_nan", True):
+            return False
+
+        defer_returns = bool(getattr(self, "_defer_clean_returns", False))
+        if "return" not in df.columns and not defer_returns:
+            close_series = df["close"]
+            try:
+                close = close_series.to_numpy(dtype="float64", copy=False)
+            except Exception:
+                close = pd.to_numeric(close_series, errors="coerce").to_numpy(dtype="float64", copy=False)
+
+            returns = np.empty(len(close), dtype="float64")
+            returns[:] = np.nan
+            if len(close) > 1:
+                prev = close[:-1]
+                curr = close[1:]
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    returns[1:] = (curr - prev) / prev
+            df = df.copy(deep=False)
+            df["return"] = returns
+            self.df = df
+        self._return_is_deferred = bool(defer_returns and "return" not in self.df.columns)
+
+        try:
+            self._data_len = int(len(self.df.index))
+        except Exception:
+            self._data_len = None
+
+        idx_values = self.df.index
+        self.iter_index = None
+        self.iter_index_dict = dict(zip(idx_values.to_pydatetime(), range(len(idx_values))))
+        self._iter_index_dict_get = self.iter_index_dict.get
+
+        try:
+            idx = idx_values
+            try:
+                idx = idx.as_unit("ns")
+            except (AttributeError, TypeError):
+                pass
+            self._index_values_ns = idx.asi8
+        except Exception:
+            self._index_values_ns = None
+
+        self._iter_count_cursor_ns = None
+        self._iter_count_cursor_i = 0
+        self._iter_count_last_dt_key = None
+
+        self.datalines = {}
+        if getattr(self, "_skip_clean_datalines", False):
+            # IBKR native daily bars are used for direct slicing/last-price reads; full Dataline
+            # wrappers add load-time CPU/RSS with no benefit on that path.
+            self.datetime = idx_values.to_numpy()
+            for column in self.df.columns:
+                setattr(self, column, self.df[column].to_numpy())
+            self._quote_required_cols_present = False
+            self._quote_missing_cols = list(_DATA_QUOTE_COLS)
+            self._quote_presence_logged = False
+        else:
+            self.to_datalines()
+
+        bars_cols = ["open", "high", "low", "close", "volume"]
+        if "return" in self.df.columns:
+            bars_cols.append("return")
+        self._bars_cols = [c for c in bars_cols if c in self.df.columns]
+        self._bars_has_volume = "volume" in self._bars_cols
+        self._bars_has_dividend = False
+        self._bars_required_cols = [c for c in ("open", "high", "low", "close") if c in self._bars_cols]
+        self._bars_df = self.df[self._bars_cols].copy(deep=False) if self._bars_cols else None
+        return True
+
     def to_datalines(self):
         self.datalines.update(
             {
@@ -636,14 +937,18 @@ class Data:
         # known data (this speeds up the process)
         i = None
 
-        # Check if we have the iter_index_dict, if not then repair the times and fill (which will create the iter_index_dict)
-        if getattr(self, "iter_index_dict", None) is None:
-            self.repair_times_and_fill(self.df.index)
+        iter_index_get = getattr(self, "_iter_index_dict_get", None)
+        if iter_index_get is None:
+            # Check if we have the iter_index_dict, if not then repair the times and fill (which will create the iter_index_dict)
+            if getattr(self, "iter_index_dict", None) is None:
+                self.repair_times_and_fill(self.df.index)
+            iter_index_get = self.iter_index_dict.get
+            self._iter_index_dict_get = iter_index_get
 
         # Normalize dt to a python datetime for fast dict lookups.
         # Callers can pass `pd.Timestamp` (common in pandas-heavy code paths); mixing Timestamp and
         # datetime keys leads to misses and forces an expensive `asof()` fallback.
-        dt_key = dt.to_pydatetime() if isinstance(dt, pd.Timestamp) else dt
+        dt_key = dt.to_pydatetime() if dt.__class__ is pd.Timestamp else dt
 
         # PERF: repeated calls in the same iteration commonly ask for the same `(data, dt)`.
         # Short-circuit before any dict membership/search work.
@@ -651,10 +956,10 @@ class Data:
         if last_dt_key == dt_key:
             cursor_i = getattr(self, "_iter_count_cursor_i", None)
             if cursor_i is not None:
-                return int(cursor_i)
+                return cursor_i
 
         # Fast-path: exact bar timestamp lookup.
-        i = self.iter_index_dict.get(dt_key)
+        i = iter_index_get(dt_key)
         if i is not None:
             index_ns = getattr(self, "_index_values_ns", None)
             if index_ns is not None:
@@ -854,6 +1159,190 @@ class Data:
             pass
 
         return price
+
+    def get_last_price_fast(self, dt) -> Union[float, Decimal, None]:
+        """Fast current-bar last price read for already-validated backtesting data."""
+        iter_count = self.get_iter_count(dt)
+        if iter_count < 0:
+            return None
+
+        lines = getattr(self, "_last_price_fast_lines", None)
+        if lines is None:
+            open_line = getattr(self, "open", None)
+            close_line = getattr(self, "close", None)
+            datetime_line = getattr(self, "datetime", None)
+            if open_line is None or close_line is None or datetime_line is None:
+                open_line = self.datalines["open"].dataline
+                close_line = self.datalines["close"].dataline
+                datetime_line = self.datalines["datetime"].dataline
+            lines = (open_line, close_line, datetime_line)
+            self._last_price_fast_lines = lines
+        else:
+            open_line, close_line, datetime_line = lines
+
+        open_price = open_line[iter_count]
+        close_price = close_line[iter_count]
+        if self.timestep == "day":
+            price = close_price
+        else:
+            price = close_price if dt > datetime_line[iter_count] else open_price
+
+        if price is None:
+            return None
+        try:
+            if price != price:
+                return None
+        except (TypeError, ValueError):
+            try:
+                if pd.isna(price):
+                    return None
+            except (TypeError, ValueError):
+                pass
+        return price
+
+    def get_previous_bar_close_fast(self, dt) -> Union[float, Decimal, None]:
+        """Fast previous-bar close for exact-clock backtesting reads."""
+        iter_index_get = getattr(self, "_iter_index_dict_get", None)
+        if iter_index_get is None:
+            return None
+        dt_key = dt.to_pydatetime() if dt.__class__ is pd.Timestamp else dt
+        i = iter_index_get(dt_key)
+        if i is None or i <= 0:
+            return None
+
+        lines = getattr(self, "_last_price_fast_lines", None)
+        if lines is None:
+            open_line = getattr(self, "open", None)
+            close_line = getattr(self, "close", None)
+            datetime_line = getattr(self, "datetime", None)
+            if open_line is None or close_line is None or datetime_line is None:
+                open_line = self.datalines["open"].dataline
+                close_line = self.datalines["close"].dataline
+                datetime_line = self.datalines["datetime"].dataline
+            lines = (open_line, close_line, datetime_line)
+            self._last_price_fast_lines = lines
+        else:
+            _, close_line, _ = lines
+
+        price = close_line[int(i) - 1]
+        if price is None:
+            return None
+        try:
+            if price != price:
+                return None
+        except (TypeError, ValueError):
+            try:
+                if pd.isna(price):
+                    return None
+            except (TypeError, ValueError):
+                pass
+        return price
+
+    def get_native_bars_fast(self, dt, length=1, timestep=MIN_TIMESTEP, mark_timezone=True):
+        """Fast native minute/day bar slice for warm-cache backtesting paths."""
+        if (
+            not self._index_is_unique
+            or timestep not in {"minute", "day"}
+            or timestep != self.timestep
+        ):
+            return self.get_bars(dt, length=length, timestep=timestep, timeshift=None)
+
+        if timestep == "day":
+            try:
+                dt_date = dt.date()
+            except Exception:
+                dt_date = None
+            day_cache = getattr(self, "_native_day_bars_fast_cache", None)
+            if day_cache is not None and day_cache[0] == dt_date and day_cache[1] == int(length):
+                cached_df = day_cache[2]
+                if cached_df is not None and len(cached_df) != 0:
+                    return cached_df
+
+        iter_count = self.get_iter_count(dt)
+        if iter_count is None:
+            iter_count = 0
+
+        df_source = getattr(self, "_bars_df", None)
+        if df_source is None:
+            bars_cols = getattr(self, "_bars_cols", None)
+            df_source = self.df[bars_cols].copy(deep=False) if bars_cols else self.df
+            if bars_cols:
+                self._bars_df = df_source
+
+        if timestep == "minute" and iter_count > 0:
+            end_row = int(iter_count)
+            start_row = end_row - int(length)
+            if start_row < 0:
+                start_row = 0
+        else:
+            end_row = int(iter_count) + 1 if timestep == "day" else int(iter_count)
+            data_len = getattr(self, "_data_len", None)
+            if data_len is None:
+                data_len = int(len(df_source.index))
+                self._data_len = data_len
+            end_row = max(0, min(end_row, data_len))
+            start_row = max(0, end_row - int(length))
+            if start_row > end_row:
+                start_row = end_row
+            if start_row == end_row and end_row > 0:
+                start_row = max(0, end_row - 1)
+
+        cache_key = None
+        if timestep == "day":
+            cache_key = ("native_fast", timestep, int(length), int(start_row), int(end_row))
+            if getattr(self, "_get_bars_slice_cache_key", None) == cache_key:
+                cached_df = getattr(self, "_get_bars_slice_cache_df", None)
+                if cached_df is not None and len(cached_df) != 0:
+                    return cached_df
+
+        slice_obj = slice(start_row, end_row)
+        if (
+            not mark_timezone
+            and timestep in {"minute", "day"}
+            and not getattr(self, "_ohlc_has_nan", True)
+            and not getattr(self, "_volume_has_nan", False)
+            and not getattr(self, "_dividend_has_nan", False)
+        ):
+            df = _lazy_pandas_slice_frame_class()(
+                df_source,
+                slice_obj,
+                end_row - start_row,
+                virtual_return=getattr(self, "_return_is_deferred", False),
+            )
+            if cache_key is not None:
+                self._get_bars_slice_cache_key = cache_key
+                self._get_bars_slice_cache_df = df
+            return df
+
+        try:
+            mgr = df_source._mgr.get_slice(slice_obj, axis=1)
+            df = df_source._constructor_from_mgr(mgr, axes=mgr.axes)
+        except Exception:
+            df = df_source._slice(slice_obj)
+        if df is None or len(df) == 0:
+            return None
+        if mark_timezone:
+            df.attrs["_lumibot_skip_timezone"] = True
+
+        if (
+            (getattr(self, "_bars_has_volume", False) and getattr(self, "_volume_has_nan", False))
+            or (getattr(self, "_bars_has_dividend", False) and getattr(self, "_dividend_has_nan", False))
+        ):
+            df = df.copy()
+            if getattr(self, "_bars_has_volume", False) and getattr(self, "_volume_has_nan", False):
+                df["volume"] = df["volume"].fillna(0)
+            if getattr(self, "_bars_has_dividend", False) and getattr(self, "_dividend_has_nan", False):
+                df["dividend"] = df["dividend"].fillna(0)
+
+        required = getattr(self, "_bars_required_cols", None)
+        if required and getattr(self, "_ohlc_has_nan", True):
+            df = df.dropna(subset=required)
+
+        self._get_bars_slice_cache_key = cache_key
+        self._get_bars_slice_cache_df = df
+        if timestep == "day":
+            self._native_day_bars_fast_cache = (dt_date, int(length), df)
+        return df
 
     @check_data
     def get_price_snapshot(self, dt, length=1, timeshift=0):
@@ -1086,7 +1575,10 @@ class Data:
         if timeshift is None:
             timeshift = 0
         # Parse the timestep
-        quantity, timestep = parse_timestep_qty_and_unit(timestep)
+        if timestep in {"minute", "hour", "day"}:
+            quantity = 1
+        else:
+            quantity, timestep = parse_timestep_qty_and_unit(timestep)
         num_periods = length
 
         if timestep == "minute" and self.timestep in {"day", "hour"}:
@@ -1118,7 +1610,7 @@ class Data:
         ):
             try:
                 iter_count = self.get_iter_count(dt)
-                if pd.isna(iter_count):
+                if iter_count is None:
                     iter_count = 0
             except Exception:
                 iter_count = self.get_iter_count(dt)
@@ -1163,15 +1655,16 @@ class Data:
             cached_key = getattr(self, "_get_bars_slice_cache_key", None)
             if cached_key == cache_key:
                 cached_df = getattr(self, "_get_bars_slice_cache_df", None)
-                if cached_df is not None and cached_df.shape[0] != 0:
+                if cached_df is not None and len(cached_df) != 0:
                     return cached_df
 
             # PERF: `.iloc[start:end]` goes through the indexer stack (`_iLocIndexer`) which
             # performs validation on every call. In backtesting we already operate on integer
             # row bounds; `_slice()` is the internal fast-path that avoids the indexer overhead.
             df = df_source._slice(slice(start_row, end_row))
-            if df is None or df.shape[0] == 0:
+            if df is None or len(df) == 0:
                 return None
+            df.attrs["_lumibot_skip_timezone"] = True
 
             # PERF: avoid `col in df.columns` membership checks (`Index.__contains__`) on every call.
             has_volume = getattr(self, "_bars_has_volume", _MISSING)
@@ -1233,7 +1726,7 @@ class Data:
             # row bounds in O(1) and return a stable OHLCV schema.
             try:
                 iter_count = self.get_iter_count(dt)
-                if pd.isna(iter_count):
+                if iter_count is None:
                     iter_count = 0
             except Exception:
                 iter_count = self.get_iter_count(dt)
@@ -1286,15 +1779,16 @@ class Data:
             cached_key = getattr(self, "_get_bars_slice_cache_key", None)
             if cached_key == cache_key:
                 cached_df = getattr(self, "_get_bars_slice_cache_df", None)
-                if cached_df is not None and cached_df.shape[0] != 0:
+                if cached_df is not None and len(cached_df) != 0:
                     return cached_df
 
             # PERF: `.iloc[start:end]` goes through the indexer stack (`_iLocIndexer`) which
             # performs validation on every call. In backtesting we already operate on integer
             # row bounds; `_slice()` is the internal fast-path that avoids the indexer overhead.
             df = df_source._slice(slice(start_row, end_row))
-            if df is None or df.shape[0] == 0:
+            if df is None or len(df) == 0:
                 return None
+            df.attrs["_lumibot_skip_timezone"] = True
 
             # PERF: avoid `col in df.columns` membership checks (`Index.__contains__`) on every call.
             has_volume = getattr(self, "_bars_has_volume", _MISSING)

--- a/lumibot/entities/data_polars.py
+++ b/lumibot/entities/data_polars.py
@@ -1,26 +1,75 @@
+from __future__ import annotations
+
 import datetime
 from decimal import Decimal
+from importlib import import_module
 from typing import Optional, Union
 
-import pandas as pd
-import polars as pl
-
-from lumibot.constants import LUMIBOT_DEFAULT_PYTZ as DEFAULT_PYTZ
 import pytz
-from lumibot.tools.helpers import parse_timestep_qty_and_unit, to_datetime_aware
 from lumibot.tools.lumibot_logger import get_logger
 
 from .asset import Asset
 from .dataline import Dataline
 
 logger = get_logger(__name__)
+_DEFAULT_PYTZ = None
+_PARSE_TIMESTEP_QTY_AND_UNIT = None
+_TO_DATETIME_AWARE = None
 
-# Set the option to raise an error if downcasting is not possible (if available in this pandas version)
-try:
-    pd.set_option('future.no_silent_downcasting', True)
-except (pd._config.config.OptionError, AttributeError):
-    # Option not available in this pandas version, skip it
-    pass
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module_name = object.__getattribute__(self, "_module_name")
+            module = import_module(module_name)
+            if module_name == "pandas":
+                try:
+                    module.set_option('future.no_silent_downcasting', True)
+                except (module._config.config.OptionError, AttributeError):
+                    pass
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+pl = _LazyModule("polars")
+
+
+def _default_pytz():
+    global _DEFAULT_PYTZ
+    if _DEFAULT_PYTZ is None:
+        from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
+
+        _DEFAULT_PYTZ = LUMIBOT_DEFAULT_PYTZ
+    return _DEFAULT_PYTZ
+
+
+def parse_timestep_qty_and_unit(*args, **kwargs):
+    global _PARSE_TIMESTEP_QTY_AND_UNIT
+    if _PARSE_TIMESTEP_QTY_AND_UNIT is None:
+        from lumibot.tools.helpers import parse_timestep_qty_and_unit as _parse_timestep_qty_and_unit
+
+        _PARSE_TIMESTEP_QTY_AND_UNIT = _parse_timestep_qty_and_unit
+    return _PARSE_TIMESTEP_QTY_AND_UNIT(*args, **kwargs)
+
+
+def to_datetime_aware(*args, **kwargs):
+    global _TO_DATETIME_AWARE
+    if _TO_DATETIME_AWARE is None:
+        from lumibot.tools.helpers import to_datetime_aware as _to_datetime_aware
+
+        _TO_DATETIME_AWARE = _to_datetime_aware
+    return _TO_DATETIME_AWARE(*args, **kwargs)
 
 
 class DataPolars:
@@ -218,9 +267,9 @@ class DataPolars:
                     self._pandas_df.index = self._localize_or_convert_index(self._pandas_df.index, polars_tz)
 
                 if not getattr(self._pandas_df.index, "tz", None):
-                    self._pandas_df.index = self._localize_or_convert_index(self._pandas_df.index, DEFAULT_PYTZ)
-                elif str(self._pandas_df.index.tz) != str(DEFAULT_PYTZ):
-                    self._pandas_df.index = self._pandas_df.index.tz_convert(DEFAULT_PYTZ)
+                    self._pandas_df.index = self._localize_or_convert_index(self._pandas_df.index, _default_pytz())
+                elif str(self._pandas_df.index.tz) != str(_default_pytz()):
+                    self._pandas_df.index = self._pandas_df.index.tz_convert(_default_pytz())
 
         return self._pandas_df
 

--- a/lumibot/entities/dataline.py
+++ b/lumibot/entities/dataline.py
@@ -1,4 +1,6 @@
 class Dataline:
+    __slots__ = ("asset", "name", "dataline", "dtype")
+
     def __init__(self, asset, name, dataline, dtype):
         self.asset = asset
         self.name = name

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -1,4 +1,5 @@
 import datetime
+import itertools
 import uuid
 from collections import namedtuple
 from decimal import Decimal
@@ -19,6 +20,7 @@ from lumibot.tools.types import check_positive, check_price
 logger = get_logger(__name__)
 
 _LAZY_EVENT_LOCK = Lock()
+_SIMPLE_BACKTEST_IDENTIFIER_COUNTER = itertools.count(1)
 
 
 class _LazyEvent:
@@ -64,6 +66,7 @@ class _LazyEvent:
                         event.set()
                     self._event = event
         return bool(event.wait(timeout=timeout))
+
 
 
 # Custom string enum implementation for Python 3.9 compatibility
@@ -152,6 +155,41 @@ NONE_TYPE = type(None)  # Order is shadowing 'type' parameter, this is a workaro
 
 class Order:
     Transaction = namedtuple("Transaction", ["quantity", "price"])
+    good_till_date = None
+    position_filled = None
+    limit_price = None
+    stop_price = None
+    stop_limit_price = None
+    trail_price = None
+    trail_percent = None
+    price_triggered = False
+    take_profit_price = None
+    stop_loss_price = None
+    stop_loss_limit_price = None
+    parent_identifier = None
+    dependent_order = None
+    dependent_order_filled = False
+    smart_limit = None
+    trade_cost = None
+    trade_slippage = 0.0
+    custom_params = None
+    pair = None
+    tag = ""
+    broker_create_date = None
+    broker_update_date = None
+    exchange = None
+    error_message = None
+    transactions = ()
+    _trail_stop_price = None
+    _avg_fill_price = None
+    _new_event = None
+    _canceled_event = None
+    _partial_filled_event = None
+    _filled_event = None
+    _closed_event = None
+    _raw = None
+    _transmitted = False
+    _error = None
 
     class OrderClass(StrEnum):
         SIMPLE = "simple"
@@ -510,14 +548,14 @@ class Order:
         self._quantity = quantity
 
         try:
-            self.side = side if isinstance(side, (self.OrderSide, NONE_TYPE)) else self.OrderSide(side)
+            self.side = side if (side is None or isinstance(side, self.OrderSide)) else self.OrderSide(side)
         except ValueError:
             raise ValueError(f"Order: Invalid side {side}. Must be one of:"
                              f" {', '.join([str(s.value) for s in self.OrderSide])}") from None
 
         try:
             self.order_class = order_class \
-                if isinstance(order_class, (self.OrderClass, NONE_TYPE)) else self.OrderClass(order_class)
+                if (order_class is None or isinstance(order_class, self.OrderClass)) else self.OrderClass(order_class)
         except ValueError:
             raise ValueError(f"Order: Invalid order_class '{order_class}'. Must be one of:"
                              f" {', '.join([str(oc.value) for oc in self.OrderClass])}") from None
@@ -612,7 +650,7 @@ class Order:
 
         try:
             self.order_type = order_type \
-                if isinstance(order_type, (self.OrderType, NONE_TYPE)) else self.OrderType(order_type)
+                if (order_type is None or isinstance(order_type, self.OrderType)) else self.OrderType(order_type)
         except ValueError:
             raise ValueError(f"Order: Invalid order_type {order_type}. Must be one of:"
                              f" {', '.join([str(t.value) for t in self.OrderType])}") from None
@@ -667,6 +705,107 @@ class Order:
             secondary_trail_price,
             secondary_trail_percent,
         )
+
+    @classmethod
+    def simple_market_backtest(
+        cls,
+        strategy,
+        asset,
+        quantity,
+        side,
+        *,
+        quote=None,
+        time_in_force="gtc",
+        date_created=None,
+        identifier=None,
+    ):
+        """Construct a normal simple MARKET order for hot backtest paths."""
+        obj = cls.__new__(cls)
+        obj.child_orders = []
+        obj.strategy = strategy
+        obj.asset = asset
+        obj.quote = quote
+        obj.symbol = asset.symbol if asset else None
+        obj._identifier = identifier if identifier else f"bt-{next(_SIMPLE_BACKTEST_IDENTIFIER_COUNTER):x}"
+        obj._status = "unprocessed"
+        obj._date_created = date_created
+        obj.side = side if (side is None or side.__class__ is cls.OrderSide) else cls.OrderSide(side)
+        obj.time_in_force = time_in_force
+        obj.order_class = cls.OrderClass.SIMPLE
+        obj.order_type = cls.OrderType.MARKET
+        asset_type = getattr(asset, "asset_type", None)
+        quote_asset_type = getattr(quote, "asset_type", None) if quote is not None else None
+        asset_type_value = getattr(asset, "_cached_asset_type_key", None)
+        if asset_type_value is None:
+            asset_type_value = str.__str__(asset_type) if isinstance(asset_type, str) else str(asset_type or "")
+        quote_asset_type_value = getattr(quote, "_cached_asset_type_key", None) if quote is not None else ""
+        if quote_asset_type_value is None:
+            quote_asset_type_value = (
+                str.__str__(quote_asset_type) if isinstance(quote_asset_type, str) else str(quote_asset_type or "")
+            )
+
+        if asset and asset_type_value == "crypto" and quote:
+            pair_cache = getattr(asset, "_lumibot_quote_pair_cache", None)
+            if pair_cache is None:
+                pair_cache = {}
+                try:
+                    setattr(asset, "_lumibot_quote_pair_cache", pair_cache)
+                except Exception:
+                    pair_cache = None
+            quote_symbol = quote.symbol
+            if pair_cache is not None:
+                pair = pair_cache.get(quote_symbol)
+                if pair is None:
+                    pair = f"{asset.symbol}/{quote_symbol}"
+                    pair_cache[quote_symbol] = pair
+                obj.pair = pair
+            else:
+                obj.pair = f"{asset.symbol}/{quote_symbol}"
+        obj._simple_asset_type_value = asset_type_value
+        obj._simple_is_crypto_forex = asset_type_value == "crypto" and quote_asset_type_value == "forex"
+        obj._simple_is_future = asset_type_value in ("future", "cont_future")
+        obj._simple_multiplier = getattr(asset, "multiplier", None) or 1
+        obj._simple_is_option = asset_type_value == "option"
+        if obj._simple_is_future:
+            obj._simple_futures_ledger_key = (obj.strategy, obj.symbol, asset_type, getattr(asset, "expiration", None))
+        obj._quantity = quantity if isinstance(quantity, Decimal) else Decimal(quantity)
+        obj._simple_quantity_float = float(obj._quantity)
+        obj._simple_backtest_order = True
+        side_obj = obj.side
+        if side_obj is cls.OrderSide.BUY:
+            obj._simple_is_buy = True
+            obj._simple_is_sell = False
+        elif side_obj is cls.OrderSide.SELL:
+            obj._simple_is_buy = False
+            obj._simple_is_sell = True
+        else:
+            obj._simple_is_buy = (
+                side_obj is cls.OrderSide.BUY_TO_OPEN
+                or side_obj is cls.OrderSide.BUY_TO_COVER
+                or side_obj is cls.OrderSide.BUY_TO_CLOSE
+            )
+            obj._simple_is_sell = (
+                side_obj is cls.OrderSide.SELL_SHORT
+                or side_obj is cls.OrderSide.SELL_TO_OPEN
+                or side_obj is cls.OrderSide.SELL_TO_CLOSE
+            )
+        obj._simple_direct_fill_eligible = (
+            (obj._simple_is_buy or obj._simple_is_sell)
+            and asset_type_value in ("crypto", "future", "cont_future")
+        )
+        obj._fast_trade_event_static = (
+            obj.strategy,
+            obj._identifier,
+            obj.symbol,
+            obj.side,
+            obj.order_type,
+            obj.trade_slippage,
+            obj.time_in_force,
+            obj._simple_multiplier,
+            asset_type,
+        )
+        return obj
+
     def is_advanced_order(self):
         order_class = self.order_class
         return (
@@ -1167,7 +1306,19 @@ class Order:
 
     def add_transaction(self, price, quantity):
         transaction = self.Transaction(price=price, quantity=quantity)
-        self.transactions.append(transaction)
+        transactions = self.transactions
+        if type(transactions) is list:
+            transactions.append(transaction)
+        else:
+            self.transactions = [transaction]
+
+    def add_transaction_fast(self, price, quantity):
+        transaction = self.Transaction(quantity=quantity, price=price)
+        transactions = self.transactions
+        if type(transactions) is list:
+            transactions.append(transaction)
+        else:
+            self.transactions = [transaction]
 
     def cash_pending(self, strategy):
         # Returns the impact to cash of any unfilled shares.
@@ -1346,28 +1497,50 @@ class Order:
     # ======Setting the events methods===========
 
     def set_new(self):
+        if self._new_event is None:
+            self._new_event = _LazyEvent()
         self._new_event.set()
 
     def set_canceled(self):
+        if self._canceled_event is None:
+            self._canceled_event = _LazyEvent()
         self._canceled_event.set()
+        if self._closed_event is None:
+            self._closed_event = _LazyEvent()
         self._closed_event.set()
 
     def set_partially_filled(self):
+        if self._partial_filled_event is None:
+            self._partial_filled_event = _LazyEvent()
         self._partial_filled_event.set()
 
     def set_filled(self):
+        if self._filled_event is None:
+            self._filled_event = _LazyEvent()
         self._filled_event.set()
+        if self._closed_event is None:
+            self._closed_event = _LazyEvent()
         self._closed_event.set()
 
     # =========Waiting methods==================
 
     def wait_to_be_registered(self):
         logger.info("Waiting for order %r to be registered" % self)
+        if self._new_event is None:
+            if self.status != "unprocessed":
+                logger.info("Order %r registered" % self)
+                return
+            self._new_event = _LazyEvent()
         self._new_event.wait()
         logger.info("Order %r registered" % self)
 
     def wait_to_be_closed(self):
         logger.info("Waiting for broker to execute order %r" % self)
+        if self._closed_event is None:
+            if self.status in {"filled", "canceled", "error"}:
+                logger.info("Order %r executed by broker" % self)
+                return
+            self._closed_event = _LazyEvent()
         self._closed_event.wait()
         logger.info("Order %r executed by broker" % self)
 

--- a/lumibot/entities/position.py
+++ b/lumibot/entities/position.py
@@ -106,6 +106,30 @@ class Position:
                     )
             self.orders = orders
 
+    @classmethod
+    def simple_backtest(cls, strategy, asset, quantity, order, avg_fill_price=None):
+        """Create a Position for the validated simple backtest fill hot path."""
+        position = cls.__new__(cls)
+        position.strategy = strategy
+        position.asset = asset
+        position.symbol = asset.symbol
+        position.orders = [order]
+        position.avg_fill_price = avg_fill_price
+        position._quantity = quantity if type(quantity) is Decimal else Decimal(quantity)
+        position._quantity_float = float(position._quantity)
+        asset_type_value = getattr(order, "_simple_asset_type_value", None)
+        if asset_type_value is None:
+            asset_type = getattr(asset, "asset_type", None)
+            asset_type_value = str.__str__(asset_type) if isinstance(asset_type, str) else str(asset_type or "")
+        if asset_type_value == "crypto":
+            position._hold = Decimal("0")
+            position._available = Decimal("0")
+        else:
+            position._hold = 0
+            position._available = 0
+        position._raw = None
+        return position
+
     def __repr__(self):
         return f"{self.strategy} Position: {self.quantity} shares of {self.asset} ({len(self.orders)} orders)"
 
@@ -221,6 +245,12 @@ class Position:
         self._quantity_float = float(self._quantity)
         if order not in self.orders:
             self.orders.append(order)
+
+    def add_simple_order(self, order: entities.Order, quantity: Decimal, is_buy: bool):
+        qty = Decimal(quantity)
+        self._quantity += qty if is_buy else -qty
+        self._quantity_float = float(self._quantity)
+        self.orders.append(order)
 
     # ========= Serialization methods ===========
     def to_minimal_dict(self) -> dict:

--- a/lumibot/example_strategies/_agent_tool.py
+++ b/lumibot/example_strategies/_agent_tool.py
@@ -1,0 +1,69 @@
+import inspect
+import textwrap
+from typing import Any, Callable
+
+
+def _get_clean_source(func: Callable[..., Any]) -> str | None:
+    try:
+        source = inspect.getsource(func)
+    except (OSError, TypeError):
+        return None
+
+    source = textwrap.dedent(source)
+    lines = source.split("\n")
+    clean_lines = []
+    past_decorator = False
+    for line in lines:
+        stripped = line.strip()
+        if not past_decorator:
+            if stripped.startswith("@"):
+                continue
+            if stripped.startswith(")") and not stripped.startswith("def"):
+                continue
+            past_decorator = True
+        clean_lines.append(line)
+    if not clean_lines:
+        return None
+    return "\n".join(clean_lines).replace("(self, ", "(", 1).replace("(self)", "()").strip()
+
+
+def _build_description(func: Callable[..., Any], explicit_description: str | None) -> str:
+    base = explicit_description or (func.__doc__ or "").strip() or func.__name__
+    source = _get_clean_source(func)
+    if source:
+        return f"{base}\n\nSource code:\n{source}"
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return base
+
+    params = []
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        annotation = param.annotation
+        type_str = annotation.__name__ if hasattr(annotation, "__name__") else str(annotation)
+        if type_str == "<class 'inspect._empty'>":
+            type_str = "any"
+        default = f", default={param.default!r}" if param.default is not inspect.Parameter.empty else ""
+        params.append(f"{name} ({type_str}{default})")
+    if params:
+        return f"{base}\n\nParameters: {', '.join(params)}"
+    return base
+
+
+def agent_tool(*, name: str | None = None, description: str | None = None) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Lightweight agent tool decorator for import-cheap example strategies."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        setattr(
+            func,
+            "_lumibot_agent_tool",
+            {
+                "name": name or func.__name__,
+                "description": _build_description(func, description),
+            },
+        )
+        return func
+
+    return decorator

--- a/lumibot/example_strategies/agent_alpaca_news_builtin.py
+++ b/lumibot/example_strategies/agent_alpaca_news_builtin.py
@@ -26,7 +26,6 @@ Usage:
 
 import os
 
-from lumibot.components.agents import BuiltinTools
 from lumibot.strategies.strategy import Strategy
 
 
@@ -35,6 +34,8 @@ IS_BACKTESTING = True
 
 class AlpacaNewsBuiltinStrategy(Strategy):
     def initialize(self):
+        from lumibot.components.agents import BuiltinTools
+
         self.sleeptime = "1D"
         self.vars.iteration_count = 0
         model_id = os.environ.get("AGENT_MODEL", "gemini-3.1-flash-lite-preview")

--- a/lumibot/example_strategies/agent_discretionary.py
+++ b/lumibot/example_strategies/agent_discretionary.py
@@ -36,12 +36,18 @@ Usage:
 import csv
 import io
 import os
-import requests
 
-from lumibot.components.agents import BuiltinTools, agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class DiscretionaryTraderStrategy(Strategy):
@@ -77,7 +83,7 @@ class DiscretionaryTraderStrategy(Strategy):
         if end_date:
             params["coed"] = end_date
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://fred.stlouisfed.org/graph/fredgraph.csv",
                 params=params,
                 timeout=15,
@@ -139,6 +145,8 @@ class DiscretionaryTraderStrategy(Strategy):
             return {"error": str(e), "symbol": symbol}
 
     def initialize(self):
+        from lumibot.components.agents import BuiltinTools
+
         self.sleeptime = "1D"
         self.vars.iteration_count = 0
         model_id = os.environ.get("AGENT_MODEL", "gemini-3.1-pro-preview")

--- a/lumibot/example_strategies/agent_m2_liquidity.py
+++ b/lumibot/example_strategies/agent_m2_liquidity.py
@@ -18,12 +18,18 @@ Usage:
 import csv
 import io
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class M2LiquidityStrategy(Strategy):
@@ -60,7 +66,7 @@ class M2LiquidityStrategy(Strategy):
         if end_date:
             params["coed"] = end_date
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://fred.stlouisfed.org/graph/fredgraph.csv",
                 params=params,
                 timeout=15,

--- a/lumibot/example_strategies/agent_m2_liquidity_anthropic.py
+++ b/lumibot/example_strategies/agent_m2_liquidity_anthropic.py
@@ -26,12 +26,18 @@ Usage:
 import csv
 import io
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class M2LiquidityAnthropicStrategy(Strategy):
@@ -56,7 +62,7 @@ class M2LiquidityAnthropicStrategy(Strategy):
         if end_date:
             params["coed"] = end_date
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://fred.stlouisfed.org/graph/fredgraph.csv",
                 params=params,
                 timeout=15,

--- a/lumibot/example_strategies/agent_m2_liquidity_grok.py
+++ b/lumibot/example_strategies/agent_m2_liquidity_grok.py
@@ -33,12 +33,18 @@ Usage:
 import csv
 import io
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class M2LiquidityGrokStrategy(Strategy):
@@ -75,7 +81,7 @@ class M2LiquidityGrokStrategy(Strategy):
         if end_date:
             params["coed"] = end_date
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://fred.stlouisfed.org/graph/fredgraph.csv",
                 params=params,
                 timeout=15,

--- a/lumibot/example_strategies/agent_m2_liquidity_openai.py
+++ b/lumibot/example_strategies/agent_m2_liquidity_openai.py
@@ -26,12 +26,18 @@ Usage:
 import csv
 import io
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class M2LiquidityOpenAIStrategy(Strategy):
@@ -68,7 +74,7 @@ class M2LiquidityOpenAIStrategy(Strategy):
         if end_date:
             params["coed"] = end_date
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://fred.stlouisfed.org/graph/fredgraph.csv",
                 params=params,
                 timeout=15,

--- a/lumibot/example_strategies/agent_macro_risk.py
+++ b/lumibot/example_strategies/agent_macro_risk.py
@@ -17,12 +17,18 @@ Usage:
 """
 
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class MacroRiskStrategy(Strategy):
@@ -56,7 +62,7 @@ class MacroRiskStrategy(Strategy):
         if end:
             params["end"] = end
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 f"https://data.alpaca.markets/v2/stocks/{symbol}/bars",
                 headers=headers, params=params, timeout=15,
             )
@@ -92,7 +98,7 @@ class MacroRiskStrategy(Strategy):
         api_secret = os.environ.get("ALPACA_API_SECRET", "")
         headers = {"APCA-API-KEY-ID": api_key, "APCA-API-SECRET-KEY": api_secret}
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://data.alpaca.markets/v1beta1/screener/stocks/movers",
                 headers=headers, params={"top": top}, timeout=15,
             )

--- a/lumibot/example_strategies/agent_momentum_allocator.py
+++ b/lumibot/example_strategies/agent_momentum_allocator.py
@@ -17,12 +17,18 @@ Usage:
 """
 
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class MomentumAllocatorStrategy(Strategy):
@@ -59,7 +65,7 @@ class MomentumAllocatorStrategy(Strategy):
         if end:
             params["end"] = end
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 f"https://data.alpaca.markets/v2/stocks/{symbol}/bars",
                 headers=headers,
                 params=params,
@@ -115,7 +121,7 @@ class MomentumAllocatorStrategy(Strategy):
         if end:
             params["end"] = end
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://data.alpaca.markets/v1beta1/news",
                 headers=headers,
                 params=params,

--- a/lumibot/example_strategies/agent_news_sentiment.py
+++ b/lumibot/example_strategies/agent_news_sentiment.py
@@ -16,12 +16,18 @@ Usage:
 """
 
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class NewsSentimentStrategy(Strategy):
@@ -61,7 +67,7 @@ class NewsSentimentStrategy(Strategy):
         if symbols:
             params["symbols"] = symbols
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://data.alpaca.markets/v1beta1/news",
                 headers=headers, params=params, timeout=15,
             )

--- a/lumibot/example_strategies/bitunix_futures_example.py
+++ b/lumibot/example_strategies/bitunix_futures_example.py
@@ -1,7 +1,5 @@
 import time
 
-from lumibot.brokers import Bitunix
-from lumibot.credentials import BITUNIX_CONFIG  # Assuming Bitunix config is in credentials
 from lumibot.entities import Asset, Order
 from lumibot.strategies.strategy import Strategy
 
@@ -57,6 +55,9 @@ class BitunixFuturesExample(Strategy):
 
 
 if __name__ == "__main__":
+    from lumibot.brokers import Bitunix
+    from lumibot.credentials import BITUNIX_CONFIG  # Assuming Bitunix config is in credentials
+
     # Ensure Bitunix credentials are set in .env or environment variables
     # BITUNIX_CONFIG should contain API_KEY, API_SECRET
     if not BITUNIX_CONFIG or not BITUNIX_CONFIG.get("API_KEY") or not BITUNIX_CONFIG.get("API_SECRET"):
@@ -68,4 +69,3 @@ if __name__ == "__main__":
         broker = Bitunix(BITUNIX_CONFIG)
         strategy = BitunixFuturesExample(broker=broker)
         strategy.run_live()
-

--- a/lumibot/example_strategies/ccxt_backtesting_example.py
+++ b/lumibot/example_strategies/ccxt_backtesting_example.py
@@ -1,8 +1,7 @@
+from __future__ import annotations
+
 from datetime import datetime
 
-from pandas import DataFrame
-
-from lumibot.backtesting import CcxtBacktesting
 from lumibot.entities import Asset, Order
 from lumibot.strategies.strategy import Strategy
 
@@ -35,7 +34,9 @@ class CcxtBacktestingExampleStrategy(Strategy):
         return self.get_historical_prices(asset=self.asset,length=self.window,
                                     timestep="day",quote=self.quote).df
 
-    def _get_bbands(self,history_df:DataFrame):
+    def _get_bbands(self, history_df):
+        from pandas import DataFrame
+
         # BBL (Lower Bollinger Band): Can act as a support level based on price volatility, and can indicate an 'oversold' condition if the price falls below this line.
         # BBM (Breaking Bollinger Bands): This is essentially a moving average over a selected period of time, used as a reference point for price trends.
         # BBU (Upper Bollinger Band): Can act as a resistance level based on price volatility, and can indicate an 'overbought' condition if the price moves above this line.
@@ -86,6 +87,7 @@ class CcxtBacktestingExampleStrategy(Strategy):
 
 
 if  __name__ == "__main__":
+    from lumibot.backtesting import CcxtBacktesting
 
     base_symbol = "ETH"
     quote_symbol = "USDT"

--- a/lumibot/example_strategies/classic_60_40.py
+++ b/lumibot/example_strategies/classic_60_40.py
@@ -1,17 +1,3 @@
-from datetime import datetime
-
-import pytz
-
-from lumibot.backtesting import AlpacaBacktesting
-from lumibot.components.configs_helper import ConfigsHelper
-from lumibot.credentials import ALPACA_TEST_CONFIG, IS_BACKTESTING
-from lumibot.entities import Asset
-from lumibot.example_strategies.drift_rebalancer import DriftRebalancer
-from lumibot.tools.pandas import print_full_pandas_dataframes
-from lumibot.traders.debug_log_trader import DebugLogTrader
-
-print_full_pandas_dataframes()
-
 """
 Strategy Description
 
@@ -24,6 +10,19 @@ assets that has drifted the least to bring the portfolio back to the target weig
 
 
 if __name__ == "__main__":
+    from datetime import datetime
+
+    import pytz
+
+    from lumibot.backtesting import AlpacaBacktesting
+    from lumibot.components.configs_helper import ConfigsHelper
+    from lumibot.credentials import ALPACA_TEST_CONFIG, IS_BACKTESTING
+    from lumibot.entities import Asset
+    from lumibot.example_strategies.drift_rebalancer import DriftRebalancer
+    from lumibot.tools.pandas import print_full_pandas_dataframes
+    from lumibot.traders.debug_log_trader import DebugLogTrader
+
+    print_full_pandas_dataframes()
 
     configs_helper = ConfigsHelper(configs_folder="example_strategies")
     parameters = configs_helper.load_config("classic_60_40_config")

--- a/lumibot/example_strategies/crypto_50_50.py
+++ b/lumibot/example_strategies/crypto_50_50.py
@@ -1,17 +1,3 @@
-from datetime import datetime
-
-import pytz
-
-from lumibot.backtesting import AlpacaBacktesting
-from lumibot.components.configs_helper import ConfigsHelper
-from lumibot.credentials import ALPACA_TEST_CONFIG, IS_BACKTESTING
-from lumibot.entities import Asset
-from lumibot.example_strategies.drift_rebalancer import DriftRebalancer
-from lumibot.tools.pandas import print_full_pandas_dataframes
-from lumibot.traders.debug_log_trader import DebugLogTrader
-
-print_full_pandas_dataframes()
-
 """
 Strategy Description
 
@@ -23,6 +9,19 @@ assets that has drifted the least to bring the portfolio back to the target weig
 
 
 if __name__ == "__main__":
+    from datetime import datetime
+
+    import pytz
+
+    from lumibot.backtesting import AlpacaBacktesting
+    from lumibot.components.configs_helper import ConfigsHelper
+    from lumibot.credentials import ALPACA_TEST_CONFIG, IS_BACKTESTING
+    from lumibot.entities import Asset
+    from lumibot.example_strategies.drift_rebalancer import DriftRebalancer
+    from lumibot.tools.pandas import print_full_pandas_dataframes
+    from lumibot.traders.debug_log_trader import DebugLogTrader
+
+    print_full_pandas_dataframes()
 
     configs_helper = ConfigsHelper(configs_folder="example_strategies")
     parameters = configs_helper.load_config("crypto_50_50_config")

--- a/lumibot/example_strategies/crypto_important_functions.py
+++ b/lumibot/example_strategies/crypto_important_functions.py
@@ -1,6 +1,5 @@
 import datetime
 
-from lumibot.brokers import Ccxt
 from lumibot.entities import Asset
 from lumibot.strategies.strategy import Strategy
 
@@ -122,6 +121,8 @@ class ImportantFunctions(Strategy):
 
 
 if __name__ == "__main__":
+    from lumibot.brokers import Ccxt
+
     KRAKEN_CONFIG = {
         "exchange_id": "kraken",
         "apiKey": "YOUR_API_KEY",

--- a/lumibot/example_strategies/drift_rebalancer.py
+++ b/lumibot/example_strategies/drift_rebalancer.py
@@ -1,11 +1,21 @@
+from __future__ import annotations
+
 from decimal import Decimal
 from typing import Any
 
-import pandas as pd
-
-from lumibot.components.drift_rebalancer_logic import DriftRebalancerLogic, DriftType
 from lumibot.entities import Order
 from lumibot.strategies.strategy import Strategy
+
+
+class DriftType:
+    ABSOLUTE = "absolute"
+    RELATIVE = "relative"
+
+
+def _pd():
+    import pandas as pd
+
+    return pd
 
 
 class DriftRebalancer(Strategy):
@@ -88,6 +98,8 @@ class DriftRebalancer(Strategy):
 
     # noinspection PyAttributeOutsideInit
     def initialize(self, parameters: Any = None) -> None:
+        from lumibot.components.drift_rebalancer_logic import DriftRebalancerLogic
+
         self.set_market(self.parameters.get("market", "NYSE"))
         self.sleeptime = self.parameters.get("sleeptime", "1D")
         self.drift_type = self.parameters.get("drift_type", DriftType.RELATIVE)
@@ -99,7 +111,7 @@ class DriftRebalancer(Strategy):
         self.shorting = self.parameters.get("shorting", False)
         self.fractional_shares = self.parameters.get("fractional_shares", False)
         self.only_rebalance_drifted_assets = self.parameters.get("only_rebalance_drifted_assets", False)
-        self.drift_df = pd.DataFrame()
+        self.drift_df = _pd().DataFrame()
         self.drift_rebalancer_logic = DriftRebalancerLogic(
             strategy=self,
             drift_type=self.drift_type,

--- a/lumibot/example_strategies/forex_hold_to_expiry.py
+++ b/lumibot/example_strategies/forex_hold_to_expiry.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from lumibot.entities import Asset
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -25,6 +24,7 @@ class FuturesHoldToExpiry(Strategy):
 
     def on_trading_iteration(self):
         """Buys the self.buy_symbol once, then never again"""
+        from lumibot.entities import Asset
 
         buy_symbol = self.parameters["buy_symbol"]
 

--- a/lumibot/example_strategies/futures_hold_to_expiry.py
+++ b/lumibot/example_strategies/futures_hold_to_expiry.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 
-from lumibot.credentials import IS_BACKTESTING
-from lumibot.entities import Asset
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -28,6 +26,7 @@ class FuturesHoldToExpiry(Strategy):
 
     def on_trading_iteration(self):
         """Buys the self.buy_symbol once, then never again"""
+        from lumibot.entities import Asset
 
         buy_symbol = self.parameters["buy_symbol"]
         expiry = self.parameters["expiry"]
@@ -67,6 +66,8 @@ class FuturesHoldToExpiry(Strategy):
 
 
 if __name__ == "__main__":
+    from lumibot.credentials import IS_BACKTESTING
+
     if IS_BACKTESTING:
         from lumibot.backtesting import PolygonDataBacktesting
 

--- a/lumibot/example_strategies/options_hold_to_expiry.py
+++ b/lumibot/example_strategies/options_hold_to_expiry.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from lumibot.entities import Asset
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -26,6 +25,7 @@ class OptionsHoldToExpiry(Strategy):
 
     def on_trading_iteration(self):
         """Buys the self.buy_symbol once, then never again"""
+        from lumibot.entities import Asset
 
         buy_symbol = self.parameters["buy_symbol"]
         expiry = self.parameters["expiry"]

--- a/lumibot/example_strategies/schedule_function.py
+++ b/lumibot/example_strategies/schedule_function.py
@@ -1,6 +1,4 @@
 
-from lumibot.brokers import Alpaca
-from lumibot.credentials import ALPACA_TEST_CONFIG
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -60,6 +58,8 @@ class ScheduledFunctionStrategy(Strategy):
 
 
 if __name__ == "__main__":
+    from lumibot.brokers import Alpaca
+    from lumibot.credentials import ALPACA_TEST_CONFIG
 
     # Verify we have the necessary configuration
     if not ALPACA_TEST_CONFIG:

--- a/lumibot/example_strategies/stock_bracket.py
+++ b/lumibot/example_strategies/stock_bracket.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from lumibot.entities import Order
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -32,6 +31,7 @@ class StockBracket(Strategy):
 
     def on_trading_iteration(self):
         """Buys the self.buy_symbol once, then never again"""
+        from lumibot.entities import Order
 
         buy_symbol = self.parameters["buy_symbol"]
         take_profit_price = self.parameters["take_profit_price"]

--- a/lumibot/example_strategies/stock_buy_and_hold.py
+++ b/lumibot/example_strategies/stock_buy_and_hold.py
@@ -1,8 +1,5 @@
 import datetime as dt
 
-import pytz
-
-from lumibot.credentials import ALPACA_TEST_CONFIG
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -60,7 +57,10 @@ if __name__ == "__main__":
     IS_BACKTESTING = True
 
     if IS_BACKTESTING:
+        import pytz
+
         from lumibot.backtesting import AlpacaBacktesting
+        from lumibot.credentials import ALPACA_TEST_CONFIG
 
         if not IS_BACKTESTING:
             print("This strategy is not meant to be run live. Please set IS_BACKTESTING to True.")

--- a/lumibot/example_strategies/stock_diversified_leverage.py
+++ b/lumibot/example_strategies/stock_diversified_leverage.py
@@ -1,8 +1,3 @@
-from datetime import datetime
-
-from lumibot.backtesting import YahooDataBacktesting
-from lumibot.brokers import Alpaca
-from lumibot.entities import TradingFee
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -121,6 +116,8 @@ class DiversifiedLeverage(Strategy):
 
 
 if __name__ == "__main__":
+    from datetime import datetime
+
     is_live = False
 
     if is_live:
@@ -128,6 +125,7 @@ if __name__ == "__main__":
         # Run the strategy live
         ####
         from credentials import ALPACA_CONFIG
+        from lumibot.brokers import Alpaca
 
         broker = Alpaca(ALPACA_CONFIG)
         strategy = DiversifiedLeverage(broker=broker)
@@ -137,6 +135,8 @@ if __name__ == "__main__":
         ####
         # Backtest the strategy
         ####
+        from lumibot.backtesting import YahooDataBacktesting
+        from lumibot.entities import TradingFee
 
         # Choose the time from and to which you want to backtest
         backtesting_start = datetime(2010, 6, 1)

--- a/lumibot/example_strategies/stock_oco.py
+++ b/lumibot/example_strategies/stock_oco.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from lumibot.entities import Order
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -33,6 +32,7 @@ class StockOco(Strategy):
 
     def on_trading_iteration(self):
         """Buys the self.buy_symbol once, then never again"""
+        from lumibot.entities import Order
 
         buy_symbol = self.parameters["buy_symbol"]
         take_profit_price = self.parameters["take_profit_price"]

--- a/lumibot/example_strategies/strangle.py
+++ b/lumibot/example_strategies/strangle.py
@@ -3,9 +3,13 @@ import logging
 import time
 from itertools import cycle
 
-from yfinance import Ticker
-
 from lumibot.strategies.strategy import Strategy
+
+
+def _ticker(symbol):
+    from yfinance import Ticker
+
+    return Ticker(symbol)
 
 
 class Strangle(Strategy):
@@ -224,7 +228,7 @@ class Strangle(Strategy):
 
             # Check to make sure date is not too close to earnings.
             print(f"Getting earnings date for {asset.symbol}")
-            edate_df = Ticker(asset.symbol).calendar
+            edate_df = _ticker(asset.symbol).calendar
             if edate_df is None:
                 print(
                     f"There was no calendar information for {asset.symbol} so it "

--- a/lumibot/indicators/indicators.py
+++ b/lumibot/indicators/indicators.py
@@ -43,14 +43,43 @@ are missing when they hand-roll indicator code inside ``on_trading_iteration``.
 from __future__ import annotations
 
 import logging
+from importlib import import_module
 from typing import Any, Callable, Optional
-
-import numpy as np
-import pandas as pd
 
 logger = logging.getLogger(__name__)
 
 _TA_MODULE: Any = None
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+np = _LazyModule("numpy")
+pd = _LazyModule("pandas")
 
 
 def _get_ta_module():

--- a/lumibot/strategies/__init__.py
+++ b/lumibot/strategies/__init__.py
@@ -1,2 +1,25 @@
-from .strategy import Strategy
-from .strategy_executor import StrategyExecutor
+"""Strategy package exports without importing executor unless requested."""
+
+from importlib import import_module as _import_module
+
+_NAME_TO_MODULE = {
+    "Strategy": "strategy",
+    "StrategyExecutor": "strategy_executor",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -327,39 +327,28 @@ def _ensure_backtesting_imports():
     if _BACKTESTING_IMPORTS_READY:
         return
 
-    from ..backtesting import (
-        AlpacaBacktesting as _AlpacaBacktesting,
-        BacktestingBroker as _BacktestingBroker,
-        CcxtBacktesting as _CcxtBacktesting,
-        DataBentoDataBacktesting as _DataBentoDataBacktesting,
-        InteractiveBrokersRESTBacktesting as _InteractiveBrokersRESTBacktesting,
-        PolygonDataBacktesting as _PolygonDataBacktesting,
-        RoutedBacktestingPandas as _RoutedBacktestingPandas,
-        ThetaDataBacktesting as _ThetaDataBacktesting,
-        ThetaDataBacktestingPandas as _ThetaDataBacktestingPandas,
-        YahooDataBacktesting as _YahooDataBacktesting,
-    )
+    backtesting = import_module("lumibot.backtesting")
 
     if AlpacaBacktesting is None:
-        AlpacaBacktesting = _AlpacaBacktesting
+        AlpacaBacktesting = backtesting.AlpacaBacktesting
     if BacktestingBroker is None:
-        BacktestingBroker = _BacktestingBroker
+        BacktestingBroker = backtesting.BacktestingBroker
     if CcxtBacktesting is None:
-        CcxtBacktesting = _CcxtBacktesting
+        CcxtBacktesting = backtesting.CcxtBacktesting
     if DataBentoDataBacktesting is None:
-        DataBentoDataBacktesting = _DataBentoDataBacktesting
+        DataBentoDataBacktesting = backtesting.DataBentoDataBacktesting
     if InteractiveBrokersRESTBacktesting is None:
-        InteractiveBrokersRESTBacktesting = _InteractiveBrokersRESTBacktesting
+        InteractiveBrokersRESTBacktesting = backtesting.InteractiveBrokersRESTBacktesting
     if PolygonDataBacktesting is None:
-        PolygonDataBacktesting = _PolygonDataBacktesting
+        PolygonDataBacktesting = backtesting.PolygonDataBacktesting
     if RoutedBacktestingPandas is None:
-        RoutedBacktestingPandas = _RoutedBacktestingPandas
+        RoutedBacktestingPandas = backtesting.RoutedBacktestingPandas
     if ThetaDataBacktesting is None:
-        ThetaDataBacktesting = _ThetaDataBacktesting
+        ThetaDataBacktesting = backtesting.ThetaDataBacktesting
     if ThetaDataBacktestingPandas is None:
-        ThetaDataBacktestingPandas = _ThetaDataBacktestingPandas
+        ThetaDataBacktestingPandas = backtesting.ThetaDataBacktestingPandas
     if YahooDataBacktesting is None:
-        YahooDataBacktesting = _YahooDataBacktesting
+        YahooDataBacktesting = backtesting.YahooDataBacktesting
     _BACKTESTING_IMPORTS_READY = True
 
 class SafeJSONEncoder(json.JSONEncoder):

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import io
 import json
@@ -10,78 +12,355 @@ import traceback
 import uuid
 from collections import deque
 from decimal import Decimal
-from typing import Dict, List, Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict, List, Union
 
-import matplotlib.dates as mdates
-import matplotlib.pyplot as plt
-import matplotlib.ticker as ticker
-import pandas as pd
-import polars as pl
-import requests
-from sqlalchemy import create_engine, inspect, text
-from sqlalchemy.exc import OperationalError
-from termcolor import colored
-
-from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.tools.lumibot_logger import get_logger, get_strategy_logger
-from lumibot.tools.parquet_utils import (
-    coerce_object_columns_to_json_strings,
-    is_parquet_required,
-    write_parquet_with_logging,
-)
 
-from ..backtesting import (
-    AlpacaBacktesting,
-    BacktestingBroker,
-    CcxtBacktesting,
-    DataBentoDataBacktesting,
-    InteractiveBrokersRESTBacktesting,
-    PolygonDataBacktesting,
-    RoutedBacktestingPandas,
-    ThetaDataBacktesting,
-    ThetaDataBacktestingPandas,
-    YahooDataBacktesting,
-)
-from ..components.agents import AgentManager
-from ..credentials import (
-    BACKTESTING_END,
-    BACKTESTING_SHOW_PROGRESS_BAR,
-    BACKTESTING_START,
-    BROKER,
-    DATA_SOURCE,
-    DB_CONNECTION_STR,
-    DISCORD_WEBHOOK_URL,
-    HIDE_POSITIONS,
-    HIDE_TRADES,
-    LIVE_CONFIG,
-    LOG_BACKTEST_PROGRESS_TO_FILE,
-    LUMIWEALTH_API_KEY,
-    MARKET,
-    POLYGON_API_KEY,
-    POLYGON_MAX_MEMORY_BYTES,
-    SHOW_INDICATORS,
-    SHOW_PLOT,
-    SHOW_TEARSHEET,
-    STRATEGY_NAME,
-    THETADATA_CONFIG,
-)
-from ..entities import Asset, CashEvent, Data, Order, Position
-from ..tools import (
-    cash_flow_adjusted_returns,
-    create_tearsheet,
-    cumulative_to_period_flows,
-    day_deduplicate,
-    get_symbol_returns,
-    plot_indicators,
-    plot_returns,
-    stats_summary,
-    to_datetime_aware,
-)
-from ..traders import Trader
-from .strategy_executor import StrategyExecutor
+from ..entities import Asset, Order
+
+if TYPE_CHECKING:
+    from ..entities import CashEvent, Data
 
 # Set the stats table name for when storing stats in a database, defined by db_connection_str
 STATS_TABLE_NAME = "strategy_tracker"
+_COMPAT_SENTINEL = object()
+_BACKTESTING_IMPORTS_READY = False
+_REQUESTS_MODULE = None
+_SQLALCHEMY_IMPORTS = None
+_POLARS_MODULE = None
+_TOOL_FUNC_CACHE = {}
+_PARQUET_UTILS = None
+_STRATEGY_EXECUTOR_CLASS = None
+_TRADER_CLASS = None
+_LUMIBOT_DEFAULT_PYTZ = None
+_CREDENTIALS_MODULE = None
+_COLORED_FN = None
+Trader = _COMPAT_SENTINEL
+BROKER = _COMPAT_SENTINEL
+DATA_SOURCE = _COMPAT_SENTINEL
+STRATEGY_NAME = _COMPAT_SENTINEL
+HIDE_POSITIONS = _COMPAT_SENTINEL
+HIDE_TRADES = _COMPAT_SENTINEL
+MARKET = _COMPAT_SENTINEL
+LIVE_CONFIG = _COMPAT_SENTINEL
+DISCORD_WEBHOOK_URL = _COMPAT_SENTINEL
+DB_CONNECTION_STR = _COMPAT_SENTINEL
+LUMIWEALTH_API_KEY = _COMPAT_SENTINEL
+BACKTESTING_START = _COMPAT_SENTINEL
+BACKTESTING_END = _COMPAT_SENTINEL
+SHOW_PLOT = _COMPAT_SENTINEL
+SHOW_TEARSHEET = _COMPAT_SENTINEL
+SHOW_INDICATORS = _COMPAT_SENTINEL
+POLYGON_API_KEY = _COMPAT_SENTINEL
+THETADATA_CONFIG = _COMPAT_SENTINEL
+BACKTESTING_SHOW_PROGRESS_BAR = _COMPAT_SENTINEL
+POLYGON_MAX_MEMORY_BYTES = _COMPAT_SENTINEL
+LOG_BACKTEST_PROGRESS_TO_FILE = _COMPAT_SENTINEL
+AlpacaBacktesting = None
+BacktestingBroker = None
+CcxtBacktesting = None
+DataBentoDataBacktesting = None
+InteractiveBrokersRESTBacktesting = None
+PolygonDataBacktesting = None
+RoutedBacktestingPandas = None
+ThetaDataBacktesting = None
+ThetaDataBacktestingPandas = None
+YahooDataBacktesting = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _strategy_executor_class():
+    global _STRATEGY_EXECUTOR_CLASS
+    if _STRATEGY_EXECUTOR_CLASS is None:
+        from .strategy_executor import StrategyExecutor
+
+        _STRATEGY_EXECUTOR_CLASS = StrategyExecutor
+    return _STRATEGY_EXECUTOR_CLASS
+
+
+def _trader_class():
+    global _TRADER_CLASS, Trader
+    if Trader is not _COMPAT_SENTINEL:
+        return Trader
+    if _TRADER_CLASS is None:
+        from ..traders import Trader as _Trader
+
+        _TRADER_CLASS = _Trader
+    return _TRADER_CLASS
+
+
+def _default_pytz():
+    global _LUMIBOT_DEFAULT_PYTZ
+    if _LUMIBOT_DEFAULT_PYTZ is None:
+        from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
+
+        _LUMIBOT_DEFAULT_PYTZ = LUMIBOT_DEFAULT_PYTZ
+    return _LUMIBOT_DEFAULT_PYTZ
+
+
+def _credential(name):
+    override = globals().get(name, _COMPAT_SENTINEL)
+    if override is not _COMPAT_SENTINEL:
+        return override
+    global _CREDENTIALS_MODULE
+    if _CREDENTIALS_MODULE is None:
+        from .. import credentials
+
+        _CREDENTIALS_MODULE = credentials
+    return getattr(_CREDENTIALS_MODULE, name)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        if name in {"_module_name", "_module"}:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+
+
+def _call_tool_func(name, *args, **kwargs):
+    fn = _TOOL_FUNC_CACHE.get(name)
+    if fn is None:
+        tools = import_module("lumibot.tools")
+        fn = getattr(tools, name)
+        _TOOL_FUNC_CACHE[name] = fn
+    return fn(*args, **kwargs)
+
+
+def _get_parquet_utils():
+    global _PARQUET_UTILS
+    if _PARQUET_UTILS is None:
+        from lumibot.tools.parquet_utils import (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+
+        _PARQUET_UTILS = (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+    return _PARQUET_UTILS
+
+
+def cash_flow_adjusted_returns(*args, **kwargs):
+    return _call_tool_func("cash_flow_adjusted_returns", *args, **kwargs)
+
+
+def create_tearsheet(*args, **kwargs):
+    return _call_tool_func("create_tearsheet", *args, **kwargs)
+
+
+def cumulative_to_period_flows(*args, **kwargs):
+    return _call_tool_func("cumulative_to_period_flows", *args, **kwargs)
+
+
+def day_deduplicate(*args, **kwargs):
+    return _call_tool_func("day_deduplicate", *args, **kwargs)
+
+
+def get_symbol_returns(*args, **kwargs):
+    return _call_tool_func("get_symbol_returns", *args, **kwargs)
+
+
+def plot_indicators(*args, **kwargs):
+    return _call_tool_func("plot_indicators", *args, **kwargs)
+
+
+def plot_returns(*args, **kwargs):
+    return _call_tool_func("plot_returns", *args, **kwargs)
+
+
+def stats_summary(*args, **kwargs):
+    return _call_tool_func("stats_summary", *args, **kwargs)
+
+
+def to_datetime_aware(*args, **kwargs):
+    return _call_tool_func("to_datetime_aware", *args, **kwargs)
+
+
+def _get_requests_module():
+    global _REQUESTS_MODULE
+    if _REQUESTS_MODULE is None:
+        import requests as _requests
+
+        _REQUESTS_MODULE = _requests
+    return _REQUESTS_MODULE
+
+
+def _get_sqlalchemy_imports():
+    global _SQLALCHEMY_IMPORTS
+    if _SQLALCHEMY_IMPORTS is None:
+        from sqlalchemy import create_engine, inspect, text
+        from sqlalchemy.exc import OperationalError
+
+        _SQLALCHEMY_IMPORTS = (create_engine, inspect, text, OperationalError)
+    return _SQLALCHEMY_IMPORTS
+
+
+def _get_polars_module():
+    global _POLARS_MODULE
+    if _POLARS_MODULE is None:
+        import polars as _pl
+
+        _POLARS_MODULE = _pl
+    return _POLARS_MODULE
+
+
+class _LazyAgentManager:
+    """Import and construct AgentManager only when strategy code uses agents."""
+
+    __slots__ = ("_strategy", "_manager")
+
+    def __init__(self, strategy):
+        self._strategy = strategy
+        self._manager = None
+
+    def _get_manager(self):
+        manager = self._manager
+        if manager is None:
+            from ..components.agents import AgentManager
+
+            manager = AgentManager(self._strategy)
+            self._manager = manager
+            try:
+                self._strategy.agents = manager
+            except Exception:
+                pass
+        return manager
+
+    def __getattr__(self, name):
+        return getattr(self._get_manager(), name)
+
+    def __getitem__(self, key):
+        return self._get_manager()[key]
+
+    def __contains__(self, key):
+        return key in self._get_manager()
+
+    def __iter__(self):
+        return iter(self._get_manager())
+
+    def __len__(self):
+        return len(self._get_manager())
+
+    def __repr__(self):
+        manager = self._manager
+        if manager is None:
+            return "<LazyAgentManager unloaded>"
+        return repr(manager)
+
+
+class _LazyIndicators:
+    """Import and construct Indicators only when strategy code uses indicators."""
+
+    __slots__ = ("_strategy", "_indicators")
+
+    def __init__(self, strategy):
+        self._strategy = strategy
+        self._indicators = None
+
+    def _get_indicators(self):
+        indicators = self._indicators
+        if indicators is None:
+            from lumibot.indicators import Indicators
+
+            indicators = Indicators(self._strategy)
+            self._indicators = indicators
+            try:
+                self._strategy.indicators = indicators
+            except Exception:
+                pass
+        return indicators
+
+    def __getattr__(self, name):
+        return getattr(self._get_indicators(), name)
+
+    def __repr__(self):
+        indicators = self._indicators
+        if indicators is None:
+            return "<LazyIndicators unloaded>"
+        return repr(indicators)
+
+
+def _ensure_backtesting_imports():
+    global _BACKTESTING_IMPORTS_READY
+    global AlpacaBacktesting, BacktestingBroker, CcxtBacktesting, DataBentoDataBacktesting
+    global InteractiveBrokersRESTBacktesting, PolygonDataBacktesting, RoutedBacktestingPandas
+    global ThetaDataBacktesting, ThetaDataBacktestingPandas, YahooDataBacktesting
+
+    if _BACKTESTING_IMPORTS_READY:
+        return
+
+    from ..backtesting import (
+        AlpacaBacktesting as _AlpacaBacktesting,
+        BacktestingBroker as _BacktestingBroker,
+        CcxtBacktesting as _CcxtBacktesting,
+        DataBentoDataBacktesting as _DataBentoDataBacktesting,
+        InteractiveBrokersRESTBacktesting as _InteractiveBrokersRESTBacktesting,
+        PolygonDataBacktesting as _PolygonDataBacktesting,
+        RoutedBacktestingPandas as _RoutedBacktestingPandas,
+        ThetaDataBacktesting as _ThetaDataBacktesting,
+        ThetaDataBacktestingPandas as _ThetaDataBacktestingPandas,
+        YahooDataBacktesting as _YahooDataBacktesting,
+    )
+
+    if AlpacaBacktesting is None:
+        AlpacaBacktesting = _AlpacaBacktesting
+    if BacktestingBroker is None:
+        BacktestingBroker = _BacktestingBroker
+    if CcxtBacktesting is None:
+        CcxtBacktesting = _CcxtBacktesting
+    if DataBentoDataBacktesting is None:
+        DataBentoDataBacktesting = _DataBentoDataBacktesting
+    if InteractiveBrokersRESTBacktesting is None:
+        InteractiveBrokersRESTBacktesting = _InteractiveBrokersRESTBacktesting
+    if PolygonDataBacktesting is None:
+        PolygonDataBacktesting = _PolygonDataBacktesting
+    if RoutedBacktestingPandas is None:
+        RoutedBacktestingPandas = _RoutedBacktestingPandas
+    if ThetaDataBacktesting is None:
+        ThetaDataBacktesting = _ThetaDataBacktesting
+    if ThetaDataBacktestingPandas is None:
+        ThetaDataBacktestingPandas = _ThetaDataBacktestingPandas
+    if YahooDataBacktesting is None:
+        YahooDataBacktesting = _YahooDataBacktesting
+    _BACKTESTING_IMPORTS_READY = True
 
 class SafeJSONEncoder(json.JSONEncoder):
     """Custom JSON encoder for Lumibot objects.
@@ -150,7 +429,7 @@ class _Strategy:
             if tzinfo is None or tzinfo.utcoffset(value) is None:
                 return to_datetime_aware(value)
             if not hasattr(tzinfo, "zone"):
-                return value.astimezone(LUMIBOT_DEFAULT_PYTZ)
+                return value.astimezone(_default_pytz())
         return value
 
     @property
@@ -306,6 +585,8 @@ class _Strategy:
         self.sell_trading_slippages = sell_trading_slippages
         self.save_logfile = save_logfile
         self.broker = broker
+        if getattr(broker, "IS_BACKTESTING_BROKER", False):
+            _ensure_backtesting_imports()
 
         # initialize cash variables
         self._position_value = None
@@ -345,8 +626,8 @@ class _Strategy:
         if name is not None:
             self._name = name
 
-        elif STRATEGY_NAME is not None:
-            self._name = STRATEGY_NAME
+        elif _credential("STRATEGY_NAME") is not None:
+            self._name = _credential("STRATEGY_NAME")
 
         else:
             self._name = self.__class__.__name__
@@ -362,12 +643,12 @@ class _Strategy:
         self._logged_get_historical_prices_assets = set()
 
         if self.broker == None:
-            self.broker = BROKER
+            self.broker = _credential("BROKER")
 
         # Handle data source initialization
         self._data_source = data_source
         if self._data_source is None:
-            self._data_source = DATA_SOURCE
+            self._data_source = _credential("DATA_SOURCE")
 
         # If we have a custom data source, attach it to the broker
         if self._data_source is not None and self.broker is not None:
@@ -377,19 +658,20 @@ class _Strategy:
             # Set the custom data source
             self.broker.data_source = self._data_source
 
-        self.hide_positions = HIDE_POSITIONS
-        self.hide_trades = HIDE_TRADES
+        self.hide_positions = _credential("HIDE_POSITIONS")
+        self.hide_trades = _credential("HIDE_TRADES")
         self.include_cash_positions = include_cash_positions
 
         # If the MARKET env variable is set, use it as the market
-        if MARKET:
+        market = _credential("MARKET")
+        if market:
             # Log the market being used
-            colored_message = colored(f"Using market from environment variables: {MARKET}", "green")
+            colored_message = colored(f"Using market from environment variables: {market}", "green")
             self.logger.info(colored_message)
-            self.set_market(MARKET)
+            self.set_market(market)
 
-        self.live_config = LIVE_CONFIG
-        self.discord_webhook_url = discord_webhook_url if discord_webhook_url is not None else DISCORD_WEBHOOK_URL
+        self.live_config = _credential("LIVE_CONFIG")
+        self.discord_webhook_url = discord_webhook_url if discord_webhook_url is not None else _credential("DISCORD_WEBHOOK_URL")
 
         if account_history_db_connection_str:
             self.db_connection_str = account_history_db_connection_str
@@ -397,7 +679,8 @@ class _Strategy:
         elif db_connection_str:
             self.db_connection_str = db_connection_str
         else:
-            self.db_connection_str = DB_CONNECTION_STR if DB_CONNECTION_STR else None
+            env_db_connection_str = _credential("DB_CONNECTION_STR")
+            self.db_connection_str = env_db_connection_str if env_db_connection_str else None
 
         self.discord_account_summary_footer = discord_account_summary_footer
         self.backup_table_name="vars_backup"
@@ -406,7 +689,7 @@ class _Strategy:
         if lumiwealth_api_key:
             self.lumiwealth_api_key = lumiwealth_api_key
         else:
-            self.lumiwealth_api_key = LUMIWEALTH_API_KEY
+            self.lumiwealth_api_key = _credential("LUMIWEALTH_API_KEY")
 
         if strategy_id is None:
             self.strategy_id = self._name
@@ -482,6 +765,8 @@ class _Strategy:
             # Create initial starting positions.
             self.starting_positions = starting_positions
             if self.starting_positions is not None and len(self.starting_positions) > 0:
+                from ..entities import Position
+
                 for asset, quantity in self.starting_positions.items():
                     position = Position(
                         self._name,
@@ -587,7 +872,7 @@ class _Strategy:
         self._minutes_after_closing = minutes_after_closing
         self._sleeptime = sleeptime
         self._risk_free_rate = risk_free_rate
-        self._executor = StrategyExecutor(self)
+        self._executor = _strategy_executor_class()(self)
         self.broker._add_subscriber(self._executor)
 
         # Stats related variables
@@ -602,10 +887,9 @@ class _Strategy:
         self.should_send_summary_to_discord = should_send_summary_to_discord
         self._last_backup_state = None
         self.vars = Vars()
-        self.agents = AgentManager(self)
+        self.agents = _LazyAgentManager(self)
 
-        from lumibot.indicators import Indicators
-        self.indicators = Indicators(self)
+        self.indicators = _LazyIndicators(self)
 
         # Storing parameters for the initialize method
         if not hasattr(self, "parameters") or not isinstance(self.parameters, dict) or self.parameters is None:
@@ -727,6 +1011,8 @@ class _Strategy:
                 return
 
         # If not in positions, create a new position for cash
+        from ..entities import Position
+
         position = Position(
             self._name,
             self._quote_asset,
@@ -740,9 +1026,10 @@ class _Strategy:
 
     def _get_cash_position(self):
         cash_position = getattr(self, "_cash_position", None)
+        cash_asset = getattr(cash_position, "asset", None) if cash_position is not None else None
         if (
             cash_position is not None
-            and getattr(cash_position, "asset", None) == self._quote_asset
+            and (cash_asset is self._quote_asset or cash_asset == self._quote_asset)
             and getattr(cash_position, "strategy", None) == self._name
         ):
             return cash_position
@@ -909,6 +1196,8 @@ class _Strategy:
             return
 
         try:
+            from ..entities import CashEvent
+
             cash_event = CashEvent(
                 broker_name="backtesting",
                 event_type=event_type,
@@ -1119,9 +1408,9 @@ class _Strategy:
             if isinstance(broker_dt, datetime.datetime):
                 try:
                     if broker_dt.tzinfo is None:
-                        option_mark_time_local = LUMIBOT_DEFAULT_PYTZ.localize(broker_dt)
+                        option_mark_time_local = _default_pytz().localize(broker_dt)
                     else:
-                        option_mark_time_local = broker_dt.astimezone(LUMIBOT_DEFAULT_PYTZ)
+                        option_mark_time_local = broker_dt.astimezone(_default_pytz())
                 except Exception:
                     option_mark_time_local = None
 
@@ -1304,8 +1593,10 @@ class _Strategy:
         if base_asset_type is None:
             base_asset_type = getattr(base_asset, "asset_type", None)
             base_asset_type = getattr(base_asset_type, "value", base_asset_type)
-            base_asset_type = str(base_asset_type).lower()
+        base_asset_type = str(base_asset_type).lower()
         is_option_asset = base_asset_type == "option"
+        if self.is_backtesting and is_option_asset:
+            _ensure_backtesting_imports()
         is_thetadata_option_backtest = (
             self.is_backtesting
             and is_option_asset
@@ -1539,7 +1830,7 @@ class _Strategy:
 
         now = self._normalize_snapshot_datetime(getattr(self.broker, "datetime", None))
         if now is None:
-            now = self._normalize_snapshot_datetime(datetime.datetime.now(LUMIBOT_DEFAULT_PYTZ))
+            now = self._normalize_snapshot_datetime(datetime.datetime.now(_default_pytz()))
 
         trade_time = self._normalize_snapshot_datetime(snapshot.get("last_trade_time"))
         bid_time = self._normalize_snapshot_datetime(snapshot.get("last_bid_time"))
@@ -1622,10 +1913,10 @@ class _Strategy:
         if isinstance(dt_value, datetime.datetime):
             if dt_value.tzinfo is None:
                 try:
-                    return LUMIBOT_DEFAULT_PYTZ.localize(dt_value)
+                    return _default_pytz().localize(dt_value)
                 except ValueError:
-                    return dt_value.replace(tzinfo=LUMIBOT_DEFAULT_PYTZ)
-            return dt_value.astimezone(LUMIBOT_DEFAULT_PYTZ)
+                    return dt_value.replace(tzinfo=_default_pytz())
+            return dt_value.astimezone(_default_pytz())
         return None
 
     @staticmethod
@@ -1816,6 +2107,11 @@ class _Strategy:
                 stats_parquet_file = (
                     self._stats_file[:-4] + ".parquet" if self._stats_file.lower().endswith(".csv") else self._stats_file + ".parquet"
                 )
+                (
+                    coerce_object_columns_to_json_strings,
+                    is_parquet_required,
+                    write_parquet_with_logging,
+                ) = _get_parquet_utils()
                 required = bool(self.is_backtesting) and is_parquet_required()
                 write_parquet_with_logging(
                     df=self._stats,
@@ -1840,6 +2136,8 @@ class _Strategy:
         if not self.is_backtesting or not self._benchmark_asset:
             return
         if self._backtesting_start is not None and self._backtesting_end is not None:
+            _ensure_backtesting_imports()
+
             # Need to adjust the backtesting end date because the data from Yahoo
             # is at the start of the day, so the graph cuts short. This may be needed
             # for other timeframes as well
@@ -1872,6 +2170,7 @@ class _Strategy:
 
                 # Add returns column
                 if hasattr(df, 'select'):  # Polars DataFrame
+                    pl = _get_polars_module()
                     df = df.with_columns(pl.col("close").pct_change().alias("return"))
                     # Add the symbol_cumprod column for polars
                     df = df.with_columns((1 + pl.col("return")).cum_prod().alias("symbol_cumprod"))
@@ -2078,6 +2377,7 @@ class _Strategy:
                     return
                 df = df.loc[self._backtesting_start:self._backtesting_end].copy()
                 if hasattr(df, 'select'):  # Polars DataFrame
+                    pl = _get_polars_module()
                     df = df.with_columns(pl.col("close").pct_change().alias("return"))
                     df = df.with_columns((1 + pl.col("return")).cumprod().alias("symbol_cumprod"))
                 else:  # Pandas DataFrame
@@ -2390,7 +2690,7 @@ class _Strategy:
         use_quote_data = False,
         show_progress_bar = True,
         quiet_logs = False,
-        trader_class = Trader,
+        trader_class = None,
         include_cash_positions=False,
         save_stats_file = True,
         **kwargs,
@@ -2522,6 +2822,8 @@ class _Strategy:
 
         if name is None:
             name = self.__name__
+        if trader_class is None:
+            trader_class = _trader_class()
 
         self._name = name
         self._analyze_backtest = analyze_backtest
@@ -2529,8 +2831,8 @@ class _Strategy:
         # Set backtesting_start: priority 1 - passed argument, 2 - BACKTESTING_START env var, 3 - default to 1 year ago
         if backtesting_start is not None:
             pass
-        elif BACKTESTING_START is not None:
-            backtesting_start = BACKTESTING_START
+        elif _credential("BACKTESTING_START") is not None:
+            backtesting_start = _credential("BACKTESTING_START")
         else:
             backtesting_start = datetime.datetime.now() - datetime.timedelta(days=365)
             get_logger(__name__).warning(
@@ -2543,8 +2845,8 @@ class _Strategy:
         # Set backtesting_end: priority 1 - passed argument, 2 - BACKTESTING_END env var, 3 - default to yesterday
         if backtesting_end is not None:
             pass
-        elif BACKTESTING_END is not None:
-            backtesting_end = BACKTESTING_END
+        elif _credential("BACKTESTING_END") is not None:
+            backtesting_end = _credential("BACKTESTING_END")
         else:
             backtesting_end = datetime.datetime.now() - datetime.timedelta(days=1)
             get_logger(__name__).warning(
@@ -2560,17 +2862,18 @@ class _Strategy:
 
         # If show_plot is None, then set it to True
         if show_plot is None:
-            show_plot = SHOW_PLOT
+            show_plot = _credential("SHOW_PLOT")
 
         # If show_tearsheet is None, then set it to True
         if show_tearsheet is None:
-            show_tearsheet = SHOW_TEARSHEET
+            show_tearsheet = _credential("SHOW_TEARSHEET")
 
         # If show_indicators is None, then set it to True
         if show_indicators is None:
-            show_indicators = SHOW_INDICATORS
+            show_indicators = _credential("SHOW_INDICATORS")
 
         from lumibot.credentials import BACKTESTING_DATA_SOURCE as _DEFAULT_BACKTESTING_DATA_SOURCE
+        _ensure_backtesting_imports()
 
         # Determine whether an environment override exists. When BACKTESTING_DATA_SOURCE
         # is set (and not blank/\"none\"), it should take precedence even if a
@@ -2659,7 +2962,7 @@ class _Strategy:
             )
 
         # Make sure polygon_api_key is set if using PolygonDataBacktesting
-        polygon_api_key = polygon_api_key if polygon_api_key is not None else POLYGON_API_KEY
+        polygon_api_key = polygon_api_key if polygon_api_key is not None else _credential("POLYGON_API_KEY")
         if datasource_class.__name__ == 'PolygonDataBacktesting' and polygon_api_key is None:
             raise ValueError(
                 "Please set `POLYGON_API_KEY` to your API key from polygon.io as an environment variable if "
@@ -2670,8 +2973,9 @@ class _Strategy:
         # Make sure thetadata_username and thetadata_password are set if using ThetaDataBacktesting
         if thetadata_username is None or thetadata_password is None:
             # Try getting the Theta Data credentials from credentials
-            thetadata_username = THETADATA_CONFIG.get('THETADATA_USERNAME')
-            thetadata_password = THETADATA_CONFIG.get('THETADATA_PASSWORD')
+            thetadata_config = _credential("THETADATA_CONFIG")
+            thetadata_username = thetadata_config.get('THETADATA_USERNAME')
+            thetadata_password = thetadata_config.get('THETADATA_PASSWORD')
 
             # Check again if theta data username and pass are set (before checking dict)
             if datasource_class.__name__ == 'ThetaDataBacktesting' and (thetadata_username is None or thetadata_password is None):
@@ -2752,7 +3056,7 @@ class _Strategy:
 
         show_progress_env = os.environ.get("BACKTESTING_SHOW_PROGRESS_BAR")
         if show_progress_env is not None:
-            show_progress_bar = BACKTESTING_SHOW_PROGRESS_BAR
+            show_progress_bar = _credential("BACKTESTING_SHOW_PROGRESS_BAR")
 
         previous_backtesting_env = {
             "IS_BACKTESTING": os.environ.get("IS_BACKTESTING"),
@@ -2783,8 +3087,8 @@ class _Strategy:
                     api_key=polygon_api_key,
                     pandas_data=pandas_data,
                     show_progress_bar=show_progress_bar,
-                    max_memory=POLYGON_MAX_MEMORY_BYTES,
-                    log_backtest_progress_to_file=LOG_BACKTEST_PROGRESS_TO_FILE,
+                    max_memory=_credential("POLYGON_MAX_MEMORY_BYTES"),
+                    log_backtest_progress_to_file=_credential("LOG_BACKTEST_PROGRESS_TO_FILE"),
                     **kwargs,
                 )
             elif issubclass(datasource_class, ThetaDataBacktestingPandas) or (
@@ -2800,7 +3104,7 @@ class _Strategy:
                     pandas_data=pandas_data,
                     use_quote_data=use_quote_data,
                     show_progress_bar=show_progress_bar,
-                    log_backtest_progress_to_file=LOG_BACKTEST_PROGRESS_TO_FILE,
+                    log_backtest_progress_to_file=_credential("LOG_BACKTEST_PROGRESS_TO_FILE"),
                     **kwargs,
                 )
             elif datasource_class == InteractiveBrokersRESTBacktesting:
@@ -2811,7 +3115,7 @@ class _Strategy:
                     auto_adjust=auto_adjust,
                     pandas_data=pandas_data,
                     show_progress_bar=show_progress_bar,
-                    log_backtest_progress_to_file=LOG_BACKTEST_PROGRESS_TO_FILE,
+                    log_backtest_progress_to_file=_credential("LOG_BACKTEST_PROGRESS_TO_FILE"),
                     **kwargs,
                 )
             else:
@@ -2822,7 +3126,7 @@ class _Strategy:
                     auto_adjust=auto_adjust,
                     pandas_data=pandas_data,
                     show_progress_bar=show_progress_bar,
-                    log_backtest_progress_to_file=LOG_BACKTEST_PROGRESS_TO_FILE,
+                    log_backtest_progress_to_file=_credential("LOG_BACKTEST_PROGRESS_TO_FILE"),
                     **kwargs,
                 )
 
@@ -3139,6 +3443,8 @@ class _Strategy:
         }
 
         normalized_events = []
+        from ..entities import CashEvent
+
         for event in fetched_events or []:
             if not isinstance(event, CashEvent):
                 continue
@@ -3286,6 +3592,7 @@ class _Strategy:
         # Apply to your data dictionary
         data = replace_nan(data)
 
+        requests = _get_requests_module()
         try:
             # Send the data to the cloud
             json_data = json.dumps(data, default=str)
@@ -3430,6 +3737,7 @@ class _Strategy:
         if silent:
             payload["flags"] = [4096]
 
+        requests = _get_requests_module()
         # Check if we have an image
         if image_buf is not None:
             # The files that you want to send
@@ -3450,6 +3758,13 @@ class _Strategy:
             )
 
     def send_spark_chart_to_discord(self, stats_df, portfolio_value, now, days=1095):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.dates as mdates
+        import matplotlib.pyplot as plt
+        import matplotlib.ticker as ticker
+
         # Check if we are in backtesting mode, if so, don't send the message
         if self.is_backtesting:
             return
@@ -3676,7 +3991,7 @@ class _Strategy:
         cash = self.get_cash()
 
         # # Get the datetime
-        now = pd.Timestamp(datetime.datetime.now()).tz_localize(LUMIBOT_DEFAULT_PYTZ)
+        now = pd.Timestamp(datetime.datetime.now()).tz_localize(_default_pytz())
 
         # Get the returns
         returns_text, stats_df = self.calculate_returns()
@@ -3688,6 +4003,7 @@ class _Strategy:
         self.send_result_text_to_discord(returns_text, portfolio_value, cash)
 
     def get_stats_from_database(self, stats_table_name, retries=5, delay=5):
+        create_engine, inspect, text, OperationalError = _get_sqlalchemy_imports()
         attempt = 0
         while attempt < retries:
             try:
@@ -3705,7 +4021,7 @@ class _Strategy:
                     self.logger.info(f"Table {stats_table_name} does not exist. Creating it now.")
 
                     # Get the current time in New York
-                    ny_tz = LUMIBOT_DEFAULT_PYTZ
+                    ny_tz = _default_pytz()
                     now = datetime.datetime.now(ny_tz)
 
                     # Create an empty stats dataframe
@@ -3741,6 +4057,7 @@ class _Strategy:
                     raise
 
     def to_sql(self, stats_df, stats_table_name, if_exists='replace', index=True, retries=5, delay=5):
+        create_engine, _inspect, _text, OperationalError = _get_sqlalchemy_imports()
         attempt = 0
         while attempt < retries:
             try:
@@ -3764,12 +4081,13 @@ class _Strategy:
         if not hasattr(self, "db_connection_str") or self.db_connection_str is None or self.db_connection_str == "" or not self.should_backup_variables_to_database:
             return
 
+        create_engine, inspect, text, _OperationalError = _get_sqlalchemy_imports()
         # Ensure we have a self.db_engine
         if not hasattr(self, 'db_engine') or not self.db_engine:
             self.db_engine = create_engine(self.db_connection_str)
 
         # Get the current time in New York
-        ny_tz = LUMIBOT_DEFAULT_PYTZ
+        ny_tz = _default_pytz()
         now = datetime.datetime.now(ny_tz)
 
         if not inspect(self.db_engine).has_table(self.backup_table_name):
@@ -3850,6 +4168,7 @@ class _Strategy:
             return
     
         try:
+            create_engine, inspect, text, _OperationalError = _get_sqlalchemy_imports()
             if not hasattr(self, 'db_engine') or not self.db_engine:
                 self.db_engine = create_engine(self.db_connection_str)
     
@@ -3923,7 +4242,7 @@ class _Strategy:
         # Calculate the return over the past 24 hours, 7 days, and 30 days using the stats dataframe
 
         # Get the current time in New York
-        ny_tz = LUMIBOT_DEFAULT_PYTZ
+        ny_tz = _default_pytz()
 
         # Get the datetime
         now = datetime.datetime.now(ny_tz)
@@ -3940,11 +4259,11 @@ class _Strategy:
         # Check if the datetime column is timezone-aware
         if stats_df['datetime'].dt.tz is None:
             # If the datetime is timezone-naive, directly localize it to "America/New_York"
-            stats_df["datetime"] = stats_df["datetime"].dt.tz_localize(LUMIBOT_DEFAULT_PYTZ, ambiguous='infer')
+            stats_df["datetime"] = stats_df["datetime"].dt.tz_localize(_default_pytz(), ambiguous='infer')
         else:
             # If the datetime is already timezone-aware, first remove timezone and then localize
             stats_df["datetime"] = stats_df["datetime"].dt.tz_localize(None)
-            stats_df["datetime"] = stats_df["datetime"].dt.tz_localize(LUMIBOT_DEFAULT_PYTZ, ambiguous='infer')
+            stats_df["datetime"] = stats_df["datetime"].dt.tz_localize(_default_pytz(), ambiguous='infer')
 
         # Get the stats
         stats_new = pd.DataFrame(
@@ -3964,7 +4283,7 @@ class _Strategy:
         stats_df = pd.concat([stats_df, stats_new])
 
         # # Convert the datetime column to eastern time
-        stats_df["datetime"] = stats_df["datetime"].dt.tz_convert(LUMIBOT_DEFAULT_PYTZ)
+        stats_df["datetime"] = stats_df["datetime"].dt.tz_convert(_default_pytz())
 
         # Remove any duplicate rows
         stats_df = stats_df[~stats_df["datetime"].duplicated(keep="last")]

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -825,6 +825,7 @@ class Strategy(_Strategy):
         broker = self.broker
         if (
             isinstance(asset, Asset)
+            and getattr(asset, "asset_type", None) not in (Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE)
             and quote is None
             and order_type is Order.OrderType.MARKET
             and time_in_force == "gtc"

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import datetime
 import inspect
+from importlib import import_module
 import logging
 import math
 import os
@@ -8,20 +11,12 @@ import time
 import uuid
 import warnings
 from decimal import Decimal
-from typing import Callable, List, Type, Union, Optional
+from types import ModuleType
+from typing import TYPE_CHECKING, Callable, List, Optional, Type, Union
 
-import jsonpickle
-import matplotlib
-from matplotlib.colors import is_color_like
-import numpy as np
-import pandas as pd
-import pandas_market_calendars as mcal
-from apscheduler.triggers.cron import CronTrigger
 from termcolor import colored, COLORS
 
-from ..data_sources import DataSource
-from ..entities import Asset, Data, Order, Position, Quote, TradingFee, TradingSlippage, SmartLimitConfig
-from ..tools import get_risk_free_rate
+from ..entities import Asset, Order, Quote, SmartLimitConfig
 from ..tools.smart_limit_utils import (
     build_price_ladder,
     compute_final_price,
@@ -30,13 +25,101 @@ from ..tools.smart_limit_utils import (
     infer_tick_size,
     round_to_tick,
 )
-from ..tools.polars_utils import PolarsResampleError, resample_polars_ohlc
-from ..traders import Trader
-from ..credentials import IS_BACKTESTING
 from ._strategy import _Strategy
-from ..constants import LUMIBOT_DEFAULT_TIMEZONE, LUMIBOT_DEFAULT_PYTZ
 
-matplotlib.use("Agg")
+if TYPE_CHECKING:
+    from ..data_sources import DataSource
+    from ..entities import Data, Position, TradingFee, TradingSlippage
+
+_FAST_LAST_PRICE_MISS = object()
+_PANDAS_MARKET_CALENDARS = None
+_TRADER_CLASS = None
+_COMPAT_SENTINEL = object()
+IS_BACKTESTING = _COMPAT_SENTINEL
+_IS_BACKTESTING = None
+_LUMIBOT_DEFAULT_TIMEZONE = None
+_LUMIBOT_DEFAULT_PYTZ = None
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        if name in {"_module_name", "_module"}:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+np = _LazyModule("numpy")
+
+
+def _get_market_calendars():
+    global _PANDAS_MARKET_CALENDARS
+    if _PANDAS_MARKET_CALENDARS is None:
+        import pandas_market_calendars as mcal
+
+        _PANDAS_MARKET_CALENDARS = mcal
+    return _PANDAS_MARKET_CALENDARS
+
+
+def _trader_class():
+    global _TRADER_CLASS
+    if _TRADER_CLASS is None:
+        from ..traders import Trader
+
+        _TRADER_CLASS = Trader
+    return _TRADER_CLASS
+
+
+def _is_backtesting_env():
+    global _IS_BACKTESTING, IS_BACKTESTING
+    if IS_BACKTESTING is not _COMPAT_SENTINEL:
+        return IS_BACKTESTING
+    if _IS_BACKTESTING is None:
+        from ..credentials import IS_BACKTESTING as _credentials_is_backtesting
+
+        _IS_BACKTESTING = _credentials_is_backtesting
+    return _IS_BACKTESTING
+
+
+def _default_timezone():
+    global _LUMIBOT_DEFAULT_TIMEZONE
+    if _LUMIBOT_DEFAULT_TIMEZONE is None:
+        from ..constants import LUMIBOT_DEFAULT_TIMEZONE
+
+        _LUMIBOT_DEFAULT_TIMEZONE = LUMIBOT_DEFAULT_TIMEZONE
+    return _LUMIBOT_DEFAULT_TIMEZONE
+
+
+def _default_pytz():
+    global _LUMIBOT_DEFAULT_PYTZ
+    if _LUMIBOT_DEFAULT_PYTZ is None:
+        from ..constants import LUMIBOT_DEFAULT_PYTZ
+
+        _LUMIBOT_DEFAULT_PYTZ = LUMIBOT_DEFAULT_PYTZ
+    return _LUMIBOT_DEFAULT_PYTZ
+
 
 class Strategy(_Strategy):
     @property
@@ -352,6 +435,8 @@ class Strategy(_Strategy):
             return self._risk_free_rate
         else:
             # Use the yahoo data to get the risk free rate, or 0 if None is returned
+            from ..tools import get_risk_free_rate
+
             now = self.get_datetime()
             return get_risk_free_rate(now) or 0.0
 
@@ -737,6 +822,53 @@ class Strategy(_Strategy):
         >>> order = self.create_order(base, 0.05, "buy", limit_price=41000,  quote=quote)
         >>> self.submit_order(order)
         """
+        broker = self.broker
+        if (
+            isinstance(asset, Asset)
+            and quote is None
+            and order_type is Order.OrderType.MARKET
+            and time_in_force == "gtc"
+            and getattr(broker, "IS_BACKTESTING_BROKER", False)
+            and (
+                order_class,
+                type,
+                smart_limit,
+                custom_params,
+                pair,
+                limit_price,
+                stop_price,
+                stop_limit_price,
+                trail_price,
+                trail_percent,
+                secondary_limit_price,
+                secondary_stop_price,
+                secondary_stop_limit_price,
+                secondary_trail_price,
+                secondary_trail_percent,
+                take_profit_price,
+                stop_loss_price,
+                stop_loss_limit_price,
+                position_filled,
+                exchange,
+                good_till_date,
+            ) == (None,) * 21
+        ):
+            seq = getattr(broker, "_backtest_order_seq", 0) + 1
+            setattr(broker, "_backtest_order_seq", seq)
+            ds = getattr(broker, "data_source", None)
+            date_created = getattr(ds, "_datetime", None)
+            if date_created is None:
+                date_created = broker.datetime
+            return Order.simple_market_backtest(
+                self._name,
+                asset,
+                quantity,
+                side,
+                time_in_force=time_in_force,
+                date_created=date_created,
+                quote=self._quote_asset,
+                identifier=f"bt_{seq}",
+            )
 
         if quote is None:
             quote = self.quote_asset
@@ -748,10 +880,17 @@ class Strategy(_Strategy):
         # PERF: uuid4() generation is a measurable hot path in high-churn backtests (1 order per bar per asset).
         # Backtests only need identifiers to be unique within the run, so use a cheap monotonic counter.
         identifier = None
-        if getattr(self.broker, "IS_BACKTESTING_BROKER", False):
-            seq = getattr(self.broker, "_backtest_order_seq", 0) + 1
-            setattr(self.broker, "_backtest_order_seq", seq)
+        is_backtesting_broker = getattr(broker, "IS_BACKTESTING_BROKER", False)
+        if is_backtesting_broker:
+            seq = getattr(broker, "_backtest_order_seq", 0) + 1
+            setattr(broker, "_backtest_order_seq", seq)
             identifier = f"bt_{seq}"
+            ds = getattr(broker, "data_source", None)
+            date_created = getattr(ds, "_datetime", None)
+            if date_created is None:
+                date_created = broker.datetime
+        else:
+            date_created = self.get_datetime()
 
         order = Order(
             self.name,
@@ -775,7 +914,7 @@ class Strategy(_Strategy):
             secondary_trail_percent=secondary_trail_percent,
             exchange=exchange,
             position_filled=position_filled,
-            date_created=self.get_datetime(),
+            date_created=date_created,
             quote=quote,
             pair=pair,
             type=type,
@@ -1703,6 +1842,13 @@ class Strategy(_Strategy):
         >>> order2 = self.create_order((asset_ETH, asset_quote), 10, "buy")
         >>> self.submit_order([order1, order2])
         """
+        if getattr(order, "_simple_backtest_order", False):
+            broker = self.broker
+            if getattr(broker, "IS_BACKTESTING_BROKER", False):
+                submit_simple = getattr(broker, "_submit_simple_backtest_order", None)
+                if submit_simple is not None:
+                    return submit_simple(order)
+                return broker._submit_order(order)
 
         if isinstance(order, list):
             # Submit multiple orders
@@ -1808,7 +1954,7 @@ class Strategy(_Strategy):
             if not self._validate_order(order):
                 return
 
-            if order.order_type == Order.OrderType.SMART_LIMIT:
+            if order.order_type is Order.OrderType.SMART_LIMIT:
                 if self.broker.IS_BACKTESTING_BROKER:
                     return self.broker.submit_order(order)
 
@@ -2404,6 +2550,54 @@ class Strategy(_Strategy):
             results.append(self.close_position(asset))
         return results
 
+    def _get_ibkr_backtest_last_price_fast(self, asset, quote=None, exchange=None, *, allow_source_fallback=False):
+        if not isinstance(asset, Asset) or quote is not None or exchange is not None:
+            return _FAST_LAST_PRICE_MISS
+
+        broker = getattr(self, "broker", None)
+        ds = getattr(broker, "data_source", None)
+        asset_type = getattr(asset, "asset_type", None)
+        asset_type_value = getattr(asset, "_cached_asset_type_key", None)
+        if asset_type_value is None:
+            asset_type_value = str.__str__(asset_type) if isinstance(asset_type, str) else str(asset_type or "")
+        if (
+            not getattr(broker, "IS_BACKTESTING_BROKER", False)
+            or getattr(ds, "SOURCE", None) != "InteractiveBrokersREST"
+            or asset_type_value not in ("crypto", "future", "cont_future")
+        ):
+            return _FAST_LAST_PRICE_MISS
+
+        quote_asset = self._quote_asset
+        now = getattr(ds, "_datetime", None)
+        if now is not None:
+            exchange_key = "AUTO" if getattr(ds, "exchange", None) is None else ds._normalize_exchange_key(ds.exchange)
+            data_cache = getattr(self, "_ibkr_last_price_data_cache", None)
+            if data_cache is None:
+                data_cache = {}
+                self._ibkr_last_price_data_cache = data_cache
+            cache_key = (id(asset), id(quote_asset), exchange_key)
+            data = data_cache.get(cache_key)
+            if data is None:
+                data = getattr(ds, "_data_store", {}).get((asset, quote_asset, "minute", exchange_key))
+                if data is not None:
+                    data_cache[cache_key] = data
+            if data is not None:
+                try:
+                    if asset_type_value in ("future", "cont_future"):
+                        price = data.get_previous_bar_close_fast(now)
+                        if price is not None:
+                            return price
+                        now = getattr(ds, "_datetime_minus_microsecond", None) or now - datetime.timedelta(
+                            microseconds=1
+                        )
+                    return data.get_last_price_fast(now)
+                except Exception:
+                    pass
+
+        if allow_source_fallback:
+            return ds.get_last_price(asset, quote=quote_asset, exchange=None)
+        return _FAST_LAST_PRICE_MISS
+
     def get_last_price(self, asset: Union[Asset, str], quote=None, exchange=None) -> Union[float, Decimal, None]:
         """Takes an asset and returns the last known price
 
@@ -2458,6 +2652,103 @@ class Strategy(_Strategy):
         >>> )
         >>> price = self.get_last_price(asset=self.base, exchange="CME")
         """
+        if isinstance(asset, Asset) and quote is None and exchange is None:
+            quote_asset = getattr(self, "_quote_asset", None)
+            fast_ctx_cache = getattr(self, "_ibkr_last_price_fast_context_cache", None) if quote_asset is not None else None
+            if fast_ctx_cache is not None:
+                ctx = fast_ctx_cache.get((id(asset), id(quote_asset)))
+                if ctx is not None:
+                    ds_for_cache, data, asset_type_value = ctx
+                    now = getattr(ds_for_cache, "_datetime", None)
+                    if now is not None:
+                        if asset_type_value in ("future", "cont_future"):
+                            price = data.get_previous_bar_close_fast(now)
+                            if price is not None:
+                                return price
+                            now = getattr(ds_for_cache, "_datetime_minus_microsecond", None) or now - datetime.timedelta(microseconds=1)
+                        try:
+                            return data.get_last_price_fast(now)
+                        except Exception:
+                            pass
+            broker = getattr(self, "broker", None)
+            ds = getattr(broker, "data_source", None)
+            last_price_ctx_cache = getattr(self, "_ibkr_last_price_context_cache", None)
+            if last_price_ctx_cache is not None and getattr(ds, "SOURCE", None) == "InteractiveBrokersREST":
+                effective_exchange = getattr(ds, "exchange", None)
+                try:
+                    exchange_key = "AUTO" if effective_exchange is None else ds._normalize_exchange_key(effective_exchange)
+                except Exception:
+                    exchange_key = str(effective_exchange or "").strip().upper() or "AUTO"
+                ctx = last_price_ctx_cache.get((id(ds), id(asset), id(quote_asset), exchange_key))
+                if ctx is not None:
+                    data, asset_type_value = ctx
+                    now = getattr(ds, "_datetime", None)
+                    if now is not None:
+                        if asset_type_value in ("future", "cont_future"):
+                            price = data.get_previous_bar_close_fast(now)
+                            if price is not None:
+                                return price
+                            now = getattr(ds, "_datetime_minus_microsecond", None) or now - datetime.timedelta(microseconds=1)
+                        try:
+                            return data.get_last_price_fast(now)
+                        except Exception:
+                            pass
+            asset_type = getattr(asset, "asset_type", None)
+            asset_type_value = getattr(asset, "_cached_asset_type_key", None)
+            if asset_type_value is None:
+                asset_type_value = str.__str__(asset_type) if isinstance(asset_type, str) else str(asset_type or "")
+            if (
+                getattr(broker, "IS_BACKTESTING_BROKER", False)
+                and getattr(ds, "SOURCE", None) == "InteractiveBrokersREST"
+                and asset_type_value in ("crypto", "future", "cont_future")
+            ):
+                quote_asset = self._quote_asset
+                now = getattr(ds, "_datetime", None)
+                if now is not None:
+                    exchange_key = "AUTO" if getattr(ds, "exchange", None) is None else ds._normalize_exchange_key(ds.exchange)
+                    data_cache = getattr(self, "_ibkr_last_price_data_cache", None)
+                    if data_cache is None:
+                        data_cache = {}
+                        self._ibkr_last_price_data_cache = data_cache
+                    cache_key = (id(asset), id(quote_asset), exchange_key)
+                    data = data_cache.get(cache_key)
+                    if data is None:
+                        data = getattr(ds, "_data_store", {}).get((asset, quote_asset, "minute", exchange_key))
+                        if data is not None:
+                            data_cache[cache_key] = data
+                    if data is not None:
+                        try:
+                            last_price_ctx_cache = getattr(self, "_ibkr_last_price_context_cache", None)
+                            if last_price_ctx_cache is None:
+                                last_price_ctx_cache = {}
+                                self._ibkr_last_price_context_cache = last_price_ctx_cache
+                            last_price_ctx_cache[(id(ds), id(asset), id(quote_asset), exchange_key)] = (
+                                data,
+                                asset_type_value,
+                            )
+                            fast_ctx_cache = getattr(self, "_ibkr_last_price_fast_context_cache", None)
+                            if fast_ctx_cache is None:
+                                fast_ctx_cache = {}
+                                self._ibkr_last_price_fast_context_cache = fast_ctx_cache
+                            fast_ctx_cache[(id(asset), id(quote_asset))] = (
+                                ds,
+                                data,
+                                asset_type_value,
+                            )
+                            if asset_type_value in ("future", "cont_future"):
+                                price = data.get_previous_bar_close_fast(now)
+                                if price is not None:
+                                    return price
+                                now = getattr(ds, "_datetime_minus_microsecond", None) or now - datetime.timedelta(
+                                    microseconds=1
+                                )
+                            return data.get_last_price_fast(now)
+                        except Exception:
+                            pass
+        else:
+            fast_price = Strategy._get_ibkr_backtest_last_price_fast(self, asset, quote=quote, exchange=exchange)
+            if fast_price is not _FAST_LAST_PRICE_MISS:
+                return fast_price
 
         # Check if the asset is valid
         if asset is None or (isinstance(asset, Asset) and not asset.is_valid()):
@@ -2473,6 +2764,16 @@ class Strategy(_Strategy):
             )
             return None
 
+        fast_price = Strategy._get_ibkr_backtest_last_price_fast(
+            self,
+            asset,
+            quote=quote,
+            exchange=exchange,
+            allow_source_fallback=True,
+        )
+        if fast_price is not _FAST_LAST_PRICE_MISS:
+            return fast_price
+
         asset = self._sanitize_user_asset(asset)
 
         if quote is None:
@@ -2481,7 +2782,7 @@ class Strategy(_Strategy):
             quote_asset = quote
 
         is_backtesting_run = bool(
-            IS_BACKTESTING
+            _is_backtesting_env()
             or getattr(self, "is_backtesting", False)
             or getattr(getattr(self, "broker", None), "IS_BACKTESTING_BROKER", False)
         )
@@ -2500,6 +2801,27 @@ class Strategy(_Strategy):
                 return cache[cache_key]
 
         try:
+            asset_type_for_last = getattr(asset, "asset_type", "")
+            asset_type_for_last = getattr(asset_type_for_last, "value", asset_type_for_last)
+            asset_type_for_last = str(asset_type_for_last).lower()
+            if is_backtesting_run and asset_type_for_last in {"crypto", "future", "cont_future"}:
+                result = self.broker.data_source.get_last_price(
+                    asset,
+                    quote=quote_asset,
+                    exchange=exchange,
+                )
+                cache[cache_key] = result
+                return result
+
+            if is_backtesting_run and asset_type_for_last not in {"stock", "equity", "index"}:
+                result = self.broker.get_last_price(
+                    asset,
+                    quote=quote_asset,
+                    exchange=exchange,
+                )
+                cache[cache_key] = result
+                return result
+
             # For daily-cadence backtests, prefer day bars for sources where minute-level
             # fetches are expensive (ThetaData/IBKR/routed backtesting). Keep Yahoo/Polygon
             # on legacy behavior to preserve existing regression anchors.
@@ -2526,7 +2848,10 @@ class Strategy(_Strategy):
             # close) instead of the 2022-07-01 close of $90.98, polluting position sizing.
             # Regression coverage lives in `tests/test_get_last_price_sim_time_safety.py` and
             # explicitly replays a polluted frame so this exact failure mode cannot re-land.
-            should_use_daily = self._should_use_daily_last_price(asset)
+            should_use_daily = (
+                asset_type_for_last in {"stock", "equity", "index"}
+                and self._should_use_daily_last_price(asset)
+            )
             if is_backtesting_run and should_use_daily and self._supports_daily_last_price_optimization():
                 try:
                     bars = self.get_historical_prices(
@@ -2624,7 +2949,7 @@ class Strategy(_Strategy):
         if asset_type not in {"stock", "equity", "index"}:
             return False
         if not (
-            IS_BACKTESTING
+            _is_backtesting_env()
             or getattr(self, "is_backtesting", False)
             or getattr(getattr(self, "broker", None), "IS_BACKTESTING_BROKER", False)
         ):
@@ -2842,6 +3167,7 @@ class Strategy(_Strategy):
         """
 
         # Load the specified market calendar
+        mcal = _get_market_calendars()
         calendar = mcal.get_calendar(exchange)
 
         # Convert the input string date to pandas Timestamp
@@ -3129,6 +3455,7 @@ class Strategy(_Strategy):
                 break
 
         # Check if the market is open on the expiration date, if not then get the previous open day
+        mcal = _get_market_calendars()
         nyse = mcal.get_calendar("NYSE")
 
         # Get the schedule for all the days that the market is open between the given date and the proposed expiration date
@@ -3268,7 +3595,7 @@ class Strategy(_Strategy):
 
         # Hard default when tzinfo is missing
         if tz is None:
-            return LUMIBOT_DEFAULT_TIMEZONE
+            return _default_timezone()
 
         # Prefer canonical zone identifiers when available
         if hasattr(tz, "zone") and getattr(tz, "zone", None):
@@ -3285,7 +3612,7 @@ class Strategy(_Strategy):
             pass
 
         # Final fallback to configured default to ensure a str is returned
-        return LUMIBOT_DEFAULT_TIMEZONE
+        return _default_timezone()
 
     @property
     def pytz(self):
@@ -3303,7 +3630,7 @@ class Strategy(_Strategy):
         >>> self.log_message(f"pytz: {pytz}")
         """
         tz = getattr(self.broker.data_source, "tzinfo", None)
-        return tz or LUMIBOT_DEFAULT_PYTZ
+        return tz or _default_pytz()
 
     def get_datetime(self, adjust_for_delay: bool = False):
         """Returns the current datetime according to the data source. In a backtest this will be the current bar's datetime. In live trading this will be the current datetime on the exchange.
@@ -3374,6 +3701,8 @@ class Strategy(_Strategy):
             return job_id
 
         # Create a CronTrigger from the schedule string using the broker's timezone
+        from apscheduler.triggers.cron import CronTrigger
+
         trigger = CronTrigger.from_crontab(cron_schedule, timezone=self.pytz)
 
         # Add the job to the scheduler
@@ -3611,6 +3940,8 @@ class Strategy(_Strategy):
             return default
 
         try:
+            from matplotlib.colors import is_color_like
+
             valid = is_color_like(normalized)
         except Exception:
             valid = False
@@ -4199,6 +4530,8 @@ class Strategy(_Strategy):
         except Exception:
             pass
         os.makedirs(os.path.dirname(settings_file), exist_ok=True)
+        import jsonpickle
+
         with open(settings_file, "w") as outfile:
             json = jsonpickle.encode(settings)
             outfile.write(json)
@@ -4393,6 +4726,265 @@ class Strategy(_Strategy):
         >>> last_ohlc = df.iloc[-1] # Get the last row of the DataFrame (the most recent pricing data we have)
         >>> self.log_message(f"Last price of BTC in USD: {last_ohlc['close']}, and the open price was {last_ohlc['open']}")
         """
+        if (
+            timeshift is None
+            and exchange is None
+            and include_after_hours is True
+            and not args
+            and not kwargs
+            and isinstance(asset, Asset)
+            and isinstance(length, int)
+            and timestep in {"minute", "day"}
+        ):
+            quote_asset = self._quote_asset if quote is None else quote
+            if quote is None:
+                request_cache = getattr(self, "_ibkr_native_hist_request_cache_default_quote", None)
+                request_key = (id(asset), length, timestep)
+            else:
+                request_cache = getattr(self, "_ibkr_native_hist_request_cache", None)
+                request_key = (id(asset), id(quote_asset), length, timestep)
+            if request_cache is not None:
+                ctx = request_cache.get(request_key)
+                if ctx is not None:
+                    ds_for_cache, bars_from_pandas_fast, data = ctx
+                    current_dt = getattr(ds_for_cache, "_datetime", None)
+                    if current_dt is not None:
+                        try:
+                            if timestep == "day":
+                                day_bars_cache = getattr(self, "_ibkr_native_day_bars_cache", None)
+                                if day_bars_cache is not None:
+                                    day_key = (
+                                        id(asset),
+                                        id(quote_asset),
+                                        length,
+                                        getattr(ds_for_cache, "exchange", None),
+                                        current_dt.date(),
+                                    )
+                                    cached_bars = day_bars_cache.get(day_key)
+                                    if cached_bars is not None:
+                                        return cached_bars
+                                else:
+                                    day_key = None
+                            else:
+                                day_key = None
+                            response = data.get_native_bars_fast(
+                                current_dt,
+                                length=length,
+                                timestep=timestep,
+                                mark_timezone=False,
+                            )
+                            if response is not None and not isinstance(response, float):
+                                bars = bars_from_pandas_fast(
+                                    response,
+                                    ds_for_cache.SOURCE,
+                                    asset,
+                                    quote=quote_asset,
+                                    raw=response,
+                                )
+                                if day_key is not None:
+                                    day_bars_cache[day_key] = bars
+                                return bars
+                        except Exception:
+                            pass
+
+        if (
+            timestep == "minute"
+            and timeshift is None
+            and exchange is None
+            and include_after_hours is True
+            and not args
+            and not kwargs
+            and isinstance(asset, Asset)
+            and isinstance(length, int)
+        ):
+            minute_ctx_cache = getattr(self, "_ibkr_native_minute_bars_context_cache", None)
+            if minute_ctx_cache is not None:
+                broker_for_cache = getattr(self, "broker", None)
+                ds_for_cache = getattr(broker_for_cache, "data_source", None)
+                if getattr(ds_for_cache, "SOURCE", None) == "InteractiveBrokersREST":
+                    quote_asset = self._quote_asset if quote is None else quote
+                    effective_exchange = getattr(ds_for_cache, "exchange", None)
+                    ctx = minute_ctx_cache.get((id(ds_for_cache), id(asset), id(quote_asset), effective_exchange))
+                    if ctx is not None:
+                        Bars, data = ctx
+                        current_dt = getattr(ds_for_cache, "_datetime", None)
+                        if current_dt is None:
+                            current_dt = getattr(broker_for_cache, "datetime", None)
+                        if current_dt is not None:
+                            try:
+                                response = data.get_native_bars_fast(
+                                    current_dt,
+                                    length=length,
+                                    timestep="minute",
+                                    mark_timezone=False,
+                                )
+                                if response is not None and not isinstance(response, float):
+                                    return Bars.from_pandas_fast(
+                                        response,
+                                        ds_for_cache.SOURCE,
+                                        asset,
+                                        quote=quote_asset,
+                                        raw=response,
+                                    )
+                            except Exception:
+                                pass
+
+        if (
+            timestep == "day"
+            and timeshift is None
+            and exchange is None
+            and include_after_hours is True
+            and not args
+            and not kwargs
+            and isinstance(asset, Asset)
+            and isinstance(length, int)
+        ):
+            day_bars_cache = getattr(self, "_ibkr_native_day_bars_cache", None)
+            if day_bars_cache is not None:
+                broker_for_cache = getattr(self, "broker", None)
+                ds_for_cache = getattr(broker_for_cache, "data_source", None)
+                current_dt = getattr(ds_for_cache, "_datetime", None)
+                if current_dt is not None and getattr(ds_for_cache, "SOURCE", None) == "InteractiveBrokersREST":
+                    quote_asset = self._quote_asset if quote is None else quote
+                    cached_bars = day_bars_cache.get(
+                        (
+                            id(asset),
+                            id(quote_asset),
+                            length,
+                            getattr(ds_for_cache, "exchange", None),
+                            current_dt.date(),
+                        )
+                    )
+                    if cached_bars is not None:
+                        return cached_bars
+
+        broker = getattr(self, "broker", None)
+        ds = getattr(broker, "data_source", None)
+        if (
+            not args
+            and not kwargs
+            and isinstance(asset, Asset)
+            and isinstance(length, int)
+            and timestep in {"minute", "hour", "day"}
+            and timeshift is None
+            and exchange is None
+            and include_after_hours is True
+            and getattr(broker, "IS_BACKTESTING_BROKER", False)
+            and getattr(ds, "SOURCE", None) == "InteractiveBrokersREST"
+        ):
+            asset_type = getattr(asset, "asset_type", None)
+            asset_type_value = getattr(asset, "_cached_asset_type_key", None)
+            if asset_type_value is None:
+                asset_type_value = str.__str__(asset_type) if isinstance(asset_type, str) else str(asset_type or "")
+            if asset_type_value == "option":
+                return ds.get_historical_prices(
+                    asset,
+                    length,
+                    timestep=timestep,
+                    timeshift=None,
+                    exchange=None,
+                    include_after_hours=True,
+                    quote=self._quote_asset if quote is None else quote,
+                    return_polars=False,
+                )
+            quote_asset = self._quote_asset if quote is None else quote
+            if timestep in {"minute", "day"}:
+                try:
+                    effective_exchange = getattr(ds, "exchange", None)
+                    current_dt = getattr(ds, "_datetime", None)
+                    if current_dt is None:
+                        current_dt = broker.datetime
+                    if timestep == "day":
+                        try:
+                            day_key = (
+                                id(asset),
+                                id(quote_asset),
+                                int(length),
+                                effective_exchange,
+                                current_dt.date(),
+                            )
+                            day_bars_cache = getattr(self, "_ibkr_native_day_bars_cache", None)
+                            if day_bars_cache is not None:
+                                cached_bars = day_bars_cache.get(day_key)
+                                if cached_bars is not None:
+                                    return cached_bars
+                        except Exception:
+                            day_key = None
+                    else:
+                        day_key = None
+                    hist_cache_key = (id(asset), id(quote_asset), timestep, effective_exchange)
+                    hist_cache = getattr(self, "_ibkr_native_hist_data_cache", None)
+                    data = hist_cache.get(hist_cache_key) if hist_cache is not None else None
+                    if data is None:
+                        data = getattr(ds, "_fully_loaded_hot_data_cache", {}).get(hist_cache_key)
+                        if data is not None:
+                            if hist_cache is None:
+                                hist_cache = {}
+                                self._ibkr_native_hist_data_cache = hist_cache
+                            hist_cache[hist_cache_key] = data
+                    if data is not None:
+                        Bars = getattr(ds, "_native_bars_fast_cls", None)
+                        if Bars is None:
+                            from lumibot.entities.bars import Bars
+
+                            ds._native_bars_fast_cls = Bars
+                        if timestep == "minute":
+                            minute_ctx_cache = getattr(self, "_ibkr_native_minute_bars_context_cache", None)
+                            if minute_ctx_cache is None:
+                                minute_ctx_cache = {}
+                                self._ibkr_native_minute_bars_context_cache = minute_ctx_cache
+                            minute_ctx_cache[(id(ds), id(asset), id(quote_asset), effective_exchange)] = (Bars, data)
+                        request_cache = getattr(self, "_ibkr_native_hist_request_cache", None)
+                        if request_cache is None:
+                            request_cache = {}
+                            self._ibkr_native_hist_request_cache = request_cache
+                        request_cache[(id(asset), id(quote_asset), int(length), timestep)] = (
+                            ds,
+                            Bars.from_pandas_fast,
+                            data,
+                        )
+                        if quote is None:
+                            default_request_cache = getattr(
+                                self,
+                                "_ibkr_native_hist_request_cache_default_quote",
+                                None,
+                            )
+                            if default_request_cache is None:
+                                default_request_cache = {}
+                                self._ibkr_native_hist_request_cache_default_quote = default_request_cache
+                            default_request_cache[(id(asset), int(length), timestep)] = (
+                                ds,
+                                Bars.from_pandas_fast,
+                                data,
+                            )
+                        response = data.get_native_bars_fast(
+                            current_dt,
+                            length=length,
+                            timestep=timestep,
+                            mark_timezone=False,
+                        )
+                        if response is not None and not isinstance(response, float):
+                            bars = Bars.from_pandas_fast(response, ds.SOURCE, asset, quote=quote_asset, raw=response)
+                            if day_key is not None:
+                                day_bars_cache = getattr(self, "_ibkr_native_day_bars_cache", None)
+                                if day_bars_cache is None:
+                                    day_bars_cache = {}
+                                    self._ibkr_native_day_bars_cache = day_bars_cache
+                                day_bars_cache[day_key] = bars
+                            return bars
+                except Exception:
+                    pass
+            return ds.get_historical_prices(
+                asset,
+                length,
+                timestep=timestep,
+                timeshift=None,
+                exchange=None,
+                include_after_hours=True,
+                quote=quote_asset,
+                return_polars=False,
+            )
+
         if args:
             if len(args) != 1:
                 raise TypeError("get_historical_prices() accepts at most 1 extra positional argument (deprecated `return_polars`)")
@@ -4426,9 +5018,49 @@ class Strategy(_Strategy):
         if quote is None:
             quote = self.quote_asset
 
+        # PERF: native-bar backtest calls are the hottest historical-price path. When no
+        # resampling or live-source compatibility work is needed, go straight to the data source.
+        if (
+            timestep in {"minute", "hour", "day"}
+            and timeshift is None
+            and exchange is None
+            and include_after_hours is True
+            and not return_polars
+            and not return_polars_provided
+            and getattr(getattr(self, "broker", None), "IS_BACKTESTING_BROKER", False)
+        ):
+            asset = self._sanitize_user_asset(asset)
+            asset = self.crypto_assets_to_tuple(asset, quote)
+            ds = self.broker.data_source
+            if self.broker.option_source and getattr(asset, "asset_type", None) == "option":
+                ds = self.broker.option_source
+            if getattr(ds, "IS_BACKTESTING_DATA_SOURCE", False):
+                return ds.get_historical_prices(
+                    asset,
+                    length,
+                    timestep=timestep,
+                    timeshift=None,
+                    exchange=None,
+                    include_after_hours=True,
+                    quote=quote,
+                    return_polars=False,
+                )
+
         # Parse timestep to check if we need to aggregate
         original_timestep = timestep
-        parsed = self._parse_timestep(timestep) if timestep else None
+        if timestep in {"minute", "day", "hour"}:
+            parsed = (1, timestep)
+        elif timestep:
+            parse_cache = getattr(self, "_historical_timestep_parse_cache", None)
+            if parse_cache is None:
+                parse_cache = {}
+                self._historical_timestep_parse_cache = parse_cache
+            parsed = parse_cache.get(timestep)
+            if timestep not in parse_cache:
+                parsed = self._parse_timestep(timestep)
+                parse_cache[timestep] = parsed
+        else:
+            parsed = None
 
         # Determine the actual timestep to use for data fetching
         if parsed and parsed[0] > 1:
@@ -4466,52 +5098,27 @@ class Strategy(_Strategy):
         if not actual_timestep:
             actual_timestep = self.broker.data_source.get_timestep()
 
-        # Only log once per asset to reduce noise.
-        # PERF: avoid per-call f-string construction in hot loops; use a tuple key.
-        asset_key = (asset, int(length), original_timestep)
-        if asset_key not in self._logged_get_historical_prices_assets:
-            if needs_resampling:
-                self.logger.info(
-                    f"Getting historical prices for {asset}, {length} bars of {original_timestep} "
-                    f"(fetching {actual_length} {actual_timestep} bars)"
-                )
-            else:
-                self.logger.info(f"Getting historical prices for {asset}, {length} bars, {original_timestep}")
-            self._logged_get_historical_prices_assets.add(asset_key)
+        # Only log once per asset to reduce noise. In quiet backtests, skip the bookkeeping too.
+        if self.logger.isEnabledFor(logging.INFO):
+            asset_key = (asset, int(length), original_timestep)
+            if asset_key not in self._logged_get_historical_prices_assets:
+                if needs_resampling:
+                    self.logger.info(
+                        f"Getting historical prices for {asset}, {length} bars of {original_timestep} "
+                        f"(fetching {actual_length} {actual_timestep} bars)"
+                    )
+                else:
+                    self.logger.info(f"Getting historical prices for {asset}, {length} bars, {original_timestep}")
+                self._logged_get_historical_prices_assets.add(asset_key)
 
         effective_return_polars = return_polars
-
-        # Call through to the appropriate data source. Only pass `return_polars` if supported
-        # to maintain compatibility with live data sources that don't yet accept it.
-        #
-        # PERF: avoid per-call nested function creation/dict allocations; keep this inline and cache
-        # `return_polars` support per data source type.
-        supports_cache = getattr(self, "_get_hist_supports_return_polars_by_ds_type", None)
-        if supports_cache is None:
-            supports_cache = {}
-            setattr(self, "_get_hist_supports_return_polars_by_ds_type", supports_cache)
 
         ds = self.broker.data_source
         if self.broker.option_source and getattr(asset, "asset_type", None) == "option":
             ds = self.broker.option_source
 
-        ds_type = type(ds)
-        supports_return_polars = supports_cache.get(ds_type)
-        if supports_return_polars is None:
-            try:
-                params = inspect.signature(ds_type.get_historical_prices).parameters
-                supports_return_polars = (
-                    "return_polars" in params
-                    or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
-                )
-            except Exception:
-                # Conservative default: if we can't inspect, assume it does NOT support return_polars
-                # so we don't raise TypeError by passing an unknown kwarg.
-                supports_return_polars = False
-            supports_cache[ds_type] = bool(supports_return_polars)
-
         fn = ds.get_historical_prices
-        if supports_return_polars:
+        if getattr(ds, "IS_BACKTESTING_DATA_SOURCE", False):
             bars = fn(
                 asset,
                 actual_length,  # Use the actual length for fetching
@@ -4523,21 +5130,56 @@ class Strategy(_Strategy):
                 return_polars=effective_return_polars,
             )
         else:
-            bars = fn(
-                asset,
-                actual_length,  # Use the actual length for fetching
-                timestep=actual_timestep,
-                timeshift=timeshift,
-                exchange=exchange,
-                include_after_hours=include_after_hours,
-                quote=quote,
-            )
+            # Live data sources vary in whether they accept `return_polars`; inspect once per type.
+            supports_cache = getattr(self, "_get_hist_supports_return_polars_by_ds_type", None)
+            if supports_cache is None:
+                supports_cache = {}
+                setattr(self, "_get_hist_supports_return_polars_by_ds_type", supports_cache)
+
+            ds_type = type(ds)
+            supports_return_polars = supports_cache.get(ds_type)
+            if supports_return_polars is None:
+                try:
+                    params = inspect.signature(ds_type.get_historical_prices).parameters
+                    supports_return_polars = (
+                        "return_polars" in params
+                        or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+                    )
+                except Exception:
+                    # Conservative default: if we can't inspect, assume it does NOT support return_polars
+                    # so we don't raise TypeError by passing an unknown kwarg.
+                    supports_return_polars = False
+                supports_cache[ds_type] = bool(supports_return_polars)
+
+            if supports_return_polars:
+                bars = fn(
+                    asset,
+                    actual_length,  # Use the actual length for fetching
+                    timestep=actual_timestep,
+                    timeshift=timeshift,
+                    exchange=exchange,
+                    include_after_hours=include_after_hours,
+                    quote=quote,
+                    return_polars=effective_return_polars,
+                )
+            else:
+                bars = fn(
+                    asset,
+                    actual_length,  # Use the actual length for fetching
+                    timestep=actual_timestep,
+                    timeshift=timeshift,
+                    exchange=exchange,
+                    include_after_hours=include_after_hours,
+                    quote=quote,
+                )
 
         # If we need to resample the data
         if needs_resampling and bars and len(bars) > 0:
             resampled_with_polars = False
             if return_polars:
                 try:
+                    from ..tools.polars_utils import PolarsResampleError, resample_polars_ohlc
+
                     polars_frame = bars.polars_df
                     resampled_frame = resample_polars_ohlc(polars_frame, multiplier, base_unit, length)
                     if resampled_frame is not None and not resampled_frame.is_empty():
@@ -5428,7 +6070,7 @@ class Strategy(_Strategy):
         Returns:
             None
         """
-        trader = Trader()
+        trader = _trader_class()()
 
         trader.add_strategy(self)
         trader.run_all()
@@ -5475,7 +6117,7 @@ class Strategy(_Strategy):
         use_quote_data: bool = True,  # Changed to True for ThetaData options support
         show_progress_bar: bool = True,
         quiet_logs: bool = True,
-        trader_class: Type[Trader] = Trader,
+        trader_class = None,
         save_stats_file: bool = True,
         **kwargs,
     ):

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -7,20 +7,15 @@ import traceback
 from datetime import datetime, timedelta
 from decimal import Decimal
 from functools import wraps
+from importlib import import_module
 from queue import Empty, Queue
 from threading import Event, Lock, Thread
-
-import pandas as pd
+from types import ModuleType
 
 logger = logging.getLogger(__name__)
-import pandas_market_calendars as mcal
-from apscheduler.jobstores.memory import MemoryJobStore
-from apscheduler.schedulers.background import BackgroundScheduler
-from apscheduler.triggers.cron import CronTrigger
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.entities import Asset, Order
-from lumibot.entities import Asset
-from lumibot.tools import append_locals, get_trading_days, staticdecorator
+from lumibot.tools.decorators import append_locals, staticdecorator
 from lumibot.tools.smart_limit_utils import (
     build_price_ladder,
     compute_final_price,
@@ -31,6 +26,83 @@ from lumibot.tools.smart_limit_utils import (
 )
 
 SNAPSHOT_CAPTURE_THROTTLE_SECONDS = 1.9
+_SCHEDULER_IMPORTS = None
+_PANDAS_MARKET_CALENDARS = None
+_GET_TRADING_DAYS = None
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+
+
+def get_trading_days(*args, **kwargs):
+    global _GET_TRADING_DAYS
+    if _GET_TRADING_DAYS is None:
+        from lumibot.tools.helpers import get_trading_days as _func
+
+        _GET_TRADING_DAYS = _func
+    return _GET_TRADING_DAYS(*args, **kwargs)
+
+
+def _get_scheduler_imports():
+    global _SCHEDULER_IMPORTS
+    if _SCHEDULER_IMPORTS is None:
+        from apscheduler.jobstores.memory import MemoryJobStore
+        from apscheduler.schedulers.background import BackgroundScheduler
+        from apscheduler.triggers.cron import CronTrigger
+
+        _SCHEDULER_IMPORTS = (MemoryJobStore, BackgroundScheduler, CronTrigger)
+    return _SCHEDULER_IMPORTS
+
+
+def _get_market_calendars():
+    global _PANDAS_MARKET_CALENDARS
+    if _PANDAS_MARKET_CALENDARS is None:
+        import pandas_market_calendars as mcal
+
+        _PANDAS_MARKET_CALENDARS = mcal
+    return _PANDAS_MARKET_CALENDARS
+
+
+class _BacktestSchedulerStub:
+    """Cheap scheduler placeholder for backtests; creates real scheduler only if used."""
+
+    running = False
+
+    def __init__(self, executor):
+        self._executor = executor
+
+    def _materialize(self):
+        MemoryJobStore, BackgroundScheduler, _CronTrigger = _get_scheduler_imports()
+        job_stores = {"default": MemoryJobStore(), "On_Trading_Iteration": MemoryJobStore()}
+        scheduler = BackgroundScheduler(jobstores=job_stores)
+        self._executor.scheduler = scheduler
+        return scheduler
+
+    def add_job(self, *args, **kwargs):
+        return self._materialize().add_job(*args, **kwargs)
+
+    def get_jobs(self):
+        return []
+
+    def get_job(self, _job_id):
+        return None
 
 
 class StrategyExecutor(Thread):
@@ -51,20 +123,21 @@ class StrategyExecutor(Thread):
         self.strategy = strategy
         self._strategy_context = None
         self.broker = self.strategy.broker
+        self._is_backtesting_strategy = bool(getattr(self.strategy, "is_backtesting", False))
         self.result = {}
         self._in_trading_iteration = False
 
         # Store any exception that occurs during execution
         self.exception = None
 
-        # Create a dictionary of job stores. A job store is where the scheduler persists its jobs. In this case,
-        # we create an in-memory job store for "default" and "On_Trading_Iteration" which is the job store we will
-        # use to store jobs for the main on_trading_iteration method.
-        job_stores = {"default": MemoryJobStore(), "On_Trading_Iteration": MemoryJobStore()}
-
-        # Instantiate a BackgroundScheduler with the job stores we just defined. This scheduler will be used to store
-        # the jobs that we create later and execute them at the correct time.
-        self.scheduler = BackgroundScheduler(jobstores=job_stores)
+        # Backtests drive iterations synchronously and never need APScheduler. Live sessions create
+        # it lazily in _setup_live_trading_scheduler().
+        if self._is_backtesting_strategy:
+            self.scheduler = _BacktestSchedulerStub(self)
+        else:
+            MemoryJobStore, BackgroundScheduler, _CronTrigger = _get_scheduler_imports()
+            job_stores = {"default": MemoryJobStore(), "On_Trading_Iteration": MemoryJobStore()}
+            self.scheduler = BackgroundScheduler(jobstores=job_stores)
 
         # Initialize a target count and a current count for cron jobs to 0.
         # These are used to determine when to execute the on_trading_iteration method.
@@ -131,7 +204,7 @@ class StrategyExecutor(Thread):
                 self._market_type_cache[market_name] = True
                 return True
 
-            cal = mcal.get_calendar(market_name)
+            cal = _get_market_calendars().get_calendar(market_name)
 
             # Sample ~1.5 weeks so we can observe weekend gaps as well as daily spans.
             reference_day = pd.Timestamp('2025-01-13', tz='UTC')  # Monday
@@ -298,7 +371,6 @@ class StrategyExecutor(Thread):
         cash_broker_max_retries = 3
         cash_broker_retries = 0
         orders_broker = []
-        positions_broker = []
         while held_trades_len > 0:
             # Snapshot for the broker and lumibot:
             self.strategy
@@ -658,8 +730,14 @@ class StrategyExecutor(Thread):
             self.strategy.logger.error(f"Event {event} not recognized. Payload: {payload}")
 
     def process_queue(self):
-        while not self.queue.empty():
-            event, payload = self.queue.get()
+        queue = self.queue
+        if self._is_backtesting_strategy and not queue.queue:
+            return
+        while True:
+            try:
+                event, payload = queue.get_nowait()
+            except Empty:
+                break
             self.process_event(event, payload)
 
     def _process_smart_limit_orders(self):
@@ -1480,6 +1558,7 @@ class StrategyExecutor(Thread):
                 )
 
         # Return a CronTrigger object with the calculated settings.
+        _MemoryJobStore, _BackgroundScheduler, CronTrigger = _get_scheduler_imports()
         return CronTrigger(**kwargs)
 
     # TODO: speed up this function, it's a major bottleneck for backtesting
@@ -1692,8 +1771,13 @@ class StrategyExecutor(Thread):
 
     def _setup_live_trading_scheduler(self):
         """Set up the APScheduler for live trading sessions"""
+        MemoryJobStore, BackgroundScheduler, _CronTrigger = _get_scheduler_imports()
         # Ensure a scheduler exists (it may have been set to None during a previous graceful_exit)
-        if not hasattr(self, 'scheduler') or self.scheduler is None:
+        if (
+            not hasattr(self, 'scheduler')
+            or self.scheduler is None
+            or not isinstance(self.scheduler, BackgroundScheduler)
+        ):
             job_stores = {"default": MemoryJobStore(), "On_Trading_Iteration": MemoryJobStore()}
             self.scheduler = BackgroundScheduler(jobstores=job_stores)
 
@@ -1977,7 +2061,10 @@ class StrategyExecutor(Thread):
 
     def get_next_ap_scheduler_run_time(self):
         # Check if scheduler object exists.
-        if self.scheduler is None or not isinstance(self.scheduler, BackgroundScheduler):
+        if self.scheduler is None or isinstance(self.scheduler, _BacktestSchedulerStub):
+            return None
+        _MemoryJobStore, BackgroundScheduler, _CronTrigger = _get_scheduler_imports()
+        if not isinstance(self.scheduler, BackgroundScheduler):
             return None
 
         # Get the current jobs from the scheduler.

--- a/lumibot/tools/__init__.py
+++ b/lumibot/tools/__init__.py
@@ -1,42 +1,165 @@
-# TODO: Using * is really bad and leads to random circular imports (especially in polygon_helper and indicators)
-# TODO: When using *, you have to ensure that the underlying module does not import ANYTHING from the lumibot package
-# TODO: This tools module is a bad place to auto import as a helper to the code because all of the modules and functions
-# TODO: are not related to each other. It's just a collection of random functions and classes and it is unclear what
-# TODO: is being loaded when simply trying to load anything from the tools module. It's better to import the specific
-# TODO: functions and classes that you need from the tools module. This has made everything from black_scholes to
-# TODO: yahoo_helper all interrelated and it's a mess.
-from .black_scholes import BS
-from .debugers import *
-from .decorators import append_locals, execute_after, snatch_locals, staticdecorator
-from .helpers import *
-from .indicators import (
-    cash_flow_adjusted_returns,
-    cagr,
-    calculate_returns,
-    create_tearsheet,
-    cumulative_to_period_flows,
-    get_risk_free_rate,
-    get_symbol_returns,
-    max_drawdown,
-    performance,
-    plot_indicators,
-    plot_returns,
-    romad,
-    sharpe,
-    stats_summary,
-    total_return,
-    volatility,
-)
-from .pandas import *
-from .types import *
-from .yahoo_helper import YahooHelper
-from .ccxt_data_store import CcxtCacheDB
-from .schwab_helper import SchwabHelper
+"""Compatibility exports for :mod:`lumibot.tools`.
 
-# Unified logging system
-from .lumibot_logger import (
-    get_logger,
-    get_strategy_logger, 
-    set_log_level,
-    add_file_handler
-)
+The old package initializer imported every helper module at once. That made
+basic imports pay for plotting, broker caches, Yahoo, CCXT, and analytics even
+when callers only needed one small helper.
+"""
+
+from importlib import import_module as _import_module
+
+_SUBMODULES = {
+    "backtest_cache",
+    "black_scholes",
+    "ccxt_data_store",
+    "data_downloader_queue_client",
+    "databento_helper",
+    "databento_helper_polars",
+    "debugers",
+    "decorators",
+    "futures_roll",
+    "helpers",
+    "ibkr_helper",
+    "ibkr_secdef",
+    "indicators",
+    "lumibot_logger",
+    "pandas",
+    "parquet_series_cache",
+    "parquet_utils",
+    "polars_utils",
+    "polygon_helper",
+    "polygon_helper_async",
+    "polygon_helper_polars_optimized",
+    "projectx_helpers",
+    "runtime_telemetry",
+    "schwab_helper",
+    "smart_limit_utils",
+    "symbol_parser",
+    "symbol_normalization",
+    "thetadata_helper",
+    "types",
+    "yahoo_helper",
+    "alpaca_helpers",
+    "bitunix_helpers",
+}
+
+_NAME_TO_MODULE = {
+    "BS": "black_scholes",
+    "CcxtCacheDB": "ccxt_data_store",
+    "SchwabHelper": "schwab_helper",
+    "YahooHelper": "yahoo_helper",
+    "append_locals": "decorators",
+    "execute_after": "decorators",
+    "snatch_locals": "decorators",
+    "staticdecorator": "decorators",
+    "add_file_handler": "lumibot_logger",
+    "get_logger": "lumibot_logger",
+    "get_strategy_logger": "lumibot_logger",
+    "set_log_level": "lumibot_logger",
+    "cagr": "indicators",
+    "calculate_returns": "indicators",
+    "cash_flow_adjusted_returns": "indicators",
+    "create_tearsheet": "indicators",
+    "cumulative_to_period_flows": "indicators",
+    "get_risk_free_rate": "indicators",
+    "get_symbol_returns": "indicators",
+    "max_drawdown": "indicators",
+    "performance": "indicators",
+    "plot_indicators": "indicators",
+    "plot_returns": "indicators",
+    "romad": "indicators",
+    "sharpe": "indicators",
+    "stats_summary": "indicators",
+    "total_return": "indicators",
+    "volatility": "indicators",
+    "Decimal": "types",
+    "check_numeric": "types",
+    "check_positive": "types",
+    "check_price": "types",
+    "check_quantity": "types",
+}
+
+_HELPER_EXPORTS = {
+    "LUMIBOT_DEFAULT_PYTZ",
+    "LUMIBOT_DEFAULT_TIMEZONE",
+    "MarketCalendar",
+    "TwentyFourSevenCalendar",
+    "ComparaisonMixin",
+    "colored",
+    "create_options_symbol",
+    "date_n_trading_days_from_date",
+    "day_deduplicate",
+    "deduplicate_sequence",
+    "dt",
+    "fill_void",
+    "get_chunks",
+    "get_decimals",
+    "get_lumibot_datetime",
+    "get_timezone_from_datetime",
+    "get_trading_days",
+    "get_trading_times",
+    "has_more_than_n_decimal_places",
+    "hashlib",
+    "is_daily_data",
+    "is_market_open",
+    "lru_cache",
+    "mcal",
+    "os",
+    "parse_symbol",
+    "parse_timestep_qty_and_unit",
+    "pd",
+    "prettify_dataframe_with_decimals",
+    "print_full_pandas_dataframes",
+    "print_progress_bar",
+    "pytz",
+    "quantize_to_num_decimals",
+    "re",
+    "set_pandas_float_display_precision",
+    "sys",
+    "time",
+    "to_datetime_aware",
+    "weakref",
+}
+
+for _name in _HELPER_EXPORTS:
+    _NAME_TO_MODULE[_name] = "helpers"
+
+_NAME_TO_MODULE["parse_symbol"] = "symbol_parser"
+
+for _name in (
+    "day_deduplicate",
+    "fill_void",
+    "is_daily_data",
+    "np",
+    "pd",
+    "prettify_dataframe_with_decimals",
+    "print_full_pandas_dataframes",
+    "set_pandas_float_display_precision",
+):
+    _NAME_TO_MODULE[_name] = "pandas"
+
+for _name in ("PerfCounters", "perf_counter", "perf_counters"):
+    _NAME_TO_MODULE[_name] = "debugers"
+
+_NAME_TO_MODULE["ROUND_HALF_EVEN"] = "helpers"
+
+__all__ = sorted(_SUBMODULES | set(_NAME_TO_MODULE))
+
+
+def __getattr__(name):
+    if name in _SUBMODULES:
+        module = _import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/tools/bitunix_helpers.py
+++ b/lumibot/tools/bitunix_helpers.py
@@ -2,9 +2,14 @@ import os
 import time
 from typing import Dict, Any, Optional
 import hashlib
-import requests
 import json
 from lumibot.tools.lumibot_logger import get_logger
+
+
+def _requests():
+    import requests
+
+    return requests
 
 class BitUnixClient:
     """
@@ -90,7 +95,7 @@ class BitUnixClient:
         url = self.BASE_URL + endpoint
         # Use custom serialization for POST bodies so that the sent JSON matches the signature body exactly
         if method.upper() == "GET":
-            resp = requests.request(
+            resp = _requests().request(
                 method=method.upper(),
                 url=url,
                 headers=headers,
@@ -100,7 +105,7 @@ class BitUnixClient:
         else:
             # Serialize body without spaces to match signature
             body_str = json.dumps(json_body, separators=(',', ':'), ensure_ascii=False) if json_body is not None else ""
-            resp = requests.request(
+            resp = _requests().request(
                 method=method.upper(),
                 url=url,
                 headers=headers,

--- a/lumibot/tools/black_scholes.py
+++ b/lumibot/tools/black_scholes.py
@@ -1,13 +1,23 @@
-from math import e, log
-import numpy as np
+from math import e, erf, exp, log, pi, sqrt
 
 import warnings
 warnings.filterwarnings("ignore", category=RuntimeWarning)
 
-try:
-    from scipy.stats import norm
-except ImportError:
-    print("Mibian requires scipy to work properly")
+_SQRT_TWO = sqrt(2.0)
+_INV_SQRT_TWO_PI = 1.0 / sqrt(2.0 * pi)
+
+
+class _NormalDistribution:
+    @staticmethod
+    def cdf(value):
+        return 0.5 * (1.0 + erf(value / _SQRT_TWO))
+
+    @staticmethod
+    def pdf(value):
+        return exp(-0.5 * value * value) * _INV_SQRT_TWO_PI
+
+
+norm = _NormalDistribution()
 
 # WARNING: All numbers should be floats -> x = 1.0
 
@@ -37,7 +47,7 @@ def impliedVolatility(className, args, callPrice=None, putPrice=None, high=500.0
             estimate = eval(className)(args, volatility=mid, performance=True).callPrice
         if putPrice:
             estimate = eval(className)(args, volatility=mid, performance=True).putPrice
-        if np.round(estimate, decimals) == target:
+        if round(estimate, decimals) == target:
             break
         elif estimate > target:
             high = mid

--- a/lumibot/tools/ccxt_data_store.py
+++ b/lumibot/tools/ccxt_data_store.py
@@ -1,19 +1,42 @@
+from __future__ import annotations
+
 import time
-import duckdb
 import os
 import uuid
-import ccxt
 from datetime import datetime
-from tabulate import tabulate
-import pandas as pd
-from pandas import DataFrame
+from importlib import import_module
 from ..constants import LUMIBOT_CACHE_FOLDER
 from lumibot.tools.lumibot_logger import get_logger
 import math
-import numpy as np
-from typing import Union
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+duckdb = _LazyModule("duckdb")
+pd = _LazyModule("pandas")
+np = _LazyModule("numpy")
 
 class CcxtCacheDB:
     """A ccxt data cache class using duckdb.
@@ -46,6 +69,8 @@ class CcxtCacheDB:
 
         """
         self.logger = get_logger(self.__class__.__name__)
+        import ccxt
+
         try:
             exchange_class = getattr(ccxt, exchange_id)
         except:
@@ -457,6 +482,8 @@ class CcxtCacheDB:
 
 
     def _table_str(self, df, headers="keys"):
+        from tabulate import tabulate
+
         return tabulate(df, headers=headers, tablefmt='psql')
 
 if __name__ == "__main__":

--- a/lumibot/tools/data_downloader_queue_client.py
+++ b/lumibot/tools/data_downloader_queue_client.py
@@ -23,13 +23,33 @@ import random
 import threading
 import time
 from dataclasses import dataclass, field
+from importlib import import_module
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
-import requests
-from requests import exceptions as requests_exceptions
-
 logger = logging.getLogger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+requests = _LazyModule("requests")
+requests_exceptions = _LazyModule("requests.exceptions")
 
 # Lightweight, non-secret telemetry for backtest audit/debugging.
 #

--- a/lumibot/tools/databento_helper.py
+++ b/lumibot/tools/databento_helper.py
@@ -1,33 +1,96 @@
+from __future__ import annotations
+
 # This file contains helper functions for getting data from DataBento
 import os
-import re
 from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
+from importlib.util import find_spec
 from pathlib import Path
 from typing import Optional, List, Dict, Tuple, Union
 from decimal import Decimal
 
-import pandas as pd
 from lumibot import LUMIBOT_CACHE_FOLDER
 from lumibot.entities import Asset
-from lumibot.tools import futures_roll
-from termcolor import colored
 
-# Set up module-specific logger
-from lumibot.tools.lumibot_logger import get_logger
-logger = get_logger(__name__)
+_COLORED_FN = None
 
 
 class DataBentoAuthenticationError(RuntimeError):
     """Raised when DataBento rejects authentication credentials."""
     pass
 
-# DataBento imports (will be installed as dependency)
-try:
-    import databento as db
-    from databento import Historical
-    DATABENTO_AVAILABLE = True
-except ImportError:
-    DATABENTO_AVAILABLE = False
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+class _LazyDatabentoHistorical:
+    def __call__(self, *args, **kwargs):
+        return getattr(import_module("databento"), "Historical")(*args, **kwargs)
+
+
+pd = _LazyModule("pandas")
+futures_roll = _LazyModule("lumibot.tools.futures_roll")
+db = _LazyModule("databento")
+Historical = _LazyDatabentoHistorical()
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        object.__setattr__(self, "_logger", None)
+
+    def _load(self):
+        logger = object.__getattribute__(self, "_logger")
+        if logger is None:
+            from lumibot.tools.lumibot_logger import get_logger
+
+            logger = get_logger(__name__)
+            object.__setattr__(self, "_logger", logger)
+        return logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _colored
+
+        _COLORED_FN = _colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+DATABENTO_AVAILABLE = find_spec("databento") is not None
+if not DATABENTO_AVAILABLE:
     logger.warning("DataBento package not available. Please install with: pip install databento")
 
 # Cache settings

--- a/lumibot/tools/databento_helper_polars.py
+++ b/lumibot/tools/databento_helper_polars.py
@@ -1,19 +1,19 @@
+from __future__ import annotations
+
 # This file contains helper functions for getting data from DataBento - POLARS VERSION
 # This is a FULL COPY of databento_helper.py that will be incrementally optimized to leverage polars
 # for filtering operations while maintaining pandas compatibility at the boundaries.
 
 import os
-import re
 from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
+from importlib.util import find_spec
 from pathlib import Path
 from typing import Optional, List, Dict, Tuple, Union
 from decimal import Decimal
 
-import pandas as pd
-import polars as pl
 from lumibot import LUMIBOT_CACHE_FOLDER
 from lumibot.entities import Asset
-from lumibot.tools import futures_roll
 from termcolor import colored
 
 # Set up module-specific logger
@@ -25,13 +25,46 @@ class DataBentoAuthenticationError(RuntimeError):
     """Raised when DataBento rejects authentication credentials."""
     pass
 
-# DataBento imports (will be installed as dependency)
-try:
-    import databento as db
-    from databento import Historical
-    DATABENTO_AVAILABLE = True
-except ImportError:
-    DATABENTO_AVAILABLE = False
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+class _LazyDatabentoHistorical:
+    def __call__(self, *args, **kwargs):
+        return getattr(import_module("databento"), "Historical")(*args, **kwargs)
+
+
+pd = _LazyModule("pandas")
+pl = _LazyModule("polars")
+futures_roll = _LazyModule("lumibot.tools.futures_roll")
+db = _LazyModule("databento")
+Historical = _LazyDatabentoHistorical()
+DATABENTO_AVAILABLE = find_spec("databento") is not None
+if not DATABENTO_AVAILABLE:
     logger.warning("DataBento package not available. Please install with: pip install databento")
 
 # Cache settings - CRITICAL: Use separate cache from pandas version to avoid contamination

--- a/lumibot/tools/helpers.py
+++ b/lumibot/tools/helpers.py
@@ -7,16 +7,68 @@ import time
 import weakref
 from functools import lru_cache
 from decimal import Decimal, ROUND_HALF_EVEN
+from importlib import import_module
+from types import ModuleType
 
 import pytz
 import datetime as dt
 
-import pandas as pd
-import pandas_market_calendars as mcal
-from pandas_market_calendars.market_calendar import MarketCalendar
 from termcolor import colored
 
-from ..constants import LUMIBOT_DEFAULT_PYTZ, LUMIBOT_DEFAULT_TIMEZONE
+LUMIBOT_DEFAULT_TIMEZONE = "America/New_York"
+LUMIBOT_DEFAULT_PYTZ = pytz.timezone(LUMIBOT_DEFAULT_TIMEZONE)
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+
+
+class _PandasMarketCalendarsProxy:
+    def _module(self):
+        import pandas_market_calendars as _mcal
+
+        return _mcal
+
+    @property
+    def __version__(self):
+        return getattr(self._module(), "__version__", "unknown")
+
+    def get_calendar(self, *args, **kwargs):
+        return self._module().get_calendar(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._module(), name)
+
+
+mcal = _PandasMarketCalendarsProxy()
+_TWENTY_FOUR_SEVEN_CALENDAR_CLASS = None
+
+
+def __getattr__(name):
+    if name == "MarketCalendar":
+        from pandas_market_calendars.market_calendar import MarketCalendar
+
+        globals()["MarketCalendar"] = MarketCalendar
+        return MarketCalendar
+    if name == "TwentyFourSevenCalendar":
+        return _twenty_four_seven_calendar_class()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 # ============================================================================
 # PERFORMANCE CACHES - Critical for backtesting performance
@@ -69,7 +121,7 @@ def _get_trading_days_disk_cache_path(market: str, start_day, end_day, tz_name: 
     if not cache_dir:
         return None
 
-    market_cal_version = getattr(mcal, "__version__", "unknown")
+    market_cal_version = "24/7" if market == "24/7" else getattr(mcal, "__version__", "unknown")
     cache_key = "|".join(
         (
             _TRADING_CALENDAR_DISK_CACHE_VERSION,
@@ -110,7 +162,7 @@ def _get_trading_schedule_for_year(market: str, year: int, tz_name: str) -> pd.D
     year_end = pd.Timestamp(year=year, month=12, day=31)
 
     if market == "24/7":
-        cal = TwentyFourSevenCalendar(tzinfo=tzinfo)
+        cal = _twenty_four_seven_calendar_class()(tzinfo=tzinfo)
     else:
         cal = mcal.get_calendar(market)
 
@@ -144,59 +196,81 @@ def deduplicate_sequence(seq, key=""):
     return seq
 
 
-class TwentyFourSevenCalendar(MarketCalendar):
-    """
-    Calendar for markets that trade 24/7, like crypto markets.
-    Market open is set to midnight (00:00) and close to 23:59 for each day.
-    """
+def _twenty_four_seven_calendar_class():
+    global _TWENTY_FOUR_SEVEN_CALENDAR_CLASS
+    if _TWENTY_FOUR_SEVEN_CALENDAR_CLASS is not None:
+        return _TWENTY_FOUR_SEVEN_CALENDAR_CLASS
 
-    regular_market_times = {
-        'market_open': [(None, dt.time(0, 0))],
-        'market_close': [(None, dt.time(23, 59, 59, 999999))],
-    }
+    from pandas_market_calendars.market_calendar import MarketCalendar
 
-    def __init__(self, tzinfo: str | pytz.BaseTzInfo = 'UTC'):
-        self._tzinfo = pytz.timezone(tzinfo) if isinstance(tzinfo, str) else tzinfo
-        super().__init__()
+    class TwentyFourSevenCalendar(MarketCalendar):
+        """
+        Calendar for markets that trade 24/7, like crypto markets.
+        Market open is set to midnight (00:00) and close to 23:59 for each day.
+        """
 
-    @property
-    def name(self):
-        return "24/7"
+        regular_market_times = {
+            'market_open': [(None, dt.time(0, 0))],
+            'market_close': [(None, dt.time(23, 59, 59, 999999))],
+        }
 
-    @property
-    def tz(self):
-        return self._tzinfo
+        def __init__(self, tzinfo: str | pytz.BaseTzInfo = 'UTC'):
+            self._tzinfo = pytz.timezone(tzinfo) if isinstance(tzinfo, str) else tzinfo
+            super().__init__()
 
-    @property
-    def open_time_default(self):
-        return dt.time(0, 0)
+        @property
+        def name(self):
+            return "24/7"
 
-    @property
-    def close_time_default(self):
-        return dt.time(23, 59)
+        @property
+        def tz(self):
+            return self._tzinfo
 
-    @property
-    def regular_holidays(self):
-        return []
+        @property
+        def open_time_default(self):
+            return dt.time(0, 0)
 
-    @property
-    def special_closes(self):
-        return []
+        @property
+        def close_time_default(self):
+            return dt.time(23, 59)
 
-    @property
-    def special_closes_adherence(self):
-        return []
+        @property
+        def regular_holidays(self):
+            return []
 
-    @property
-    def special_opens(self):
-        return []
+        @property
+        def special_closes(self):
+            return []
 
-    @property
-    def special_opens_adherence(self):
-        return []
+        @property
+        def special_closes_adherence(self):
+            return []
 
-    def valid_days(self, start_date, end_date, tz=None):
-        return pd.date_range(start=start_date, end=end_date, freq='D')
+        @property
+        def special_opens(self):
+            return []
+
+        @property
+        def special_opens_adherence(self):
+            return []
+
+        def valid_days(self, start_date, end_date, tz=None):
+            return pd.date_range(start=start_date, end=end_date, freq='D', tz=tz or self._tzinfo)
+
+        def schedule(self, start_date, end_date, tz=None):
+            tzinfo = tz or self._tzinfo
+            idx = self.valid_days(start_date, end_date, tz=tzinfo)
+            return pd.DataFrame(
+                {
+                    "market_open": idx,
+                    "market_close": idx + pd.Timedelta(days=1) - pd.Timedelta(microseconds=1),
+                },
+                index=idx,
+            )
+
+    _TWENTY_FOUR_SEVEN_CALENDAR_CLASS = TwentyFourSevenCalendar
+    globals()["TwentyFourSevenCalendar"] = TwentyFourSevenCalendar
+    return TwentyFourSevenCalendar
 
 
 def get_trading_days(
@@ -305,7 +379,7 @@ def get_trading_days(
     span_days = int((schedule_end_day - start_day).days)
     if span_days >= 365:
         if market == "24/7":
-            cal = TwentyFourSevenCalendar(tzinfo=tzinfo)
+            cal = _twenty_four_seven_calendar_class()(tzinfo=tzinfo)
         else:
             cal = mcal.get_calendar(market)
 
@@ -668,34 +742,9 @@ def to_datetime_aware(dt_in):
 
 
 def parse_symbol(symbol):
-    """
-    Parse the given symbol and determine if it's an option or a stock.
-    For options, extract and return the stock symbol, expiration date (as a datetime.date object),
-    type (call or put), and strike price.
-    For stocks, simply return the stock symbol.
-    TODO: Crypto and Forex support
-    """
-    # Check that the symbol is a string
-    if not isinstance(symbol, str):
-        return {"type": None}
-    
-    # Pattern to match the option symbol format
-    option_pattern = r"([A-Z]+)(\d{6})([CP])(\d+)"
+    from lumibot.tools.symbol_parser import parse_symbol as _parse_symbol
 
-    match = re.match(option_pattern, symbol)
-    if match:
-        stock_symbol, expiration, option_type, strike_price = match.groups()
-        expiration_date = dt.datetime.strptime(expiration, "%y%m%d").date()
-        option_type = "CALL" if option_type == "C" else "PUT"
-        return {
-            "type": "option",
-            "stock_symbol": stock_symbol,
-            "expiration_date": expiration_date,
-            "option_type": option_type,
-            "strike_price": round(float(strike_price) / 1000, 3),  # assuming strike price is in thousandths
-        }
-    else:
-        return {"type": "stock", "stock_symbol": symbol}
+    return _parse_symbol(symbol)
 
 
 def create_options_symbol(stock_symbol, expiration_date, option_type, strike_price):

--- a/lumibot/tools/ibkr_helper.py
+++ b/lumibot/tools/ibkr_helper.py
@@ -6,22 +6,91 @@ import os
 import time
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Dict, Optional, Tuple
-
-import pandas as pd
 
 from lumibot.constants import LUMIBOT_CACHE_FOLDER, LUMIBOT_DEFAULT_PYTZ
 from lumibot.entities import Asset
-from lumibot.tools.backtest_cache import CacheMode, get_backtest_cache
-from lumibot.tools.data_downloader_queue_client import queue_request
 from lumibot.tools.ibkr_secdef import (
     IbkrFuturesExchangeAmbiguousError,
     select_futures_exchange_from_secdef_search_payload,
 )
-from lumibot.tools.parquet_series_cache import ParquetSeriesCache
 
 logger = logging.getLogger(__name__)
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BACKTEST_CACHE_MODE = None
+_BACKTEST_CACHE_GETTER = None
+_QUEUE_REQUEST = None
+_PARQUET_SERIES_CACHE = None
+
+
+class _LazyCacheMode:
+    def __getattr__(self, name):
+        global _BACKTEST_CACHE_MODE
+        if _BACKTEST_CACHE_MODE is None:
+            from lumibot.tools.backtest_cache import CacheMode as _CacheMode
+
+            _BACKTEST_CACHE_MODE = _CacheMode
+        return getattr(_BACKTEST_CACHE_MODE, name)
+
+
+class _LazyParquetSeriesCache:
+    def _load(self):
+        global _PARQUET_SERIES_CACHE
+        if _PARQUET_SERIES_CACHE is None:
+            from lumibot.tools.parquet_series_cache import ParquetSeriesCache as _ParquetSeriesCache
+
+            _PARQUET_SERIES_CACHE = _ParquetSeriesCache
+        return _PARQUET_SERIES_CACHE
+
+    def __call__(self, *args, **kwargs):
+        return self._load()(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+CacheMode = _LazyCacheMode()
+ParquetSeriesCache = _LazyParquetSeriesCache()
+
+
+def get_backtest_cache():
+    global _BACKTEST_CACHE_GETTER
+    if _BACKTEST_CACHE_GETTER is None:
+        from lumibot.tools.backtest_cache import get_backtest_cache as _get_backtest_cache
+
+        _BACKTEST_CACHE_GETTER = _get_backtest_cache
+    return _BACKTEST_CACHE_GETTER()
+
+
+def queue_request(*args, **kwargs):
+    global _QUEUE_REQUEST
+    if _QUEUE_REQUEST is None:
+        from lumibot.tools.data_downloader_queue_client import queue_request as _queue_request
+
+        _QUEUE_REQUEST = _queue_request
+    return _QUEUE_REQUEST(*args, **kwargs)
 
 CACHE_SUBFOLDER = "ibkr"
 

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -1,34 +1,135 @@
+from __future__ import annotations
+
 import contextlib
 import json
 import math
 import os
-import webbrowser
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
+from importlib import import_module
 
-import pandas as pd
-import numpy as np
-import plotly.graph_objects as go
 import pytz
-import quantstats_lumi as qs
-from plotly.subplots import make_subplots
 
 from ..constants import LUMIBOT_DEFAULT_TIMEZONE
 from lumibot.tools import to_datetime_aware
 
-from .yahoo_helper import YahooHelper as yh
 
-from lumibot.tools.lumibot_logger import get_logger
-from lumibot.tools.parquet_utils import (
-    coerce_object_columns_to_json_strings,
-    is_parquet_required,
-    write_parquet_with_logging,
-)
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
 
-logger = get_logger(__name__)
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+np = _LazyModule("numpy")
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        object.__setattr__(self, "_logger", None)
+
+    def _load(self):
+        logger = object.__getattribute__(self, "_logger")
+        if logger is None:
+            from lumibot.tools.lumibot_logger import get_logger
+
+            logger = get_logger(__name__)
+            object.__setattr__(self, "_logger", logger)
+        return logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
 
 _TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 _FALSE_ENV_VALUES = {"0", "false", "no", "off"}
+
+
+def _get_quantstats_lumi():
+    import quantstats_lumi as qs
+
+    globals()["qs"] = qs
+    return qs
+
+
+def _get_plotly_imports():
+    go = globals().get("go")
+    make_subplots = globals().get("make_subplots")
+    if go is None:
+        import plotly.graph_objects as go
+
+        globals()["go"] = go
+    if make_subplots is None:
+        from plotly.subplots import make_subplots
+
+        globals()["make_subplots"] = make_subplots
+
+    return go, make_subplots
+
+
+def _get_webbrowser():
+    module = globals().get("webbrowser")
+    if module is None:
+        module = import_module("webbrowser")
+        globals()["webbrowser"] = module
+    return module
+
+
+def _parquet_utils():
+    from lumibot.tools.parquet_utils import (
+        coerce_object_columns_to_json_strings,
+        is_parquet_required,
+        write_parquet_with_logging,
+    )
+
+    return coerce_object_columns_to_json_strings, is_parquet_required, write_parquet_with_logging
+
+
+def coerce_object_columns_to_json_strings(*args, **kwargs):
+    fn, _, _ = _parquet_utils()
+    return fn(*args, **kwargs)
+
+
+def is_parquet_required(*args, **kwargs):
+    _, fn, _ = _parquet_utils()
+    return fn(*args, **kwargs)
+
+
+def write_parquet_with_logging(*args, **kwargs):
+    _, _, fn = _parquet_utils()
+    return fn(*args, **kwargs)
+
+
+def __getattr__(name):
+    if name == "qs":
+        return _get_quantstats_lumi()
+    if name == "yh":
+        from .yahoo_helper import YahooHelper as yh
+
+        globals()["yh"] = yh
+        return yh
+    if name in {"go", "make_subplots"}:
+        go, make_subplots = _get_plotly_imports()
+        return go if name == "go" else make_subplots
+    if name == "webbrowser":
+        return _get_webbrowser()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 TERMINAL_TRADE_STATUSES_FOR_MARKERS = {
     "fill",
@@ -567,6 +668,8 @@ def get_symbol_returns(symbol, start=datetime(1900, 1, 1), end=datetime.now()):
 
     """
     # Fetch the symbol data
+    from .yahoo_helper import YahooHelper as yh
+
     returns_df = yh.get_symbol_data(symbol)
 
     if returns_df is None:
@@ -706,6 +809,7 @@ def plot_indicators(
         return
 
     logger.info("\nCreating indicators plot...")
+    go, make_subplots = _get_plotly_imports()
 
     # Assign "default_plot" as plot_name for markers and lines that don't have one
     if chart_markers_df is not None and not chart_markers_df.empty:
@@ -1131,6 +1235,8 @@ def plot_returns(
     if not show_plot:
         logger.info("show_plot is False; trades CSV/parquet written, skipping HTML plot.")
         return
+
+    go, make_subplots = _get_plotly_imports()
 
     dfs_concat = []
 
@@ -1745,6 +1851,8 @@ def create_tearsheet(
     # Set the name of the benchmark column so that quantstats can use it in the report
     df_final["benchmark"].name = str(benchmark_asset)
 
+    qs = _get_quantstats_lumi()
+
     # Run quantstats reports surpressing any logs because it can be noisy for no reason
     try:
         with open(os.devnull, "w") as f, contextlib.redirect_stdout(f), contextlib.redirect_stderr(f):
@@ -1879,7 +1987,7 @@ def create_tearsheet(
                 return f"{float(value) * 100.0:.2f}%"
 
             try:
-                import quantstats_lumi as _qs
+                _qs = qs
 
                 strat_returns = _qs.utils._prepare_returns(df_final["strategy"].astype(float))
                 bench_returns = _qs.utils._prepare_returns(df_final["benchmark"].astype(float))
@@ -2009,13 +2117,15 @@ def create_tearsheet(
 
     if show_tearsheet and not disable_ui:
         url = "file://" + os.path.abspath(str(tearsheet_file))
-        webbrowser.open(url)
+        _get_webbrowser().open(url)
 
     return result
 
 
 def get_risk_free_rate(dt: datetime = None):
     try:
+        from .yahoo_helper import YahooHelper as yh
+
         result = yh.get_risk_free_rate(dt=dt)
     except Exception as e:
         logger.error(f"Error getting the risk free rate: {e}")

--- a/lumibot/tools/lumibot_logger.py
+++ b/lumibot/tools/lumibot_logger.py
@@ -50,14 +50,10 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Tuple, Optional
+from typing import Dict, Tuple
 from enum import Enum
 
-# Import LUMIWEALTH_API_KEY from credentials
-try:
-    from ..credentials import LUMIWEALTH_API_KEY
-except ImportError:
-    LUMIWEALTH_API_KEY = None
+LUMIWEALTH_API_KEY = os.environ.get("LUMIWEALTH_API_KEY")
 
 class CSVErrorHandler(logging.Handler):
     """

--- a/lumibot/tools/pandas.py
+++ b/lumibot/tools/pandas.py
@@ -1,8 +1,31 @@
+from __future__ import annotations
+
 from datetime import time
 from decimal import Decimal
 
-import pandas as pd
-import numpy as np
+
+def _pd():
+    import pandas as pd
+
+    return pd
+
+
+def _np():
+    import numpy as np
+
+    return np
+
+
+def __getattr__(name):
+    if name == "pd":
+        module = _pd()
+        globals()["pd"] = module
+        return module
+    if name == "np":
+        module = _np()
+        globals()["np"] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def day_deduplicate(df_):
@@ -13,6 +36,7 @@ def day_deduplicate(df_):
 
 
 def is_daily_data(df_):
+    pd = _pd()
     times = pd.Series(df_.index).apply(lambda x: x.time()).unique()
     if len(times) == 1 and times[0] == time(0, 0):
         return True
@@ -20,6 +44,7 @@ def is_daily_data(df_):
 
 
 def fill_void(df_, interval, end):
+    pd = _pd()
     n_rows = len(df_.index)
     missing_lines = pd.DataFrame()
     for index, row in df_.iterrows():
@@ -50,6 +75,7 @@ def print_full_pandas_dataframes():
     """
     Show the whole dataframe when printing pandas dataframes
     """
+    pd = _pd()
     pd.set_option('display.max_columns', None)
     pd.set_option('display.max_colwidth', None)
     pd.set_option('display.max_rows', None)
@@ -57,11 +83,14 @@ def print_full_pandas_dataframes():
 
 
 def set_pandas_float_display_precision(precision: int = 5):
+    pd = _pd()
     format_str = '{:.' + str(precision) + 'f}'
     pd.set_option('display.float_format', format_str.format)
 
 
-def prettify_dataframe_with_decimals(df: pd.DataFrame, decimal_places: int = 5) -> str:
+def prettify_dataframe_with_decimals(df, decimal_places: int = 5) -> str:
+    np = _np()
+
     def decimal_formatter(x):
         if isinstance(x, (Decimal, float, int, np.float64, np.int64)):
             return f"{x:.{decimal_places}f}"

--- a/lumibot/tools/parquet_series_cache.py
+++ b/lumibot/tools/parquet_series_cache.py
@@ -2,15 +2,35 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from importlib import import_module
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
-
-import pandas as pd
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.tools.backtest_cache import get_backtest_cache
 
 logger = logging.getLogger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
 
 
 @dataclass(frozen=True)

--- a/lumibot/tools/parquet_utils.py
+++ b/lumibot/tools/parquet_utils.py
@@ -4,11 +4,31 @@ import json
 import os
 import time
 from dataclasses import dataclass
+from importlib import import_module
 from typing import Any, Callable, Optional
 
-import pandas as pd
-
 _TRUTHY = {"required", "require", "strict", "1", "true", "yes"}
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
 
 
 @dataclass(frozen=True)

--- a/lumibot/tools/polars_utils.py
+++ b/lumibot/tools/polars_utils.py
@@ -4,7 +4,22 @@ from __future__ import annotations
 
 from typing import Iterable, Optional, Sequence, Set
 
-import polars as pl
+
+class _LazyPolars:
+    _module = None
+
+    def _load(self):
+        if self._module is None:
+            import polars as pl
+
+            self._module = pl
+        return self._module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pl = _LazyPolars()
 
 
 class PolarsResampleError(Exception):

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -1,29 +1,101 @@
+from __future__ import annotations
+
 # This file contains helper functions for getting data from Polygon.io
 import os
 import time
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
 from pathlib import Path
-from typing import Iterator, List, Optional
+from typing import TYPE_CHECKING, Iterator, List, Optional
 from urllib.parse import urlparse, urlunparse
 
-import pandas as pd
-import pandas_market_calendars as mcal
-from polygon.exceptions import BadResponse
-
-# noinspection PyPackageRequirements
-from polygon.rest import RESTClient
-from termcolor import colored
-from tqdm import tqdm
-from urllib3.exceptions import MaxRetryError
-
-from lumibot.constants import LUMIBOT_CACHE_FOLDER, LUMIBOT_DEFAULT_PYTZ
-from lumibot.credentials import POLYGON_API_KEY
+from lumibot import LUMIBOT_CACHE_FOLDER
 from lumibot.entities import Asset
-from lumibot.tools.lumibot_logger import get_logger
 
-logger = get_logger(__name__)
+if TYPE_CHECKING:
+    from polygon.rest import RESTClient
+
+_POLYGON_CLIENT_CLASSES = {}
+_COLORED_FN = None
+_DEFAULT_PYTZ = None
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_TQDM_FUNC = None
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        object.__setattr__(self, "_logger", None)
+
+    def _load(self):
+        logger = object.__getattribute__(self, "_logger")
+        if logger is None:
+            from lumibot.tools.lumibot_logger import get_logger
+
+            logger = get_logger(__name__)
+            object.__setattr__(self, "_logger", logger)
+        return logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _colored
+
+        _COLORED_FN = _colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _default_pytz():
+    global _DEFAULT_PYTZ
+    if _DEFAULT_PYTZ is None:
+        from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
+
+        _DEFAULT_PYTZ = LUMIBOT_DEFAULT_PYTZ
+    return _DEFAULT_PYTZ
+
+
+def _polygon_api_key():
+    from lumibot.credentials import POLYGON_API_KEY
+
+    return POLYGON_API_KEY
+
+
+def tqdm(*args, **kwargs):
+    global _TQDM_FUNC
+    if _TQDM_FUNC is None:
+        from tqdm import tqdm as _real_tqdm
+
+        _TQDM_FUNC = _real_tqdm
+    return _TQDM_FUNC(*args, **kwargs)
 
 # Adjust as desired, in days. We'll reuse any existing chain file
 # that is not older than RECENT_FILE_TOLERANCE_DAYS.
@@ -35,6 +107,16 @@ MAX_POLYGON_DAYS = 30
 # Define a cache dictionary to store schedules and a global dictionary for buffered schedules
 schedule_cache = {}
 buffered_schedules = {}
+_PANDAS_MARKET_CALENDARS = None
+
+
+def _get_market_calendars():
+    global _PANDAS_MARKET_CALENDARS
+    if _PANDAS_MARKET_CALENDARS is None:
+        import pandas_market_calendars as mcal
+
+        _PANDAS_MARKET_CALENDARS = mcal
+    return _PANDAS_MARKET_CALENDARS
 
 
 def get_cached_schedule(cal, start_date, end_date, buffer_days=30):
@@ -213,6 +295,8 @@ def get_price_data_from_polygon(
             limit=50000,
         )
 
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_to_range = {executor.submit(fetch_chunk, cstart, cend): (cstart, cend)
                            for (cstart, cend) in chunks}
@@ -373,11 +457,13 @@ def get_trading_dates(asset: Asset, start: datetime, end: datetime):
         or asset.asset_type == Asset.AssetType.STOCK
         or asset.asset_type == Asset.AssetType.OPTION
     ):
+        mcal = _get_market_calendars()
         cal = mcal.get_calendar("NYSE")
 
     # Forex Asset for Backtesting - Forex trades weekdays, 24hrs starting Sunday 5pm EST
     # Calendar: "CME_FX"
     elif asset.asset_type == Asset.AssetType.FOREX:
+        mcal = _get_market_calendars()
         cal = mcal.get_calendar("CME_FX")
 
     else:
@@ -633,7 +719,7 @@ def update_cache(
         if d not in cached_dates:
             # Create a datetime at the start of the day using the default timezone,
             # then convert to UTC.
-            dt = datetime(year=d.year, month=d.month, day=d.day, tzinfo=LUMIBOT_DEFAULT_PYTZ)
+            dt = datetime(year=d.year, month=d.month, day=d.day, tzinfo=_default_pytz())
             dt_utc = dt.astimezone(timezone.utc)
             dummy_rows.append((dt_utc, {"missing": True}))
     # If any dummy rows were created, add them to the DataFrame.
@@ -871,10 +957,29 @@ def get_chains_cached(
     return option_contracts
 
 
-class PolygonClient(RESTClient):
+def _polygon_client_class(facade_cls):
+    client_class = _POLYGON_CLIENT_CLASSES.get(facade_cls)
+    if client_class is not None:
+        return client_class
+
+    from polygon.rest import RESTClient
+
+    client_class = type(
+        "_RateLimitedPolygonClient",
+        (facade_cls, RESTClient),
+        {"__module__": __name__},
+    )
+    _POLYGON_CLIENT_CLASSES[facade_cls] = client_class
+    return client_class
+
+
+class PolygonClient:
     ''' Rate Limited RESTClient with factory method '''
 
     WAIT_SECONDS_RETRY = 60
+
+    def __new__(cls, *args, **kwargs):
+        return object.__new__(_polygon_client_class(cls))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -916,7 +1021,7 @@ class PolygonClient(RESTClient):
 
         """
         if 'api_key' not in kwargs or kwargs.get('api_key') is None:
-            kwargs['api_key'] = POLYGON_API_KEY
+            kwargs['api_key'] = _polygon_api_key()
 
         return cls(*args, **kwargs)
 
@@ -925,6 +1030,9 @@ class PolygonClient(RESTClient):
         Override to handle rate-limits by sleeping 60s, but *throttle*
         the log message so it isn't repeated too frequently.
         """
+        from polygon.exceptions import BadResponse
+        from urllib3.exceptions import MaxRetryError
+
         max_attempts = int(os.environ.get("POLYGON_MAX_RETRY_ATTEMPTS", "0") or "0")
         max_total_sleep = int(os.environ.get("POLYGON_MAX_RETRY_SLEEP_SECONDS", "0") or "0")
         wait_seconds = int(os.environ.get("POLYGON_WAIT_SECONDS_RETRY", str(PolygonClient.WAIT_SECONDS_RETRY)) or "0")

--- a/lumibot/tools/polygon_helper_async.py
+++ b/lumibot/tools/polygon_helper_async.py
@@ -1,16 +1,11 @@
 # Async implementation for Polygon data downloads - significantly faster than sync version
-import asyncio
+from __future__ import annotations
+
 import time
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional
+from importlib import import_module
+from typing import Any, Dict, List, Optional
 
-import aiohttp
-import polars as pl
-
-try:
-    from tqdm.asyncio import tqdm
-except ImportError:
-    from tqdm import tqdm
 from lumibot.entities import Asset
 from lumibot.tools.lumibot_logger import get_logger
 
@@ -20,9 +15,54 @@ logger = get_logger(__name__)
 MAX_CONCURRENT_REQUESTS = 50  # Much higher than sync version
 MAX_POLYGON_DAYS = 7  # Smaller chunks for better parallelization
 RATE_LIMIT_PER_MINUTE = 100  # Polygon rate limit
-CONNECTION_TIMEOUT = aiohttp.ClientTimeout(total=60, connect=10, sock_read=30)
 MAX_RETRIES = 3
 RETRY_DELAY = 0.5
+
+_AIOHTTP = None
+_ASYNCIO = None
+_POLARS = None
+_TQDM = None
+
+
+def _asyncio():
+    global _ASYNCIO
+    if _ASYNCIO is None:
+        _ASYNCIO = import_module("asyncio")
+    return _ASYNCIO
+
+
+def _aiohttp():
+    global _AIOHTTP
+    if _AIOHTTP is None:
+        import aiohttp
+
+        _AIOHTTP = aiohttp
+    return _AIOHTTP
+
+
+def _pl():
+    global _POLARS
+    if _POLARS is None:
+        import polars as pl
+
+        _POLARS = pl
+    return _POLARS
+
+
+def _tqdm():
+    global _TQDM
+    if _TQDM is None:
+        try:
+            from tqdm.asyncio import tqdm
+        except ImportError:
+            from tqdm import tqdm
+
+        _TQDM = tqdm
+    return _TQDM
+
+
+def _connection_timeout():
+    return _aiohttp().ClientTimeout(total=60, connect=10, sock_read=30)
 
 class AsyncPolygonClient:
     """Async Polygon client for high-performance data downloads."""
@@ -30,11 +70,12 @@ class AsyncPolygonClient:
     def __init__(self, api_key: str):
         self.api_key = api_key
         self.base_url = "https://api.polygon.io"
-        self.session: Optional[aiohttp.ClientSession] = None
+        self.session = None
         self.rate_limiter = RateLimiter(RATE_LIMIT_PER_MINUTE)
 
     async def __aenter__(self):
         """Create session on context enter."""
+        aiohttp = _aiohttp()
         connector = aiohttp.TCPConnector(
             limit=100,
             limit_per_host=50,
@@ -43,7 +84,7 @@ class AsyncPolygonClient:
         )
         self.session = aiohttp.ClientSession(
             connector=connector,
-            timeout=CONNECTION_TIMEOUT,
+            timeout=_connection_timeout(),
             headers={"Authorization": f"Bearer {self.api_key}"}
         )
         return self
@@ -64,6 +105,7 @@ class AsyncPolygonClient:
     ) -> Optional[List[Dict]]:
         """Get aggregated bars data."""
         await self.rate_limiter.acquire()
+        asyncio = _asyncio()
 
         # Format dates
         from_str = from_date.strftime("%Y-%m-%d")
@@ -106,10 +148,11 @@ class RateLimiter:
         self.calls_per_minute = calls_per_minute
         self.min_interval = 60.0 / calls_per_minute
         self.last_call = 0
-        self.lock = asyncio.Lock()
+        self.lock = _asyncio().Lock()
 
     async def acquire(self):
         """Wait if necessary to respect rate limit."""
+        asyncio = _asyncio()
         async with self.lock:
             now = time.time()
             time_since_last = now - self.last_call
@@ -126,7 +169,7 @@ async def download_polygon_data_async(
     timespan: str = "minute",
     quote_asset: Optional[Asset] = None,
     symbol: Optional[str] = None
-) -> Optional[pl.DataFrame]:
+) -> Optional[Any]:
     """
     Download Polygon data using async/await for maximum performance.
     
@@ -178,8 +221,10 @@ async def download_polygon_data_async(
 
     # Download all chunks in parallel
     async with AsyncPolygonClient(api_key) as client:
+        asyncio = _asyncio()
+
         # Create progress bar
-        pbar = tqdm(
+        pbar = _tqdm()(
             total=len(chunks),
             desc=f"Async downloading {asset.symbol} {timespan}",
             dynamic_ncols=True
@@ -208,6 +253,7 @@ async def download_polygon_data_async(
         return None
 
     # Optimized DataFrame creation
+    pl = _pl()
     df = pl.DataFrame(results, schema_overrides={
         "o": pl.Float64,
         "h": pl.Float64,
@@ -238,7 +284,7 @@ def get_price_data_from_polygon_async(
     timespan: str = "minute",
     quote_asset: Optional[Asset] = None,
     force_cache_update: bool = False
-) -> Optional[pl.DataFrame]:
+) -> Optional[Any]:
     """
     Wrapper function to use async download in sync context.
     
@@ -260,7 +306,7 @@ def get_price_data_from_polygon_async(
     # Validate cache
     force_cache_update = validate_cache_polars(force_cache_update, asset, cache_file, api_key)
 
-    df_all: Optional[pl.DataFrame] = None
+    df_all: Optional[Any] = None
 
     # Load cached data if available
     if cache_file.exists() and not force_cache_update:
@@ -283,6 +329,7 @@ def get_price_data_from_polygon_async(
     end_dt = datetime.combine(poly_end, datetime.max.time(), tzinfo=timezone.utc)
 
     # Run async download
+    asyncio = _asyncio()
     try:
         loop = asyncio.get_event_loop()
     except RuntimeError:
@@ -300,6 +347,7 @@ def get_price_data_from_polygon_async(
         if df_all is None or len(df_all) == 0:
             df_all = new_data
         else:
+            pl = _pl()
             df_all = (
                 pl.concat([df_all.lazy(), new_data.lazy()])
                 .sort("datetime")
@@ -312,6 +360,7 @@ def get_price_data_from_polygon_async(
     df_all = update_cache_polars(cache_file, df_all, missing_dates)
 
     # Reload and clean cache
+    pl = _pl()
     df_all_full = load_cache_polars(cache_file)
     if "missing" in df_all_full.columns:
         df_all_output = df_all_full.filter(~pl.col("missing").cast(pl.Boolean))

--- a/lumibot/tools/polygon_helper_polars_optimized.py
+++ b/lumibot/tools/polygon_helper_polars_optimized.py
@@ -1,23 +1,38 @@
 # This file contains helper functions for getting data from Polygon.io optimized with Polars
+from __future__ import annotations
+
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Iterator, List, Optional
-
-import pandas_market_calendars as mcal
-import polars as pl
-
-# noinspection PyPackageRequirements
-from termcolor import colored
-from tqdm import tqdm
+from typing import TYPE_CHECKING, Iterator, List, Optional
 
 from lumibot.constants import LUMIBOT_CACHE_FOLDER
 from lumibot.entities import Asset
 from lumibot.tools.lumibot_logger import get_logger
 
+if TYPE_CHECKING:
+    from lumibot.tools.polygon_helper import PolygonClient
+
 logger = get_logger(__name__)
+
+
+class _LazyPolars:
+    _module = None
+
+    def _load(self):
+        if self._module is None:
+            import polars as pl
+
+            self._module = pl
+        return self._module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pl = _LazyPolars()
 
 # Adjust as desired, in days. We'll reuse any existing chain file
 # that is not older than RECENT_FILE_TOLERANCE_DAYS.
@@ -33,6 +48,16 @@ MAX_CONCURRENT_REQUESTS = 20
 # Define a cache dictionary to store schedules and a global dictionary for buffered schedules
 schedule_cache = {}
 buffered_schedules = {}
+_PANDAS_MARKET_CALENDARS = None
+
+
+def _get_market_calendars():
+    global _PANDAS_MARKET_CALENDARS
+    if _PANDAS_MARKET_CALENDARS is None:
+        import pandas_market_calendars as mcal
+
+        _PANDAS_MARKET_CALENDARS = mcal
+    return _PANDAS_MARKET_CALENDARS
 
 
 def get_cached_schedule(cal, start_date, end_date, buffer_days=30):
@@ -169,6 +194,8 @@ def get_price_data_from_polygon_polars(
         s_date = e_date + timedelta(days=1)
 
     # Download data in parallel with optimized batch processing
+    from tqdm import tqdm
+
     pbar = tqdm(total=total_queries,
             desc=f"Downloading and caching {asset} / {quote_asset.symbol if quote_asset else ''} '{timespan}'",
             dynamic_ncols=True)
@@ -322,11 +349,13 @@ def get_trading_dates(asset: Asset, start: datetime, end: datetime):
         or asset.asset_type == Asset.AssetType.STOCK
         or asset.asset_type == Asset.AssetType.OPTION
     ):
+        mcal = _get_market_calendars()
         cal = mcal.get_calendar("NYSE")
 
     # Forex Asset for Backtesting - Forex trades weekdays, 24hrs starting Sunday 5pm EST
     # Calendar: "CME_FX"
     elif asset.asset_type == Asset.AssetType.FOREX:
+        mcal = _get_market_calendars()
         cal = mcal.get_calendar("CME_FX")
 
     else:
@@ -395,6 +424,8 @@ def get_polygon_symbol(asset, polygon_client, quote_asset=None):
         )
 
         if len(contracts) == 0:
+            from termcolor import colored
+
             text = colored(f"Unable to find option contract for {asset}", "red")
             logger.debug(text)
             return

--- a/lumibot/tools/projectx_helpers.py
+++ b/lumibot/tools/projectx_helpers.py
@@ -4,15 +4,16 @@ ProjectX Helper Utilities for Lumibot Integration
 This module provides the core ProjectX API client and streaming functionality
 integrated into Lumibot's architecture based on the actual working Project X library.
 """
+from __future__ import annotations
 
 import time
 import warnings
 from datetime import datetime
+from importlib import import_module
+from importlib.util import find_spec
 from typing import Callable, Optional, Dict, List
 
-import pandas as pd
 import pytz
-import requests
 
 from lumibot.tools.lumibot_logger import get_logger
 
@@ -25,12 +26,45 @@ warnings.filterwarnings("ignore", category=DeprecationWarning, message="websocke
 
 logger = get_logger(__name__)
 
-# SignalR imports - will be imported when needed
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+requests = _LazyModule("requests")
+_SIGNALR_MODULE = _LazyModule("signalrcore.hub_connection_builder")
 try:
-    from signalrcore.hub_connection_builder import HubConnectionBuilder
-    SIGNALR_AVAILABLE = True
-except ImportError:
+    SIGNALR_AVAILABLE = find_spec("signalrcore.hub_connection_builder") is not None
+except ModuleNotFoundError:
     SIGNALR_AVAILABLE = False
+
+
+def _hub_connection_builder_class():
+    return _SIGNALR_MODULE.HubConnectionBuilder
 
 
 class ProjectXAuth:
@@ -129,7 +163,7 @@ class ProjectXStreaming:
             
             hub_url_with_auth = f"{self.user_hub_url}?access_token={self.token}"
             
-            self.user_connection = HubConnectionBuilder() \
+            self.user_connection = _hub_connection_builder_class()() \
                 .with_url(hub_url_with_auth) \
                 .with_automatic_reconnect({
                     "type": "raw",

--- a/lumibot/tools/symbol_parser.py
+++ b/lumibot/tools/symbol_parser.py
@@ -1,0 +1,30 @@
+import datetime as dt
+import re
+
+_OPTION_SYMBOL_PATTERN = re.compile(r"([A-Z]+)(\d{6})([CP])(\d+)")
+
+
+def parse_symbol(symbol):
+    """
+    Parse the given symbol and determine if it's an option or a stock.
+    For options, extract and return the stock symbol, expiration date (as a datetime.date object),
+    type (call or put), and strike price.
+    For stocks, simply return the stock symbol.
+    TODO: Crypto and Forex support
+    """
+    if not isinstance(symbol, str):
+        return {"type": None}
+
+    match = _OPTION_SYMBOL_PATTERN.match(symbol)
+    if match:
+        stock_symbol, expiration, option_type, strike_price = match.groups()
+        expiration_date = dt.datetime.strptime(expiration, "%y%m%d").date()
+        option_type = "CALL" if option_type == "C" else "PUT"
+        return {
+            "type": "option",
+            "stock_symbol": stock_symbol,
+            "expiration_date": expiration_date,
+            "option_type": option_type,
+            "strike_price": round(float(strike_price) / 1000, 3),
+        }
+    return {"type": "stock", "stock_symbol": symbol}

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -587,19 +587,13 @@ SPLIT_DENOMINATOR_COLUMNS = ("split_from", "from", "denominator", "ratio_from", 
 SPLIT_RATIO_COLUMNS = ("ratio", "split_ratio")
 
 
-def _env_truthy(name: str, default: str = "true") -> bool:
-    value = os.environ.get(name, default)
-    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
-
-
 def _corporate_action_horizon_date() -> date:
-    if _env_truthy("IS_BACKTESTING", "false"):
-        backtesting_end = os.environ.get("BACKTESTING_END")
-        if backtesting_end:
-            try:
-                return datetime.fromisoformat(backtesting_end).date()
-            except ValueError:
-                logger.debug("Ignoring unparseable BACKTESTING_END=%r for corporate actions", backtesting_end)
+    backtesting_end = os.environ.get("BACKTESTING_END")
+    if backtesting_end:
+        try:
+            return datetime.fromisoformat(backtesting_end).date()
+        except ValueError:
+            logger.debug("Ignoring unparseable BACKTESTING_END=%r for corporate actions", backtesting_end)
     return date.today()
 
 OPTION_LIST_ENDPOINTS = {

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -1,4 +1,6 @@
 # This file contains helper functions for getting data from Polygon.io
+from __future__ import annotations
+
 import functools
 import hashlib
 import json
@@ -9,26 +11,124 @@ import re
 import signal
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlencode, urlparse
 
-import pandas as pd
-import pandas_market_calendars as mcal
 import pytz
-import requests
-from dateutil import parser as dateutil_parser
-from tqdm import tqdm
 
-from lumibot import LUMIBOT_CACHE_FOLDER, LUMIBOT_DEFAULT_PYTZ
+from lumibot import LUMIBOT_CACHE_FOLDER, LUMIBOT_DEFAULT_TIMEZONE
 from lumibot.entities import Asset
-from lumibot.tools.backtest_cache import CacheMode, get_backtest_cache
-from lumibot.tools.lumibot_logger import get_logger
 
-logger = get_logger(__name__)
+LUMIBOT_DEFAULT_PYTZ = pytz.timezone(LUMIBOT_DEFAULT_TIMEZONE)
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        if name in {"_module_name", "_module"}:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+mcal = _LazyModule("pandas_market_calendars")
+requests = _LazyModule("requests")
+_TQDM_FUNC = None
+_BACKTEST_CACHE_MODE = None
+_BACKTEST_CACHE_GETTER = None
+_DATEUTIL_PARSE = None
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        object.__setattr__(self, "_logger", None)
+
+    def _load(self):
+        logger = object.__getattribute__(self, "_logger")
+        if logger is None:
+            from lumibot.tools.lumibot_logger import get_logger
+
+            logger = get_logger(__name__)
+            object.__setattr__(self, "_logger", logger)
+        return logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
+
+
+def _dateutil_parse(value):
+    global _DATEUTIL_PARSE
+    if _DATEUTIL_PARSE is None:
+        from dateutil import parser as dateutil_parser
+
+        _DATEUTIL_PARSE = dateutil_parser.parse
+    return _DATEUTIL_PARSE(value)
+
+
+class _LazyCacheMode:
+    def __getattr__(self, name):
+        global _BACKTEST_CACHE_MODE
+        if _BACKTEST_CACHE_MODE is None:
+            from lumibot.tools.backtest_cache import CacheMode as _CacheMode
+
+            _BACKTEST_CACHE_MODE = _CacheMode
+        return getattr(_BACKTEST_CACHE_MODE, name)
+
+
+CacheMode = _LazyCacheMode()
+
+
+def get_backtest_cache():
+    global _BACKTEST_CACHE_GETTER
+    if _BACKTEST_CACHE_GETTER is None:
+        from lumibot.tools.backtest_cache import get_backtest_cache as _get_backtest_cache
+
+        _BACKTEST_CACHE_GETTER = _get_backtest_cache
+    return _BACKTEST_CACHE_GETTER()
+
+
+def _tqdm(*args, **kwargs):
+    global _TQDM_FUNC
+    if _TQDM_FUNC is None:
+        from tqdm import tqdm
+
+        _TQDM_FUNC = tqdm
+    return _TQDM_FUNC(*args, **kwargs)
+
+
+def tqdm(*args, **kwargs):
+    return _tqdm(*args, **kwargs)
 
 # ==============================================================================
 # Download Status Tracking
@@ -3344,6 +3444,8 @@ def get_price_data(
             result_df=result_df,
         )
     else:
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
         with ThreadPoolExecutor(max_workers=chunk_workers) as executor:
             future_map: Dict[Any, Tuple[datetime, datetime, float]] = {}
             for chunk_start, chunk_end in chunk_ranges:
@@ -5756,7 +5858,7 @@ def get_historical_eod_data(
             ts = pd.to_datetime(value, errors="coerce")
             if ts is None or pd.isna(ts):
                 try:
-                    parsed = dateutil_parser.parse(str(value))
+                    parsed = _dateutil_parse(str(value))
                 except Exception:
                     return None
                 if parsed.tzinfo is None:

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -586,6 +586,22 @@ SPLIT_NUMERATOR_COLUMNS = ("split_to", "to", "numerator", "ratio_to", "after_sha
 SPLIT_DENOMINATOR_COLUMNS = ("split_from", "from", "denominator", "ratio_from", "before_shares")
 SPLIT_RATIO_COLUMNS = ("ratio", "split_ratio")
 
+
+def _env_truthy(name: str, default: str = "true") -> bool:
+    value = os.environ.get(name, default)
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _corporate_action_horizon_date() -> date:
+    if _env_truthy("IS_BACKTESTING", "false"):
+        backtesting_end = os.environ.get("BACKTESTING_END")
+        if backtesting_end:
+            try:
+                return datetime.fromisoformat(backtesting_end).date()
+            except ValueError:
+                logger.debug("Ignoring unparseable BACKTESTING_END=%r for corporate actions", backtesting_end)
+    return date.today()
+
 OPTION_LIST_ENDPOINTS = {
     "expirations": "/v3/option/list/expirations",
     "strikes": "/v3/option/list/strikes",
@@ -1742,11 +1758,11 @@ def _get_option_query_strike(option_asset: Asset, sim_datetime: datetime = None)
     # Get the underlying stock asset
     underlying_asset = Asset(option_asset.symbol, asset_type="stock")
 
-    from datetime import date as date_type
-    today = date_type.today()
+    today = _corporate_action_horizon_date()
 
     # FIX (2025-12-12): Use sim_datetime as the reference date for split lookup.
-    # This ensures we catch all splits between the simulation date and today.
+    # This ensures we catch all splits between the simulation date and the
+    # corporate-action horizon (BACKTESTING_END for deterministic backtests, today otherwise).
     # Previously, we used option expiration, which missed splits that occurred
     # BEFORE the expiration but AFTER the sim_datetime.
     if sim_datetime is not None:
@@ -1895,9 +1911,7 @@ def _apply_corporate_actions_to_frame(
         if underlying_asset is None:
             underlying_asset = Asset(getattr(asset, "symbol", ""), asset_type="stock")
 
-        from datetime import date as date_type
-
-        today = date_type.today()
+        today = _corporate_action_horizon_date()
         splits = _get_theta_splits(underlying_asset, start_day, today, username, password)
 
         if splits is None or splits.empty:
@@ -1934,12 +1948,11 @@ def _apply_corporate_actions_to_frame(
         return frame
 
     dividends = _get_theta_dividends(asset, start_day, end_day, username, password)
-    # CRITICAL: Fetch splits up to TODAY, not the data's end date!
+    # CRITICAL: Fetch splits up to the corporate-action horizon, not the data's end date!
     # When fetching March 2020 data, we still need to know about the July 2022 split
     # so we can adjust historical prices to be comparable to current prices.
     # This matches Yahoo Finance behavior where Adj Close always reflects current splits.
-    from datetime import date as date_type
-    today = date_type.today()
+    today = _corporate_action_horizon_date()
     splits = _get_theta_splits(asset, start_day, today, username, password)
     if "dividend" not in frame.columns:
         frame["dividend"] = 0.0
@@ -1969,7 +1982,7 @@ def _apply_corporate_actions_to_frame(
             # Sort splits by date (oldest first)
             sorted_splits = splits.sort_values("event_date")
 
-            # IMPORTANT: Apply ALL splits up to TODAY's date, not the data's end date.
+            # IMPORTANT: Apply ALL splits up to the corporate-action horizon, not the data's end date.
             # When we fetch March 2020 data in 2025, we need to apply the July 2022 split
             # so that historical prices are comparable to current split-adjusted prices.
             # This matches how Yahoo Finance calculates Adj Close - it always reflects
@@ -6858,9 +6871,8 @@ def build_historical_chain(
     # - Without this fix, the strategy tries to buy $1320 strike (wrong!)
     # - With this fix, strikes are adjusted: $1320 / 20 = $66 (correct!)
     #
-    # We fetch splits from as_of_date to TODAY and apply the cumulative ratio.
-    from datetime import date as date_type
-    today = date_type.today()
+    # We fetch splits from as_of_date to the corporate-action horizon and apply the cumulative ratio.
+    today = _corporate_action_horizon_date()
 
     # Fetch splits that occurred AFTER the backtest date
     splits = _get_theta_splits(asset, as_of_date, today)

--- a/lumibot/tools/yahoo_helper.py
+++ b/lumibot/tools/yahoo_helper.py
@@ -1,22 +1,87 @@
+from __future__ import annotations
+
 import os
 import pickle
 import time
 import random
-from pathlib import Path
+from importlib import import_module
 from datetime import datetime, timedelta
+from pathlib import Path
 
-import pandas as pd
-import yfinance as yf
-from fp.fp import FreeProxy
+from lumibot import LUMIBOT_CACHE_FOLDER
 
-from ..constants import LUMIBOT_CACHE_FOLDER, LUMIBOT_DEFAULT_PYTZ
-from .lumibot_logger import get_logger
-from .helpers import get_lumibot_datetime
-
-logger = get_logger(__name__)
+_DEFAULT_PYTZ = None
+_GET_LUMIBOT_DATETIME = None
 
 INFO_DATA = "info"
 INVALID_SYMBOLS = set()
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        object.__setattr__(self, "_logger", None)
+
+    def _load(self):
+        logger = object.__getattribute__(self, "_logger")
+        if logger is None:
+            from .lumibot_logger import get_logger
+
+            logger = get_logger(__name__)
+            object.__setattr__(self, "_logger", logger)
+        return logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
+
+
+def _default_pytz():
+    global _DEFAULT_PYTZ
+    if _DEFAULT_PYTZ is None:
+        from ..constants import LUMIBOT_DEFAULT_PYTZ
+
+        _DEFAULT_PYTZ = LUMIBOT_DEFAULT_PYTZ
+    return _DEFAULT_PYTZ
+
+
+def _get_lumibot_datetime():
+    global _GET_LUMIBOT_DATETIME
+    if _GET_LUMIBOT_DATETIME is None:
+        from .helpers import get_lumibot_datetime
+
+        _GET_LUMIBOT_DATETIME = get_lumibot_datetime
+    return _GET_LUMIBOT_DATETIME()
+
+
+def _get_yfinance():
+    import yfinance as yf
+
+    return yf
 
 
 class _YahooData:
@@ -28,7 +93,7 @@ class _YahooData:
 
     def is_up_to_date(self, last_needed_datetime=None):
         if last_needed_datetime is None:
-            last_needed_datetime = get_lumibot_datetime()
+            last_needed_datetime = _get_lumibot_datetime()
 
         if self.type == '1d':
             last_needed_date = last_needed_datetime.date()
@@ -76,6 +141,8 @@ class YahooHelper:
         time.sleep(random.uniform(2, 5))
 
         if YahooHelper.YAHOO_FREE_PROXY_ENABLED:
+            from fp.fp import FreeProxy
+
             return FreeProxy(timeout=5).get()
         return None
 
@@ -169,9 +236,9 @@ class YahooHelper:
         df.sort_index(inplace=True)
 
         if df.index.tzinfo is None:
-            df.index = pd.to_datetime(df.index).tz_localize(LUMIBOT_DEFAULT_PYTZ)
+            df.index = pd.to_datetime(df.index).tz_localize(_default_pytz())
         else:
-            df.index = df.index.tz_convert(LUMIBOT_DEFAULT_PYTZ)
+            df.index = df.index.tz_convert(_default_pytz())
 
         return df
 
@@ -179,6 +246,7 @@ class YahooHelper:
 
     @staticmethod
     def download_symbol_info(symbol):
+        yf = _get_yfinance()
         proxy = YahooHelper.sleep_and_get_proxy()
         if proxy:
             yf.set_config(proxy=proxy)
@@ -191,20 +259,21 @@ class YahooHelper:
             logger.debug(e)
             return {
                 "ticker": symbol,
-                "last_update": get_lumibot_datetime(),
+                "last_update": _get_lumibot_datetime(),
                 "error": True,
                 "info": None,
             }
 
         return {
             "ticker": ticker.ticker,
-            "last_update": get_lumibot_datetime(),
+            "last_update": _get_lumibot_datetime(),
             "error": False,
             "info": info,
         }
 
     @staticmethod
     def get_symbol_info(symbol):
+        yf = _get_yfinance()
         proxy = YahooHelper.sleep_and_get_proxy()
         if proxy:
             yf.set_config(proxy=proxy)
@@ -213,6 +282,7 @@ class YahooHelper:
 
     @staticmethod
     def get_symbol_last_price(symbol):
+        yf = _get_yfinance()
         proxy = YahooHelper.sleep_and_get_proxy()
         if proxy:
             yf.set_config(proxy=proxy)
@@ -239,6 +309,7 @@ class YahooHelper:
             logger.debug(f"{symbol} is already marked invalid. Skipping yfinance calls.")
             return None
 
+        yf = _get_yfinance()
         ticker = yf.Ticker(symbol)
 
         # --- HISTORICAL DATA RETRY LOGIC ---
@@ -254,13 +325,13 @@ class YahooHelper:
                 if interval == "1m":
                     df = ticker.history(
                         interval=interval,
-                        start=get_lumibot_datetime() - timedelta(days=7),
+                        start=_get_lumibot_datetime() - timedelta(days=7),
                         auto_adjust=False
                     )
                 elif interval == "15m":
                     df = ticker.history(
                         interval=interval,
-                        start=get_lumibot_datetime() - timedelta(days=60),
+                        start=_get_lumibot_datetime() - timedelta(days=60),
                         auto_adjust=False
                     )
                 else:
@@ -337,6 +408,7 @@ class YahooHelper:
             return {symbols[0]: item}
 
         result = {}
+        yf = _get_yfinance()
         proxy = YahooHelper.sleep_and_get_proxy()
         if proxy:
             yf.set_config(proxy=proxy)

--- a/lumibot/tools/yahoo_helper_polars_optimized.py
+++ b/lumibot/tools/yahoo_helper_polars_optimized.py
@@ -1,16 +1,37 @@
 """Optimized Yahoo finance helper using pure polars with minimal conversions."""
+from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from importlib import import_module
 from pathlib import Path
 from typing import Any, Dict, Optional
-
-import polars as pl
-import yfinance as yf
 
 from lumibot.constants import LUMIBOT_CACHE_FOLDER
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pl = _LazyModule("polars")
+yf = _LazyModule("yfinance")
 
 
 class YahooHelperPolarsOptimized:

--- a/lumibot/traders/__init__.py
+++ b/lumibot/traders/__init__.py
@@ -1,1 +1,24 @@
-from .trader import Trader
+"""Trader package exports without eager imports."""
+
+from importlib import import_module as _import_module
+
+_NAME_TO_MODULE = {
+    "Trader": "trader",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/trading_builtins/safe_list.py
+++ b/lumibot/trading_builtins/safe_list.py
@@ -300,6 +300,13 @@ class SafeOrderDict:
         with lock:
             return self._remove_unlocked(value, key=key)
 
+    def get(self, identifier, default=None):
+        lock = self.__lock
+        if lock is None:
+            return self.__items.get(str(identifier), default)
+        with lock:
+            return self.__items.get(str(identifier), default)
+
     def _remove_unlocked(self, value, key=None):
         if key is None:
             if isinstance(value, str):

--- a/scripts/bench_ibkr_speed_burner_stubbed.py
+++ b/scripts/bench_ibkr_speed_burner_stubbed.py
@@ -124,8 +124,13 @@ def main() -> int:
                 self.submit_order(order)
             self._i += 1
 
+    iterations = int(os.environ.get("LUMIBOT_BENCH_ITERATIONS", "1000"))
+
     tz = "America/New_York"
-    minute_index = pd.date_range("2025-12-08 09:30", periods=600, freq="1min", tz=tz)
+    # Keep enough minute bars for longer runs. A 200-iteration benchmark with a shared broker
+    # overweights one-time lazy series loads; 1000 iterations gives a steadier runtime signal.
+    minute_periods = max(4000, (iterations * 2) + 300)
+    minute_index = pd.date_range("2025-12-08 09:30", periods=minute_periods, freq="1min", tz=tz)
     # Provide enough daily history for `length=20` at the chosen intraday timestamps.
     day_index = pd.date_range("2025-09-01 00:00", periods=200, freq="1D", tz=tz)
 
@@ -197,7 +202,6 @@ def main() -> int:
     # Ensure multi-timeframe paths are exercised.
     _ = futures.get_historical_prices(fut_mes, length=10, timestep="15min")
 
-    iterations = 200
     t0 = perf_counter()
     for _ in range(iterations):
         futures.on_trading_iteration()

--- a/tests/backtest/performance_tracker.py
+++ b/tests/backtest/performance_tracker.py
@@ -4,7 +4,6 @@ Automatically records execution time and key metrics to CSV for long-term tracki
 """
 import csv
 import datetime
-import os
 from pathlib import Path
 
 
@@ -43,7 +42,7 @@ class PerformanceTracker:
         """Create CSV file with headers if it doesn't exist"""
         if not self.csv_path.exists():
             with open(self.csv_path, 'w', newline='') as f:
-                writer = csv.DictWriter(f, fieldnames=self.COLUMNS)
+                writer = csv.DictWriter(f, fieldnames=self.COLUMNS, lineterminator="\n")
                 writer.writeheader()
 
     def _get_git_commit(self):
@@ -111,7 +110,7 @@ class PerformanceTracker:
         }
 
         with open(self.csv_path, 'a', newline='') as f:
-            writer = csv.DictWriter(f, fieldnames=self.COLUMNS)
+            writer = csv.DictWriter(f, fieldnames=self.COLUMNS, lineterminator="\n")
             writer.writerow(row)
 
     def get_recent_performance(self, test_name=None, limit=10):

--- a/tests/test_backtesting_broker.py
+++ b/tests/test_backtesting_broker.py
@@ -4,7 +4,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 import pandas as pd
-from datetime import datetime as dt, time, timedelta # Renamed datetime to dt to avoid conflict
+from datetime import datetime as dt # Renamed datetime to dt to avoid conflict
 import pytz
 
 
@@ -238,6 +238,26 @@ class TestBacktestingBroker:
         broker._partially_filled_orders = MagicMock()
 
         orders = broker.get_active_tracked_orders(strategy="test", asset=asset)
+
+        assert orders == [matching]
+
+    def test_get_active_tracked_orders_normalizes_strategy_object_for_simple_pending(self):
+        broker = BacktestingBroker.__new__(BacktestingBroker)
+        asset = Asset("SPY")
+        strategy = SimpleNamespace(name="test")
+        matching = MagicMock()
+        matching.asset = asset
+        matching.strategy = "test"
+        matching.is_active.return_value = True
+        broker._simple_new_orders_by_strategy = {"test": [matching]}
+        broker._unprocessed_orders = MagicMock()
+        broker._unprocessed_orders.get_list.return_value = []
+        broker._new_orders = MagicMock()
+        broker._new_orders.get_list.return_value = []
+        broker._partially_filled_orders = MagicMock()
+        broker._partially_filled_orders.get_list.return_value = []
+
+        orders = broker.get_active_tracked_orders(strategy=strategy, asset=asset)
 
         assert orders == [matching]
 

--- a/tests/test_backtesting_futures_flips.py
+++ b/tests/test_backtesting_futures_flips.py
@@ -1,9 +1,11 @@
 from collections import defaultdict
+from decimal import Decimal
 
 import pytest
 
 from lumibot.backtesting.backtesting_broker import BacktestingBroker
 from lumibot.entities import Asset, Order
+from lumibot.trading_builtins import SafeList
 
 
 class DummyStrategy:
@@ -69,3 +71,57 @@ def test_futures_flip_releases_margin_and_creates_new_entry():
 
     assert strategy.cash == pytest.approx(100_700)
     assert key not in broker._futures_lot_ledgers
+
+
+def test_simple_futures_fast_fill_flip_matches_margin_and_position_semantics():
+    broker = make_broker()
+    broker._filled_positions = SafeList(None)
+    broker._filled_orders = SafeList(None)
+    broker._tracked_position_cache = {}
+    broker._trade_event_log_enabled = False
+    strategy = DummyStrategy()
+    asset = make_asset()
+
+    buy_order = Order.simple_market_backtest(
+        strategy.name,
+        asset,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+    )
+    broker._execute_simple_futures_backtest_fast_fill(buy_order, price=2000, strategy=strategy)
+
+    assert strategy.cash == pytest.approx(90_000)
+    position = broker.get_tracked_position(strategy.name, asset)
+    assert position is not None
+    assert position.quantity == pytest.approx(1)
+
+    reverse_order = Order.simple_market_backtest(
+        strategy.name,
+        asset,
+        Decimal("2"),
+        Order.OrderSide.SELL,
+    )
+    broker._execute_simple_futures_backtest_fast_fill(reverse_order, price=2005, strategy=strategy)
+
+    assert strategy.cash == pytest.approx(90_500)
+    position = broker.get_tracked_position(strategy.name, asset)
+    assert position is not None
+    assert position.quantity == pytest.approx(-1)
+    key = broker._get_futures_ledger_key(strategy, asset)
+    ledger = broker._futures_lot_ledgers[key]
+    assert len(ledger) == 1
+    assert ledger[0]["qty"] == pytest.approx(-1)
+    assert ledger[0]["price"] == pytest.approx(2005)
+
+    cover_order = Order.simple_market_backtest(
+        strategy.name,
+        asset,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+    )
+    broker._execute_simple_futures_backtest_fast_fill(cover_order, price=2003, strategy=strategy)
+
+    assert strategy.cash == pytest.approx(100_700)
+    assert key not in broker._futures_lot_ledgers
+    position = broker.get_tracked_position(strategy.name, asset)
+    assert position is None

--- a/tests/test_credentials_disable_dotenv.py
+++ b/tests/test_credentials_disable_dotenv.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import inspect
 
 
 def test_disable_dotenv_skips_recursive_scan(monkeypatch):
@@ -15,3 +16,44 @@ def test_disable_dotenv_skips_recursive_scan(monkeypatch):
     # credentials.py runs at import-time; force a clean import for this test.
     sys.modules.pop("lumibot.credentials", None)
     __import__("lumibot.credentials")
+
+
+def test_find_and_load_dotenv_walks_upward_and_loads_local_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("LUMIBOT_DISABLE_DOTENV", "1")
+    monkeypatch.delenv("LUMIBOT_TEST_DOTENV_VALUE", raising=False)
+
+    root = tmp_path / "repo"
+    child = root / "nested" / "tests"
+    child.mkdir(parents=True)
+    (root / ".env").write_text("LUMIBOT_TEST_DOTENV_VALUE=base\n", encoding="utf-8")
+    (root / ".env.local").write_text("LUMIBOT_TEST_DOTENV_VALUE=local\n", encoding="utf-8")
+
+    sys.modules.pop("lumibot.credentials", None)
+    credentials = __import__("lumibot.credentials").credentials
+
+    assert credentials.find_and_load_dotenv(child)
+    assert os.environ["LUMIBOT_TEST_DOTENV_VALUE"] == "local"
+
+
+def test_find_and_load_dotenv_ignores_dotenv_directory(monkeypatch, tmp_path):
+    monkeypatch.setenv("LUMIBOT_DISABLE_DOTENV", "1")
+    root = tmp_path / "repo"
+    child = root / "nested"
+    child.mkdir(parents=True)
+    (root / ".env").mkdir()
+
+    sys.modules.pop("lumibot.credentials", None)
+    credentials = __import__("lumibot.credentials").credentials
+
+    assert not credentials.find_and_load_dotenv(child)
+
+
+def test_credentials_broker_exports_are_real_classes(monkeypatch):
+    monkeypatch.setenv("LUMIBOT_DISABLE_DOTENV", "1")
+    sys.modules.pop("lumibot.credentials", None)
+
+    from lumibot.brokers import Alpaca as BrokerAlpaca
+    from lumibot.credentials import Alpaca
+
+    assert inspect.isclass(Alpaca)
+    assert Alpaca is BrokerAlpaca

--- a/tests/test_data_entity.py
+++ b/tests/test_data_entity.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
+import pytest
 import pytz
 
 from lumibot.entities import Asset
@@ -159,3 +160,90 @@ class TestDataGetLastPriceTradeOnly:
         tz = pytz.timezone("America/New_York")
         dt = tz.localize(datetime(2024, 1, 3, 9, 30))
         assert data.get_last_price(dt) == 5.0
+
+
+def test_native_minute_bars_fast_returns_lazy_pandas_slice_until_used():
+    asset = Asset("SPY")
+    tz = pytz.timezone("America/New_York")
+    idx = pd.date_range(tz.localize(datetime(2024, 1, 2, 9, 30)), periods=20, freq="1min")
+    df = pd.DataFrame(
+        {
+            "open": range(20),
+            "high": range(1, 21),
+            "low": range(20),
+            "close": range(2, 22),
+            "volume": [100] * 20,
+        },
+        index=idx,
+    )
+    data = Data(asset, df, timestep="minute")
+
+    bars_df = data.get_native_bars_fast(idx[10].to_pydatetime(), length=5, timestep="minute", mark_timezone=False)
+
+    assert isinstance(bars_df, pd.DataFrame)
+    assert len(bars_df) == 5
+    assert getattr(bars_df, "_lumibot_real_df", None) is None
+    assert bars_df["close"].iloc[-1] == 11
+    assert getattr(bars_df, "_lumibot_real_df", None) is not None
+
+
+def test_native_minute_bars_fast_lazy_slice_matches_common_pandas_ops():
+    asset = Asset("SPY")
+    tz = pytz.timezone("America/New_York")
+    idx = pd.date_range(tz.localize(datetime(2024, 1, 2, 9, 30)), periods=20, freq="1min")
+    df = pd.DataFrame(
+        {
+            "open": range(20),
+            "high": range(1, 21),
+            "low": range(20),
+            "close": range(2, 22),
+            "volume": [100] * 20,
+        },
+        index=idx,
+    )
+    data = Data(asset, df, timestep="minute")
+
+    fast_df = data.get_native_bars_fast(idx[10].to_pydatetime(), length=5, timestep="minute", mark_timezone=False)
+    slow_df = data.get_bars(idx[10].to_pydatetime(), length=5, timestep="minute", timeshift=None)
+
+    ops = {
+        "shape": lambda x: x.shape,
+        "dtypes": lambda x: tuple(map(str, x.dtypes)),
+        "iloc": lambda x: float(x.iloc[-1]["close"]),
+        "tail": lambda x: float(x.tail(1)["close"].iloc[0]),
+        "copy": lambda x: float(x.copy()["close"].iloc[-1]),
+        "reset_index": lambda x: x.reset_index().shape,
+        "to_numpy": lambda x: x.to_numpy().shape,
+        "describe": lambda x: round(float(x.describe().loc["mean", "close"]), 4),
+        "iterrows": lambda x: sum(1 for _ in x.iterrows()),
+    }
+
+    for op_name, op in ops.items():
+        assert op(fast_df) == op(slow_df), op_name
+
+
+def test_native_minute_bars_fast_lazy_slice_can_defer_return_column():
+    asset = Asset("SPY")
+    tz = pytz.timezone("America/New_York")
+    idx = pd.date_range(tz.localize(datetime(2024, 1, 2, 9, 30)), periods=20, freq="1min")
+    df = pd.DataFrame(
+        {
+            "open": range(20),
+            "high": range(1, 21),
+            "low": range(20),
+            "close": range(2, 22),
+            "volume": [100] * 20,
+        },
+        index=idx,
+    )
+    data = Data(asset, df, timestep="minute", assume_clean=True)
+    data._defer_clean_returns = True
+    data._initialize_clean_repaired_state()
+
+    bars_df = data.get_native_bars_fast(idx[10].to_pydatetime(), length=5, timestep="minute", mark_timezone=False)
+
+    assert getattr(bars_df, "_lumibot_real_df", None) is None
+    assert "return" in bars_df.columns
+    assert getattr(bars_df, "_lumibot_real_df", None) is None
+    assert bars_df["return"].iloc[0] == pytest.approx(1 / 6)
+    assert bars_df["return"].iloc[-1] == pytest.approx(0.1)

--- a/tests/test_ibkr_crypto_backtesting_smoke_stubbed.py
+++ b/tests/test_ibkr_crypto_backtesting_smoke_stubbed.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import timedelta
 from decimal import Decimal
 
 import pandas as pd
@@ -20,6 +19,27 @@ class _DummyIbkrCryptoStrategy(Strategy):
 
     def on_trading_iteration(self):
         return
+
+
+class _CallbackIbkrCryptoStrategy(_DummyIbkrCryptoStrategy):
+    def initialize(self, parameters=None):
+        super().initialize(parameters=parameters)
+        self.filled_events = []
+
+    def on_filled_order(self, position, order, price, quantity, multiplier):
+        filled_events = getattr(self, "filled_events", None)
+        if filled_events is None:
+            filled_events = []
+            self.filled_events = filled_events
+        filled_events.append(
+            {
+                "symbol": order.asset.symbol,
+                "side": order.side,
+                "price": price,
+                "quantity": quantity,
+                "multiplier": multiplier,
+            }
+        )
 
 
 def test_ibkr_rest_backtesting_crypto_market_orders_fill_at_ask_and_bid(monkeypatch):
@@ -120,6 +140,85 @@ def test_ibkr_rest_backtesting_crypto_market_orders_fill_at_ask_and_bid(monkeypa
 
     assert sell.is_filled()
     assert sell.get_fill_price() == pytest.approx(expected_bid_1, rel=1e-12)
+
+
+def test_ibkr_rest_backtesting_crypto_market_fill_preserves_custom_callback(monkeypatch):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    idx = pd.date_range("2025-01-01 00:00", periods=3, freq="1min", tz="America/New_York")
+    df = pd.DataFrame(
+        {
+            "open": [20_000.0, 20_100.0, 20_200.0],
+            "high": [20_050.0, 20_150.0, 20_250.0],
+            "low": [19_900.0, 20_000.0, 20_100.0],
+            "close": [20_010.0, 20_120.0, 20_230.0],
+            "bid": [20_005.0, 20_115.0, 20_225.0],
+            "ask": [20_015.0, 20_125.0, 20_235.0],
+            "volume": [1_000, 1_000, 1_000],
+        },
+        index=idx,
+    )
+
+    def fake_get_price_data(*, asset, quote, timestep, start_dt, end_dt, exchange=None, include_after_hours=True, source=None):
+        return df
+
+    monkeypatch.setattr(ibkr_helper, "get_price_data", fake_get_price_data)
+
+    data_source = InteractiveBrokersRESTBacktesting(
+        datetime_start=idx[0].to_pydatetime(),
+        datetime_end=(idx[-1] + pd.Timedelta(minutes=1)).to_pydatetime(),
+        market="24/7",
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    data_source.load_data()
+
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+    broker._update_datetime(idx[0].to_pydatetime())
+
+    strategy = _CallbackIbkrCryptoStrategy(
+        broker=broker,
+        budget=100_000.0,
+        analyze_backtest=False,
+        parameters={},
+    )
+    strategy._first_iteration = False
+
+    base = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+    data_source.get_historical_prices_between_dates(
+        (base, quote),
+        timestep="minute",
+        quote=quote,
+        start_date=idx[0].to_pydatetime(),
+        end_date=idx[-1].to_pydatetime(),
+    )
+    expected_ask = float(getattr(broker.get_quote(base, quote=quote), "ask"))
+
+    order = strategy.create_order(
+        base,
+        Decimal("0.5"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.MARKET,
+        quote=quote,
+    )
+    strategy.submit_order(order)
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert order.is_filled()
+    assert strategy.filled_events == [
+        {
+            "symbol": "BTC",
+            "side": Order.OrderSide.BUY,
+            "price": pytest.approx(expected_ask),
+            "quantity": pytest.approx(0.5),
+            "multiplier": 1,
+        }
+    ]
 
 
 def test_ibkr_rest_backtesting_crypto_limit_orders_fill_against_quotes(monkeypatch):

--- a/tests/test_ibkr_futures_backtesting_smoke_stubbed.py
+++ b/tests/test_ibkr_futures_backtesting_smoke_stubbed.py
@@ -22,6 +22,27 @@ class _DummyIbkrFuturesStrategy(Strategy):
         return
 
 
+class _CallbackIbkrFuturesStrategy(_DummyIbkrFuturesStrategy):
+    def initialize(self, parameters=None):
+        super().initialize(parameters=parameters)
+        self.filled_events = []
+
+    def on_filled_order(self, position, order, price, quantity, multiplier):
+        filled_events = getattr(self, "filled_events", None)
+        if filled_events is None:
+            filled_events = []
+            self.filled_events = filled_events
+        filled_events.append(
+            {
+                "symbol": order.asset.symbol,
+                "side": order.side,
+                "price": price,
+                "quantity": quantity,
+                "multiplier": multiplier,
+            }
+        )
+
+
 def _make_df(*, bid0: float, ask0: float, bid1: float, ask1: float) -> pd.DataFrame:
     idx = pd.date_range("2025-12-08 09:31", periods=2, freq="1min", tz="America/New_York")
     df = pd.DataFrame(
@@ -129,6 +150,64 @@ def test_ibkr_rest_backtesting_futures_market_roundtrip_uses_bid_ask_and_multipl
     expected_pnl = (100.75 - 100.25) * 1.0 * 5.0
     expected_cash = 10_000.0 + expected_pnl
     assert strategy.cash == pytest.approx(expected_cash, rel=1e-9)
+
+
+def test_ibkr_rest_backtesting_futures_market_fill_preserves_custom_callback(monkeypatch):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    df = _make_quote_only_df(bids=[100.00, 100.75], asks=[100.25, 101.00])
+
+    def fake_get_price_data(*, asset, quote, timestep, start_dt, end_dt, exchange=None, include_after_hours=True, source=None):
+        return df
+
+    monkeypatch.setattr(ibkr_helper, "get_price_data", fake_get_price_data)
+
+    data_source = InteractiveBrokersRESTBacktesting(
+        datetime_start=df.index[0].to_pydatetime(),
+        datetime_end=(df.index[-1] + pd.Timedelta(minutes=1)).to_pydatetime(),
+        market="24/7",
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    data_source.load_data()
+
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = _CallbackIbkrFuturesStrategy(
+        broker=broker,
+        budget=10_000.0,
+        analyze_backtest=False,
+        parameters={},
+    )
+    strategy._first_iteration = False
+
+    fut = Asset("MES", asset_type=Asset.AssetType.FUTURE, expiration=date(2025, 12, 19), multiplier=5)
+
+    data_source.get_historical_prices_between_dates(
+        (fut, Asset("USD", asset_type=Asset.AssetType.FOREX)),
+        timestep="minute",
+        quote=None,
+        start_date=df.index[0].to_pydatetime(),
+        end_date=df.index[-1].to_pydatetime(),
+    )
+
+    order = strategy.create_order(fut, Decimal("1"), Order.OrderSide.BUY, order_type=Order.OrderType.MARKET)
+    strategy.submit_order(order)
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert order.is_filled()
+    assert strategy.filled_events == [
+        {
+            "symbol": "MES",
+            "side": Order.OrderSide.BUY,
+            "price": pytest.approx(100.25),
+            "quantity": pytest.approx(1.0),
+            "multiplier": 5,
+        }
+    ]
 
 
 def test_ibkr_rest_backtesting_futures_smart_limit_uses_asset_min_tick(monkeypatch):

--- a/tests/test_ibkr_futures_daily_series.py
+++ b/tests/test_ibkr_futures_daily_series.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import date, datetime, timezone
 
 import pandas as pd
-import pytest
 
 from lumibot.entities import Asset
 
@@ -23,7 +22,7 @@ def test_ibkr_futures_daily_bars_are_session_aligned_not_midnight(monkeypatch):
     close_local = pd.Timestamp(sess["market_close"]).tz_convert("America/New_York")
     assert open_local < close_local
 
-    idx = pd.date_range(open_local, close_local, freq="1H", tz="America/New_York")
+    idx = pd.date_range(open_local, close_local, freq="1h", tz="America/New_York")
     intraday = pd.DataFrame(
         {
             "open": [100.0 for _ in idx],
@@ -61,4 +60,3 @@ def test_ibkr_futures_daily_bars_are_session_aligned_not_midnight(monkeypatch):
     # Futures "day" bar should be timestamped at the session close, not midnight.
     assert out.index[0].tz is not None
     assert out.index[0].hour != 0
-

--- a/tests/test_ibkr_speed_burner_stubbed.py
+++ b/tests/test_ibkr_speed_burner_stubbed.py
@@ -183,6 +183,24 @@ def test_ibkr_speed_burner_prefetches_once_and_slices_forever(monkeypatch):
     assert len(bars_15m.df) == 10
     assert (bars_15m.df.index[1] - bars_15m.df.index[0]) == pd.Timedelta(minutes=15)
 
+    # Prime the strategy-native cache, then prove repeated reads do not need the data-source
+    # fallback path after the Data object is cached on the strategy.
+    assert futures.get_last_price(fut_mes) == pytest.approx(6400.0 + 199 * 0.01)
+    bars_1m_first = futures.get_historical_prices(fut_mes, length=100, timestep="minute")
+    bars_1m_second = futures.get_historical_prices(fut_mes, length=100, timestep="minute")
+    assert len(bars_1m_first.df) == 100
+    assert len(bars_1m_second.df) == 100
+
+    original_get_historical_prices = futures_broker.data_source.get_historical_prices
+
+    def fail_get_historical_prices(*args, **kwargs):
+        raise AssertionError("strategy-native IBKR historical cache was bypassed")
+
+    monkeypatch.setattr(futures_broker.data_source, "get_historical_prices", fail_get_historical_prices)
+    bars_1m_cached = futures.get_historical_prices(fut_mes, length=100, timestep="minute")
+    assert len(bars_1m_cached.df) == 100
+    monkeypatch.setattr(futures_broker.data_source, "get_historical_prices", original_get_historical_prices)
+
     # Run a few hundred iterations of each loop. This is a correctness/speed-structure test:
     # it should not refetch the same series per iteration.
     iterations = 200
@@ -299,6 +317,12 @@ def test_ibkr_speed_burner_prefetches_once_and_slices_forever(monkeypatch):
     crypto_fills = trade_events_crypto[trade_events_crypto["status"] == "fill"].reset_index(drop=True)
     assert len(crypto_fills) == orders_total_crypto
     assert list(crypto_fills.iloc[:3]["symbol"]) == ["BTC", "ETH", "SOL"]
+    assert len(getattr(crypto_broker, "_filled_order_identifiers", ())) == 0
+    for order in crypto_broker._filled_orders.get_list()[:6]:
+        assert not hasattr(order, "_fast_trade_event_pair_row")
+        assert not hasattr(order, "_fast_trade_event_pair_row_index")
+        assert not hasattr(order, "_fast_trade_event_static")
+    assert isinstance(crypto_broker._trade_event_log_rows[0], tuple)
 
     # Crypto: first iteration (dt=minute_index[200]).
     _assert_fill(

--- a/tests/test_lazy_exports.py
+++ b/tests/test_lazy_exports.py
@@ -1,0 +1,135 @@
+import importlib
+import inspect
+from unittest.mock import patch
+
+
+def test_lazy_package_all_exports_resolve():
+    modules = [
+        "lumibot",
+        "lumibot.backtesting",
+        "lumibot.brokers",
+        "lumibot.components",
+        "lumibot.components.agents",
+        "lumibot.data_sources",
+        "lumibot.entities",
+        "lumibot.strategies",
+        "lumibot.tools",
+        "lumibot.traders",
+    ]
+
+    for module_name in modules:
+        module = importlib.import_module(module_name)
+        for export_name in getattr(module, "__all__", ()):
+            getattr(module, export_name)
+
+
+def test_legacy_star_import_exports_resolve():
+    namespace = {}
+
+    exec("from lumibot.tools import *", namespace)
+    for name in ("np", "pd", "parse_symbol", "get_logger", "YahooHelper"):
+        assert name in namespace
+    assert namespace["pd"].__name__ == "pandas"
+    assert namespace["np"].__name__ == "numpy"
+
+    exec("from lumibot.entities import *", namespace)
+    for name in ("Asset", "Order", "Position", "Data"):
+        assert name in namespace
+
+    exec("from lumibot.backtesting import *", namespace)
+    for name in ("BacktestingBroker", "PandasDataBacktesting", "YahooDataBacktesting"):
+        assert name in namespace
+
+
+def test_lazy_module_proxies_preserve_module_identity():
+    from lumibot.backtesting import backtesting_broker
+    from lumibot.entities import bars, data
+    from lumibot.strategies import strategy, strategy_executor
+    from lumibot.tools import helpers
+    from lumibot.tools import ibkr_helper, thetadata_helper
+
+    for value in (
+        helpers.pd,
+        ibkr_helper.pd,
+        thetadata_helper.pd,
+        thetadata_helper.mcal,
+        thetadata_helper.requests,
+        data.pd,
+        data.np,
+        bars.pd,
+        bars.np,
+        backtesting_broker.pd,
+        backtesting_broker.np,
+        strategy.pd,
+        strategy.np,
+        strategy_executor.pd,
+    ):
+        assert inspect.ismodule(value)
+
+
+def test_lazy_module_patch_teardown_forwards_deletion():
+    targets = [
+        "lumibot.tools.thetadata_helper.requests._lumibot_patch_probe",
+        "lumibot.brokers.tradier.requests._lumibot_patch_probe",
+        "lumibot.components.agents.builtins.requests._lumibot_patch_probe",
+        "lumibot.tools.projectx_helpers.requests._lumibot_patch_probe",
+        "lumibot.backtesting.routed_backtesting.pd._lumibot_patch_probe",
+        "lumibot.backtesting.databento_backtesting_pandas.pd._lumibot_patch_probe",
+        "lumibot.data_sources.databento_data_pandas.pd._lumibot_patch_probe",
+        "lumibot.indicators.indicators.pd._lumibot_patch_probe",
+    ]
+
+    for target in targets:
+        with patch(target, object(), create=True):
+            pass
+
+
+def test_lazy_module_patch_teardown_restores_existing_attributes():
+    from lumibot.brokers import tradier
+    from lumibot.components.agents import builtins
+    from lumibot.tools import projectx_helpers, thetadata_helper
+
+    target_pairs = [
+        (thetadata_helper.requests, "lumibot.tools.thetadata_helper.requests.get"),
+        (tradier.requests, "lumibot.brokers.tradier.requests.get"),
+        (builtins.requests, "lumibot.components.agents.builtins.requests.get"),
+        (projectx_helpers.requests, "lumibot.tools.projectx_helpers.requests.get"),
+    ]
+
+    for proxy, target in target_pairs:
+        original = proxy.get
+        with patch(target) as mocked:
+            assert proxy.get is mocked
+        assert proxy.get is original
+
+
+def test_legacy_entities_package_alias_resolves_submodules():
+    import lumibot  # noqa: F401
+    import entities
+    from entities import asset as asset_module
+    from entities.asset import Asset
+    from entities.order import Order
+
+    assert importlib.util.find_spec("entities.asset") is not None
+    assert importlib.util.find_spec("entities.order") is not None
+    assert importlib.reload(entities) is entities
+    assert importlib.reload(asset_module).Asset is Asset
+    assert entities.Asset is Asset
+    assert entities.Order is Order
+    assert Asset("SPY").symbol == "SPY"
+    assert Order.OrderType.MARKET.value == "market"
+
+
+def test_lightweight_example_agent_tool_preserves_source_description():
+    from lumibot.example_strategies._agent_tool import agent_tool
+
+    @agent_tool(description="Demo tool")
+    def sample_tool(value: int) -> int:
+        return value + 1
+
+    metadata = sample_tool._lumibot_agent_tool
+
+    assert metadata["name"] == "sample_tool"
+    assert metadata["description"].startswith("Demo tool")
+    assert "Source code:" in metadata["description"]
+    assert "def sample_tool(value: int) -> int:" in metadata["description"]

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -273,6 +273,14 @@ class TestOrderBasics:
         assert position.available == 0
         assert position.avg_fill_price == order.avg_fill_price
 
+    def test_add_transaction_fast_matches_transaction_field_order(self):
+        order = Order(strategy='abc', asset=Asset("SPY"), side="buy", quantity=100)
+
+        order.add_transaction_fast(price=101.25, quantity=2)
+
+        assert order.transactions[-1].price == 101.25
+        assert order.transactions[-1].quantity == 2
+
 
 class TestOrderAdvanced:
     def test_oco_type_reassigned(self):


### PR DESCRIPTION
Draft PR for CI validation of the clean fix from ef2edac0.\n\nChanges:\n- Replace stale Ruff target with the existing data downloader queue client.\n- Fix lazy backtesting imports without reformat churn.\n- Keep futures/continuous futures off the simple market-order fast path so IBKR MES backtests use the normal futures order lifecycle instead of rebaselining metrics.