### PR TITLE
[codex] Lazy-load package exports and example imports

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -65,7 +65,7 @@ jobs:
           # tests this PR touches.
           ruff check --select F,I \
             lumibot/tools/thetadata_helper.py \
-            lumibot/tools/thetadata_queue_client.py \
+            lumibot/tools/data_downloader_queue_client.py \
             lumibot/backtesting/thetadata_backtesting_pandas.py \
             lumibot/components/options_helper.py \
             lumibot/strategies/_strategy.py \

--- a/lumibot/__init__.py
+++ b/lumibot/__init__.py
@@ -1,13 +1,8 @@
 import os
 import sys
 import warnings
-import importlib
-import re
-from pathlib import Path
-
-from lumibot.tools.lumibot_logger import get_logger
-
-logger = get_logger(__name__)
+import types
+from importlib.machinery import ModuleSpec
 
 
 def _read_version_from_setup_py() -> str | None:
@@ -18,15 +13,22 @@ def _read_version_from_setup_py() -> str | None:
     """
 
     try:
-        module_path = Path(__file__).resolve()
-        for parent in module_path.parents:
-            setup_py = parent / "setup.py"
-            if not setup_py.is_file():
-                continue
-            text = setup_py.read_text(encoding="utf-8", errors="ignore")
-            match = re.search(r"version\s*=\s*['\"]([^'\"]+)['\"]", text)
-            if match:
-                return match.group(1).strip()
+        current = os.path.dirname(os.path.abspath(__file__))
+        while True:
+            setup_py = os.path.join(current, "setup.py")
+            if os.path.isfile(setup_py):
+                with open(setup_py, encoding="utf-8", errors="ignore") as file:
+                    for line in file:
+                        if "version" not in line:
+                            continue
+                        _, _, value = line.partition("=")
+                        value = value.strip().strip(",")
+                        if len(value) >= 2 and value[0] in "'\"" and value[-1] == value[0]:
+                            return value[1:-1].strip()
+            parent = os.path.dirname(current)
+            if parent == current:
+                break
+            current = parent
     except Exception:
         pass
     return None
@@ -49,8 +51,6 @@ except ImportError:
 except:
     __version__ = "unknown"
 
-logger.info(f"LumiBot v{__version__} starting")
-
 # Get the major and minor Python version
 major, minor = sys.version_info[:2]
 
@@ -59,66 +59,187 @@ if (major, minor) < (3, 10):
     warnings.warn("Lumibot requires Python 3.10 or higher.", RuntimeWarning)
 
 # SOURCE PATH
-# Import constants from constants module (before importing submodules to avoid circular imports)
-from .constants import (
-    LUMIBOT_CACHE_FOLDER,
-    LUMIBOT_DEFAULT_PYTZ,
-    LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL,
-    LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE,
-    LUMIBOT_DEFAULT_TIMEZONE,
-    LUMIBOT_SOURCE_PATH,
-)
+LUMIBOT_SOURCE_PATH = os.path.dirname(os.path.abspath(__file__))
+LUMIBOT_DEFAULT_TIMEZONE = "America/New_York"
+LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL = "USD"
+LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE = "forex"
 
-# Import main submodules (after constants to avoid circular imports)
-from . import backtesting, brokers, data_sources, entities, strategies, traders
+
+def _default_cache_folder() -> str:
+    env_value = os.environ.get("LUMIBOT_CACHE_FOLDER")
+    if env_value:
+        return env_value
+    if sys.platform == "darwin":
+        return os.path.expanduser("~/Library/Caches/lumibot/1.0")
+    if os.name == "nt":
+        root = os.environ.get("LOCALAPPDATA") or os.path.expanduser("~\\AppData\\Local")
+        return os.path.join(root, "LumiWealth", "lumibot", "Cache", "1.0")
+    root = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return os.path.join(root, "lumibot", "1.0")
+
+
+LUMIBOT_CACHE_FOLDER = _default_cache_folder()
 
 # Ensure cache folder exists
 if not os.path.exists(LUMIBOT_CACHE_FOLDER):
     try:
         os.makedirs(LUMIBOT_CACHE_FOLDER)
     except Exception as e:
-        logger.critical(
+        warnings.warn(
             f"""Could not create cache folder because of the following error:
             {e}. Please fix the issue to use data caching."""
         )
 
-# === Backward Compatibility Aliases ===
-# Some older code and documentation may still refer to the top-level
-# package name `entities` (e.g. `entities.asset`) that existed in
-# earlier Lumibot versions.  To avoid breaking those references we
-# expose `lumibot.entities` and its sub-modules under the legacy name
-# when the library is imported.
+_SUBMODULE_EXPORTS = {
+    "strategies",
+    "brokers",
+    "backtesting",
+    "entities",
+    "data_sources",
+    "traders",
+    "tools",
+    "components",
+    "constants",
+    "credentials",
+    "trading_builtins",
+}
 
-# Map the root package alias.
-import lumibot.entities as _lb_entities
-sys.modules.setdefault("entities", _lb_entities)
 
-# Expose common sub-modules (asset, bars, data, order, position, trading_fee)
-# so that e.g. `import entities.asset` keeps working.
-for _sub in ("asset", "bars", "data", "order", "position", "trading_fee"):
-    _full = f"lumibot.entities.{_sub}"
-    _alias = f"entities.{_sub}"
-    try:
-        _mod = importlib.import_module(_full)
-        sys.modules[_alias] = _mod
-    except ModuleNotFoundError as e:
-        # If a particular sub-module was removed or fails to import (e.g., due to deeper issues like 'fp')
-        # log a warning and skip. Sphinx will simply not find this specific alias.
-        logger.warning(f"[lumibot/__init__.py] Could not create alias '{_alias}' for '{_full}': {e}")
-        # Ensure the problematic alias isn't lingering if it was partially set or if it's a mock
-        if _alias in sys.modules and isinstance(sys.modules[_alias], importlib.util.LazyLoader):
-            pass # Don't remove if it's a lazy loader that might resolve later or differently
-        elif _alias in sys.modules:
-            # If it's a real module or a simple mock that failed, best to remove its alias attempt
-            # to avoid Sphinx confusion with a potentially broken module object.
-            # However, if Sphinx/autodoc is running, it might be safer to leave mocks as they are.
-            # For now, we'll log and continue, letting Sphinx handle missing modules.
-            # Reconsidering removal: could interfere with Sphinx's own mock handling.
-            pass # Reconsidering removal: could interfere with Sphinx's own mock handling
-    except ImportError as e: # Catch other import-related errors
-        logger.warning(f"[lumibot/__init__.py] ImportError while creating alias '{_alias}' for '{_full}': {e}")
-    except Exception as e: # Catch any other unexpected errors during aliasing
-        logger.warning(f"[lumibot/__init__.py] Unexpected error creating alias '{_alias}' for '{_full}': {e}")
+class _EntitiesAliasLoader:
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        load = module.__dict__.get("_load")
+        if load is not None:
+            load()
+
+
+_ENTITIES_ALIAS_LOADER = _EntitiesAliasLoader()
+
+
+class _EntitiesAliasFinder:
+    _lumibot_entities_alias_finder = True
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname in _ENTITY_SUBMODULE_ALIAS_NAMES:
+            return ModuleSpec(fullname, _ENTITIES_ALIAS_LOADER, is_package=False)
+        if fullname == "entities":
+            spec = ModuleSpec(fullname, _ENTITIES_ALIAS_LOADER, is_package=True)
+            spec.submodule_search_locations = _EntitiesAlias.__path__
+            return spec
+        return None
+
+
+class _EntitiesAlias(types.ModuleType):
+    __path__ = [os.path.join(os.path.dirname(os.path.abspath(__file__)), "entities")]
+    __file__ = os.path.join(os.path.dirname(os.path.abspath(__file__)), "entities", "__init__.py")
+    __package__ = "entities"
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.__spec__ = ModuleSpec(name, _ENTITIES_ALIAS_LOADER, is_package=True)
+        self.__spec__.submodule_search_locations = self.__path__
+
+    def __getattr__(self, name):
+        import importlib
+
+        entities_module = importlib.import_module("lumibot.entities")
+        if name in getattr(entities_module, "__all__", ()):
+            value = getattr(entities_module, name)
+            setattr(self, name, value)
+            return value
+
+        alias = sys.modules.get(f"entities.{name}")
+        if alias is not None:
+            return alias
+
+        try:
+            module = importlib.import_module(f"lumibot.entities.{name}")
+            sys.modules[f"entities.{name}"] = module
+        except ModuleNotFoundError:
+            module = importlib.import_module(f"entities.{name}")
+        return module
+
+
+class _EntitiesSubmoduleAlias(types.ModuleType):
+    def __init__(self, alias_name: str, target_name: str):
+        super().__init__(alias_name)
+        self.__package__ = "entities"
+        self.__spec__ = ModuleSpec(alias_name, _ENTITIES_ALIAS_LOADER, is_package=False)
+        self._target_name = target_name
+        self._target_module = None
+
+    def _load(self):
+        import importlib
+
+        module = self._target_module
+        if module is None:
+            module = importlib.import_module(self._target_name)
+            self._target_module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __dir__(self):
+        return dir(self._load())
+
+
+_ENTITY_SUBMODULES = (
+    "asset",
+    "bar",
+    "bars",
+    "cash_event",
+    "chains",
+    "data",
+    "data_polars",
+    "dataline",
+    "order",
+    "position",
+    "quote",
+    "trading_fee",
+    "trading_slippage",
+    "smart_limit",
+)
+_ENTITY_SUBMODULE_ALIAS_NAMES = {f"entities.{_submodule}" for _submodule in _ENTITY_SUBMODULES}
+if not any(getattr(_finder, "_lumibot_entities_alias_finder", False) for _finder in sys.meta_path):
+    sys.meta_path.insert(0, _EntitiesAliasFinder())
+
+sys.modules.setdefault("entities", _EntitiesAlias("entities"))
+for _submodule in _ENTITY_SUBMODULES:
+    sys.modules.setdefault(
+        f"entities.{_submodule}",
+        _EntitiesSubmoduleAlias(f"entities.{_submodule}", f"lumibot.entities.{_submodule}"),
+    )
+
+
+def __getattr__(name):
+    if name == "LUMIBOT_DEFAULT_PYTZ":
+        from .constants import LUMIBOT_DEFAULT_PYTZ
+
+        globals()[name] = LUMIBOT_DEFAULT_PYTZ
+        return LUMIBOT_DEFAULT_PYTZ
+    if name in _SUBMODULE_EXPORTS:
+        import importlib
+
+        module = importlib.import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    if name == "get_logger":
+        from lumibot.tools.lumibot_logger import get_logger
+
+        globals()[name] = get_logger
+        return get_logger
+    if name == "logger":
+        logger = __getattr__("get_logger")(__name__)
+        globals()[name] = logger
+        return logger
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))
 
 # Export the default timezone constants so they can be imported by other modules
 __all__ = [
@@ -134,5 +255,12 @@ __all__ = [
     'backtesting',
     'entities',
     'data_sources',
-    'traders'
+    'traders',
+    'tools',
+    'components',
+    'constants',
+    'credentials',
+    'trading_builtins',
+    'get_logger',
+    'logger',
 ]

--- a/lumibot/backtesting/__init__.py
+++ b/lumibot/backtesting/__init__.py
@@ -1,32 +1,37 @@
-from .alpaca_backtesting import AlpacaBacktesting
-from .alpha_vantage_backtesting import AlphaVantageBacktesting
-from .backtesting_broker import BacktestingBroker
-from .ccxt_backtesting import CcxtBacktesting
-from .interactive_brokers_rest_backtesting import InteractiveBrokersRESTBacktesting
-from .pandas_backtesting import PandasDataBacktesting
-from .polygon_backtesting import PolygonDataBacktesting
-from .routed_backtesting import RoutedBacktestingPandas
-from .thetadata_backtesting import ThetaDataBacktesting
-from .thetadata_backtesting_pandas import ThetaDataBacktestingPandas
-from .yahoo_backtesting import YahooDataBacktesting
+"""Backtesting package exports without importing every backend."""
 
-from .databento_backtesting import DataBentoDataBacktesting
-from .databento_backtesting_pandas import DataBentoDataBacktestingPandas
-from .databento_backtesting_polars import DataBentoDataBacktestingPolars
+from importlib import import_module as _import_module
 
-__all__ = [
-    "AlpacaBacktesting",
-    "AlphaVantageBacktesting",
-    "BacktestingBroker",
-    "CcxtBacktesting",
-    "InteractiveBrokersRESTBacktesting",
-    "PandasDataBacktesting",
-    "PolygonDataBacktesting",
-    "RoutedBacktestingPandas",
-    "ThetaDataBacktesting",
-    "ThetaDataBacktestingPandas",
-    "YahooDataBacktesting",
-    "DataBentoDataBacktesting",
-    "DataBentoDataBacktestingPandas",
-    "DataBentoDataBacktestingPolars",
-]
+_NAME_TO_MODULE = {
+    "AlpacaBacktesting": "alpaca_backtesting",
+    "AlphaVantageBacktesting": "alpha_vantage_backtesting",
+    "BacktestingBroker": "backtesting_broker",
+    "CcxtBacktesting": "ccxt_backtesting",
+    "DataBentoDataBacktesting": "databento_backtesting",
+    "DataBentoDataBacktestingPandas": "databento_backtesting_pandas",
+    "DataBentoDataBacktestingPolars": "databento_backtesting_polars",
+    "InteractiveBrokersRESTBacktesting": "interactive_brokers_rest_backtesting",
+    "PandasDataBacktesting": "pandas_backtesting",
+    "PolygonDataBacktesting": "polygon_backtesting",
+    "RoutedBacktestingPandas": "routed_backtesting",
+    "ThetaDataBacktesting": "thetadata_backtesting",
+    "ThetaDataBacktestingPandas": "thetadata_backtesting_pandas",
+    "YahooDataBacktesting": "yahoo_backtesting",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/brokers/__init__.py
+++ b/lumibot/brokers/__init__.py
@@ -1,11 +1,35 @@
-from .alpaca import Alpaca
-from .bitunix import Bitunix
-from .broker import Broker, LumibotBrokerAPIError
-from .ccxt import Ccxt
-from .example_broker import ExampleBroker
-from .interactive_brokers import InteractiveBrokers
-from .interactive_brokers_rest import InteractiveBrokersREST
-from .projectx import ProjectX
-from .schwab import Schwab
-from .tradier import Tradier
-from .tradovate import Tradovate
+"""Broker package exports without importing every broker backend."""
+
+from importlib import import_module as _import_module
+
+_NAME_TO_MODULE = {
+    "Alpaca": "alpaca",
+    "Bitunix": "bitunix",
+    "Broker": "broker",
+    "LumibotBrokerAPIError": "broker",
+    "Ccxt": "ccxt",
+    "ExampleBroker": "example_broker",
+    "InteractiveBrokers": "interactive_brokers",
+    "InteractiveBrokersREST": "interactive_brokers_rest",
+    "ProjectX": "projectx",
+    "Schwab": "schwab",
+    "Tradier": "tradier",
+    "Tradovate": "tradovate",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/components/__init__.py
+++ b/lumibot/components/__init__.py
@@ -1,9 +1,26 @@
-from .agents import AgentManager, AgentRunResult, BuiltinTools, MCPServer, agent_tool
+"""Lazy exports for optional component packages."""
 
-__all__ = [
+from importlib import import_module as _import_module
+
+_AGENT_EXPORTS = {
     "AgentManager",
     "AgentRunResult",
     "BuiltinTools",
     "MCPServer",
     "agent_tool",
-]
+}
+
+__all__ = sorted(_AGENT_EXPORTS)
+
+
+def __getattr__(name):
+    if name in _AGENT_EXPORTS:
+        agents = _import_module(f"{__name__}.agents")
+        value = getattr(agents, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/components/agents/__init__.py
+++ b/lumibot/components/agents/__init__.py
@@ -1,17 +1,31 @@
-from .builtins import BuiltinTools
-from .manager import AgentHandle, AgentManager
-from .runtime import GoogleADKRuntime, StubAgentRuntime
-from .schemas import AgentRunResult, AgentTraceEvent, MCPServer
-from .tools import agent_tool
+"""Lazy exports for agent runtime components."""
 
-__all__ = [
-    "AgentHandle",
-    "AgentManager",
-    "AgentRunResult",
-    "AgentTraceEvent",
-    "BuiltinTools",
-    "GoogleADKRuntime",
-    "MCPServer",
-    "StubAgentRuntime",
-    "agent_tool",
-]
+from importlib import import_module as _import_module
+
+_NAME_TO_MODULE = {
+    "AgentHandle": "manager",
+    "AgentManager": "manager",
+    "AgentRunResult": "schemas",
+    "AgentTraceEvent": "schemas",
+    "BuiltinTools": "builtins",
+    "GoogleADKRuntime": "runtime",
+    "MCPServer": "schemas",
+    "StubAgentRuntime": "runtime",
+    "agent_tool": "tools",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/components/agents/builtins.py
+++ b/lumibot/components/agents/builtins.py
@@ -1,11 +1,8 @@
 import math
 import os
 from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
 from typing import Any, Literal
-
-import requests
-
-from lumibot.entities import Order
 
 from .docs_tools import search_lumibot_docs
 from .asset_resolution import resolve_asset_and_quote
@@ -17,6 +14,43 @@ OrderSideArg = Literal["buy", "sell", "buy_to_open", "sell_to_close", "sell_shor
 OrderTypeArg = Literal["market", "limit", "stop", "stop_limit", "trailing_stop", "smart_limit"]
 TimeInForceArg = Literal["day", "gtc", "gtd"]
 NewsSortArg = Literal["asc", "desc"]
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        if name in {"_module_name", "_module"}:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+requests = _LazyModule("requests")
+
+
+def _requests():
+    return requests
 
 
 def _parse_datetime_value(value: Any) -> datetime | None:
@@ -395,7 +429,7 @@ def _bind_alpaca_news(strategy: Any, manager: Any) -> BoundTool:
         if page_token:
             params["page_token"] = page_token
 
-        response = requests.get(
+        response = _requests().get(
             "https://data.alpaca.markets/v1beta1/news",
             headers={
                 "APCA-API-KEY-ID": api_key,

--- a/lumibot/components/agents/duckdb_tools.py
+++ b/lumibot/components/agents/duckdb_tools.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 import hashlib
 import re
 import time
 from collections import defaultdict
+from importlib import import_module
 from typing import Any
-
-import duckdb
-import pandas as pd
 
 from lumibot.tools.helpers import parse_timestep_qty_and_unit
 
@@ -13,6 +13,28 @@ from .asset_resolution import resolve_asset_and_quote
 
 
 _READ_ONLY_SQL_RE = re.compile(r"^\s*(select|with|show|describe|pragma|explain)\b", re.IGNORECASE)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+duckdb = _LazyModule("duckdb")
+pd = _LazyModule("pandas")
 
 
 class DuckDBQueryLayer:

--- a/lumibot/components/agents/manager.py
+++ b/lumibot/components/agents/manager.py
@@ -8,19 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-import pandas as pd
+from lumibot import LUMIBOT_CACHE_FOLDER
 
-from lumibot.constants import LUMIBOT_CACHE_FOLDER
-from lumibot.tools.parquet_utils import (
-    coerce_object_columns_to_json_strings,
-    is_parquet_required,
-    write_parquet_with_logging,
-)
-
-from .builtins import _order_to_dict, _position_to_dict
-from .duckdb_tools import DuckDBQueryLayer
-from .replay_cache import AgentReplayCache, _normalize_json
-from .runtime import GoogleADKRuntime, RuntimeRequest, StubAgentRuntime, call_mcp_tool
 from .schemas import AgentRunResult, AgentTraceEvent, BoundTool, MCPServer, ToolDefinition
 from .tools import bind_callable_tool
 
@@ -29,6 +18,78 @@ _TIMESTAMP_HINT_RE = re.compile(
     r"(time|date|datetime|published|updated|created|accepted|released|release|as_of|realtime)",
     re.IGNORECASE,
 )
+_PANDAS_MODULE = None
+_REPLAY_IMPORTS = None
+_DUCKDB_QUERY_LAYER = None
+_RUNTIME_IMPORTS = None
+_PARQUET_UTILS = None
+_BUILTIN_SERIALIZERS = None
+
+
+def _get_pandas():
+    global _PANDAS_MODULE
+    if _PANDAS_MODULE is None:
+        import pandas as pd
+
+        _PANDAS_MODULE = pd
+    return _PANDAS_MODULE
+
+
+def _get_replay_imports():
+    global _REPLAY_IMPORTS
+    if _REPLAY_IMPORTS is None:
+        from .replay_cache import AgentReplayCache, _normalize_json as normalize_json
+
+        _REPLAY_IMPORTS = (AgentReplayCache, normalize_json)
+    return _REPLAY_IMPORTS
+
+
+def _normalize_json(value: Any) -> Any:
+    return _get_replay_imports()[1](value)
+
+
+def _get_duckdb_query_layer_class():
+    global _DUCKDB_QUERY_LAYER
+    if _DUCKDB_QUERY_LAYER is None:
+        from .duckdb_tools import DuckDBQueryLayer
+
+        _DUCKDB_QUERY_LAYER = DuckDBQueryLayer
+    return _DUCKDB_QUERY_LAYER
+
+
+def _get_runtime_imports():
+    global _RUNTIME_IMPORTS
+    if _RUNTIME_IMPORTS is None:
+        from .runtime import GoogleADKRuntime, RuntimeRequest, StubAgentRuntime, call_mcp_tool
+
+        _RUNTIME_IMPORTS = (GoogleADKRuntime, RuntimeRequest, StubAgentRuntime, call_mcp_tool)
+    return _RUNTIME_IMPORTS
+
+
+def _get_parquet_utils():
+    global _PARQUET_UTILS
+    if _PARQUET_UTILS is None:
+        from lumibot.tools.parquet_utils import (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+
+        _PARQUET_UTILS = (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+    return _PARQUET_UTILS
+
+
+def _get_builtin_serializers():
+    global _BUILTIN_SERIALIZERS
+    if _BUILTIN_SERIALIZERS is None:
+        from .builtins import _order_to_dict, _position_to_dict
+
+        _BUILTIN_SERIALIZERS = (_order_to_dict, _position_to_dict)
+    return _BUILTIN_SERIALIZERS
 
 
 def _safe_call(func, default=None):
@@ -76,6 +137,9 @@ def _strategy_timezone_name(strategy: Any, current_dt: Any) -> str | None:
 def _serialize_recent_trade_events(strategy: Any, limit: int = 10) -> list[dict[str, Any]]:
     broker = getattr(strategy, "broker", None)
     rows = list(getattr(broker, "_trade_event_log_rows", []) or [])
+    expand_rows = getattr(broker, "_expand_trade_event_rows", None)
+    if callable(expand_rows):
+        rows = expand_rows(rows)
     columns = list(getattr(broker, "_trade_event_log_columns", []) or [])
     serialized: list[dict[str, Any]] = []
     for row in rows[-limit:]:
@@ -502,7 +566,8 @@ class AgentHandle:
             # Always include built-in tools, plus any custom tools the user added
             self._tool_inputs = builtin_tools + list(tools)
         self._mcp_servers = mcp_servers or []
-        self._runtime = runtime or GoogleADKRuntime(mcp_servers=self._mcp_servers)
+        google_runtime, _RuntimeRequest, _StubAgentRuntime, _call_mcp_tool = _get_runtime_imports()
+        self._runtime = runtime or google_runtime(mcp_servers=self._mcp_servers)
         self._bound_tools: list[BoundTool] | None = None
 
     def _state_bucket(self) -> dict[str, Any]:
@@ -543,6 +608,7 @@ class AgentHandle:
         if not hasattr(self.manager.strategy, "get_positions"):
             return []
         positions = _safe_call(lambda: self.manager.strategy.get_positions(include_cash_positions=True), default=[]) or []
+        _order_to_dict, _position_to_dict = _get_builtin_serializers()
         return [_position_to_dict(position) for position in positions]
 
     def _serialize_account_state(self) -> dict[str, Any]:
@@ -557,6 +623,7 @@ class AgentHandle:
         if not hasattr(self.manager.strategy, "get_orders"):
             return []
         orders = _safe_call(self.manager.strategy.get_orders, default=[]) or []
+        _order_to_dict, _position_to_dict = _get_builtin_serializers()
         return [_order_to_dict(order) for order in orders[-limit:]]
 
     def _runtime_mode(self) -> str:
@@ -718,6 +785,7 @@ class AgentHandle:
                                     color="yellow",
                                 )
                             self.manager._warned_backtest_mcp_tools.add(warning_key)
+                        _GoogleADKRuntime, _RuntimeRequest, _StubAgentRuntime, call_mcp_tool = _get_runtime_imports()
                         return call_mcp_tool(_server, _tool_name, payload)
 
                     return remote_tool
@@ -1131,7 +1199,8 @@ class AgentHandle:
                 self._log_run_summary(result, runtime_context)
                 return result
 
-        request = RuntimeRequest(
+        _GoogleADKRuntime, runtime_request_class, _StubAgentRuntime, _call_mcp_tool = _get_runtime_imports()
+        request = runtime_request_class(
             agent_name=self.name,
             model=model_name,
             system_prompt=effective_system_prompt,
@@ -1336,8 +1405,9 @@ class AgentManager:
         self.strategy = strategy
         self._agents: dict[str, AgentHandle] = {}
         self._warned_backtest_mcp_tools: set[tuple[str, str]] = set()
-        self.replay_cache = AgentReplayCache()
-        self.duckdb = DuckDBQueryLayer(strategy)
+        agent_replay_cache_class, _normalize_json_func = _get_replay_imports()
+        self.replay_cache = agent_replay_cache_class()
+        self.duckdb = _get_duckdb_query_layer_class()(strategy)
         self._observability_totals: dict[str, dict[str, int]] = {}
         self._observability_call_index: dict[str, int] = {}
         self._observability_rows: dict[str, list[dict[str, Any]]] = {}
@@ -1483,7 +1553,12 @@ class AgentManager:
             )
         agent_rows = self._observability_rows.setdefault(handle.name, [])
         agent_rows.extend(rows)
-        detail_df = pd.DataFrame(agent_rows, columns=_AGENT_DETAIL_COLUMNS)
+        detail_df = _get_pandas().DataFrame(agent_rows, columns=_AGENT_DETAIL_COLUMNS)
+        (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        ) = _get_parquet_utils()
         write_parquet_with_logging(
             df=detail_df,
             path=str(detail_path),

--- a/lumibot/components/agents/replay_cache.py
+++ b/lumibot/components/agents/replay_cache.py
@@ -11,7 +11,17 @@ from pathlib import Path
 from typing import Any
 
 from lumibot.constants import LUMIBOT_CACHE_FOLDER
-from lumibot.tools.backtest_cache import get_backtest_cache
+
+_BACKTEST_CACHE_GETTER = None
+
+
+def get_backtest_cache():
+    global _BACKTEST_CACHE_GETTER
+    if _BACKTEST_CACHE_GETTER is None:
+        from lumibot.tools.backtest_cache import get_backtest_cache as _get_backtest_cache
+
+        _BACKTEST_CACHE_GETTER = _get_backtest_cache
+    return _BACKTEST_CACHE_GETTER()
 
 
 def _normalize_json(value: Any) -> Any:

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -1,4 +1,5 @@
-import asyncio
+from __future__ import annotations
+
 import contextlib
 import hashlib
 import importlib
@@ -17,17 +18,31 @@ from datetime import date, datetime, timezone
 from typing import Any
 from uuid import uuid4
 
-import httpx
-from anyio import run as anyio_run
-from anyio.from_thread import start_blocking_portal
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
-
 from .schemas import AgentRunResult, AgentTraceEvent, BoundTool, MCPServer
 
 
 _GOOGLE_SDK_NOISE_FILTERS_CONFIGURED = False
+ClientSession = None
+StdioServerParameters = None
+stdio_client = None
+streamablehttp_client = None
+
+
+def _ensure_mcp_client_imports():
+    global ClientSession, StdioServerParameters, stdio_client, streamablehttp_client
+    if ClientSession is None or StdioServerParameters is None:
+        from mcp import ClientSession as _ClientSession, StdioServerParameters as _StdioServerParameters
+
+        ClientSession = _ClientSession
+        StdioServerParameters = _StdioServerParameters
+    if stdio_client is None:
+        from mcp.client.stdio import stdio_client as _stdio_client
+
+        stdio_client = _stdio_client
+    if streamablehttp_client is None:
+        from mcp.client.streamable_http import streamablehttp_client as _streamablehttp_client
+
+        streamablehttp_client = _streamablehttp_client
 
 
 class _GoogleGenAITypesNoiseFilter(logging.Filter):
@@ -776,6 +791,8 @@ class GoogleADKRuntime:
         last_exc: BaseException | None = None
         for attempt in range(1, self._MAX_RUN_ATTEMPTS + 1):
             try:
+                import asyncio
+
                 return asyncio.run(self._run_async(request))
             except (KeyboardInterrupt, SystemExit):
                 raise
@@ -894,6 +911,7 @@ def _jsonable(value: Any) -> Any:
 
 
 async def _with_mcp_session(server: MCPServer, callback):
+    _ensure_mcp_client_imports()
     transport = (server.transport or "http").lower().replace("-", "_")
     if transport == "stdio":
         parameters = StdioServerParameters(
@@ -924,10 +942,16 @@ async def _with_mcp_session(server: MCPServer, callback):
 
 
 def _run_mcp_sync(async_fn, *args):
+    import asyncio
+
     try:
         asyncio.get_running_loop()
     except RuntimeError:
+        from anyio import run as anyio_run
+
         return anyio_run(async_fn, *args)
+    from anyio.from_thread import start_blocking_portal
+
     with start_blocking_portal() as portal:
         return portal.call(async_fn, *args)
 
@@ -966,6 +990,8 @@ async def _call_mcp_tool_async(server: MCPServer, name: str, arguments: dict[str
 
 
 async def _legacy_http_list_tools(server: MCPServer) -> list[dict[str, Any]]:
+    import httpx
+
     payload = {
         "jsonrpc": "2.0",
         "id": "tools-list",
@@ -982,6 +1008,8 @@ async def _legacy_http_list_tools(server: MCPServer) -> list[dict[str, Any]]:
 
 
 async def _legacy_http_call_tool(server: MCPServer, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    import httpx
+
     payload = {
         "jsonrpc": "2.0",
         "id": f"{name}-call",

--- a/lumibot/components/drift_rebalancer_logic.py
+++ b/lumibot/components/drift_rebalancer_logic.py
@@ -1,13 +1,46 @@
+from __future__ import annotations
+
 import time
 from decimal import ROUND_DOWN, ROUND_UP, Decimal
-from typing import Any, Dict, List
-
-import pandas as pd
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from lumibot.entities import Asset, TradingFee
 from lumibot.entities.order import Order
-from lumibot.strategies.strategy import Strategy
-from lumibot.tools.pandas import prettify_dataframe_with_decimals
+
+if TYPE_CHECKING:
+    from lumibot.strategies.strategy import Strategy
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_PRETTIFY_DATAFRAME_WITH_DECIMALS = None
+
+
+def _prettify_dataframe_with_decimals(*args, **kwargs):
+    global _PRETTIFY_DATAFRAME_WITH_DECIMALS
+    if _PRETTIFY_DATAFRAME_WITH_DECIMALS is None:
+        from lumibot.tools.pandas import prettify_dataframe_with_decimals
+
+        _PRETTIFY_DATAFRAME_WITH_DECIMALS = prettify_dataframe_with_decimals
+    return _PRETTIFY_DATAFRAME_WITH_DECIMALS(*args, **kwargs)
 
 
 class DriftType:
@@ -364,7 +397,7 @@ class DriftOrderLogic:
 
         # Just print the drift_df to the log but sort it by symbol column
         drift_df = drift_df.sort_values(by='symbol')
-        self.strategy.logger.info(f"drift_df:\n{prettify_dataframe_with_decimals(df=drift_df)}")
+        self.strategy.logger.info(f"drift_df:\n{_prettify_dataframe_with_decimals(df=drift_df)}")
 
         rebalance_needed = self._check_if_rebalance_needed(drift_df)
         if rebalance_needed:

--- a/lumibot/components/grok_helper.py
+++ b/lumibot/components/grok_helper.py
@@ -2,11 +2,15 @@ import json
 import re
 import time
 
-from openai import OpenAI
-
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _openai_client_class():
+    from openai import OpenAI
+
+    return OpenAI
 
 class GrokHelper:
     """
@@ -39,7 +43,7 @@ class GrokHelper:
                 raise ValueError("API key is required for GrokHelper. Set it as GROK_API_KEY or XAI_API_KEY in your environment or pass it directly.")
 
         self.api_key = api_key
-        self.client = OpenAI(
+        self.client = _openai_client_class()(
             api_key=self.api_key,
             base_url="https://api.x.ai/v1",
         )

--- a/lumibot/components/perplexity_helper.py
+++ b/lumibot/components/perplexity_helper.py
@@ -2,11 +2,15 @@ import json
 import re
 import time
 
-from openai import OpenAI
-
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _openai_client_class():
+    from openai import OpenAI
+
+    return OpenAI
 
 # --- constants ---------------------------------------------------------------
 _MODEL_LIMITS = {
@@ -126,7 +130,7 @@ class PerplexityHelper:
                 raise ValueError("API key is required for PerplexityHelper. Set it as PERPLEXITY_API_KEY in your environment or your secrets")
 
         self.api_key = api_key
-        self.client = OpenAI(
+        self.client = _openai_client_class()(
             api_key=self.api_key,
             base_url="https://api.perplexity.ai",  # Correct base URL
         )

--- a/lumibot/components/vix_helper.py
+++ b/lumibot/components/vix_helper.py
@@ -1,23 +1,9 @@
+from __future__ import annotations
+
 import datetime
 import traceback
 from datetime import timedelta
-
-import pandas as pd
-import yfinance as yf
-from scipy import stats
-import traceback
-import datetime
-
-# Fix for NumPy 2.0+ compatibility with pandas_ta
-import numpy as np
-
-# pandas_ta 0.3.14b uses numpy.NaN which was removed in NumPy 2.0
-# Create alias for backward compatibility if needed
-if not hasattr(np, 'NaN'):
-    np.NaN = np.nan
-
-# Import pandas-ta-classic
-import pandas_ta_classic as ta
+from importlib import import_module
 
 """ 
     Description
@@ -26,6 +12,49 @@ import pandas_ta_classic as ta
     This is a general component for working with the VIX. It can be used to check the 
     VIX, VIX 1D, VIX RSI, VIX percentile values and more.
 """
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+yf = _LazyModule("yfinance")
+stats = _LazyModule("scipy.stats")
+_TA_MODULE = None
+
+
+def _get_ta_module():
+    global _TA_MODULE
+    if _TA_MODULE is None:
+        np = import_module("numpy")
+        if not hasattr(np, "NaN"):
+            np.NaN = np.nan
+        _TA_MODULE = import_module("pandas_ta_classic")
+    return _TA_MODULE
 
 class VixHelper:
     def __init__(self, strategy) -> None:
@@ -420,7 +449,7 @@ class VixHelper:
         vix_df = pd.DataFrame(vix_values, columns=['VIX'])
 
         # Calculate the RSI
-        vix_df['RSI'] = ta.rsi(vix_df['VIX'], length=window)
+        vix_df['RSI'] = _get_ta_module().rsi(vix_df['VIX'], length=window)
 
         # Get the last VIX RSI value
         vix_rsi = vix_df['RSI'].iloc[-1]
@@ -1103,7 +1132,7 @@ class VixHelper:
         gvz_df = pd.DataFrame(gvz_values, columns=['GVZ'])
 
         # Calculate the RSI
-        gvz_df['RSI'] = ta.rsi(gvz_df['GVZ'], length=window)
+        gvz_df['RSI'] = _get_ta_module().rsi(gvz_df['GVZ'], length=window)
 
         # Get the last GVZ RSI value
         gvz_rsi = gvz_df['RSI'].iloc[-1]
@@ -1482,7 +1511,7 @@ class VixHelper:
         vix_df = pd.DataFrame(vix_values, columns=['VIX'])
 
         # Calculate the RSI
-        vix_df['RSI'] = ta.rsi(vix_df['VIX'], length=window)
+        vix_df['RSI'] = _get_ta_module().rsi(vix_df['VIX'], length=window)
 
         # Get the last VIX RSI value
         vix_rsi = vix_df['RSI'].iloc[-1]

--- a/lumibot/credentials.py
+++ b/lumibot/credentials.py
@@ -9,14 +9,58 @@
 import os
 import sys
 
-from .brokers import Alpaca, Ccxt, InteractiveBrokers, InteractiveBrokersREST, Tradier, Tradovate, Schwab, Bitunix, ProjectX
-from dotenv import load_dotenv
 import termcolor
-from dateutil import parser
 
 # Configure logging
 from lumibot.tools.lumibot_logger import get_logger
 logger = get_logger(__name__)
+_LOAD_DOTENV = None
+_DATEUTIL_PARSER = None
+
+
+def _load_dotenv(dotenv_path, *, override=False):
+    global _LOAD_DOTENV
+    if _LOAD_DOTENV is None:
+        from dotenv import load_dotenv
+
+        _LOAD_DOTENV = load_dotenv
+    return _LOAD_DOTENV(dotenv_path, override=override)
+
+
+def _parse_datetime(value):
+    global _DATEUTIL_PARSER
+    if _DATEUTIL_PARSER is None:
+        from dateutil import parser
+
+        _DATEUTIL_PARSER = parser
+    return _DATEUTIL_PARSER.parse(value)
+
+
+def _broker_class(name: str):
+    from . import brokers
+
+    return getattr(brokers, name)
+
+
+_BROKER_CLASS_NAMES = {
+    "Alpaca",
+    "Ccxt",
+    "InteractiveBrokers",
+    "InteractiveBrokersREST",
+    "Tradier",
+    "Tradovate",
+    "Schwab",
+    "Bitunix",
+    "ProjectX",
+}
+
+
+def __getattr__(name: str):
+    if name in _BROKER_CLASS_NAMES:
+        cls = _broker_class(name)
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _quiet_backtest_logs_requested() -> bool:
@@ -24,13 +68,16 @@ def _quiet_backtest_logs_requested() -> bool:
 
 
 def find_and_load_dotenv(base_dir) -> bool:
-    for root, dirs, files in os.walk(base_dir):
-        logger.debug(f"Checking {root} for .env file")
-        if '.env' in files:
-            dotenv_path = os.path.join(root, '.env')
-            load_dotenv(dotenv_path)
+    current = os.path.abspath(base_dir)
+    if os.path.isfile(current):
+        current = os.path.dirname(current)
 
-            # Create a colored message for the log using termcolor
+    while True:
+        logger.debug(f"Checking {current} for .env file")
+        dotenv_path = os.path.join(current, ".env")
+        if os.path.isfile(dotenv_path):
+            _load_dotenv(dotenv_path)
+
             colored_message = termcolor.colored(f".env file loaded from: {dotenv_path}", "green")
             if _quiet_backtest_logs_requested():
                 logger.debug(colored_message)
@@ -40,9 +87,9 @@ def find_and_load_dotenv(base_dir) -> bool:
             # Optional local override file. This is intentionally loaded *after* `.env` so it can
             # override settings without requiring edits to the primary file (which may contain
             # shared or sensitive values).
-            dotenv_local_path = os.path.join(root, ".env.local")
-            if os.path.exists(dotenv_local_path):
-                load_dotenv(dotenv_local_path, override=True)
+            dotenv_local_path = os.path.join(current, ".env.local")
+            if os.path.isfile(dotenv_local_path):
+                _load_dotenv(dotenv_local_path, override=True)
                 colored_message = termcolor.colored(f".env.local file loaded from: {dotenv_local_path}", "green")
                 if _quiet_backtest_logs_requested():
                     logger.debug(colored_message)
@@ -50,6 +97,10 @@ def find_and_load_dotenv(base_dir) -> bool:
                     logger.info(colored_message)
             return True
 
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
     return False
 
 
@@ -104,10 +155,10 @@ backtesting_end = os.environ.get("BACKTESTING_END")
 # Check if the dates are not None and not empty strings before parsing
 BACKTESTING_START = None
 if backtesting_start:
-    BACKTESTING_START = parser.parse(backtesting_start)
+    BACKTESTING_START = _parse_datetime(backtesting_start)
 BACKTESTING_END = None
 if backtesting_end:
-    BACKTESTING_END = parser.parse(backtesting_end)
+    BACKTESTING_END = _parse_datetime(backtesting_end)
 
 # Get the backtesting data source
 BACKTESTING_DATA_SOURCE = os.environ.get("BACKTESTING_DATA_SOURCE", "ThetaData")
@@ -490,27 +541,27 @@ if not is_backtesting or is_backtesting.lower() == "false":
     if trading_broker_name:
         # Create broker instance based on explicitly specified name
         if trading_broker_name.lower() == "alpaca":
-            broker = Alpaca(ALPACA_CONFIG)
+            broker = _broker_class("Alpaca")(ALPACA_CONFIG)
         elif trading_broker_name.lower() == "tradier":
-            broker = Tradier(TRADIER_CONFIG)
+            broker = _broker_class("Tradier")(TRADIER_CONFIG)
         elif trading_broker_name.lower() == "ccxt":
-            broker = Ccxt(COINBASE_CONFIG)
+            broker = _broker_class("Ccxt")(COINBASE_CONFIG)
         elif trading_broker_name.lower() == "coinbase":
-            broker = Ccxt(COINBASE_CONFIG)
+            broker = _broker_class("Ccxt")(COINBASE_CONFIG)
         elif trading_broker_name.lower() == "kraken":
-            broker = Ccxt(KRAKEN_CONFIG)
+            broker = _broker_class("Ccxt")(KRAKEN_CONFIG)
         elif trading_broker_name.lower() == "weex":
-            broker = Ccxt(WEEX_CONFIG)
+            broker = _broker_class("Ccxt")(WEEX_CONFIG)
         elif trading_broker_name.lower() == "ib" or trading_broker_name.lower() == "interactivebrokers":
-            broker = InteractiveBrokers(INTERACTIVE_BROKERS_CONFIG)
+            broker = _broker_class("InteractiveBrokers")(INTERACTIVE_BROKERS_CONFIG)
         elif trading_broker_name.lower() == "ibrest" or trading_broker_name.lower() == "interactivebrokersrest":
-            broker = InteractiveBrokersREST(INTERACTIVE_BROKERS_REST_CONFIG)
+            broker = _broker_class("InteractiveBrokersREST")(INTERACTIVE_BROKERS_REST_CONFIG)
         elif trading_broker_name.lower() == "tradovate":
-            broker = Tradovate(TRADOVATE_CONFIG)
+            broker = _broker_class("Tradovate")(TRADOVATE_CONFIG)
         elif trading_broker_name.lower() == "schwab":
-            broker = Schwab(SCHWAB_CONFIG)
+            broker = _broker_class("Schwab")(SCHWAB_CONFIG)
         elif trading_broker_name.lower() == "bitunix":
-            broker = Bitunix(BITUNIX_CONFIG)
+            broker = _broker_class("Bitunix")(BITUNIX_CONFIG)
         elif trading_broker_name.lower() == "projectx":
             try:
                 # Get specified firm or use auto-detection
@@ -522,7 +573,7 @@ if not is_backtesting or is_backtesting.lower() == "false":
                 
                 from .data_sources import ProjectXData
                 data_source = ProjectXData(config)
-                broker = ProjectX(config, data_source=data_source)
+                broker = _broker_class("ProjectX")(config, data_source=data_source)
             except Exception as e:
                 colored_message = termcolor.colored(f"Failed to initialize ProjectX broker: {e}", "red")
                 logger.error(colored_message)
@@ -568,7 +619,7 @@ if not is_backtesting or is_backtesting.lower() == "false":
                 
                 from .data_sources import ProjectXData
                 data_source = ProjectXData(config)
-                broker = ProjectX(config, data_source=data_source)
+                broker = _broker_class("ProjectX")(config, data_source=data_source)
             except Exception as e:
                 colored_message = termcolor.colored(f"Failed to initialize ProjectX broker {trading_broker_name}: {e}", "red")
                 logger.error(colored_message)
@@ -579,7 +630,7 @@ if not is_backtesting or is_backtesting.lower() == "false":
         # Auto-detect broker based on available credentials if not explicitly specified
         if ALPACA_CONFIG["API_KEY"] or ALPACA_CONFIG["OAUTH_TOKEN"]:
             try:
-                broker = Alpaca(ALPACA_CONFIG)
+                broker = _broker_class("Alpaca")(ALPACA_CONFIG)
             except ValueError as e:
                 # If Alpaca initialization fails due to missing credentials, skip it
                 if "Either OAuth token or API key/secret must be provided" in str(e):
@@ -587,14 +638,14 @@ if not is_backtesting or is_backtesting.lower() == "false":
                 else:
                     raise e
         elif TRADIER_CONFIG["ACCESS_TOKEN"]:
-            broker = Tradier(TRADIER_CONFIG)
+            broker = _broker_class("Tradier")(TRADIER_CONFIG)
         elif INTERACTIVE_BROKERS_CONFIG["CLIENT_ID"]:
-            broker = InteractiveBrokers(INTERACTIVE_BROKERS_CONFIG)
+            broker = _broker_class("InteractiveBrokers")(INTERACTIVE_BROKERS_CONFIG)
         elif INTERACTIVE_BROKERS_REST_CONFIG["IB_USERNAME"]:
-            broker = InteractiveBrokersREST(INTERACTIVE_BROKERS_REST_CONFIG)
+            broker = _broker_class("InteractiveBrokersREST")(INTERACTIVE_BROKERS_REST_CONFIG)
         elif TRADOVATE_CONFIG["USERNAME"]:
             try:
-                broker = Tradovate(TRADOVATE_CONFIG)
+                broker = _broker_class("Tradovate")(TRADOVATE_CONFIG)
             except Exception as e:
                 # Handle rate limiting and other connection errors gracefully
                 error_str = str(e)
@@ -610,15 +661,15 @@ if not is_backtesting or is_backtesting.lower() == "false":
                     raise
         # Only check for SCHWAB_ACCOUNT_NUMBER to select Schwab
         elif SCHWAB_CONFIG.get("SCHWAB_ACCOUNT_NUMBER"):
-            broker = Schwab(SCHWAB_CONFIG)
+            broker = _broker_class("Schwab")(SCHWAB_CONFIG)
         elif COINBASE_CONFIG["apiKey"]:
-            broker = Ccxt(COINBASE_CONFIG)
+            broker = _broker_class("Ccxt")(COINBASE_CONFIG)
         elif KRAKEN_CONFIG["apiKey"]:
-            broker = Ccxt(KRAKEN_CONFIG)
+            broker = _broker_class("Ccxt")(KRAKEN_CONFIG)
         elif WEEX_CONFIG["apiKey"] and WEEX_CONFIG["secret"] and WEEX_CONFIG["password"]:
-            broker = Ccxt(WEEX_CONFIG)
+            broker = _broker_class("Ccxt")(WEEX_CONFIG)
         elif BITUNIX_CONFIG["API_KEY"] and BITUNIX_CONFIG["API_SECRET"]:
-            broker = Bitunix(BITUNIX_CONFIG)
+            broker = _broker_class("Bitunix")(BITUNIX_CONFIG)
         elif get_available_projectx_firms():
             try:
                 # Use first available ProjectX firm
@@ -628,7 +679,7 @@ if not is_backtesting or is_backtesting.lower() == "false":
                 if config.get("api_key") and config.get("username"):
                     from .data_sources import ProjectXData
                     data_source = ProjectXData(config)
-                    broker = ProjectX(config, data_source=data_source)
+                    broker = _broker_class("ProjectX")(config, data_source=data_source)
             except Exception as e:
                 colored_message = termcolor.colored(f"Failed to initialize ProjectX broker: {e}", "red")
                 logger.error(colored_message)

--- a/lumibot/data_sources/__init__.py
+++ b/lumibot/data_sources/__init__.py
@@ -1,22 +1,51 @@
-from .alpaca_data import AlpacaData
-from .alpha_vantage_data import AlphaVantageData
-from .ccxt_data import CcxtData
-from .data_source import DataSource
-from .data_source_backtesting import DataSourceBacktesting
-from .exceptions import NoDataFound, UnavailabeTimestep
-from .interactive_brokers_data import InteractiveBrokersData
-from .pandas_data import PandasData
-from .polars_data import PolarsData
-from .tradier_data import TradierData
-from .bitunix_data import BitunixData
-from .ccxt_backtesting_data import CcxtBacktestingData
-from .example_broker_data import ExampleBrokerData
-from .interactive_brokers_rest_data import InteractiveBrokersRESTData
-from .schwab_data import SchwabData
-from .tradovate_data import TradovateData
-from .yahoo_data import YahooData
+"""Data source package exports without importing every provider backend."""
 
-from .databento_data import DataBentoData, DataBentoDataPandas, DataBentoDataPolars
-from .projectx_data import ProjectXData
+from importlib import import_module as _import_module
 
-from ..backtesting.polygon_backtesting import PolygonDataBacktesting
+_NAME_TO_MODULE = {
+    "AlpacaData": "alpaca_data",
+    "AlphaVantageData": "alpha_vantage_data",
+    "BitunixData": "bitunix_data",
+    "CcxtBacktestingData": "ccxt_backtesting_data",
+    "CcxtData": "ccxt_data",
+    "DataBentoData": "databento_data",
+    "DataBentoDataPandas": "databento_data",
+    "DataBentoDataPolars": "databento_data",
+    "DataSource": "data_source",
+    "DataSourceBacktesting": "data_source_backtesting",
+    "ExampleBrokerData": "example_broker_data",
+    "InteractiveBrokersData": "interactive_brokers_data",
+    "InteractiveBrokersRESTData": "interactive_brokers_rest_data",
+    "NoDataFound": "exceptions",
+    "PandasData": "pandas_data",
+    "PolarsData": "polars_data",
+    "PolygonDataBacktesting": "polygon_backtesting",
+    "ProjectXData": "projectx_data",
+    "SchwabData": "schwab_data",
+    "TradierData": "tradier_data",
+    "TradovateData": "tradovate_data",
+    "UnavailabeTimestep": "exceptions",
+    "YahooData": "yahoo_data",
+}
+
+_EXTERNAL_MODULES = {
+    "polygon_backtesting": "lumibot.backtesting.polygon_backtesting",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import_name = _EXTERNAL_MODULES.get(module_name, f"{__name__}.{module_name}")
+    module = _import_module(import_name)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/entities/__init__.py
+++ b/lumibot/entities/__init__.py
@@ -1,38 +1,39 @@
-from .asset import Asset, AssetsMapping
-from .bar import Bar
+"""Compatibility exports for entity classes without importing every entity."""
 
-# Import base implementations
-from .bars import Bars as _BarsBase
-from .cash_event import CashEvent
-from .chains import Chains
-from .data import Data as _DataBase
-from .data_polars import DataPolars
-from .dataline import Dataline
-from .order import Order
-from .position import Position
-from .quote import Quote
-from .trading_fee import TradingFee
-from .trading_slippage import TradingSlippage
-from .smart_limit import SmartLimitConfig, SmartLimitPreset
+from importlib import import_module as _import_module
 
-# Use base implementations directly
-Bars = _BarsBase
-Data = _DataBase
-__all__ = [
-    "Asset",
-    "AssetsMapping",
-    "Bar",
-    "Bars",
-    "CashEvent",
-    "Chains",
-    "Data",
-    "DataPolars",
-    "Dataline",
-    "Order",
-    "Position",
-    "Quote",
-    "TradingFee",
-    "TradingSlippage",
-    "SmartLimitConfig",
-    "SmartLimitPreset",
-]
+_NAME_TO_MODULE = {
+    "Asset": "asset",
+    "AssetsMapping": "asset",
+    "Bar": "bar",
+    "Bars": "bars",
+    "CashEvent": "cash_event",
+    "Chains": "chains",
+    "Data": "data",
+    "DataPolars": "data_polars",
+    "Dataline": "dataline",
+    "Order": "order",
+    "Position": "position",
+    "Quote": "quote",
+    "TradingFee": "trading_fee",
+    "TradingSlippage": "trading_slippage",
+    "SmartLimitConfig": "smart_limit",
+    "SmartLimitPreset": "smart_limit",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/example_strategies/_agent_tool.py
+++ b/lumibot/example_strategies/_agent_tool.py
@@ -1,0 +1,69 @@
+import inspect
+import textwrap
+from typing import Any, Callable
+
+
+def _get_clean_source(func: Callable[..., Any]) -> str | None:
+    try:
+        source = inspect.getsource(func)
+    except (OSError, TypeError):
+        return None
+
+    source = textwrap.dedent(source)
+    lines = source.split("\n")
+    clean_lines = []
+    past_decorator = False
+    for line in lines:
+        stripped = line.strip()
+        if not past_decorator:
+            if stripped.startswith("@"):
+                continue
+            if stripped.startswith(")") and not stripped.startswith("def"):
+                continue
+            past_decorator = True
+        clean_lines.append(line)
+    if not clean_lines:
+        return None
+    return "\n".join(clean_lines).replace("(self, ", "(", 1).replace("(self)", "()").strip()
+
+
+def _build_description(func: Callable[..., Any], explicit_description: str | None) -> str:
+    base = explicit_description or (func.__doc__ or "").strip() or func.__name__
+    source = _get_clean_source(func)
+    if source:
+        return f"{base}\n\nSource code:\n{source}"
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return base
+
+    params = []
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        annotation = param.annotation
+        type_str = annotation.__name__ if hasattr(annotation, "__name__") else str(annotation)
+        if type_str == "<class 'inspect._empty'>":
+            type_str = "any"
+        default = f", default={param.default!r}" if param.default is not inspect.Parameter.empty else ""
+        params.append(f"{name} ({type_str}{default})")
+    if params:
+        return f"{base}\n\nParameters: {', '.join(params)}"
+    return base
+
+
+def agent_tool(*, name: str | None = None, description: str | None = None) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Lightweight agent tool decorator for import-cheap example strategies."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        setattr(
+            func,
+            "_lumibot_agent_tool",
+            {
+                "name": name or func.__name__,
+                "description": _build_description(func, description),
+            },
+        )
+        return func
+
+    return decorator

--- a/lumibot/example_strategies/agent_alpaca_news_builtin.py
+++ b/lumibot/example_strategies/agent_alpaca_news_builtin.py
@@ -26,7 +26,6 @@ Usage:
 
 import os
 
-from lumibot.components.agents import BuiltinTools
 from lumibot.strategies.strategy import Strategy
 
 
@@ -35,6 +34,8 @@ IS_BACKTESTING = True
 
 class AlpacaNewsBuiltinStrategy(Strategy):
     def initialize(self):
+        from lumibot.components.agents import BuiltinTools
+
         self.sleeptime = "1D"
         self.vars.iteration_count = 0
         model_id = os.environ.get("AGENT_MODEL", "gemini-3.1-flash-lite-preview")

--- a/lumibot/example_strategies/agent_discretionary.py
+++ b/lumibot/example_strategies/agent_discretionary.py
@@ -36,12 +36,18 @@ Usage:
 import csv
 import io
 import os
-import requests
 
-from lumibot.components.agents import BuiltinTools, agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class DiscretionaryTraderStrategy(Strategy):
@@ -77,7 +83,7 @@ class DiscretionaryTraderStrategy(Strategy):
         if end_date:
             params["coed"] = end_date
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://fred.stlouisfed.org/graph/fredgraph.csv",
                 params=params,
                 timeout=15,
@@ -139,6 +145,8 @@ class DiscretionaryTraderStrategy(Strategy):
             return {"error": str(e), "symbol": symbol}
 
     def initialize(self):
+        from lumibot.components.agents import BuiltinTools
+
         self.sleeptime = "1D"
         self.vars.iteration_count = 0
         model_id = os.environ.get("AGENT_MODEL", "gemini-3.1-pro-preview")

--- a/lumibot/example_strategies/agent_m2_liquidity.py
+++ b/lumibot/example_strategies/agent_m2_liquidity.py
@@ -18,12 +18,18 @@ Usage:
 import csv
 import io
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class M2LiquidityStrategy(Strategy):
@@ -60,7 +66,7 @@ class M2LiquidityStrategy(Strategy):
         if end_date:
             params["coed"] = end_date
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://fred.stlouisfed.org/graph/fredgraph.csv",
                 params=params,
                 timeout=15,

--- a/lumibot/example_strategies/agent_m2_liquidity_anthropic.py
+++ b/lumibot/example_strategies/agent_m2_liquidity_anthropic.py
@@ -26,12 +26,18 @@ Usage:
 import csv
 import io
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class M2LiquidityAnthropicStrategy(Strategy):
@@ -56,7 +62,7 @@ class M2LiquidityAnthropicStrategy(Strategy):
         if end_date:
             params["coed"] = end_date
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://fred.stlouisfed.org/graph/fredgraph.csv",
                 params=params,
                 timeout=15,

--- a/lumibot/example_strategies/agent_m2_liquidity_grok.py
+++ b/lumibot/example_strategies/agent_m2_liquidity_grok.py
@@ -33,12 +33,18 @@ Usage:
 import csv
 import io
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class M2LiquidityGrokStrategy(Strategy):
@@ -75,7 +81,7 @@ class M2LiquidityGrokStrategy(Strategy):
         if end_date:
             params["coed"] = end_date
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://fred.stlouisfed.org/graph/fredgraph.csv",
                 params=params,
                 timeout=15,

--- a/lumibot/example_strategies/agent_m2_liquidity_openai.py
+++ b/lumibot/example_strategies/agent_m2_liquidity_openai.py
@@ -26,12 +26,18 @@ Usage:
 import csv
 import io
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class M2LiquidityOpenAIStrategy(Strategy):
@@ -68,7 +74,7 @@ class M2LiquidityOpenAIStrategy(Strategy):
         if end_date:
             params["coed"] = end_date
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://fred.stlouisfed.org/graph/fredgraph.csv",
                 params=params,
                 timeout=15,

--- a/lumibot/example_strategies/agent_macro_risk.py
+++ b/lumibot/example_strategies/agent_macro_risk.py
@@ -17,12 +17,18 @@ Usage:
 """
 
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class MacroRiskStrategy(Strategy):
@@ -56,7 +62,7 @@ class MacroRiskStrategy(Strategy):
         if end:
             params["end"] = end
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 f"https://data.alpaca.markets/v2/stocks/{symbol}/bars",
                 headers=headers, params=params, timeout=15,
             )
@@ -92,7 +98,7 @@ class MacroRiskStrategy(Strategy):
         api_secret = os.environ.get("ALPACA_API_SECRET", "")
         headers = {"APCA-API-KEY-ID": api_key, "APCA-API-SECRET-KEY": api_secret}
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://data.alpaca.markets/v1beta1/screener/stocks/movers",
                 headers=headers, params={"top": top}, timeout=15,
             )

--- a/lumibot/example_strategies/agent_momentum_allocator.py
+++ b/lumibot/example_strategies/agent_momentum_allocator.py
@@ -17,12 +17,18 @@ Usage:
 """
 
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class MomentumAllocatorStrategy(Strategy):
@@ -59,7 +65,7 @@ class MomentumAllocatorStrategy(Strategy):
         if end:
             params["end"] = end
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 f"https://data.alpaca.markets/v2/stocks/{symbol}/bars",
                 headers=headers,
                 params=params,
@@ -115,7 +121,7 @@ class MomentumAllocatorStrategy(Strategy):
         if end:
             params["end"] = end
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://data.alpaca.markets/v1beta1/news",
                 headers=headers,
                 params=params,

--- a/lumibot/example_strategies/agent_news_sentiment.py
+++ b/lumibot/example_strategies/agent_news_sentiment.py
@@ -16,12 +16,18 @@ Usage:
 """
 
 import os
-import requests
 
-from lumibot.components.agents import agent_tool
 from lumibot.strategies.strategy import Strategy
 
+from ._agent_tool import agent_tool
+
 IS_BACKTESTING = True
+
+
+def _requests():
+    import requests
+
+    return requests
 
 
 class NewsSentimentStrategy(Strategy):
@@ -61,7 +67,7 @@ class NewsSentimentStrategy(Strategy):
         if symbols:
             params["symbols"] = symbols
         try:
-            resp = requests.get(
+            resp = _requests().get(
                 "https://data.alpaca.markets/v1beta1/news",
                 headers=headers, params=params, timeout=15,
             )

--- a/lumibot/example_strategies/bitunix_futures_example.py
+++ b/lumibot/example_strategies/bitunix_futures_example.py
@@ -1,7 +1,5 @@
 import time
 
-from lumibot.brokers import Bitunix
-from lumibot.credentials import BITUNIX_CONFIG  # Assuming Bitunix config is in credentials
 from lumibot.entities import Asset, Order
 from lumibot.strategies.strategy import Strategy
 
@@ -57,6 +55,9 @@ class BitunixFuturesExample(Strategy):
 
 
 if __name__ == "__main__":
+    from lumibot.brokers import Bitunix
+    from lumibot.credentials import BITUNIX_CONFIG  # Assuming Bitunix config is in credentials
+
     # Ensure Bitunix credentials are set in .env or environment variables
     # BITUNIX_CONFIG should contain API_KEY, API_SECRET
     if not BITUNIX_CONFIG or not BITUNIX_CONFIG.get("API_KEY") or not BITUNIX_CONFIG.get("API_SECRET"):
@@ -68,4 +69,3 @@ if __name__ == "__main__":
         broker = Bitunix(BITUNIX_CONFIG)
         strategy = BitunixFuturesExample(broker=broker)
         strategy.run_live()
-

--- a/lumibot/example_strategies/ccxt_backtesting_example.py
+++ b/lumibot/example_strategies/ccxt_backtesting_example.py
@@ -1,8 +1,7 @@
+from __future__ import annotations
+
 from datetime import datetime
 
-from pandas import DataFrame
-
-from lumibot.backtesting import CcxtBacktesting
 from lumibot.entities import Asset, Order
 from lumibot.strategies.strategy import Strategy
 
@@ -35,7 +34,9 @@ class CcxtBacktestingExampleStrategy(Strategy):
         return self.get_historical_prices(asset=self.asset,length=self.window,
                                     timestep="day",quote=self.quote).df
 
-    def _get_bbands(self,history_df:DataFrame):
+    def _get_bbands(self, history_df):
+        from pandas import DataFrame
+
         # BBL (Lower Bollinger Band): Can act as a support level based on price volatility, and can indicate an 'oversold' condition if the price falls below this line.
         # BBM (Breaking Bollinger Bands): This is essentially a moving average over a selected period of time, used as a reference point for price trends.
         # BBU (Upper Bollinger Band): Can act as a resistance level based on price volatility, and can indicate an 'overbought' condition if the price moves above this line.
@@ -86,6 +87,7 @@ class CcxtBacktestingExampleStrategy(Strategy):
 
 
 if  __name__ == "__main__":
+    from lumibot.backtesting import CcxtBacktesting
 
     base_symbol = "ETH"
     quote_symbol = "USDT"

--- a/lumibot/example_strategies/classic_60_40.py
+++ b/lumibot/example_strategies/classic_60_40.py
@@ -1,17 +1,3 @@
-from datetime import datetime
-
-import pytz
-
-from lumibot.backtesting import AlpacaBacktesting
-from lumibot.components.configs_helper import ConfigsHelper
-from lumibot.credentials import ALPACA_TEST_CONFIG, IS_BACKTESTING
-from lumibot.entities import Asset
-from lumibot.example_strategies.drift_rebalancer import DriftRebalancer
-from lumibot.tools.pandas import print_full_pandas_dataframes
-from lumibot.traders.debug_log_trader import DebugLogTrader
-
-print_full_pandas_dataframes()
-
 """
 Strategy Description
 
@@ -24,6 +10,19 @@ assets that has drifted the least to bring the portfolio back to the target weig
 
 
 if __name__ == "__main__":
+    from datetime import datetime
+
+    import pytz
+
+    from lumibot.backtesting import AlpacaBacktesting
+    from lumibot.components.configs_helper import ConfigsHelper
+    from lumibot.credentials import ALPACA_TEST_CONFIG, IS_BACKTESTING
+    from lumibot.entities import Asset
+    from lumibot.example_strategies.drift_rebalancer import DriftRebalancer
+    from lumibot.tools.pandas import print_full_pandas_dataframes
+    from lumibot.traders.debug_log_trader import DebugLogTrader
+
+    print_full_pandas_dataframes()
 
     configs_helper = ConfigsHelper(configs_folder="example_strategies")
     parameters = configs_helper.load_config("classic_60_40_config")

--- a/lumibot/example_strategies/crypto_50_50.py
+++ b/lumibot/example_strategies/crypto_50_50.py
@@ -1,17 +1,3 @@
-from datetime import datetime
-
-import pytz
-
-from lumibot.backtesting import AlpacaBacktesting
-from lumibot.components.configs_helper import ConfigsHelper
-from lumibot.credentials import ALPACA_TEST_CONFIG, IS_BACKTESTING
-from lumibot.entities import Asset
-from lumibot.example_strategies.drift_rebalancer import DriftRebalancer
-from lumibot.tools.pandas import print_full_pandas_dataframes
-from lumibot.traders.debug_log_trader import DebugLogTrader
-
-print_full_pandas_dataframes()
-
 """
 Strategy Description
 
@@ -23,6 +9,19 @@ assets that has drifted the least to bring the portfolio back to the target weig
 
 
 if __name__ == "__main__":
+    from datetime import datetime
+
+    import pytz
+
+    from lumibot.backtesting import AlpacaBacktesting
+    from lumibot.components.configs_helper import ConfigsHelper
+    from lumibot.credentials import ALPACA_TEST_CONFIG, IS_BACKTESTING
+    from lumibot.entities import Asset
+    from lumibot.example_strategies.drift_rebalancer import DriftRebalancer
+    from lumibot.tools.pandas import print_full_pandas_dataframes
+    from lumibot.traders.debug_log_trader import DebugLogTrader
+
+    print_full_pandas_dataframes()
 
     configs_helper = ConfigsHelper(configs_folder="example_strategies")
     parameters = configs_helper.load_config("crypto_50_50_config")

--- a/lumibot/example_strategies/crypto_important_functions.py
+++ b/lumibot/example_strategies/crypto_important_functions.py
@@ -1,6 +1,5 @@
 import datetime
 
-from lumibot.brokers import Ccxt
 from lumibot.entities import Asset
 from lumibot.strategies.strategy import Strategy
 
@@ -122,6 +121,8 @@ class ImportantFunctions(Strategy):
 
 
 if __name__ == "__main__":
+    from lumibot.brokers import Ccxt
+
     KRAKEN_CONFIG = {
         "exchange_id": "kraken",
         "apiKey": "YOUR_API_KEY",

--- a/lumibot/example_strategies/drift_rebalancer.py
+++ b/lumibot/example_strategies/drift_rebalancer.py
@@ -1,11 +1,21 @@
+from __future__ import annotations
+
 from decimal import Decimal
 from typing import Any
 
-import pandas as pd
-
-from lumibot.components.drift_rebalancer_logic import DriftRebalancerLogic, DriftType
 from lumibot.entities import Order
 from lumibot.strategies.strategy import Strategy
+
+
+class DriftType:
+    ABSOLUTE = "absolute"
+    RELATIVE = "relative"
+
+
+def _pd():
+    import pandas as pd
+
+    return pd
 
 
 class DriftRebalancer(Strategy):
@@ -88,6 +98,8 @@ class DriftRebalancer(Strategy):
 
     # noinspection PyAttributeOutsideInit
     def initialize(self, parameters: Any = None) -> None:
+        from lumibot.components.drift_rebalancer_logic import DriftRebalancerLogic
+
         self.set_market(self.parameters.get("market", "NYSE"))
         self.sleeptime = self.parameters.get("sleeptime", "1D")
         self.drift_type = self.parameters.get("drift_type", DriftType.RELATIVE)
@@ -99,7 +111,7 @@ class DriftRebalancer(Strategy):
         self.shorting = self.parameters.get("shorting", False)
         self.fractional_shares = self.parameters.get("fractional_shares", False)
         self.only_rebalance_drifted_assets = self.parameters.get("only_rebalance_drifted_assets", False)
-        self.drift_df = pd.DataFrame()
+        self.drift_df = _pd().DataFrame()
         self.drift_rebalancer_logic = DriftRebalancerLogic(
             strategy=self,
             drift_type=self.drift_type,

--- a/lumibot/example_strategies/forex_hold_to_expiry.py
+++ b/lumibot/example_strategies/forex_hold_to_expiry.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from lumibot.entities import Asset
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -25,6 +24,7 @@ class FuturesHoldToExpiry(Strategy):
 
     def on_trading_iteration(self):
         """Buys the self.buy_symbol once, then never again"""
+        from lumibot.entities import Asset
 
         buy_symbol = self.parameters["buy_symbol"]
 

--- a/lumibot/example_strategies/futures_hold_to_expiry.py
+++ b/lumibot/example_strategies/futures_hold_to_expiry.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 
-from lumibot.credentials import IS_BACKTESTING
-from lumibot.entities import Asset
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -28,6 +26,7 @@ class FuturesHoldToExpiry(Strategy):
 
     def on_trading_iteration(self):
         """Buys the self.buy_symbol once, then never again"""
+        from lumibot.entities import Asset
 
         buy_symbol = self.parameters["buy_symbol"]
         expiry = self.parameters["expiry"]
@@ -67,6 +66,8 @@ class FuturesHoldToExpiry(Strategy):
 
 
 if __name__ == "__main__":
+    from lumibot.credentials import IS_BACKTESTING
+
     if IS_BACKTESTING:
         from lumibot.backtesting import PolygonDataBacktesting
 

--- a/lumibot/example_strategies/options_hold_to_expiry.py
+++ b/lumibot/example_strategies/options_hold_to_expiry.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from lumibot.entities import Asset
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -26,6 +25,7 @@ class OptionsHoldToExpiry(Strategy):
 
     def on_trading_iteration(self):
         """Buys the self.buy_symbol once, then never again"""
+        from lumibot.entities import Asset
 
         buy_symbol = self.parameters["buy_symbol"]
         expiry = self.parameters["expiry"]

--- a/lumibot/example_strategies/schedule_function.py
+++ b/lumibot/example_strategies/schedule_function.py
@@ -1,6 +1,4 @@
 
-from lumibot.brokers import Alpaca
-from lumibot.credentials import ALPACA_TEST_CONFIG
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -60,6 +58,8 @@ class ScheduledFunctionStrategy(Strategy):
 
 
 if __name__ == "__main__":
+    from lumibot.brokers import Alpaca
+    from lumibot.credentials import ALPACA_TEST_CONFIG
 
     # Verify we have the necessary configuration
     if not ALPACA_TEST_CONFIG:

--- a/lumibot/example_strategies/stock_bracket.py
+++ b/lumibot/example_strategies/stock_bracket.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from lumibot.entities import Order
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -32,6 +31,7 @@ class StockBracket(Strategy):
 
     def on_trading_iteration(self):
         """Buys the self.buy_symbol once, then never again"""
+        from lumibot.entities import Order
 
         buy_symbol = self.parameters["buy_symbol"]
         take_profit_price = self.parameters["take_profit_price"]

--- a/lumibot/example_strategies/stock_buy_and_hold.py
+++ b/lumibot/example_strategies/stock_buy_and_hold.py
@@ -1,8 +1,5 @@
 import datetime as dt
 
-import pytz
-
-from lumibot.credentials import ALPACA_TEST_CONFIG
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -60,7 +57,10 @@ if __name__ == "__main__":
     IS_BACKTESTING = True
 
     if IS_BACKTESTING:
+        import pytz
+
         from lumibot.backtesting import AlpacaBacktesting
+        from lumibot.credentials import ALPACA_TEST_CONFIG
 
         if not IS_BACKTESTING:
             print("This strategy is not meant to be run live. Please set IS_BACKTESTING to True.")

--- a/lumibot/example_strategies/stock_diversified_leverage.py
+++ b/lumibot/example_strategies/stock_diversified_leverage.py
@@ -1,8 +1,3 @@
-from datetime import datetime
-
-from lumibot.backtesting import YahooDataBacktesting
-from lumibot.brokers import Alpaca
-from lumibot.entities import TradingFee
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -121,6 +116,8 @@ class DiversifiedLeverage(Strategy):
 
 
 if __name__ == "__main__":
+    from datetime import datetime
+
     is_live = False
 
     if is_live:
@@ -128,6 +125,7 @@ if __name__ == "__main__":
         # Run the strategy live
         ####
         from credentials import ALPACA_CONFIG
+        from lumibot.brokers import Alpaca
 
         broker = Alpaca(ALPACA_CONFIG)
         strategy = DiversifiedLeverage(broker=broker)
@@ -137,6 +135,8 @@ if __name__ == "__main__":
         ####
         # Backtest the strategy
         ####
+        from lumibot.backtesting import YahooDataBacktesting
+        from lumibot.entities import TradingFee
 
         # Choose the time from and to which you want to backtest
         backtesting_start = datetime(2010, 6, 1)

--- a/lumibot/example_strategies/stock_oco.py
+++ b/lumibot/example_strategies/stock_oco.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from lumibot.entities import Order
 from lumibot.strategies.strategy import Strategy
 
 """
@@ -33,6 +32,7 @@ class StockOco(Strategy):
 
     def on_trading_iteration(self):
         """Buys the self.buy_symbol once, then never again"""
+        from lumibot.entities import Order
 
         buy_symbol = self.parameters["buy_symbol"]
         take_profit_price = self.parameters["take_profit_price"]

--- a/lumibot/example_strategies/strangle.py
+++ b/lumibot/example_strategies/strangle.py
@@ -3,9 +3,13 @@ import logging
 import time
 from itertools import cycle
 
-from yfinance import Ticker
-
 from lumibot.strategies.strategy import Strategy
+
+
+def _ticker(symbol):
+    from yfinance import Ticker
+
+    return Ticker(symbol)
 
 
 class Strangle(Strategy):
@@ -224,7 +228,7 @@ class Strangle(Strategy):
 
             # Check to make sure date is not too close to earnings.
             print(f"Getting earnings date for {asset.symbol}")
-            edate_df = Ticker(asset.symbol).calendar
+            edate_df = _ticker(asset.symbol).calendar
             if edate_df is None:
                 print(
                     f"There was no calendar information for {asset.symbol} so it "

--- a/lumibot/strategies/__init__.py
+++ b/lumibot/strategies/__init__.py
@@ -1,2 +1,25 @@
-from .strategy import Strategy
-from .strategy_executor import StrategyExecutor
+"""Strategy package exports without importing executor unless requested."""
+
+from importlib import import_module as _import_module
+
+_NAME_TO_MODULE = {
+    "Strategy": "strategy",
+    "StrategyExecutor": "strategy_executor",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/tools/__init__.py
+++ b/lumibot/tools/__init__.py
@@ -1,42 +1,165 @@
-# TODO: Using * is really bad and leads to random circular imports (especially in polygon_helper and indicators)
-# TODO: When using *, you have to ensure that the underlying module does not import ANYTHING from the lumibot package
-# TODO: This tools module is a bad place to auto import as a helper to the code because all of the modules and functions
-# TODO: are not related to each other. It's just a collection of random functions and classes and it is unclear what
-# TODO: is being loaded when simply trying to load anything from the tools module. It's better to import the specific
-# TODO: functions and classes that you need from the tools module. This has made everything from black_scholes to
-# TODO: yahoo_helper all interrelated and it's a mess.
-from .black_scholes import BS
-from .debugers import *
-from .decorators import append_locals, execute_after, snatch_locals, staticdecorator
-from .helpers import *
-from .indicators import (
-    cash_flow_adjusted_returns,
-    cagr,
-    calculate_returns,
-    create_tearsheet,
-    cumulative_to_period_flows,
-    get_risk_free_rate,
-    get_symbol_returns,
-    max_drawdown,
-    performance,
-    plot_indicators,
-    plot_returns,
-    romad,
-    sharpe,
-    stats_summary,
-    total_return,
-    volatility,
-)
-from .pandas import *
-from .types import *
-from .yahoo_helper import YahooHelper
-from .ccxt_data_store import CcxtCacheDB
-from .schwab_helper import SchwabHelper
+"""Compatibility exports for :mod:`lumibot.tools`.
 
-# Unified logging system
-from .lumibot_logger import (
-    get_logger,
-    get_strategy_logger, 
-    set_log_level,
-    add_file_handler
-)
+The old package initializer imported every helper module at once. That made
+basic imports pay for plotting, broker caches, Yahoo, CCXT, and analytics even
+when callers only needed one small helper.
+"""
+
+from importlib import import_module as _import_module
+
+_SUBMODULES = {
+    "backtest_cache",
+    "black_scholes",
+    "ccxt_data_store",
+    "data_downloader_queue_client",
+    "databento_helper",
+    "databento_helper_polars",
+    "debugers",
+    "decorators",
+    "futures_roll",
+    "helpers",
+    "ibkr_helper",
+    "ibkr_secdef",
+    "indicators",
+    "lumibot_logger",
+    "pandas",
+    "parquet_series_cache",
+    "parquet_utils",
+    "polars_utils",
+    "polygon_helper",
+    "polygon_helper_async",
+    "polygon_helper_polars_optimized",
+    "projectx_helpers",
+    "runtime_telemetry",
+    "schwab_helper",
+    "smart_limit_utils",
+    "symbol_parser",
+    "symbol_normalization",
+    "thetadata_helper",
+    "types",
+    "yahoo_helper",
+    "alpaca_helpers",
+    "bitunix_helpers",
+}
+
+_NAME_TO_MODULE = {
+    "BS": "black_scholes",
+    "CcxtCacheDB": "ccxt_data_store",
+    "SchwabHelper": "schwab_helper",
+    "YahooHelper": "yahoo_helper",
+    "append_locals": "decorators",
+    "execute_after": "decorators",
+    "snatch_locals": "decorators",
+    "staticdecorator": "decorators",
+    "add_file_handler": "lumibot_logger",
+    "get_logger": "lumibot_logger",
+    "get_strategy_logger": "lumibot_logger",
+    "set_log_level": "lumibot_logger",
+    "cagr": "indicators",
+    "calculate_returns": "indicators",
+    "cash_flow_adjusted_returns": "indicators",
+    "create_tearsheet": "indicators",
+    "cumulative_to_period_flows": "indicators",
+    "get_risk_free_rate": "indicators",
+    "get_symbol_returns": "indicators",
+    "max_drawdown": "indicators",
+    "performance": "indicators",
+    "plot_indicators": "indicators",
+    "plot_returns": "indicators",
+    "romad": "indicators",
+    "sharpe": "indicators",
+    "stats_summary": "indicators",
+    "total_return": "indicators",
+    "volatility": "indicators",
+    "Decimal": "types",
+    "check_numeric": "types",
+    "check_positive": "types",
+    "check_price": "types",
+    "check_quantity": "types",
+}
+
+_HELPER_EXPORTS = {
+    "LUMIBOT_DEFAULT_PYTZ",
+    "LUMIBOT_DEFAULT_TIMEZONE",
+    "MarketCalendar",
+    "TwentyFourSevenCalendar",
+    "ComparaisonMixin",
+    "colored",
+    "create_options_symbol",
+    "date_n_trading_days_from_date",
+    "day_deduplicate",
+    "deduplicate_sequence",
+    "dt",
+    "fill_void",
+    "get_chunks",
+    "get_decimals",
+    "get_lumibot_datetime",
+    "get_timezone_from_datetime",
+    "get_trading_days",
+    "get_trading_times",
+    "has_more_than_n_decimal_places",
+    "hashlib",
+    "is_daily_data",
+    "is_market_open",
+    "lru_cache",
+    "mcal",
+    "os",
+    "parse_symbol",
+    "parse_timestep_qty_and_unit",
+    "pd",
+    "prettify_dataframe_with_decimals",
+    "print_full_pandas_dataframes",
+    "print_progress_bar",
+    "pytz",
+    "quantize_to_num_decimals",
+    "re",
+    "set_pandas_float_display_precision",
+    "sys",
+    "time",
+    "to_datetime_aware",
+    "weakref",
+}
+
+for _name in _HELPER_EXPORTS:
+    _NAME_TO_MODULE[_name] = "helpers"
+
+_NAME_TO_MODULE["parse_symbol"] = "symbol_parser"
+
+for _name in (
+    "day_deduplicate",
+    "fill_void",
+    "is_daily_data",
+    "np",
+    "pd",
+    "prettify_dataframe_with_decimals",
+    "print_full_pandas_dataframes",
+    "set_pandas_float_display_precision",
+):
+    _NAME_TO_MODULE[_name] = "pandas"
+
+for _name in ("PerfCounters", "perf_counter", "perf_counters"):
+    _NAME_TO_MODULE[_name] = "debugers"
+
+_NAME_TO_MODULE["ROUND_HALF_EVEN"] = "helpers"
+
+__all__ = sorted(_SUBMODULES | set(_NAME_TO_MODULE))
+
+
+def __getattr__(name):
+    if name in _SUBMODULES:
+        module = _import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/tools/symbol_parser.py
+++ b/lumibot/tools/symbol_parser.py
@@ -1,0 +1,30 @@
+import datetime as dt
+import re
+
+_OPTION_SYMBOL_PATTERN = re.compile(r"([A-Z]+)(\d{6})([CP])(\d+)")
+
+
+def parse_symbol(symbol):
+    """
+    Parse the given symbol and determine if it's an option or a stock.
+    For options, extract and return the stock symbol, expiration date (as a datetime.date object),
+    type (call or put), and strike price.
+    For stocks, simply return the stock symbol.
+    TODO: Crypto and Forex support
+    """
+    if not isinstance(symbol, str):
+        return {"type": None}
+
+    match = _OPTION_SYMBOL_PATTERN.match(symbol)
+    if match:
+        stock_symbol, expiration, option_type, strike_price = match.groups()
+        expiration_date = dt.datetime.strptime(expiration, "%y%m%d").date()
+        option_type = "CALL" if option_type == "C" else "PUT"
+        return {
+            "type": "option",
+            "stock_symbol": stock_symbol,
+            "expiration_date": expiration_date,
+            "option_type": option_type,
+            "strike_price": round(float(strike_price) / 1000, 3),
+        }
+    return {"type": "stock", "stock_symbol": symbol}

--- a/lumibot/traders/__init__.py
+++ b/lumibot/traders/__init__.py
@@ -1,1 +1,24 @@
-from .trader import Trader
+"""Trader package exports without eager imports."""
+
+from importlib import import_module as _import_module
+
+_NAME_TO_MODULE = {
+    "Trader": "trader",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/tests/test_credentials_disable_dotenv.py
+++ b/tests/test_credentials_disable_dotenv.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import inspect
 
 
 def test_disable_dotenv_skips_recursive_scan(monkeypatch):
@@ -15,3 +16,44 @@ def test_disable_dotenv_skips_recursive_scan(monkeypatch):
     # credentials.py runs at import-time; force a clean import for this test.
     sys.modules.pop("lumibot.credentials", None)
     __import__("lumibot.credentials")
+
+
+def test_find_and_load_dotenv_walks_upward_and_loads_local_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("LUMIBOT_DISABLE_DOTENV", "1")
+    monkeypatch.delenv("LUMIBOT_TEST_DOTENV_VALUE", raising=False)
+
+    root = tmp_path / "repo"
+    child = root / "nested" / "tests"
+    child.mkdir(parents=True)
+    (root / ".env").write_text("LUMIBOT_TEST_DOTENV_VALUE=base\n", encoding="utf-8")
+    (root / ".env.local").write_text("LUMIBOT_TEST_DOTENV_VALUE=local\n", encoding="utf-8")
+
+    sys.modules.pop("lumibot.credentials", None)
+    credentials = __import__("lumibot.credentials").credentials
+
+    assert credentials.find_and_load_dotenv(child)
+    assert os.environ["LUMIBOT_TEST_DOTENV_VALUE"] == "local"
+
+
+def test_find_and_load_dotenv_ignores_dotenv_directory(monkeypatch, tmp_path):
+    monkeypatch.setenv("LUMIBOT_DISABLE_DOTENV", "1")
+    root = tmp_path / "repo"
+    child = root / "nested"
+    child.mkdir(parents=True)
+    (root / ".env").mkdir()
+
+    sys.modules.pop("lumibot.credentials", None)
+    credentials = __import__("lumibot.credentials").credentials
+
+    assert not credentials.find_and_load_dotenv(child)
+
+
+def test_credentials_broker_exports_are_real_classes(monkeypatch):
+    monkeypatch.setenv("LUMIBOT_DISABLE_DOTENV", "1")
+    sys.modules.pop("lumibot.credentials", None)
+
+    from lumibot.brokers import Alpaca as BrokerAlpaca
+    from lumibot.credentials import Alpaca
+
+    assert inspect.isclass(Alpaca)
+    assert Alpaca is BrokerAlpaca

--- a/tests/test_lazy_exports.py
+++ b/tests/test_lazy_exports.py
@@ -1,0 +1,135 @@
+import importlib
+import inspect
+from unittest.mock import patch
+
+
+def test_lazy_package_all_exports_resolve():
+    modules = [
+        "lumibot",
+        "lumibot.backtesting",
+        "lumibot.brokers",
+        "lumibot.components",
+        "lumibot.components.agents",
+        "lumibot.data_sources",
+        "lumibot.entities",
+        "lumibot.strategies",
+        "lumibot.tools",
+        "lumibot.traders",
+    ]
+
+    for module_name in modules:
+        module = importlib.import_module(module_name)
+        for export_name in getattr(module, "__all__", ()):
+            getattr(module, export_name)
+
+
+def test_legacy_star_import_exports_resolve():
+    namespace = {}
+
+    exec("from lumibot.tools import *", namespace)
+    for name in ("np", "pd", "parse_symbol", "get_logger", "YahooHelper"):
+        assert name in namespace
+    assert namespace["pd"].__name__ == "pandas"
+    assert namespace["np"].__name__ == "numpy"
+
+    exec("from lumibot.entities import *", namespace)
+    for name in ("Asset", "Order", "Position", "Data"):
+        assert name in namespace
+
+    exec("from lumibot.backtesting import *", namespace)
+    for name in ("BacktestingBroker", "PandasDataBacktesting", "YahooDataBacktesting"):
+        assert name in namespace
+
+
+def test_lazy_module_proxies_preserve_module_identity():
+    from lumibot.backtesting import backtesting_broker
+    from lumibot.entities import bars, data
+    from lumibot.strategies import strategy, strategy_executor
+    from lumibot.tools import helpers
+    from lumibot.tools import ibkr_helper, thetadata_helper
+
+    for value in (
+        helpers.pd,
+        ibkr_helper.pd,
+        thetadata_helper.pd,
+        thetadata_helper.mcal,
+        thetadata_helper.requests,
+        data.pd,
+        data.np,
+        bars.pd,
+        bars.np,
+        backtesting_broker.pd,
+        backtesting_broker.np,
+        strategy.pd,
+        strategy.np,
+        strategy_executor.pd,
+    ):
+        assert inspect.ismodule(value)
+
+
+def test_lazy_module_patch_teardown_forwards_deletion():
+    targets = [
+        "lumibot.tools.thetadata_helper.requests._lumibot_patch_probe",
+        "lumibot.brokers.tradier.requests._lumibot_patch_probe",
+        "lumibot.components.agents.builtins.requests._lumibot_patch_probe",
+        "lumibot.tools.projectx_helpers.requests._lumibot_patch_probe",
+        "lumibot.backtesting.routed_backtesting.pd._lumibot_patch_probe",
+        "lumibot.backtesting.databento_backtesting_pandas.pd._lumibot_patch_probe",
+        "lumibot.data_sources.databento_data_pandas.pd._lumibot_patch_probe",
+        "lumibot.indicators.indicators.pd._lumibot_patch_probe",
+    ]
+
+    for target in targets:
+        with patch(target, object(), create=True):
+            pass
+
+
+def test_lazy_module_patch_teardown_restores_existing_attributes():
+    from lumibot.brokers import tradier
+    from lumibot.components.agents import builtins
+    from lumibot.tools import projectx_helpers, thetadata_helper
+
+    target_pairs = [
+        (thetadata_helper.requests, "lumibot.tools.thetadata_helper.requests.get"),
+        (tradier.requests, "lumibot.brokers.tradier.requests.get"),
+        (builtins.requests, "lumibot.components.agents.builtins.requests.get"),
+        (projectx_helpers.requests, "lumibot.tools.projectx_helpers.requests.get"),
+    ]
+
+    for proxy, target in target_pairs:
+        original = proxy.get
+        with patch(target) as mocked:
+            assert proxy.get is mocked
+        assert proxy.get is original
+
+
+def test_legacy_entities_package_alias_resolves_submodules():
+    import lumibot  # noqa: F401
+    import entities
+    from entities import asset as asset_module
+    from entities.asset import Asset
+    from entities.order import Order
+
+    assert importlib.util.find_spec("entities.asset") is not None
+    assert importlib.util.find_spec("entities.order") is not None
+    assert importlib.reload(entities) is entities
+    assert importlib.reload(asset_module).Asset is Asset
+    assert entities.Asset is Asset
+    assert entities.Order is Order
+    assert Asset("SPY").symbol == "SPY"
+    assert Order.OrderType.MARKET.value == "market"
+
+
+def test_lightweight_example_agent_tool_preserves_source_description():
+    from lumibot.example_strategies._agent_tool import agent_tool
+
+    @agent_tool(description="Demo tool")
+    def sample_tool(value: int) -> int:
+        return value + 1
+
+    metadata = sample_tool._lumibot_agent_tool
+
+    assert metadata["name"] == "sample_tool"
+    assert metadata["description"].startswith("Demo tool")
+    assert "Source code:" in metadata["description"]
+    assert "def sample_tool(value: int) -> int:" in metadata["description"]


### PR DESCRIPTION
Split from #1013.

Scope:
- Lazy-load top-level package exports and legacy `entities.*` aliases.
- Defer optional component and example-strategy imports until use.
- Keep dotenv loading controllable for tests/imports.
- Fix the CI Ruff target to point at the existing downloader queue client.

Validation:
- `uv run pytest -q tests/test_lazy_exports.py tests/test_credentials_disable_dotenv.py`