### PR TITLE
[codex] Optimize market data hot paths

### DIFF
--- a/lumibot/backtesting/alpaca_backtesting.py
+++ b/lumibot/backtesting/alpaca_backtesting.py
@@ -1,17 +1,20 @@
+from __future__ import annotations
+
 import os
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Optional
+from importlib import import_module
+from typing import TYPE_CHECKING, Optional
 
-import pandas as pd
 import pytz
-from alpaca.data.historical import CryptoHistoricalDataClient, StockHistoricalDataClient
-from alpaca.data.requests import CryptoBarsRequest, StockBarsRequest
-from alpaca.data.timeframe import TimeFrame
 
-from lumibot.constants import LUMIBOT_CACHE_FOLDER
-from lumibot.data_sources import AlpacaData, DataSourceBacktesting
-from lumibot.entities import Asset, Bars
+from lumibot.constants import (
+    LUMIBOT_CACHE_FOLDER,
+    LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL,
+    LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE,
+)
+from lumibot.data_sources import DataSourceBacktesting
+from lumibot.entities import Asset
 from lumibot.tools.helpers import (
     date_n_trading_days_from_date,
     get_decimals,
@@ -22,19 +25,95 @@ from lumibot.tools.helpers import (
 )
 from lumibot.tools.lumibot_logger import get_logger
 
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
+
 logger = get_logger(__name__)
 
-from lumibot.tools.alpaca_helpers import sanitize_base_and_quote_asset
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BARS_CLASS = None
+_ALPACA_DATA_CLASS = None
+_ALPACA_HELPERS = None
+
+
+def _alpaca_attr(module_name: str, attr_name: str):
+    return getattr(import_module(module_name), attr_name)
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _alpaca_data_class():
+    global _ALPACA_DATA_CLASS
+    if _ALPACA_DATA_CLASS is None:
+        from lumibot.data_sources import AlpacaData
+
+        _ALPACA_DATA_CLASS = AlpacaData
+    return _ALPACA_DATA_CLASS
+
+
+def _alpaca_timeframe_from_source_value(value):
+    module = import_module("lumibot.data_sources.alpaca_data")
+    return module._timeframe_from_source_value(value)
+
+
+def _sanitize_base_and_quote_asset(*args, **kwargs):
+    global _ALPACA_HELPERS
+    if _ALPACA_HELPERS is None:
+        _ALPACA_HELPERS = import_module("lumibot.tools.alpaca_helpers")
+    return _ALPACA_HELPERS.sanitize_base_and_quote_asset(*args, **kwargs)
 
 
 class AlpacaBacktesting(DataSourceBacktesting):
     SOURCE = "ALPACA"
     MIN_TIMESTEP = "minute"
     TIMESTEP_MAPPING = [
-        {"timestep": "day", "representations": [TimeFrame.Day]},
-        {"timestep": "minute", "representations": [TimeFrame.Minute]},
+        {"timestep": "day", "representations": ["day"]},
+        {"timestep": "minute", "representations": ["minute"]},
     ]
-    LUMIBOT_DEFAULT_QUOTE_ASSET = AlpacaData.LUMIBOT_DEFAULT_QUOTE_ASSET
+    LUMIBOT_DEFAULT_QUOTE_ASSET = Asset(LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL, LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE)
+
+    def _parse_source_timestep(self, timestep, reverse=False):
+        timestep_text = str(timestep)
+        for item in _alpaca_data_class().TIMESTEP_MAPPING:
+            if reverse and timestep_text == item["timestep"]:
+                return _alpaca_timeframe_from_source_value(item["representations"][0])
+            if not reverse and timestep_text in item["representations"]:
+                return item["timestep"]
+
+        if reverse:
+            normalized = super()._parse_source_timestep(timestep, reverse=False)
+            TimeFrame = _alpaca_attr("alpaca.data.timeframe", "TimeFrame")
+            if normalized == "day":
+                return TimeFrame.Day
+            if normalized == "minute":
+                return TimeFrame.Minute
+        return super()._parse_source_timestep(timestep, reverse=reverse)
 
     def __init__(
             self,
@@ -120,6 +199,8 @@ class AlpacaBacktesting(DataSourceBacktesting):
             raise ValueError("Backtesting is restricted to paper accounts. Pass in a paper account config.")
 
         # Initialize clients based on available authentication method
+        CryptoHistoricalDataClient = _alpaca_attr("alpaca.data.historical", "CryptoHistoricalDataClient")
+        StockHistoricalDataClient = _alpaca_attr("alpaca.data.historical", "StockHistoricalDataClient")
         oauth_token = config.get("OAUTH_TOKEN")
         api_key = config.get("API_KEY")
         api_secret = config.get("API_SECRET")
@@ -140,7 +221,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             raise ValueError("Either OAuth token or API key/secret must be provided for Alpaca authentication")
 
         # Create an AlpacaData instance for internal use
-        self._alpaca_data = AlpacaData(config)
+        self._alpaca_data = _alpaca_data_class()(config)
 
         # Ensure datetime_start and datetime_end have the same tzinfo
         if str(datetime_start.tzinfo) != str(datetime_end.tzinfo):
@@ -216,7 +297,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
         self._datetime = self.datetime_start
 
     def _sanitize_base_and_quote_asset(self, base_asset, quote_asset) -> tuple[Asset, Asset]:
-        asset, quote = sanitize_base_and_quote_asset(base_asset, quote_asset)
+        asset, quote = _sanitize_base_and_quote_asset(base_asset, quote_asset)
         return asset, quote
 
     def get_last_price(
@@ -374,7 +455,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
         else:
             result_df = df.iloc[max(0, current_index - length + 1): current_index + 1]
 
-        return Bars(
+        return _bars_class()(
             result_df,
             self.SOURCE,
             asset=asset,
@@ -512,6 +593,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
 
         if base_asset.asset_type == 'crypto':
             client = self._crypto_client
+            CryptoBarsRequest = _alpaca_attr("alpaca.data.requests", "CryptoBarsRequest")
 
             symbol = base_asset.symbol + '/' + quote_asset.symbol
 
@@ -524,6 +606,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             )
         else:
             client = self._stock_client
+            StockBarsRequest = _alpaca_attr("alpaca.data.requests", "StockBarsRequest")
             adjustment = 'all' if auto_adjust else 'split'
 
             # noinspection PyArgumentList
@@ -536,6 +619,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             )
 
         try:
+            CryptoBarsRequest = _alpaca_attr("alpaca.data.requests", "CryptoBarsRequest")
             if isinstance(request_params, CryptoBarsRequest):
                 bars = client.get_crypto_bars(request_params)
             else:

--- a/lumibot/backtesting/databento_backtesting_pandas.py
+++ b/lumibot/backtesting/databento_backtesting_pandas.py
@@ -1,13 +1,12 @@
+from __future__ import annotations
+
 import traceback
 from datetime import datetime, timedelta
-
-import pandas as pd
+from importlib import import_module
 
 from lumibot import LUMIBOT_DEFAULT_PYTZ
 from lumibot.data_sources import PandasData
-from lumibot.entities import Asset, Data
-from lumibot.tools import databento_helper
-from lumibot.tools.databento_helper import DataBentoAuthenticationError
+from lumibot.entities import Asset
 from lumibot.tools.helpers import to_datetime_aware
 from termcolor import colored
 
@@ -15,6 +14,57 @@ from lumibot.tools.lumibot_logger import get_logger
 logger = get_logger(__name__)
 
 START_BUFFER = timedelta(days=5)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+databento_helper = _LazyModule("lumibot.tools.databento_helper")
+_DATA_CLASS = None
+_DATABENTO_AUTH_ERROR_CLASS = None
+
+
+def _data_class():
+    global _DATA_CLASS
+    if _DATA_CLASS is None:
+        from lumibot.entities import Data
+
+        _DATA_CLASS = Data
+    return _DATA_CLASS
+
+
+def _databento_auth_error_class():
+    global _DATABENTO_AUTH_ERROR_CLASS
+    if _DATABENTO_AUTH_ERROR_CLASS is None:
+        from lumibot.tools.databento_helper import DataBentoAuthenticationError
+
+        _DATABENTO_AUTH_ERROR_CLASS = DataBentoAuthenticationError
+    return _DATABENTO_AUTH_ERROR_CLASS
 
 
 class DataBentoDataBacktestingPandas(PandasData):
@@ -161,7 +211,7 @@ class DataBentoDataBacktestingPandas(PandasData):
 
             logger.debug(f"Successfully set multiplier for {asset.symbol}: {asset.multiplier}")
 
-        except DataBentoAuthenticationError as e:
+        except _databento_auth_error_class() as e:
             logger.error(colored(f"DataBento authentication failed while fetching multiplier for {asset.symbol}: {e}", "red"))
             raise
         except Exception as e:
@@ -217,7 +267,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                     # Create an empty DatetimeIndex with proper timezone
                     empty_df.index = pd.DatetimeIndex([], tz=LUMIBOT_DEFAULT_PYTZ, name='datetime')
                     
-                    data_obj = Data(
+                    data_obj = _data_class()(
                         asset,
                         df=empty_df,
                         timestep=timestep,
@@ -229,7 +279,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                     self.pandas_data[search_asset] = data_obj
                 else:
                     # Create Data object and store
-                    data_obj = Data(
+                    data_obj = _data_class()(
                         asset,
                         df=df,
                         timestep=timestep,
@@ -241,7 +291,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                 # Mark as prefetched
                 self._prefetched_assets.add(search_asset)
                 
-            except DataBentoAuthenticationError as e:
+            except _databento_auth_error_class() as e:
                 logger.error(colored(f"DataBento authentication failed while prefetching {asset.symbol}: {e}", "red"))
                 raise
             except Exception as e:
@@ -354,7 +404,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                 # Create an empty DatetimeIndex with proper timezone
                 empty_df.index = pd.DatetimeIndex([], tz=LUMIBOT_DEFAULT_PYTZ, name='datetime')
                 
-                data_obj = Data(
+                data_obj = _data_class()(
                     asset_separated,
                     df=empty_df,
                     timestep=ts_unit,
@@ -372,7 +422,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                 return
 
             # Create Data object and store in pandas_data
-            data_obj = Data(
+            data_obj = _data_class()(
                 asset_separated,
                 df=df,
                 timestep=ts_unit,
@@ -381,7 +431,7 @@ class DataBentoDataBacktestingPandas(PandasData):
             
             self.pandas_data[search_asset] = data_obj
 
-        except DataBentoAuthenticationError as e:
+        except _databento_auth_error_class() as e:
             logger.error(colored(f"DataBento authentication failed for {asset_separated.symbol}: {e}", "red"))
             raise
         except Exception as e:
@@ -494,7 +544,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                 reference_date=current_dt_aware
             )
             
-        except DataBentoAuthenticationError as e:
+        except _databento_auth_error_class() as e:
             logger.error(colored(f"DataBento authentication failed while getting last price for {asset.symbol}: {e}", "red"))
             raise
         except Exception as e:
@@ -594,7 +644,7 @@ class DataBentoDataBacktestingPandas(PandasData):
                     logger.warning(f"No data found for {asset.symbol}")
                     result[asset] = None
                     
-            except DataBentoAuthenticationError as e:
+            except _databento_auth_error_class() as e:
                 logger.error(colored(f"DataBento authentication failed while getting bars for {asset}: {e}", "red"))
                 raise
             except Exception as e:

--- a/lumibot/backtesting/databento_backtesting_polars.py
+++ b/lumibot/backtesting/databento_backtesting_polars.py
@@ -1,16 +1,12 @@
+from __future__ import annotations
+
 import traceback
 from datetime import datetime, timedelta
-
-import pandas as pd
-import polars as pl
-import numpy as np
+from importlib import import_module
 
 from lumibot import LUMIBOT_DEFAULT_PYTZ
 from lumibot.data_sources import PolarsData
-from lumibot.entities import Asset, Data, Quote
-from lumibot.entities.data_polars import DataPolars
-from lumibot.tools import databento_helper_polars as databento_helper
-from lumibot.tools.databento_helper_polars import DataBentoAuthenticationError
+from lumibot.entities import Asset, Quote
 from lumibot.tools.helpers import to_datetime_aware
 from termcolor import colored
 
@@ -23,6 +19,69 @@ def _log_conversion(operation, from_type, to_type, location):
     logger.debug(f"[CONVERSION] {operation} | {from_type} → {to_type} | {location}")
 
 START_BUFFER = timedelta(days=5)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+pl = _LazyModule("polars")
+np = _LazyModule("numpy")
+databento_helper = _LazyModule("lumibot.tools.databento_helper_polars")
+_DATA_CLASS = None
+_DATA_POLARS_CLASS = None
+_DATABENTO_AUTH_ERROR_CLASS = None
+
+
+def _data_class():
+    global _DATA_CLASS
+    if _DATA_CLASS is None:
+        from lumibot.entities import Data
+
+        _DATA_CLASS = Data
+    return _DATA_CLASS
+
+
+def _data_polars_class():
+    global _DATA_POLARS_CLASS
+    if _DATA_POLARS_CLASS is None:
+        from lumibot.entities.data_polars import DataPolars
+
+        _DATA_POLARS_CLASS = DataPolars
+    return _DATA_POLARS_CLASS
+
+
+def _databento_auth_error_class():
+    global _DATABENTO_AUTH_ERROR_CLASS
+    if _DATABENTO_AUTH_ERROR_CLASS is None:
+        from lumibot.tools.databento_helper_polars import DataBentoAuthenticationError
+
+        _DATABENTO_AUTH_ERROR_CLASS = DataBentoAuthenticationError
+    return _DATABENTO_AUTH_ERROR_CLASS
 
 
 class DataBentoDataBacktestingPolars(PolarsData):
@@ -174,7 +233,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
 
             logger.debug(f"Successfully set multiplier for {asset.symbol}: {asset.multiplier}")
 
-        except DataBentoAuthenticationError as e:
+        except _databento_auth_error_class() as e:
             logger.error(colored(f"DataBento authentication failed while fetching multiplier for {asset.symbol}: {e}", "red"))
             raise
         except Exception as e:
@@ -238,7 +297,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                     # Create an empty DatetimeIndex with proper timezone
                     empty_df.index = pd.DatetimeIndex([], tz=LUMIBOT_DEFAULT_PYTZ, name='datetime')
                     
-                    data_obj = Data(
+                    data_obj = _data_class()(
                         asset,
                         df=empty_df,
                         timestep=timestep,
@@ -252,7 +311,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                 else:
                     pandas_df = df.to_pandas() if hasattr(df, "to_pandas") else df
                     # Create Data object and store
-                    data_obj = Data(
+                    data_obj = _data_class()(
                         asset,
                         df=pandas_df,
                         timestep=timestep,
@@ -266,7 +325,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                 # Mark as prefetched
                 self._prefetched_assets.add(search_asset)
                 
-            except DataBentoAuthenticationError as e:
+            except _databento_auth_error_class() as e:
                 logger.error(colored(f"DataBento authentication failed while prefetching {asset.symbol}: {e}", "red"))
                 raise
             except Exception as e:
@@ -317,7 +376,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
             asset_data = self.pandas_data[search_asset]
 
             # OPTIMIZATION: For DataPolars, check polars_df directly without converting to pandas
-            if isinstance(asset_data, DataPolars):
+            if isinstance(asset_data, _data_polars_class()):
                 # Avoid conversion overhead by reading DataPolars.polars_df directly
                 polars_df = asset_data.polars_df
                 if polars_df.height > 0:
@@ -443,7 +502,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                 # Create an empty DatetimeIndex with proper timezone
                 empty_df.index = pd.DatetimeIndex([], tz=LUMIBOT_DEFAULT_PYTZ, name='datetime')
                 
-                data_obj = Data(
+                data_obj = _data_class()(
                     asset_separated,
                     df=empty_df,
                     timestep=ts_unit,
@@ -461,7 +520,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                 _log_conversion("STORE", "polars", "DataPolars", "_update_pandas_data")
                 logger.debug(f"[POLARS] Storing polars DataFrame for {asset_separated.symbol}: {df.height} rows")
                 # Create DataPolars object with polars DataFrame (keeps polars end-to-end)
-                data_obj = DataPolars(
+                data_obj = _data_polars_class()(
                     asset_separated,
                     df=df,
                     timestep=ts_unit,
@@ -473,7 +532,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                     logger.error(f"DataBento data for {asset_separated.symbol} doesn't have datetime index")
                     return
                 # Create Data object with pandas DataFrame
-                data_obj = Data(
+                data_obj = _data_class()(
                     asset_separated,
                     df=df,
                     timestep=ts_unit,
@@ -486,7 +545,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
             self.pandas_data[search_asset] = data_obj
             self._cache_datetime_series(search_asset, data_obj)
 
-        except DataBentoAuthenticationError as e:
+        except _databento_auth_error_class() as e:
             logger.error(colored(f"DataBento authentication failed for {asset_separated.symbol}: {e}", "red"))
             raise
         except Exception as e:
@@ -501,7 +560,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
             timestep = getattr(data_obj, "timestep", "minute")
             cache_key = (search_asset, timestep)
 
-            if isinstance(data_obj, DataPolars):
+            if isinstance(data_obj, _data_polars_class()):
                 dt_series = data_obj.polars_df["datetime"]
                 if dt_series.dtype.time_zone:
                     dt_series = dt_series.dt.convert_time_zone("UTC")
@@ -587,7 +646,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                     datetime_ns = self._datetime_ns_cache.get(datetime_key)
 
                 # OPTIMIZATION: If asset_data is DataPolars, work with polars directly to avoid conversion
-                if isinstance(asset_data, DataPolars):
+                if isinstance(asset_data, _data_polars_class()):
                     polars_df = asset_data.polars_df
 
                     if polars_df.height > 0 and 'close' in polars_df.columns and datetime_ns is not None and len(datetime_ns) > 0:
@@ -654,7 +713,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                 venue=exchange
             )
             
-        except DataBentoAuthenticationError as e:
+        except _databento_auth_error_class() as e:
             logger.error(colored(f"DataBento authentication failed while getting last price for {asset.symbol}: {e}", "red"))
             raise
         except Exception as e:
@@ -688,7 +747,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
             search_asset = asset if isinstance(asset, tuple) else (asset, Asset("USD", "forex"))
             asset_data = self.pandas_data.get(search_asset)
             df = None
-            if isinstance(asset_data, DataPolars):
+            if isinstance(asset_data, _data_polars_class()):
                 df = asset_data.polars_df
             elif asset_data is not None:
                 df = asset_data.polars_df if hasattr(asset_data, "polars_df") else asset_data.df
@@ -721,7 +780,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
             )
             quote_obj.source = "polars"
             return quote_obj
-        except DataBentoAuthenticationError as exc:
+        except _databento_auth_error_class() as exc:
             logger.error(colored(f"DataBento authentication failed while getting quote for {asset}: {exc}", "red"))
             raise
         except Exception as exc:
@@ -800,7 +859,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
                     logger.warning(f"No data found for {asset.symbol}")
                     result[asset] = None
                     
-            except DataBentoAuthenticationError as e:
+            except _databento_auth_error_class() as e:
                 logger.error(colored(f"DataBento authentication failed while getting bars for {asset}: {e}", "red"))
                 raise
             except Exception as e:
@@ -863,7 +922,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
             asset_data = self.pandas_data[search_asset]
 
             # OPTIMIZATION: If asset_data is DataPolars, work with polars directly to avoid conversion
-            if isinstance(asset_data, DataPolars):
+            if isinstance(asset_data, _data_polars_class()):
                 polars_df = asset_data.polars_df
 
                 if polars_df.height > 0:

--- a/lumibot/backtesting/interactive_brokers_rest_backtesting.py
+++ b/lumibot/backtesting/interactive_brokers_rest_backtesting.py
@@ -1,19 +1,79 @@
+from __future__ import annotations
+
 import logging
 import uuid
 from datetime import datetime, timedelta
+from functools import lru_cache
+from importlib import import_module
 from typing import Optional
 
-import pandas as pd
-
 from lumibot.data_sources import PandasData
-from lumibot.entities import Asset, Data
-import lumibot.tools.ibkr_helper as ibkr_helper
-from lumibot.tools.helpers import parse_timestep_qty_and_unit
-from lumibot.tools.data_downloader_queue_client import set_queue_client_id
+from lumibot.entities import Asset
 
 logger = logging.getLogger(__name__)
 
 _USD_FOREX = Asset("USD", "forex")
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+ibkr_helper = _LazyModule("lumibot.tools.ibkr_helper")
+_DATA_CLASS = None
+_BARS_CLASS = None
+_PARSE_TIMESTEP_QTY_AND_UNIT = None
+
+
+def _data_class():
+    global _DATA_CLASS
+    if _DATA_CLASS is None:
+        from lumibot.entities import Data
+
+        _DATA_CLASS = Data
+    return _DATA_CLASS
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities.bars import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _parse_timestep_qty_and_unit(*args, **kwargs):
+    global _PARSE_TIMESTEP_QTY_AND_UNIT
+    if _PARSE_TIMESTEP_QTY_AND_UNIT is None:
+        from lumibot.tools.helpers import parse_timestep_qty_and_unit
+
+        _PARSE_TIMESTEP_QTY_AND_UNIT = parse_timestep_qty_and_unit
+    return _PARSE_TIMESTEP_QTY_AND_UNIT(*args, **kwargs)
 
 
 class InteractiveBrokersRESTBacktesting(PandasData):
@@ -44,10 +104,13 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         self._timestep = self.MIN_TIMESTEP
         self.exchange = exchange
         self.history_source = history_source
+        self.market = kwargs.get("market")
 
         unique_id = uuid.uuid4().hex[:8]
         strategy_name = kwargs.get("name", "Backtest")
         client_id = f"{strategy_name}_{unique_id}"
+        from lumibot.tools.data_downloader_queue_client import set_queue_client_id
+
         set_queue_client_id(client_id)
         logger.info("[IBKR][QUEUE] Set client_id for queue fairness: %s", client_id)
 
@@ -101,14 +164,89 @@ class InteractiveBrokersRESTBacktesting(PandasData):
           not collide with "minute".
         - Keeps the `Data.timestep` base unit as "minute"/"day" for compatibility.
         """
-        qty, unit = parse_timestep_qty_and_unit(timestep)
+        if timestep in {"minute", "day", "hour"}:
+            return timestep
+        qty, unit = _parse_timestep_qty_and_unit(timestep)
         qty = int(qty)
         unit = str(unit)
         if qty == 1:
             return unit
         return f"{qty}{unit}"
 
+    def get_historical_prices(
+        self,
+        asset: Asset,
+        length: int,
+        timestep: str = None,
+        timeshift: int = None,
+        quote: Asset = None,
+        exchange: str = None,
+        include_after_hours: bool = True,
+        return_polars: bool = False,
+    ):
+        """Get bars for a given asset, with a hot path for fully prefetched IBKR series."""
+        if isinstance(asset, str):
+            asset = Asset(symbol=asset)
+
+        if not timestep:
+            timestep = self.get_timestep()
+
+        asset_separated = asset
+        quote_asset = quote
+        if isinstance(asset_separated, tuple):
+            asset_separated, quote_asset = asset_separated
+
+        quote_key = quote_asset if quote_asset is not None else _USD_FOREX
+        effective_exchange = exchange if exchange is not None else self.exchange
+        timestep_key = timestep if isinstance(timestep, str) else str(timestep)
+        hot_cache = getattr(self, "_fully_loaded_hot_data_cache", None)
+        if hot_cache is not None:
+            data = hot_cache.get((id(asset_separated), id(quote_key), timestep_key, effective_exchange))
+            if data is not None:
+                try:
+                    if timeshift is None and timestep in {"minute", "day"}:
+                        response = data.get_native_bars_fast(self._datetime, length=length, timestep=timestep)
+                    else:
+                        response = data.get_bars(self._datetime, length=length, timestep=timestep, timeshift=timeshift)
+                except ValueError:
+                    return None
+                if isinstance(response, float) or response is None:
+                    return response
+                if (
+                    not return_polars
+                    and isinstance(response, pd.DataFrame)
+                    and response.attrs.get("_lumibot_skip_timezone", False)
+                    and "return" in response.columns
+                    and "dividend" not in response.columns
+                ):
+                    return _bars_class().from_pandas_fast(
+                        response,
+                        self.SOURCE,
+                        asset_separated,
+                        quote=quote_asset,
+                        raw=response,
+                    )
+                return self._parse_source_symbol_bars(
+                    response,
+                    asset,
+                    quote=quote,
+                    length=length,
+                    return_polars=return_polars,
+                )
+
+        return super().get_historical_prices(
+            asset,
+            length,
+            timestep=timestep,
+            timeshift=timeshift,
+            quote=quote,
+            exchange=exchange,
+            include_after_hours=include_after_hours,
+            return_polars=return_polars,
+        )
+
     @staticmethod
+    @lru_cache(maxsize=256)
     def _previous_us_futures_session_open(dt_value: datetime) -> Optional[datetime]:
         """Return the most recent `us_futures` session open at or before `dt_value`.
 
@@ -161,8 +299,12 @@ class InteractiveBrokersRESTBacktesting(PandasData):
 
         effective_exchange = exchange if exchange is not None else self.exchange
 
-        asset_type = self._normalize_asset_type(getattr(base_asset, "asset_type", ""))
-        now = self.get_datetime()
+        raw_asset_type = getattr(base_asset, "asset_type", "")
+        if raw_asset_type in {"crypto", "future", "cont_future", "stock", "index"}:
+            asset_type = raw_asset_type
+        else:
+            asset_type = self._normalize_asset_type(raw_asset_type)
+        now = self._datetime
         # Futures backtests should not look ahead into the current (incomplete) bar. Interpret
         # "last price at dt" as the last completed bar's close by nudging dt slightly earlier.
         #
@@ -193,6 +335,9 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             day_data = self._data_store.get(day_key)
             if day_data is not None:
                 try:
+                    get_last_price_fast = getattr(day_data, "get_last_price_fast", None)
+                    if callable(get_last_price_fast):
+                        return get_last_price_fast(now)
                     return day_data.get_last_price(now)
                 except Exception:
                     pass
@@ -205,6 +350,9 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             day_data = self._data_store.get(day_key)
             if day_data is not None:
                 try:
+                    get_last_price_fast = getattr(day_data, "get_last_price_fast", None)
+                    if callable(get_last_price_fast):
+                        return get_last_price_fast(now)
                     return day_data.get_last_price(now)
                 except Exception:
                     pass
@@ -226,8 +374,13 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             self._fully_loaded_series.add(minute_key)
         data = self._data_store.get(minute_key)
         if data is not None:
+            hot_cache = getattr(self, "_fully_loaded_hot_data_cache", None)
+            if hot_cache is None:
+                hot_cache = {}
+                self._fully_loaded_hot_data_cache = hot_cache
+            hot_cache[(id(base_asset), id(quote_asset), "minute", effective_exchange)] = data
             try:
-                return data.get_last_price(now)
+                return data.get_last_price_fast(now)
             except Exception:
                 pass
         return None
@@ -390,10 +543,21 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         # `Data` supports only base units ("minute"/"day"). Store multi-minute datasets under a
         # separate key (e.g., "15minute") and annotate the instance so it can fast-path slices
         # without resampling on every call.
-        qty, unit = parse_timestep_qty_and_unit(dataset_key)
+        qty, unit = _parse_timestep_qty_and_unit(dataset_key)
         unit = str(unit)
         data_timestep = unit if unit in {"minute", "day"} else "minute"
-        data = Data(asset, merged, timestep=data_timestep, quote=quote)
+        assume_clean = bool(
+            isinstance(merged, pd.DataFrame)
+            and isinstance(merged.index, pd.DatetimeIndex)
+            and merged.index.tz is not None
+            and merged.index.is_monotonic_increasing
+            and all(col in merged.columns for col in ("open", "high", "low", "close", "volume"))
+        )
+        data = _data_class()(asset, merged, timestep=data_timestep, quote=quote, assume_clean=assume_clean)
+        if dataset_key in {"minute", "day"}:
+            data._defer_clean_returns = True
+        if dataset_key == "day":
+            data._skip_clean_datalines = True
         data._native_timestep_quantity = int(qty)  # type: ignore[attr-defined]
         data._native_timestep_unit = unit  # type: ignore[attr-defined]
         # CRITICAL: Pandas backtesting expects each Data object to have `iter_index`/datalines
@@ -409,7 +573,8 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         # See: docs/BACKTESTING_SESSION_GAPS_AND_DATA_GAPS.md
         try:
             if isinstance(merged.index, pd.DatetimeIndex) and len(merged.index) > 0:
-                data.repair_times_and_fill(merged.index)
+                if not data._initialize_clean_repaired_state():
+                    data.repair_times_and_fill(merged.index)
         except Exception:
             # Fallback: if repair fails, leave data as-is (callers will treat as missing).
             pass
@@ -438,26 +603,54 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         if timestep is None:
             timestep = self.get_timestep()
 
-        dataset_key = self._normalize_timestep_key(timestep)
-        end_dt = self.get_datetime()
+        end_dt = self._datetime
 
         # PERF: warm-cache minute backtests call `_pull_source_symbol_bars()` in tight loops. Once a
         # (asset, quote, timestep) series has been prefetched for the full backtest window, we can
         # skip start/end datetime calculations and downloader bookkeeping and slice immediately.
         quote_key = quote_asset if quote_asset is not None else _USD_FOREX
         effective_exchange = exchange if exchange is not None else self.exchange
+        timestep_key = timestep if isinstance(timestep, str) else str(timestep)
+        hot_cache_key = (id(asset_separated), id(quote_key), timestep_key, effective_exchange)
+        hot_cache = getattr(self, "_fully_loaded_hot_data_cache", None)
+        if hot_cache is not None:
+            data = hot_cache.get(hot_cache_key)
+            if data is not None:
+                try:
+                    return data.get_bars(end_dt, length=length, timestep=timestep, timeshift=timeshift)
+                except ValueError:
+                    return None
+        dataset_key = self._normalize_timestep_key(timestep)
         exchange_key = self._normalize_exchange_key(effective_exchange)
         fully_loaded_key = (asset_separated, quote_key, dataset_key, exchange_key)
         if fully_loaded_key in self._fully_loaded_series:
-            canonical_key, legacy_key = self._build_dataset_keys(asset_separated, quote_asset, dataset_key, effective_exchange)
-            data = self._data_store.get(canonical_key)
-            if data is None and dataset_key == "minute":
-                data = self._data_store.get(legacy_key)
+            data_cache = getattr(self, "_fully_loaded_data_cache", None)
+            if data_cache is None:
+                data_cache = {}
+                self._fully_loaded_data_cache = data_cache
+
+            data = data_cache.get(fully_loaded_key)
+            if data is None:
+                canonical_key, legacy_key = self._build_dataset_keys(
+                    asset_separated,
+                    quote_asset,
+                    dataset_key,
+                    effective_exchange,
+                )
+                data = self._data_store.get(canonical_key)
+                if data is None and dataset_key == "minute":
+                    data = self._data_store.get(legacy_key)
+                if data is not None:
+                    data_cache[fully_loaded_key] = data
+                    hot_cache = getattr(self, "_fully_loaded_hot_data_cache", None)
+                    if hot_cache is None:
+                        hot_cache = {}
+                        self._fully_loaded_hot_data_cache = hot_cache
+                    hot_cache[hot_cache_key] = data
             if data is None:
                 return None
-            now = self.get_datetime()
             try:
-                return data.get_bars(now, length=length, timestep=timestep, timeshift=timeshift)
+                return data.get_bars(end_dt, length=length, timestep=timestep, timeshift=timeshift)
             except ValueError:
                 return None
 
@@ -478,7 +671,7 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             quote_key = quote_asset if quote_asset is not None else _USD_FOREX
             key = (asset_separated, quote_key, dataset_key, exchange_key)
             if key not in self._fully_loaded_series:
-                prev_open = self._previous_us_futures_session_open(self.datetime_start)
+                prev_open = None if self.market == "24/7" else self._previous_us_futures_session_open(self.datetime_start)
                 if prev_open is not None:
                     prefetch_start = min(start_dt, prev_open)
                 else:
@@ -608,6 +801,12 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             data = self._data_store.get(legacy_key)
         if data is None:
             return None
+        if fully_loaded_key in self._fully_loaded_series:
+            hot_cache = getattr(self, "_fully_loaded_hot_data_cache", None)
+            if hot_cache is None:
+                hot_cache = {}
+                self._fully_loaded_hot_data_cache = hot_cache
+            hot_cache[hot_cache_key] = data
 
         now = self.get_datetime()
         try:
@@ -636,7 +835,7 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             return None
 
         dataset_key = self._normalize_timestep_key(timestep)
-        qty, unit = parse_timestep_qty_and_unit(dataset_key)
+        qty, unit = _parse_timestep_qty_and_unit(dataset_key)
         unit = str(unit or "").strip().lower()
         asset_type = self._normalize_asset_type(getattr(asset_separated, "asset_type", ""))
         include_after_hours = self._ibkr_include_after_hours(asset_type, unit)

--- a/lumibot/backtesting/polygon_backtesting.py
+++ b/lumibot/backtesting/polygon_backtesting.py
@@ -1,20 +1,81 @@
+from __future__ import annotations
+
 import traceback
 from collections import OrderedDict
 from datetime import timedelta
 from decimal import Decimal
+from importlib import import_module
 from typing import Union
 
-from polygon.exceptions import BadResponse
 from termcolor import colored
 
 from lumibot.tools.lumibot_logger import get_logger
 from lumibot.data_sources import PandasData
-from lumibot.entities import Asset, Data
-from lumibot.tools import polygon_helper
-from lumibot.tools.polygon_helper import PolygonClient
+from lumibot.entities import Asset
 
 logger = get_logger(__name__)
 START_BUFFER = timedelta(days=5)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+polygon_helper = _LazyModule("lumibot.tools.polygon_helper")
+_POLYGON_CLIENT_CLASS = None
+_BAD_RESPONSE_CLASS = None
+_DATA_CLASS = None
+
+
+def _polygon_client_class():
+    global _POLYGON_CLIENT_CLASS
+    if _POLYGON_CLIENT_CLASS is None:
+        from lumibot.tools.polygon_helper import PolygonClient
+
+        _POLYGON_CLIENT_CLASS = PolygonClient
+    return _POLYGON_CLIENT_CLASS
+
+
+def _bad_response_class():
+    global _BAD_RESPONSE_CLASS
+    if _BAD_RESPONSE_CLASS is None:
+        from polygon.exceptions import BadResponse
+
+        _BAD_RESPONSE_CLASS = BadResponse
+    return _BAD_RESPONSE_CLASS
+
+
+def _data_class():
+    global _DATA_CLASS
+    if _DATA_CLASS is None:
+        from lumibot.entities import Data
+
+        _DATA_CLASS = Data
+    return _DATA_CLASS
+
 
 class PolygonDataBacktesting(PandasData):
     """
@@ -43,7 +104,7 @@ class PolygonDataBacktesting(PandasData):
         # Store errors CSV path for use in data retrieval
 
         # RESTClient API for Polygon.io polygon-api-client
-        self.polygon_client = PolygonClient.create(api_key=api_key)
+        self.polygon_client = _polygon_client_class().create(api_key=api_key)
 
     def _enforce_storage_limit(pandas_data: OrderedDict):
         storage_used = sum(data.df.memory_usage().sum() for data in pandas_data.values())
@@ -138,7 +199,7 @@ class PolygonDataBacktesting(PandasData):
                 timespan=ts_unit,
                 quote_asset=quote_asset
             )
-        except BadResponse as e:
+        except _bad_response_class() as e:
             # Assuming e.message or similar attribute contains the error message
             formatted_start_datetime = start_datetime.strftime("%Y-%m-%d")
             formatted_end_datetime = self.datetime_end.strftime("%Y-%m-%d")
@@ -180,7 +241,7 @@ class PolygonDataBacktesting(PandasData):
 
         if (df is None) or df.empty:
             return
-        data = Data(asset_separated, df, timestep=ts_unit, quote=quote_asset)
+        data = _data_class()(asset_separated, df, timestep=ts_unit, quote=quote_asset)
         pandas_data_update = self._set_pandas_data_keys([data])
         # Add the keys to the self.pandas_data dictionary
         self.pandas_data.update(pandas_data_update)

--- a/lumibot/backtesting/routed_backtesting.py
+++ b/lumibot/backtesting/routed_backtesting.py
@@ -5,21 +5,65 @@ import os
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from importlib import import_module
 from typing import Any, Dict, Optional
-
-import pandas as pd
 
 from lumibot.backtesting.thetadata_backtesting_pandas import ThetaDataBacktestingPandas
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
-from lumibot.credentials import ALPACA_CONFIG, COINBASE_CONFIG, KRAKEN_CONFIG, POLYGON_API_KEY
-from lumibot.entities import Asset, Data
-from lumibot.tools import ibkr_helper
-from lumibot.tools import polygon_helper
+from lumibot.entities import Asset
 from lumibot.tools.helpers import parse_timestep_qty_and_unit
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_QUOTE_ASSET = Asset("USD", "forex")
+_DATA_CLASS = None
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+ibkr_helper = _LazyModule("lumibot.tools.ibkr_helper")
+polygon_helper = _LazyModule("lumibot.tools.polygon_helper")
+
+
+def _credential(name: str):
+    import lumibot.credentials as credentials
+
+    return getattr(credentials, name)
+
+
+def _data_class():
+    global _DATA_CLASS
+    if _DATA_CLASS is None:
+        from lumibot.entities import Data
+
+        _DATA_CLASS = Data
+    return _DATA_CLASS
 
 
 class RoutingProviderError(ValueError):
@@ -82,9 +126,9 @@ def _infer_default_ccxt_exchange_id() -> str:
         if resolved:
             return resolved
 
-    if (COINBASE_CONFIG.get("apiKey") or "").strip():
+    if (_credential("COINBASE_CONFIG").get("apiKey") or "").strip():
         return "coinbase"
-    if (KRAKEN_CONFIG.get("apiKey") or "").strip():
+    if (_credential("KRAKEN_CONFIG").get("apiKey") or "").strip():
         return "kraken"
     return "binance"
 
@@ -280,7 +324,7 @@ class _DataFrameRoutingAdapter(_RoutingAdapter):
         else:
             merged = df
 
-        data = Data(asset, merged, timestep=ts_unit, quote=quote_asset)
+        data = _data_class()(asset, merged, timestep=ts_unit, quote=quote_asset)
         self._router._data_store[canonical_key] = data
         if legacy_key not in self._router._data_store:
             self._router._data_store[legacy_key] = data
@@ -575,7 +619,7 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
         # a separate key (e.g., "60minute") and annotate the instance so `Data.get_bars()` can
         # slice directly without resampling each iteration.
         data_timestep = unit if unit in {"minute", "hour", "day"} else "minute"
-        data = Data(asset, merged, timestep=data_timestep, quote=quote_asset)
+        data = _data_class()(asset, merged, timestep=data_timestep, quote=quote_asset)
         data._native_timestep_quantity = int(qty)  # type: ignore[attr-defined]
         data._native_timestep_unit = unit  # type: ignore[attr-defined]
         try:
@@ -720,7 +764,7 @@ class _PolygonRoutingAdapter(_DataFrameRoutingAdapter):
         require_quote_data: bool,
         require_ohlc_data: bool,
     ) -> pd.DataFrame | None:
-        polygon_key = (os.environ.get("POLYGON_API_KEY") or POLYGON_API_KEY or "").strip()
+        polygon_key = (os.environ.get("POLYGON_API_KEY") or _credential("POLYGON_API_KEY") or "").strip()
         if not polygon_key:
             raise RoutingProviderError("Routing selected Polygon but POLYGON_API_KEY is not configured.")
 
@@ -797,9 +841,10 @@ class _AlpacaRoutingAdapter(_DataFrameRoutingAdapter):
         require_ohlc_data: bool,
     ) -> pd.DataFrame | None:
         if self._source is None:
+            alpaca_config = _credential("ALPACA_CONFIG")
             if not (
-                ALPACA_CONFIG.get("OAUTH_TOKEN")
-                or (ALPACA_CONFIG.get("API_KEY") and ALPACA_CONFIG.get("API_SECRET"))
+                alpaca_config.get("OAUTH_TOKEN")
+                or (alpaca_config.get("API_KEY") and alpaca_config.get("API_SECRET"))
             ):
                 raise RoutingProviderError(
                     "Routing selected Alpaca but Alpaca credentials are not configured. "
@@ -810,7 +855,7 @@ class _AlpacaRoutingAdapter(_DataFrameRoutingAdapter):
             self._source = AlpacaBacktesting(
                 datetime_start=self._router.datetime_start,
                 datetime_end=self._router.datetime_end,
-                config=ALPACA_CONFIG,
+                config=alpaca_config,
                 show_progress_bar=False,
             )
 

--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import math
@@ -5,17 +7,65 @@ import os
 import subprocess
 from datetime import date, datetime, timedelta
 from decimal import Decimal
-from typing import Dict, List, Optional, Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-import pandas as pd
 import pytz
 
-from lumibot.credentials import THETADATA_CONFIG
 from lumibot.data_sources import PandasData
-from lumibot.entities import Asset, AssetsMapping, Data
-from lumibot.tools import thetadata_helper
+from lumibot.entities import Asset, AssetsMapping
+
+if TYPE_CHECKING:
+    from lumibot.entities import Data
 
 logger = logging.getLogger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+thetadata_helper = _LazyModule("lumibot.tools.thetadata_helper")
+_DATA_CLASS = None
+
+
+def _thetadata_config():
+    from lumibot.credentials import THETADATA_CONFIG
+
+    return THETADATA_CONFIG
+
+
+def _data_class():
+    global _DATA_CLASS
+    if _DATA_CLASS is None:
+        from lumibot.entities import Data
+
+        _DATA_CLASS = Data
+    return _DATA_CLASS
 
 
 def _parity_log(message: str, *args) -> None:
@@ -132,10 +182,11 @@ class ThetaDataBacktestingPandas(PandasData):
         self._cadence_last_dt = None
         self._observed_intraday_cadence = False
 
+        config = _thetadata_config()
         if username is None:
-            username = THETADATA_CONFIG.get("THETADATA_USERNAME")
+            username = config.get("THETADATA_USERNAME")
         if password is None:
-            password = THETADATA_CONFIG.get("THETADATA_PASSWORD")
+            password = config.get("THETADATA_PASSWORD")
         if username is None or password is None:
             logger.warning("ThetaData credentials are not configured; ThetaTerminal may fail to authenticate.")
 
@@ -2261,7 +2312,7 @@ class ThetaDataBacktestingPandas(PandasData):
                     data_start_candidate,
                     data_end_candidate,
                 ) = _process_frame(merged_df)
-        data = Data(asset_separated, cleaned_df, timestep=ts_unit, quote=quote_asset)
+        data = _data_class()(asset_separated, cleaned_df, timestep=ts_unit, quote=quote_asset)
         # For minute data we want strict cache boundary enforcement so missing bars force a refresh.
         # For daily data, the backtester queries intraday timestamps (09:30/16:00) while the latest
         # completed daily bar represents the prior session; allow Data.check_data's tolerance window.

--- a/lumibot/data_sources/alpaca_data.py
+++ b/lumibot/data_sources/alpaca_data.py
@@ -1,34 +1,117 @@
+from __future__ import annotations
+
 import datetime as dt
 import os
 from decimal import Decimal
-from typing import Optional, Union, List, Dict
-import os
-import datetime as dt
-import pandas as pd
-import pytz
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-import pandas as pd
 import pytz
-from alpaca.data.enums import Adjustment
-from alpaca.data.historical import CryptoHistoricalDataClient, OptionHistoricalDataClient, StockHistoricalDataClient
-from alpaca.data.requests import (
-    CryptoBarsRequest,
-    OptionBarsRequest,
-    OptionChainRequest,
-    OptionSnapshotRequest,
-    StockBarsRequest,
-)
-from alpaca.data.timeframe import TimeFrame
 
 from lumibot.constants import LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL, LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE
-from lumibot.entities import Asset, Bars, Quote
+from lumibot.entities import Asset, Quote
 from lumibot.tools.alpaca_helpers import sanitize_base_and_quote_asset
-from lumibot.tools.helpers import date_n_trading_days_from_date
 from lumibot.tools.lumibot_logger import get_logger
 
 from .data_source import DataSource
 
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
+
 logger = get_logger(__name__)
+
+Adjustment = None
+CryptoHistoricalDataClient = None
+OptionHistoricalDataClient = None
+StockHistoricalDataClient = None
+CryptoBarsRequest = None
+OptionBarsRequest = None
+OptionChainRequest = None
+OptionSnapshotRequest = None
+StockBarsRequest = None
+TimeFrame = None
+TimeFrameUnit = None
+_DATE_N_TRADING_DAYS_FROM_DATE = None
+_BARS_CLASS = None
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+
+
+_ALPACA_ATTR_MODULES = {
+    "Adjustment": "alpaca.data.enums",
+    "CryptoHistoricalDataClient": "alpaca.data.historical",
+    "OptionHistoricalDataClient": "alpaca.data.historical",
+    "StockHistoricalDataClient": "alpaca.data.historical",
+    "CryptoBarsRequest": "alpaca.data.requests",
+    "OptionBarsRequest": "alpaca.data.requests",
+    "OptionChainRequest": "alpaca.data.requests",
+    "OptionSnapshotRequest": "alpaca.data.requests",
+    "StockBarsRequest": "alpaca.data.requests",
+    "TimeFrame": "alpaca.data.timeframe",
+    "TimeFrameUnit": "alpaca.data.timeframe",
+}
+
+
+def _get_alpaca_attr(name):
+    value = globals().get(name)
+    if value is None:
+        module = import_module(_ALPACA_ATTR_MODULES[name])
+        value = getattr(module, name)
+        globals()[name] = value
+    return value
+
+
+def _date_n_trading_days_from_date(*args, **kwargs):
+    global _DATE_N_TRADING_DAYS_FROM_DATE
+    if _DATE_N_TRADING_DAYS_FROM_DATE is None:
+        from lumibot.tools.helpers import date_n_trading_days_from_date
+
+        _DATE_N_TRADING_DAYS_FROM_DATE = date_n_trading_days_from_date
+    return _DATE_N_TRADING_DAYS_FROM_DATE(*args, **kwargs)
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _timeframe_from_source_value(value):
+    text = str(value)
+    amount_text = "".join(ch for ch in text if ch.isdigit()) or "1"
+    unit_text = text[len(amount_text):]
+    amount = int(amount_text)
+    timeframe = _get_alpaca_attr("TimeFrame")
+    unit_enum = _get_alpaca_attr("TimeFrameUnit")
+    if unit_text == "Min":
+        return timeframe.Minute if amount == 1 else timeframe(amount, unit_enum.Minute)
+    if unit_text == "Hour":
+        return timeframe.Hour if amount == 1 else timeframe(amount, unit_enum.Hour)
+    if unit_text == "Day":
+        return timeframe.Day if amount == 1 else timeframe(amount, unit_enum.Day)
+    return value
 
 
 class AlpacaData(DataSource):
@@ -37,59 +120,59 @@ class AlpacaData(DataSource):
     TIMESTEP_MAPPING = [
         {
             "timestep": "minute",
-            "representations": [TimeFrame.Minute, "minute"],
+            "representations": ["1Min", "minute"],
         },
         {
             "timestep": "5 minutes",
             "representations": [
-                [f"5{TimeFrame.Minute}", "minute"],
+                "5Min",
             ],
         },
         {
             "timestep": "10 minutes",
             "representations": [
-                [f"10{TimeFrame.Minute}", "minute"],
+                "10Min",
             ],
         },
         {
             "timestep": "15 minutes",
             "representations": [
-                [f"15{TimeFrame.Minute}", "minute"],
+                "15Min",
             ],
         },
         {
             "timestep": "30 minutes",
             "representations": [
-                [f"30{TimeFrame.Minute}", "minute"],
+                "30Min",
             ],
         },
         {
             "timestep": "hour",
             "representations": [
-                [f"{TimeFrame.Hour}", "hour"],
+                "1Hour",
             ],
         },
         {
             "timestep": "1 hour",
             "representations": [
-                [f"{TimeFrame.Hour}", "hour"],
+                "1Hour",
             ],
         },
         {
             "timestep": "2 hours",
             "representations": [
-                [f"2{TimeFrame.Hour}", "hour"],
+                "2Hour",
             ],
         },
         {
             "timestep": "4 hours",
             "representations": [
-                [f"4{TimeFrame.Hour}", "hour"],
+                "4Hour",
             ],
         },
         {
             "timestep": "day",
-            "representations": [TimeFrame.Day, "day"],
+            "representations": ["1Day", "day"],
         },
     ]
     LUMIBOT_DEFAULT_QUOTE_ASSET = Asset(LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL, LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE)
@@ -99,6 +182,10 @@ class AlpacaData(DataSource):
     @staticmethod
     def _format_datetime(dt):
         return pd.Timestamp(dt).isoformat()
+
+    def _parse_source_timestep(self, timestep, reverse=False):
+        parsed = super()._parse_source_timestep(str(timestep), reverse=reverse)
+        return _timeframe_from_source_value(parsed) if reverse else parsed
 
     def _handle_auth_error(self, e, operation="data request"):
         """
@@ -160,10 +247,11 @@ class AlpacaData(DataSource):
         """Lazily initialize and return the stock client."""
         if self._stock_client is None:
             try:
+                stock_client_class = _get_alpaca_attr("StockHistoricalDataClient")
                 if self.oauth_token:
-                    self._stock_client = StockHistoricalDataClient(oauth_token=self.oauth_token)
+                    self._stock_client = stock_client_class(oauth_token=self.oauth_token)
                 else:
-                    self._stock_client = StockHistoricalDataClient(self.api_key, self.api_secret)
+                    self._stock_client = stock_client_class(self.api_key, self.api_secret)
             except Exception as e:
                 # Check if this is specifically an authentication error
                 error_message = str(e).lower()
@@ -182,10 +270,11 @@ class AlpacaData(DataSource):
         """Lazily initialize and return the crypto client."""
         if self._crypto_client is None:
             try:
+                crypto_client_class = _get_alpaca_attr("CryptoHistoricalDataClient")
                 if self.oauth_token:
-                    self._crypto_client = CryptoHistoricalDataClient(oauth_token=self.oauth_token)
+                    self._crypto_client = crypto_client_class(oauth_token=self.oauth_token)
                 else:
-                    self._crypto_client = CryptoHistoricalDataClient(self.api_key, self.api_secret)
+                    self._crypto_client = crypto_client_class(self.api_key, self.api_secret)
             except Exception as e:
                 # Check if this is specifically an authentication error
                 error_message = str(e).lower()
@@ -204,10 +293,11 @@ class AlpacaData(DataSource):
         """Lazily initialize and return the option client."""
         if self._option_client is None:
             try:
+                option_client_class = _get_alpaca_attr("OptionHistoricalDataClient")
                 if self.oauth_token:
-                    self._option_client = OptionHistoricalDataClient(oauth_token=self.oauth_token)
+                    self._option_client = option_client_class(oauth_token=self.oauth_token)
                 else:
-                    self._option_client = OptionHistoricalDataClient(self.api_key, self.api_secret)
+                    self._option_client = option_client_class(self.api_key, self.api_secret)
             except Exception as e:
                 # Log the actual error without going through auth error handler immediately
                 logger.error(f"Error initializing option client: {e}")
@@ -388,7 +478,8 @@ class AlpacaData(DataSource):
             client = self._get_option_client()
 
             # Use OptionChainRequest with underlying_symbol for stock assets
-            req = OptionChainRequest(
+            option_chain_request = _get_alpaca_attr("OptionChainRequest")
+            req = option_chain_request(
                 underlying_symbol=asset.symbol,
             )
 
@@ -596,7 +687,7 @@ class AlpacaData(DataSource):
         else:
             minutes_per_day = 390
             days_needed = (length // minutes_per_day) + 2  # + buffer
-        start_date = date_n_trading_days_from_date(
+        start_date = _date_n_trading_days_from_date(
             n_days=days_needed,
             start_datetime=end_dt,
             market="NYSE",
@@ -655,14 +746,16 @@ class AlpacaData(DataSource):
                 yield lst[i : i + size]
 
         # Adjustment setting
-        adjustment = Adjustment.ALL if getattr(self, "_auto_adjust", True) else Adjustment.RAW
+        adjustment_enum = _get_alpaca_attr("Adjustment")
+        adjustment = adjustment_enum.ALL if getattr(self, "_auto_adjust", True) else adjustment_enum.RAW
 
         # Stocks batching
         if stock_assets:
             client = self._get_stock_client()
             for chunk in _chunks(stock_assets, chunk_size):
                 syms = [a.symbol for a in chunk]
-                params = StockBarsRequest(
+                stock_bars_request = _get_alpaca_attr("StockBarsRequest")
+                params = stock_bars_request(
                     symbol_or_symbols=syms,
                     timeframe=timeframe,
                     start=start_dt,
@@ -684,7 +777,7 @@ class AlpacaData(DataSource):
                                 cleaned = _clean_df(df_sym, sym)
                                 if cleaned is not None:
                                     asset_obj = next(a for a in chunk if a.symbol == sym)
-                                    result[asset_obj] = Bars(
+                                    result[asset_obj] = _bars_class()(
                                         cleaned,
                                         self.SOURCE,
                                         asset_obj,
@@ -696,7 +789,7 @@ class AlpacaData(DataSource):
                         cleaned = _clean_df(df_multi, sym)
                         if cleaned is not None:
                             asset_obj = chunk[0]
-                            result[asset_obj] = Bars(
+                            result[asset_obj] = _bars_class()(
                                 cleaned,
                                 self.SOURCE,
                                 asset_obj,
@@ -711,7 +804,8 @@ class AlpacaData(DataSource):
             client = self._get_option_client()
             for chunk in _chunks(option_assets, chunk_size):
                 syms = [_option_symbol(a) for a in chunk]
-                params = OptionBarsRequest(
+                option_bars_request = _get_alpaca_attr("OptionBarsRequest")
+                params = option_bars_request(
                     symbol_or_symbols=syms,
                     timeframe=timeframe,
                     start=start_dt,
@@ -732,7 +826,7 @@ class AlpacaData(DataSource):
                                 continue
                             cleaned = _clean_df(df_sym, sym)
                             if cleaned is not None:
-                                result[a] = Bars(
+                                result[a] = _bars_class()(
                                     cleaned,
                                     self.SOURCE,
                                     a,
@@ -743,7 +837,7 @@ class AlpacaData(DataSource):
                         sym = syms[0]
                         cleaned = _clean_df(df_multi, sym)
                         if cleaned is not None:
-                            result[chunk[0]] = Bars(
+                            result[chunk[0]] = _bars_class()(
                                 cleaned,
                                 self.SOURCE,
                                 chunk[0],
@@ -765,7 +859,8 @@ class AlpacaData(DataSource):
                     symbol_fmt = f"{base_asset.symbol}/{quote_asset.symbol}"
                     syms.append(symbol_fmt)
                     asset_map[symbol_fmt] = a
-                params = CryptoBarsRequest(
+                crypto_bars_request = _get_alpaca_attr("CryptoBarsRequest")
+                params = crypto_bars_request(
                     symbol_or_symbols=syms,
                     timeframe=timeframe,
                     start=start_dt,
@@ -787,7 +882,7 @@ class AlpacaData(DataSource):
                             cleaned = _clean_df(df_sym, sym)
                             if cleaned is not None:
                                 a = asset_map[sym]
-                                result[a] = Bars(
+                                result[a] = _bars_class()(
                                     cleaned,
                                     self.SOURCE,
                                     a,
@@ -799,7 +894,7 @@ class AlpacaData(DataSource):
                         cleaned = _clean_df(df_multi, sym)
                         if cleaned is not None:
                             a = asset_map[sym]
-                            result[a] = Bars(
+                            result[a] = _bars_class()(
                                 cleaned,
                                 self.SOURCE,
                                 a,
@@ -884,7 +979,7 @@ class AlpacaData(DataSource):
             minutes_per_day = 390  # ~6.5 hours of trading per day
             days_needed = (length // minutes_per_day) + 1
 
-        start_date = date_n_trading_days_from_date(
+        start_date = _date_n_trading_days_from_date(
             n_days=days_needed,
             start_datetime=end_dt,
             # TODO: pass market into DataSource
@@ -900,7 +995,8 @@ class AlpacaData(DataSource):
                 client = self._get_crypto_client()
 
                 # noinspection PyArgumentList
-                params = CryptoBarsRequest(
+                crypto_bars_request = _get_alpaca_attr("CryptoBarsRequest")
+                params = crypto_bars_request(
                     symbol_or_symbols=symbol,
                     timeframe=timeframe,
                     start=start_dt,
@@ -915,7 +1011,8 @@ class AlpacaData(DataSource):
                 client = self._get_option_client()
 
                 # noinspection PyArgumentList
-                params = OptionBarsRequest(
+                option_bars_request = _get_alpaca_attr("OptionBarsRequest")
+                params = option_bars_request(
                     symbol_or_symbols=symbol,
                     timeframe=timeframe,
                     start=start_dt,
@@ -928,12 +1025,14 @@ class AlpacaData(DataSource):
                 client = self._get_stock_client()
 
                 # noinspection PyArgumentList
-                params = StockBarsRequest(
+                stock_bars_request = _get_alpaca_attr("StockBarsRequest")
+                adjustment_enum = _get_alpaca_attr("Adjustment")
+                params = stock_bars_request(
                     symbol_or_symbols=symbol,
                     timeframe=timeframe,
                     start=start_dt,
                     end=end_dt,
-                    adjustment=Adjustment.ALL if self._auto_adjust else Adjustment.RAW
+                    adjustment=adjustment_enum.ALL if self._auto_adjust else adjustment_enum.RAW
                 )
                 barset = client.get_stock_bars(params)
 
@@ -985,7 +1084,7 @@ class AlpacaData(DataSource):
         return df
 
     def _parse_source_symbol_bars(self, response, asset, quote=None, length=None):
-        bars = Bars(
+        bars = _bars_class()(
             response,
             self.SOURCE,
             asset,
@@ -1125,11 +1224,13 @@ class AlpacaData(DataSource):
         option_symbol = f"{asset.symbol}{date}{asset.right[0]}{strike_formatted}"
 
         # Initialize the historical data client
+        option_client_class = _get_alpaca_attr("OptionHistoricalDataClient")
         if self.oauth_token:
-            client = OptionHistoricalDataClient(oauth_token=self.oauth_token)
+            client = option_client_class(oauth_token=self.oauth_token)
         else:
-            client = OptionHistoricalDataClient(self.api_key, self.api_secret)
-        request = OptionSnapshotRequest(symbol_or_symbols=option_symbol)
+            client = option_client_class(self.api_key, self.api_secret)
+        option_snapshot_request = _get_alpaca_attr("OptionSnapshotRequest")
+        request = option_snapshot_request(symbol_or_symbols=option_symbol)
         try:
             snapshots = client.get_option_snapshot(request)
             snapshot = snapshots.get(option_symbol)

--- a/lumibot/data_sources/alpha_vantage_data.py
+++ b/lumibot/data_sources/alpha_vantage_data.py
@@ -1,16 +1,48 @@
+from __future__ import annotations
+
 import os.path
 import time
 from datetime import datetime, timedelta
-
-import pandas as pd
+from importlib import import_module
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
-from lumibot.entities import Asset, Bars
+from lumibot.entities import Asset
 from lumibot.tools.lumibot_logger import get_logger
 
 from .data_source import DataSource
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BARS_CLASS = None
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class AlphaVantageData(DataSource):
@@ -141,5 +173,5 @@ class AlphaVantageData(DataSource):
         return result
 
     def _parse_source_symbol_bars(self, response, asset, quote=None, length=None):
-        bars = Bars(response, self.SOURCE, asset, raw=response, quote=quote)
+        bars = _bars_class()(response, self.SOURCE, asset, raw=response, quote=quote)
         return bars

--- a/lumibot/data_sources/bitunix_data.py
+++ b/lumibot/data_sources/bitunix_data.py
@@ -1,11 +1,56 @@
-from typing import Optional
+from __future__ import annotations
 
-import pandas as pd
+from importlib import import_module
+from typing import TYPE_CHECKING, Optional
+
 import pytz
 
 from lumibot.data_sources.data_source import DataSource
-from lumibot.entities import Asset, Bars
-from lumibot.tools.bitunix_helpers import BitUnixClient
+from lumibot.entities import Asset
+
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+BitUnixClient = None
+_BARS_CLASS = None
+
+
+def _bitunix_client_class():
+    global BitUnixClient
+    if BitUnixClient is None:
+        from lumibot.tools.bitunix_helpers import BitUnixClient as _BitUnixClient
+
+        BitUnixClient = _BitUnixClient
+    return BitUnixClient
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class BitunixData(DataSource):
@@ -42,7 +87,7 @@ class BitunixData(DataSource):
             self.api_secret = getattr(config, "API_SECRET", None)
             if not self.api_key or not self.api_secret:
                 raise ValueError("API_KEY and API_SECRET must be provided in config")
-        self.client = BitUnixClient(self.api_key, self.api_secret)
+        self.client = _bitunix_client_class()(self.api_key, self.api_secret)
         # Track symbols we're interested in for WebSocket subscriptions
         self.client_symbols = set()
 
@@ -206,7 +251,7 @@ class BitunixData(DataSource):
         """
         Wraps the raw DataFrame into a Bars entity with source metadata.
         """
-        return Bars(df, self.SOURCE, asset, raw=df, quote=quote)
+        return _bars_class()(df, self.SOURCE, asset, raw=df, quote=quote)
 
     def get_chains(self, asset: Asset, quote: Asset = None, exchange: str = None, strike_count: int = 100) -> dict:
         """Option chains not supported by BitUnix."""

--- a/lumibot/data_sources/ccxt_backtesting_data.py
+++ b/lumibot/data_sources/ccxt_backtesting_data.py
@@ -1,18 +1,63 @@
+from __future__ import annotations
+
 import logging
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any, Dict, Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Dict, Union
 
-import numpy as np
 import pytz
-from pandas import DataFrame
 
 logger = logging.getLogger(__name__)
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.data_sources import DataSourceBacktesting
-from lumibot.entities import Asset, Bars
-from lumibot.tools import CcxtCacheDB
+from lumibot.entities import Asset
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
+    from lumibot.entities import Bars
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+np = _LazyModule("numpy")
+_CCXT_CACHE_DB_CLASS = None
+_BARS_CLASS = None
+
+
+def _ccxt_cache_db_class():
+    global _CCXT_CACHE_DB_CLASS
+    if _CCXT_CACHE_DB_CLASS is None:
+        from lumibot.tools import CcxtCacheDB
+
+        _CCXT_CACHE_DB_CLASS = CcxtCacheDB
+    return _CCXT_CACHE_DB_CLASS
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class CcxtBacktestingData(DataSourceBacktesting):
@@ -43,7 +88,7 @@ class CcxtBacktestingData(DataSourceBacktesting):
         # The number of historical data is downloaded earlier than the start date when downloading historical data.
         self._download_start_dt_prebuffer = 300
 
-        self.cache_db = CcxtCacheDB(self.name,max_download_limit=download_limit)
+        self.cache_db = _ccxt_cache_db_class()(self.name,max_download_limit=download_limit)
 
 
     def _to_utc_timezone(self, dt:datetime)->datetime:
@@ -235,7 +280,7 @@ class CcxtBacktestingData(DataSourceBacktesting):
     def _parse_source_symbol_bars(self, response:DataFrame, asset:tuple[Asset,Asset],
                                   quote:Asset=None, length:int=None)->Bars:
         # Parse the dataframe returned from CCXT.
-        bars = Bars(response, self.SOURCE, asset, quote=quote, raw=response)
+        bars = _bars_class()(response, self.SOURCE, asset, quote=quote, raw=response)
         return bars
 
     def get_last_price(self, asset, timestep=None, quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:

--- a/lumibot/data_sources/ccxt_data.py
+++ b/lumibot/data_sources/ccxt_data.py
@@ -1,17 +1,48 @@
+from __future__ import annotations
+
 import datetime
 import time
 from decimal import Decimal
+from importlib import import_module
 from typing import Union
 
-import ccxt
-import pandas as pd
-
-from lumibot.entities import Asset, Bars
+from lumibot.entities import Asset
 from lumibot.tools.lumibot_logger import get_logger
 
 from .data_source import DataSource
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BARS_CLASS = None
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class CcxtData(DataSource):
@@ -38,6 +69,8 @@ class CcxtData(DataSource):
         # if there is too many assets, the best thing to do would
         # be to split it into chunks and request data for each chunk
         self.chunk_size = min(chunk_size, 100)
+
+        import ccxt
 
         try:
             exchange_class = getattr(ccxt, config["exchange_id"])
@@ -225,7 +258,7 @@ class CcxtData(DataSource):
 
     def _parse_source_symbol_bars(self, response, asset, quote=None, length=None):
         # Parse the dataframe returned from CCXT.
-        bars = Bars(response, self.SOURCE, asset, quote=quote, raw=response)
+        bars = _bars_class()(response, self.SOURCE, asset, quote=quote, raw=response)
         return bars
 
     def get_last_price(self, asset, quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:

--- a/lumibot/data_sources/data_source.py
+++ b/lumibot/data_sources/data_source.py
@@ -1,23 +1,75 @@
+from __future__ import annotations
+
 import os
 import time
 import traceback
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime, timedelta
 from decimal import Decimal
-from typing import Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Union
 
-import pandas as pd
 import pytz
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ, LUMIBOT_DEFAULT_TIMEZONE
-from lumibot.entities import Asset, AssetsMapping, Bars, Quote
-from lumibot.tools import black_scholes, create_options_symbol
-from lumibot.tools.lumibot_logger import get_logger
+from lumibot.entities import Asset, AssetsMapping, Quote
+from lumibot.tools import black_scholes
 
 from .exceptions import UnavailabeTimestep
 
-logger = get_logger(__name__)
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_CREATE_OPTIONS_SYMBOL = None
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        self._logger = None
+
+    def _load(self):
+        if self._logger is None:
+            from lumibot.tools.lumibot_logger import get_logger
+
+            self._logger = get_logger(__name__)
+        return self._logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
+
+
+def _create_options_symbol(*args, **kwargs):
+    global _CREATE_OPTIONS_SYMBOL
+    if _CREATE_OPTIONS_SYMBOL is None:
+        from lumibot.tools import create_options_symbol
+
+        _CREATE_OPTIONS_SYMBOL = create_options_symbol
+    return _CREATE_OPTIONS_SYMBOL(*args, **kwargs)
 
 
 class DataSource(ABC):
@@ -435,6 +487,8 @@ class DataSource(ABC):
 
         results = {}
         # Reuse thread pool to avoid creation/destruction overhead
+        from concurrent.futures import as_completed
+
         executor = self._get_or_create_thread_pool()
         futures = [executor.submit(process_chunk, chunk) for chunk in chunks]
         for future in as_completed(futures):
@@ -629,7 +683,7 @@ class DataSource(ABC):
                     right=right,
                 )
                 query_t = time.perf_counter()
-                option_symbol = create_options_symbol(opt_asset.symbol, expiry_dt, right, strike)
+                option_symbol = _create_options_symbol(opt_asset.symbol, expiry_dt, right, strike)
                 opt_price = self.get_last_price(opt_asset)
                 greeks = self.calculate_greeks(opt_asset, opt_price, underlying_price, risk_free_rate)
                 query_total += time.perf_counter() - query_t

--- a/lumibot/data_sources/data_source_backtesting.py
+++ b/lumibot/data_sources/data_source_backtesting.py
@@ -7,8 +7,18 @@ from collections import deque
 from datetime import datetime, timedelta
 
 from lumibot.data_sources import DataSource
-from lumibot.tools import print_progress_bar, to_datetime_aware
-from lumibot.tools.helpers import get_timezone_from_datetime
+
+_HELPER_FUNCS = {}
+
+
+def _helper_func(name):
+    func = _HELPER_FUNCS.get(name)
+    if func is None:
+        from lumibot import tools
+
+        func = getattr(tools, name)
+        _HELPER_FUNCS[name] = func
+    return func
 
 
 class DataSourceBacktesting(DataSource, ABC):
@@ -65,13 +75,13 @@ class DataSourceBacktesting(DataSource, ABC):
         else:
             _backtesting_started = backtesting_started
 
-        self.datetime_start = to_datetime_aware(datetime_start)
-        self.datetime_end = to_datetime_aware(datetime_end)
+        self.datetime_start = _helper_func("to_datetime_aware")(datetime_start)
+        self.datetime_end = _helper_func("to_datetime_aware")(datetime_end)
         self._datetime = self.datetime_start
         self._iter_count = None
         self.backtesting_started = _backtesting_started
         self.log_backtest_progress_to_file = log_backtest_progress_to_file
-        self.tzinfo = get_timezone_from_datetime(self.datetime_start)
+        self.tzinfo = _helper_func("get_timezone_from_datetime")(self.datetime_start)
         self._eta_history = deque()
         self._eta_window_seconds = 30
         self._eta_calibration_seconds = 25
@@ -330,6 +340,10 @@ class DataSourceBacktesting(DataSource, ABC):
         import json
 
         self._datetime = new_datetime
+        try:
+            self._datetime_minus_microsecond = new_datetime - timedelta(microseconds=1)
+        except Exception:
+            self._datetime_minus_microsecond = None
 
         if not self._show_progress_bar and not self.log_backtest_progress_to_file:
             return
@@ -371,7 +385,7 @@ class DataSourceBacktesting(DataSource, ABC):
 
         if should_print_progress_bar:
             self._last_progress_bar_update = now_wall
-            print_progress_bar(
+            _helper_func("print_progress_bar")(
                 new_datetime,
                 self.datetime_start,
                 self.datetime_end,

--- a/lumibot/data_sources/databento_data.py
+++ b/lumibot/data_sources/databento_data.py
@@ -1,7 +1,26 @@
 """Canonical DataBento data source aliasing the Polars implementation."""
 
-from .databento_data_polars import DataBentoDataPolars as DataBentoData
-from .databento_data_pandas import DataBentoDataPandas
-from .databento_data_polars import DataBentoDataPolars
+from importlib import import_module
 
 __all__ = ["DataBentoData", "DataBentoDataPandas", "DataBentoDataPolars"]
+
+_NAME_TO_IMPORT = {
+    "DataBentoData": ("lumibot.data_sources.databento_data_polars", "DataBentoDataPolars"),
+    "DataBentoDataPolars": ("lumibot.data_sources.databento_data_polars", "DataBentoDataPolars"),
+    "DataBentoDataPandas": ("lumibot.data_sources.databento_data_pandas", "DataBentoDataPandas"),
+}
+
+
+def __getattr__(name):
+    try:
+        module_name, attr_name = _NAME_TO_IMPORT[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    value = getattr(import_module(module_name), attr_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/data_sources/databento_data_pandas.py
+++ b/lumibot/data_sources/databento_data_pandas.py
@@ -1,21 +1,75 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Union, Optional
-
-import pandas as pd
-import polars as pl
+from importlib import import_module
+from typing import TYPE_CHECKING, Optional, Union
 
 from .data_source import DataSource
-from lumibot.entities import Asset, Bars, Quote
-from lumibot.tools import databento_helper, databento_helper_polars
+from lumibot.entities import Asset, Quote
 from lumibot.tools.lumibot_logger import get_logger
 
-try:
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
     from .databento_data_polars import DataBentoDataPolars
-except Exception:  # pragma: no cover - optional dependency path
-    DataBentoDataPolars = None
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+pl = _LazyModule("polars")
+databento_helper = _LazyModule("lumibot.tools.databento_helper")
+databento_helper_polars = _LazyModule("lumibot.tools.databento_helper_polars")
+_BARS_CLASS = None
+_DATABENTO_DATA_POLARS_CLASS = None
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _databento_data_polars_class():
+    global _DATABENTO_DATA_POLARS_CLASS
+    if _DATABENTO_DATA_POLARS_CLASS is None:
+        try:
+            from .databento_data_polars import DataBentoDataPolars
+        except Exception:  # pragma: no cover - optional dependency path
+            return None
+
+        _DATABENTO_DATA_POLARS_CLASS = DataBentoDataPolars
+    return _DATABENTO_DATA_POLARS_CLASS
 
 
 class DataBentoDataPandas(DataSource):
@@ -247,7 +301,7 @@ class DataBentoDataPandas(DataSource):
             return None
 
         # Create and return Bars object
-        bars = Bars(
+        bars = _bars_class()(
             df=df_result,
             source=self.SOURCE,
             asset=asset,
@@ -376,12 +430,13 @@ class DataBentoDataPandas(DataSource):
     def _ensure_live_delegate(self) -> Optional['DataBentoDataPolars']:
         if not self.enable_live_stream:
             return None
-        if DataBentoDataPolars is None or self.is_backtesting_mode:
+        databento_data_polars_class = _databento_data_polars_class()
+        if databento_data_polars_class is None or self.is_backtesting_mode:
             return None
 
         if self._live_delegate is None:
             try:
-                self._live_delegate = DataBentoDataPolars(
+                self._live_delegate = databento_data_polars_class(
                     api_key=self._api_key,
                     has_paid_subscription=True,
                     enable_cache=False,
@@ -425,7 +480,7 @@ class DataBentoDataPandas(DataSource):
                 return None
 
             # Create Bars object
-            bars = Bars(
+            bars = _bars_class()(
                 df=response,
                 source=self.SOURCE,
                 asset=asset,

--- a/lumibot/data_sources/databento_data_polars.py
+++ b/lumibot/data_sources/databento_data_polars.py
@@ -7,36 +7,100 @@ This implementation uses:
 - Correct price conversion from fixed-point format
 """
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
-from typing import Dict, Optional, Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict, Optional
 import time
 import threading
 import queue
 from collections import defaultdict
 
-import polars as pl
-try:
-    import databento as db
-except ImportError:  # pragma: no cover - optional dependency
-    db = None
-
 from .data_source import DataSource
-from .polars_mixin import PolarsMixin
-from lumibot.entities import Asset, Bars, Quote
-from lumibot.tools import databento_helper_polars, futures_roll
-from lumibot.tools.databento_helper_polars import (
-    _ensure_polars_datetime_timezone as _ensure_polars_tz,
-    _ensure_polars_datetime_precision as _ensure_polars_precision,
-    _format_futures_symbol_for_databento,
-    _generate_databento_symbol_alternatives,
-)
+from lumibot.entities import Asset, Quote
 from lumibot.tools.lumibot_logger import get_logger
+
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
 
 logger = get_logger(__name__)
 
 
-class DataBentoDataPolars(PolarsMixin, DataSource):
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pl = _LazyModule("polars")
+databento_helper_polars = _LazyModule("lumibot.tools.databento_helper_polars")
+futures_roll = _LazyModule("lumibot.tools.futures_roll")
+db = None
+_DATABENTO_MODULE = None
+_BARS_CLASS = None
+
+
+def _databento_module():
+    global _DATABENTO_MODULE, db
+    if db is not None:
+        return db
+    if _DATABENTO_MODULE is None:
+        try:
+            _DATABENTO_MODULE = import_module("databento")
+        except ImportError:  # pragma: no cover - optional dependency
+            return None
+    db = _DATABENTO_MODULE
+    return _DATABENTO_MODULE
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _ensure_polars_tz(*args, **kwargs):
+    return databento_helper_polars._ensure_polars_datetime_timezone(*args, **kwargs)
+
+
+def _ensure_polars_precision(*args, **kwargs):
+    return databento_helper_polars._ensure_polars_datetime_precision(*args, **kwargs)
+
+
+def _format_futures_symbol_for_databento(*args, **kwargs):
+    return databento_helper_polars._format_futures_symbol_for_databento(*args, **kwargs)
+
+
+def _generate_databento_symbol_alternatives(*args, **kwargs):
+    return databento_helper_polars._generate_databento_symbol_alternatives(*args, **kwargs)
+
+
+class DataBentoDataPolars(DataSource):
     """
     DataBento data source optimized with Polars and proper Live API usage.
 
@@ -65,7 +129,7 @@ class DataBentoDataPolars(PolarsMixin, DataSource):
         """Initialize DataBento data source with Live API support"""
         super().__init__(api_key=api_key, has_paid_subscription=has_paid_subscription)
 
-        if db is None:
+        if _databento_module() is None:
             raise ImportError("DataBento package not available. Please install with: pip install databento")
 
         # Core configuration
@@ -159,7 +223,7 @@ class DataBentoDataPolars(PolarsMixin, DataSource):
         while not self._stop_streaming and reconnect_attempts < max_reconnect_attempts:
             try:
                 # Create a new client for this producer
-                client = db.Live(key=self._api_key)
+                client = _databento_module().Live(key=self._api_key)
                 
                 logger.debug(f"[DATABENTO][PRODUCER] Subscribing to {symbol} from {start_time.isoformat()}")
                 
@@ -682,7 +746,7 @@ class DataBentoDataPolars(PolarsMixin, DataSource):
             df = df.tail(length)
             df = _ensure_polars_tz(df)
             df = _ensure_polars_precision(df)
-            return Bars(
+            return _bars_class()(
                 df=df,
                 source=self.SOURCE,
                 asset=asset,

--- a/lumibot/data_sources/interactive_brokers_data.py
+++ b/lumibot/data_sources/interactive_brokers_data.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 import datetime
 import math
 from decimal import Decimal
+from importlib import import_module
 from typing import Union
 
-import pandas as pd
-
-from lumibot.entities import Asset, Bars, Quote
+from lumibot.entities import Asset, Quote
 
 from .data_source import DataSource
 
@@ -17,6 +18,37 @@ TYPE_MAP = dict(
     index="IND",
     multileg="BAG",
 )
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BARS_CLASS = None
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class InteractiveBrokersData(DataSource):
@@ -259,7 +291,7 @@ class InteractiveBrokersData(DataSource):
     def _parse_source_symbol_bars(self, response, asset, quote=None, length=None):
         # Catch empty dataframe.
         if isinstance(response, float) or response.empty:
-            bars = Bars(response, self.SOURCE, asset, raw=response)
+            bars = _bars_class()(response, self.SOURCE, asset, raw=response)
             return bars
         df = response.copy()
         # df["date"] = pd.to_datetime(df["date"], unit='s')
@@ -286,7 +318,7 @@ class InteractiveBrokersData(DataSource):
             ]
         ]
 
-        bars = Bars(df, self.SOURCE, asset, raw=response, quote=quote)
+        bars = _bars_class()(df, self.SOURCE, asset, raw=response, quote=quote)
         return bars
 
     def _start_realtime_bars(self, asset, keep_bars=12):

--- a/lumibot/data_sources/interactive_brokers_rest_data.py
+++ b/lumibot/data_sources/interactive_brokers_rest_data.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import os
 import subprocess
 import time
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Union
 
-import requests
-import urllib3
 from termcolor import colored
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
@@ -16,16 +17,15 @@ from lumibot.tools.ibkr_secdef import (
     select_futures_exchange_from_secdef_search_payload,
 )
 
-from ..entities import Asset, Bars
+from ..entities import Asset
 from .data_source import DataSource
+
+if TYPE_CHECKING:
+    from ..entities import Bars
 
 logger = get_logger(__name__)
 import importlib.resources  # Added
 import tempfile  # Added
-
-import pandas as pd
-
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 TYPE_MAP = dict(
     stock="STK",
@@ -35,6 +35,47 @@ TYPE_MAP = dict(
     index="IND",
     multileg="BAG",
 )
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+requests = _LazyModule("requests")
+urllib3 = _LazyModule("urllib3")
+_BARS_CLASS = None
+_URLLIB3_WARNINGS_DISABLED = False
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _disable_urllib3_warnings():
+    global _URLLIB3_WARNINGS_DISABLED
+    if not _URLLIB3_WARNINGS_DISABLED:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        _URLLIB3_WARNINGS_DISABLED = True
 
 
 class InteractiveBrokersRESTData(DataSource):
@@ -442,6 +483,7 @@ class InteractiveBrokersRESTData(DataSource):
 
         while retrying or not allow_fail:
             try:
+                _disable_urllib3_warnings()
                 response = requests.get(url, verify=False)
             except requests.exceptions.RequestException as e:
                 response = requests.Response()
@@ -469,6 +511,7 @@ class InteractiveBrokersRESTData(DataSource):
 
         while retrying or not allow_fail:
             try:
+                _disable_urllib3_warnings()
                 response = requests.post(url, json=json, verify=False)
             except requests.exceptions.RequestException as e:
                 response = requests.Response()
@@ -491,6 +534,7 @@ class InteractiveBrokersRESTData(DataSource):
 
         while retrying or not allow_fail:
             try:
+                _disable_urllib3_warnings()
                 response = requests.delete(url, verify=False)
             except requests.exceptions.RequestException as e:
                 response = requests.Response()
@@ -776,6 +820,7 @@ class InteractiveBrokersRESTData(DataSource):
         exchange_val = str(exchange or "").strip().upper() or self._resolve_futures_exchange(symbol)
         params = {"symbols": symbol, "secType": "CONTFUT", "exchange": exchange_val}
         try:
+            _disable_urllib3_warnings()
             response = requests.get(url, params=params, verify=False)
             if response.status_code != 200:
                 logger.error(colored(f"Failed to retrieve security definition for {symbol}: {response.text}", "red"))
@@ -933,7 +978,7 @@ class InteractiveBrokersRESTData(DataSource):
             timestep = f"{timestep_value}y"
         else:
             logger.error(colored(f"Unsupported timestep: {timestep}", "red"))
-            return Bars(
+            return _bars_class()(
                 pd.DataFrame(
                     columns=["timestamp", "open", "high", "low", "close", "volume"]
                 ),
@@ -957,7 +1002,7 @@ class InteractiveBrokersRESTData(DataSource):
             logger.error(
                 colored(f"Error getting historical prices: {result['error']}", "red")
             )
-            return Bars(
+            return _bars_class()(
                 pd.DataFrame(
                     columns=["timestamp", "open", "high", "low", "close", "volume"]
                 ),
@@ -976,7 +1021,7 @@ class InteractiveBrokersRESTData(DataSource):
                     "red",
                 )
             )
-            return Bars(
+            return _bars_class()(
                 pd.DataFrame(
                     columns=["timestamp", "open", "high", "low", "close", "volume"]
                 ),
@@ -1017,7 +1062,7 @@ class InteractiveBrokersRESTData(DataSource):
         df['stock_splits'] = 0.0
         """
 
-        bars = Bars(df, self.SOURCE, asset, raw=df, quote=quote)
+        bars = _bars_class()(df, self.SOURCE, asset, raw=df, quote=quote)
 
         return bars
 

--- a/lumibot/data_sources/pandas_data.py
+++ b/lumibot/data_sources/pandas_data.py
@@ -1,16 +1,75 @@
+from __future__ import annotations
+
 from collections import OrderedDict, defaultdict
 from datetime import timedelta
 from decimal import Decimal
+from importlib import import_module
 from typing import Union
 
-import pandas as pd
-
 from lumibot.data_sources import DataSourceBacktesting
-from lumibot.entities import Asset, Bars, Quote
-from lumibot.tools.helpers import parse_timestep_qty_and_unit
-from lumibot.tools.lumibot_logger import get_logger
+from lumibot.entities import Asset, Quote
 
-logger = get_logger(__name__)
+_BARS_CLASS = None
+_PARSE_TIMESTEP_QTY_AND_UNIT = None
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        self._logger = None
+
+    def _load(self):
+        if self._logger is None:
+            from lumibot.tools.lumibot_logger import get_logger
+
+            self._logger = get_logger(__name__)
+        return self._logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _parse_timestep_qty_and_unit(*args, **kwargs):
+    global _PARSE_TIMESTEP_QTY_AND_UNIT
+    if _PARSE_TIMESTEP_QTY_AND_UNIT is None:
+        from lumibot.tools.helpers import parse_timestep_qty_and_unit
+
+        _PARSE_TIMESTEP_QTY_AND_UNIT = parse_timestep_qty_and_unit
+    return _PARSE_TIMESTEP_QTY_AND_UNIT(*args, **kwargs)
 
 # PERF: `find_asset_in_data_store()` is called in tight loops (often 200K+ times per backtest). It
 # constructs `Asset("USD", "forex")` as the default quote on every call, which shows up as ~3s of
@@ -412,7 +471,7 @@ class PandasData(DataSourceBacktesting):
             requested_asset_type = requested_asset_type.split(".")[-1]
         if timestep is not None:
             try:
-                qty, requested_unit = parse_timestep_qty_and_unit(str(timestep))
+                qty, requested_unit = _parse_timestep_qty_and_unit(str(timestep))
             except Exception:
                 qty, requested_unit = 1, str(timestep)
                 requested_unit = str(timestep)
@@ -615,7 +674,27 @@ class PandasData(DataSourceBacktesting):
         asset2 = quote
         if isinstance(asset, tuple):
             asset1, asset2 = asset
-        bars = Bars(response, self.SOURCE, asset1, quote=asset2, raw=response, return_polars=return_polars)
+        skip_timezone = bool(getattr(response, "attrs", {}).get("_lumibot_skip_timezone", False))
+        if not skip_timezone and getattr(self, "IS_BACKTESTING_DATA_SOURCE", False):
+            response_index = getattr(response, "index", None)
+            skip_timezone = bool(hasattr(response_index, "tz") and response_index.tz is not None)
+        if (
+            skip_timezone
+            and not return_polars
+            and isinstance(response, pd.DataFrame)
+            and "return" in response.columns
+            and "dividend" not in response.columns
+        ):
+            return _bars_class().from_pandas_fast(response, self.SOURCE, asset1, quote=asset2, raw=response)
+        bars = _bars_class()(
+            response,
+            self.SOURCE,
+            asset1,
+            quote=asset2,
+            raw=response,
+            return_polars=return_polars,
+            skip_timezone=skip_timezone,
+        )
         return bars
 
     def get_yesterday_dividend(self, asset, quote=None):

--- a/lumibot/data_sources/polars_data.py
+++ b/lumibot/data_sources/polars_data.py
@@ -1,16 +1,51 @@
+from __future__ import annotations
+
 from collections import OrderedDict, defaultdict
 from datetime import timedelta
 from decimal import Decimal
-from typing import Union
-
-import pandas as pd
+from importlib import import_module
+from typing import TYPE_CHECKING, Union
 
 from lumibot.data_sources import DataSourceBacktesting
-from lumibot.entities import Asset, Bars, Quote
+from lumibot.entities import Asset
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.tools.lumibot_logger import get_logger
 
+if TYPE_CHECKING:
+    from lumibot.entities import Quote
+
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BARS_CLASS = None
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class PolarsData(DataSourceBacktesting):
@@ -751,7 +786,6 @@ class PolarsData(DataSourceBacktesting):
                 # CRITICAL: Integer timeshift represents BAR offsets, not minute deltas!
                 # Must calculate adjustment based on the actual timestep being requested.
                 if timeshift:
-                    from datetime import timedelta
                     if isinstance(timeshift, int):
                         # Calculate timedelta for one bar of this timestep
                         timestep_delta, _ = self.convert_timestep_str_to_timedelta(timestep)
@@ -886,7 +920,7 @@ class PolarsData(DataSourceBacktesting):
         asset2 = quote
         if isinstance(asset, tuple):
             asset1, asset2 = asset
-        bars = Bars(response, self.SOURCE, asset1, quote=asset2, raw=response, return_polars=return_polars)
+        bars = _bars_class()(response, self.SOURCE, asset1, quote=asset2, raw=response, return_polars=return_polars)
         return bars
 
     def get_yesterday_dividend(self, asset, quote=None):

--- a/lumibot/data_sources/polars_mixin.py
+++ b/lumibot/data_sources/polars_mixin.py
@@ -3,15 +3,32 @@
 This mixin provides common polars operations without disrupting inheritance.
 """
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
-
-import polars as pl
 
 from lumibot.entities import Asset, Bars
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+
+
+class _LazyPolars:
+    _module = None
+
+    def _load(self):
+        if self._module is None:
+            import polars as pl
+
+            self._module = pl
+        return self._module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pl = _LazyPolars()
 
 # DEBUG-LOG: Always-on debug logging (will be removed after debugging is complete)
 _THETA_PARITY_DEBUG = False

--- a/lumibot/data_sources/projectx_data.py
+++ b/lumibot/data_sources/projectx_data.py
@@ -5,20 +5,65 @@ Provides market data functionality through ProjectX data feed.
 Supports historical data retrieval for futures contracts.
 """
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta
-import pandas as pd
-from typing import Dict, List
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict, List
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.data_sources.data_source import DataSource
-from lumibot.entities import Asset, Bars, Quote
+from lumibot.entities import Asset, Quote
 from lumibot.tools.lumibot_logger import get_logger
-from lumibot.tools.projectx_helpers import ProjectXClient
+
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
 
 # Import moved to avoid circular dependency
 # from lumibot.credentials import PROJECTX_CONFIG
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+ProjectXClient = None
+_BARS_CLASS = None
+
+
+def _projectx_client_class():
+    global ProjectXClient
+    if ProjectXClient is None:
+        from lumibot.tools.projectx_helpers import ProjectXClient as _ProjectXClient
+
+        ProjectXClient = _ProjectXClient
+    return ProjectXClient
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
 
 
 class ProjectXData(DataSource):
@@ -79,7 +124,7 @@ class ProjectXData(DataSource):
             )
 
         # Initialize ProjectX client
-        self.client = ProjectXClient(config)
+        self.client = _projectx_client_class()(config)
 
         # Setup logging
         self.logger = get_logger(f"ProjectXData_{self.firm}")
@@ -312,7 +357,7 @@ class ProjectXData(DataSource):
                 logger.debug(debug_msg)
             except Exception as log_exc:
                 self.logger.debug(f"Datetime normalization debug failed for {asset.symbol}: {log_exc}")
-            return Bars(df=df, source=self.SOURCE, asset=asset, raw=df.to_dict())
+            return _bars_class()(df=df, source=self.SOURCE, asset=asset, raw=df.to_dict())
         except Exception as e:
             self.logger.error(f"Error fetching bars for {getattr(asset, 'symbol', asset)}: {e}")
             return None
@@ -576,7 +621,7 @@ class ProjectXData(DataSource):
                 return None
 
             # Create Bars object
-            bars = Bars(
+            bars = _bars_class()(
                 df=df,
                 source=self.SOURCE,
                 asset=asset,

--- a/lumibot/data_sources/schwab_data.py
+++ b/lumibot/data_sources/schwab_data.py
@@ -1,19 +1,75 @@
+from __future__ import annotations
+
 import datetime
 import os
 from datetime import timedelta
 from decimal import Decimal
-from typing import Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Union
 
-import pandas as pd
 from termcolor import colored
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ, LUMIBOT_DEFAULT_TIMEZONE
 from lumibot.data_sources import DataSource
-from lumibot.entities import Asset, Bars, Chains, Quote
-from lumibot.tools import get_trading_days, parse_timestep_qty_and_unit
+from lumibot.entities import Asset, Chains, Quote
 from lumibot.tools.lumibot_logger import get_logger
 
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
+
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BARS_CLASS = None
+_GET_TRADING_DAYS = None
+_PARSE_TIMESTEP_QTY_AND_UNIT = None
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _get_trading_days(*args, **kwargs):
+    global _GET_TRADING_DAYS
+    if _GET_TRADING_DAYS is None:
+        from lumibot.tools import get_trading_days
+
+        _GET_TRADING_DAYS = get_trading_days
+    return _GET_TRADING_DAYS(*args, **kwargs)
+
+
+def _parse_timestep_qty_and_unit(*args, **kwargs):
+    global _PARSE_TIMESTEP_QTY_AND_UNIT
+    if _PARSE_TIMESTEP_QTY_AND_UNIT is None:
+        from lumibot.tools import parse_timestep_qty_and_unit
+
+        _PARSE_TIMESTEP_QTY_AND_UNIT = parse_timestep_qty_and_unit
+    return _PARSE_TIMESTEP_QTY_AND_UNIT(*args, **kwargs)
+
 
 class SchwabData(DataSource):
     """
@@ -280,7 +336,7 @@ class SchwabData(DataSource):
         Returns:
             tuple: (timedelta object, timestep_unit string)
         """
-        qty, unit = parse_timestep_qty_and_unit(timestep_str)
+        qty, unit = _parse_timestep_qty_and_unit(timestep_str)
 
         if unit == "minute":
             return timedelta(minutes=qty), unit
@@ -339,7 +395,7 @@ class SchwabData(DataSource):
         timestep = timestep if timestep else self.MIN_TIMESTEP
 
         # Parse the timestep
-        timestep_qty, timestep_unit = parse_timestep_qty_and_unit(timestep)
+        timestep_qty, timestep_unit = _parse_timestep_qty_and_unit(timestep)
 
         # Calculate end date in Eastern time
         end_date = datetime.datetime.now()
@@ -361,7 +417,7 @@ class SchwabData(DataSource):
             tcal_start_date = end_date - (td * length * 2 + timedelta(days=3))
 
             try:
-                trading_days = get_trading_days(market='NYSE', start_date=tcal_start_date, end_date=end_date)
+                trading_days = _get_trading_days(market='NYSE', start_date=tcal_start_date, end_date=end_date)
                 # Filter out trading days when the market_open is after the end_date
                 trading_days = trading_days[trading_days['market_open'] < end_date]
                 # Now, start_date is the length bars before the last trading day
@@ -488,7 +544,7 @@ class SchwabData(DataSource):
                 df.index = df.index.tz_convert(LUMIBOT_DEFAULT_TIMEZONE)
 
             # Create and return the Bars object
-            bars = Bars(df, self.SOURCE, asset, raw=df, quote=quote)
+            bars = _bars_class()(df, self.SOURCE, asset, raw=df, quote=quote)
             return bars
 
         except Exception as e:

--- a/lumibot/data_sources/tradier_data.py
+++ b/lumibot/data_sources/tradier_data.py
@@ -1,21 +1,92 @@
+from __future__ import annotations
+
 import datetime as dt
 from collections import defaultdict
 from decimal import Decimal
+from importlib import import_module
 from typing import Union
 
-import pandas as pd
 import pytz
-from lumiwealth_tradier import Tradier
 
 from lumibot.constants import LUMIBOT_DEFAULT_TIMEZONE
-from lumibot.entities import Asset, Bars, Quote
+from lumibot.entities import Asset, Quote
 from lumibot.tools import black_scholes
-from lumibot.tools.helpers import create_options_symbol, date_n_trading_days_from_date, parse_timestep_qty_and_unit
 from lumibot.tools.lumibot_logger import get_logger
 
 from .data_source import DataSource
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_TRADIER_CLASS = None
+_BARS_CLASS = None
+_CREATE_OPTIONS_SYMBOL = None
+_DATE_N_TRADING_DAYS_FROM_DATE = None
+_PARSE_TIMESTEP_QTY_AND_UNIT = None
+
+
+def _tradier_class():
+    global _TRADIER_CLASS
+    if _TRADIER_CLASS is None:
+        from lumiwealth_tradier import Tradier
+
+        _TRADIER_CLASS = Tradier
+    return _TRADIER_CLASS
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _create_options_symbol(*args, **kwargs):
+    global _CREATE_OPTIONS_SYMBOL
+    if _CREATE_OPTIONS_SYMBOL is None:
+        from lumibot.tools.helpers import create_options_symbol
+
+        _CREATE_OPTIONS_SYMBOL = create_options_symbol
+    return _CREATE_OPTIONS_SYMBOL(*args, **kwargs)
+
+
+def _date_n_trading_days_from_date(*args, **kwargs):
+    global _DATE_N_TRADING_DAYS_FROM_DATE
+    if _DATE_N_TRADING_DAYS_FROM_DATE is None:
+        from lumibot.tools.helpers import date_n_trading_days_from_date
+
+        _DATE_N_TRADING_DAYS_FROM_DATE = date_n_trading_days_from_date
+    return _DATE_N_TRADING_DAYS_FROM_DATE(*args, **kwargs)
+
+
+def _parse_timestep_qty_and_unit(*args, **kwargs):
+    global _PARSE_TIMESTEP_QTY_AND_UNIT
+    if _PARSE_TIMESTEP_QTY_AND_UNIT is None:
+        from lumibot.tools.helpers import parse_timestep_qty_and_unit
+
+        _PARSE_TIMESTEP_QTY_AND_UNIT = parse_timestep_qty_and_unit
+    return _PARSE_TIMESTEP_QTY_AND_UNIT(*args, **kwargs)
 
 
 class TradierAPIError(Exception):
@@ -98,7 +169,7 @@ class TradierData(DataSource):
         self._account_number = account_number
         self._paper = paper
         self.max_workers = min(max_workers, 50)
-        self.tradier = Tradier(account_number, access_token, paper)
+        self.tradier = _tradier_class()(account_number, access_token, paper)
         self._remove_incomplete_current_bar = remove_incomplete_current_bar
 
     def _sanitize_base_and_quote_asset(self, base_asset, quote_asset) -> tuple[Asset, Asset]:
@@ -234,12 +305,12 @@ class TradierData(DataSource):
         timestep = timestep if timestep else self.MIN_TIMESTEP
 
         # Parse the timestep
-        timestep_qty, timestep_unit = parse_timestep_qty_and_unit(timestep)
+        timestep_qty, timestep_unit = _parse_timestep_qty_and_unit(timestep)
 
         parsed_timestep_unit = self._parse_source_timestep(timestep_unit, reverse=True)
 
         if asset.asset_type == "option":
-            symbol = create_options_symbol(
+            symbol = _create_options_symbol(
                 asset.symbol,
                 asset.expiration,
                 asset.right,
@@ -268,7 +339,7 @@ class TradierData(DataSource):
             minutes_per_day = 24 * 60 / timestep_qty  # Need to include premarket and after hours
             days_needed = int(length // minutes_per_day) + 1
 
-        start_date = date_n_trading_days_from_date(
+        start_date = _date_n_trading_days_from_date(
             n_days=days_needed,
             start_datetime=end_dt,
             # TODO: pass market into DataSource
@@ -331,7 +402,7 @@ class TradierData(DataSource):
             df = df.iloc[-length:]
 
         # Convert the dataframe to a Bars object
-        bars = Bars(df, self.SOURCE, asset, raw=df, quote=quote)
+        bars = _bars_class()(df, self.SOURCE, asset, raw=df, quote=quote)
 
         return bars
 
@@ -357,7 +428,7 @@ class TradierData(DataSource):
         symbol = None
         try:
             if asset.asset_type == "option":
-                symbol = create_options_symbol(
+                symbol = _create_options_symbol(
                     asset.symbol,
                     asset.expiration,
                     asset.right,
@@ -396,7 +467,7 @@ class TradierData(DataSource):
         asset, quote = self._sanitize_base_and_quote_asset(asset, quote)
 
         if asset.asset_type == "option":
-            symbol = create_options_symbol(
+            symbol = _create_options_symbol(
                 asset.symbol,
                 asset.expiration,
                 asset.right,
@@ -446,7 +517,7 @@ class TradierData(DataSource):
         greeks = {}
         stock_symbol = asset.symbol
         expiration = asset.expiration
-        option_symbol = create_options_symbol(stock_symbol, expiration, asset.right, asset.strike)
+        option_symbol = _create_options_symbol(stock_symbol, expiration, asset.right, asset.strike)
         df_chains = self.tradier.market.get_option_chains(stock_symbol, expiration, greeks=True)
         df = df_chains[df_chains["symbol"] == option_symbol]
         if df.empty:

--- a/lumibot/data_sources/tradovate_data.py
+++ b/lumibot/data_sources/tradovate_data.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 from decimal import Decimal
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from termcolor import colored
 
 from lumibot.data_sources import DataSource
-from lumibot.entities import Asset, Bars
+from lumibot.entities import Asset
 from lumibot.tools.lumibot_logger import get_logger
+
+if TYPE_CHECKING:
+    from lumibot.entities import Bars
 
 logger = get_logger(__name__)
 

--- a/lumibot/data_sources/yahoo_data.py
+++ b/lumibot/data_sources/yahoo_data.py
@@ -1,16 +1,57 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from decimal import Decimal
+from importlib import import_module
 from typing import Union
 
-import numpy
-import pandas as pd
-
 from lumibot.data_sources import DataSourceBacktesting
-from lumibot.entities import Asset, Bars
-from lumibot.tools import YahooHelper
+from lumibot.entities import Asset
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+_BARS_CLASS = None
+_YAHOO_HELPER = None
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+numpy = _LazyModule("numpy")
+pd = _LazyModule("pandas")
+
+
+def _bars_class():
+    global _BARS_CLASS
+    if _BARS_CLASS is None:
+        from lumibot.entities import Bars
+
+        _BARS_CLASS = Bars
+    return _BARS_CLASS
+
+
+def _yahoo_helper():
+    global _YAHOO_HELPER
+    if _YAHOO_HELPER is None:
+        from lumibot.tools import YahooHelper
+
+        _YAHOO_HELPER = YahooHelper
+    return _YAHOO_HELPER
 
 
 class YahooData(DataSourceBacktesting):
@@ -254,7 +295,7 @@ class YahooData(DataSourceBacktesting):
         for sym in symbols_to_try:
             logger.info("Attempting to fetch data for symbol: %s", sym)
             try:
-                data = YahooHelper.get_symbol_data(
+                data = _yahoo_helper().get_symbol_data(
                     sym,
                     interval=interval,
                     auto_adjust=self.auto_adjust,
@@ -336,7 +377,7 @@ class YahooData(DataSourceBacktesting):
 
         if missing_assets:
             # Fetch data using the helper without restricting dates here
-            dfs = YahooHelper.get_symbols_data(
+            dfs = _yahoo_helper().get_symbols_data(
                 missing_assets,
                 interval=interval,
                 auto_adjust=self.auto_adjust
@@ -363,7 +404,7 @@ class YahooData(DataSourceBacktesting):
         if quote is not None:
             logger.warning(f"quote is not implemented for YahooData, but {quote} was passed as the quote")
 
-        bars = Bars(response, self.SOURCE, asset, raw=response)
+        bars = _bars_class()(response, self.SOURCE, asset, raw=response)
         return bars
 
     def get_last_price(self, asset, timestep=None, quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:

--- a/lumibot/entities/asset.py
+++ b/lumibot/entities/asset.py
@@ -2,7 +2,7 @@ from collections import UserDict
 from datetime import date, datetime
 from enum import Enum
 
-from lumibot.tools import parse_symbol
+from lumibot.tools.symbol_parser import parse_symbol
 
 
 FUTURES_MONTH_CODES = {

--- a/lumibot/entities/bars.py
+++ b/lumibot/entities/bars.py
@@ -1,14 +1,14 @@
-from datetime import datetime, timedelta
+from __future__ import annotations
+
+from datetime import datetime
+from importlib import import_module
 import re
 import weakref
 from decimal import Decimal
+from types import ModuleType
 from typing import Union, Set
-import warnings
 import atexit
 
-import numpy as np
-import pandas as pd
-import polars as pl
 import pytz
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
@@ -22,6 +22,44 @@ logger = get_logger(__name__)
 # share the same `df.columns` object; cache column presence flags to avoid repeated
 # `Index.__contains__` probes in tight loops.
 _PANDAS_COLUMNS_FLAGS_CACHE: dict[int, tuple[weakref.ReferenceType, tuple[bool, bool, bool, bool]]] = {}
+_POLARS_MODULE = None
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+np = _LazyModule("numpy")
+pd = _LazyModule("pandas")
+
+
+def _get_polars_module():
+    global _POLARS_MODULE
+    if _POLARS_MODULE is None:
+        import polars as _pl
+
+        _POLARS_MODULE = _pl
+    return _POLARS_MODULE
+
+
+def _is_polars_df(value) -> bool:
+    if value.__class__.__name__ != "DataFrame":
+        return False
+    module = getattr(value.__class__, "__module__", "")
+    return module == "polars" or module.startswith("polars.")
 
 
 class PolarsConversionTracker:
@@ -166,7 +204,27 @@ class Bars:
     >>> self.log_message(df["close"][-1])
     """
 
-    def __init__(self, df, source, asset, quote=None, raw=None, return_polars=False, tzinfo=None):
+    @classmethod
+    def from_pandas_fast(cls, df, source, asset, quote=None, raw=None):
+        """Build a pandas-backed Bars object for pre-normalized backtesting slices."""
+        obj = cls.__new__(cls)
+        obj.source = str(source).upper()
+        obj.asset = asset
+        if isinstance(asset, tuple):
+            obj.symbol = f"{asset[0].symbol}/{asset[1].symbol}".upper()
+        else:
+            obj.symbol = asset.symbol.upper()
+        obj.quote = quote
+        obj._raw = raw if raw is not None else df
+        obj._return_polars = False
+        obj._polars_cache = None
+        obj._pandas_cache = None
+        obj._tzinfo = None
+        obj._df = df
+        obj._df_is_pandas = True
+        return obj
+
+    def __init__(self, df, source, asset, quote=None, raw=None, return_polars=False, tzinfo=None, skip_timezone=False):
         """
         df columns: open, high, low, close, volume, dividend, stock_splits
         datetime column for polars DataFrames
@@ -185,13 +243,26 @@ class Bars:
         self._polars_cache = None
         self._pandas_cache = None
         self._tzinfo = self._normalize_tzinfo(tzinfo)
+        self._df_is_pandas = isinstance(df, pd.DataFrame)
+
+        if (
+            skip_timezone
+            and not return_polars
+            and isinstance(df, pd.DataFrame)
+            and "return" in df.columns
+            and "dividend" not in df.columns
+        ):
+            self._df = df
+            return
         
         # Check if empty
-        if (isinstance(df, pl.DataFrame) and df.shape[0] == 0) or \
+        is_polars_df = _is_polars_df(df)
+        if (is_polars_df and df.shape[0] == 0) or \
            (isinstance(df, pd.DataFrame) and df.shape[0] == 0):
             logger.warning(f"Unable to get bar data for {asset} {source}")
         
-        if isinstance(df, pl.DataFrame):
+        if is_polars_df:
+            pl = _get_polars_module()
             # Already polars, process it
             columns = df.columns
             
@@ -324,16 +395,22 @@ class Bars:
                         returns[1:] = (curr - prev) / prev
                 self._df["return"] = returns
 
-            self._apply_timezone()
+            if not skip_timezone:
+                self._apply_timezone()
             if self._return_polars:
                 self._pandas_cache = self._df
                 self._df = self._convert_pandas_to_polars(self._df)
                 self._polars_cache = None
+                self._df_is_pandas = False
 
     @property
     def df(self):
         """Return the active DataFrame representation based on return_polars flag."""
-        return self.polars_df if self._return_polars else self.pandas_df
+        if self._return_polars:
+            return self.polars_df
+        if self._df_is_pandas:
+            return self._df
+        return self.pandas_df
 
     @df.setter
     def df(self, value):
@@ -341,13 +418,14 @@ class Bars:
         self._df = value
         self._polars_cache = None
         self._pandas_cache = None
+        self._df_is_pandas = isinstance(value, pd.DataFrame)
 
         if isinstance(value, pd.DataFrame):
             self._apply_timezone()
             if self._return_polars:
                 self._pandas_cache = value
                 self._df = self._convert_pandas_to_polars(value)
-        elif isinstance(value, pl.DataFrame) and not self._return_polars:
+        elif _is_polars_df(value) and not self._return_polars:
             tracker = PolarsConversionTracker()
             tracker.track_conversion(self.asset.symbol if hasattr(self.asset, 'symbol') else str(self.asset))
             pandas_df = value.to_pandas()
@@ -361,7 +439,7 @@ class Bars:
     @property
     def polars_df(self):
         """Return as Polars DataFrame if needed"""
-        if isinstance(self._df, pl.DataFrame):
+        if _is_polars_df(self._df):
             return self._df
         else:
             # Convert pandas to polars once and cache
@@ -398,17 +476,17 @@ class Bars:
 
     def __len__(self):
         """Return the number of bars (rows) in the DataFrame"""
-        if isinstance(self._df, pl.DataFrame):
+        if _is_polars_df(self._df):
             return self._df.height
         if isinstance(self._df, pd.DataFrame):
             return len(self._df)
         df = self.df
-        return df.height if isinstance(df, pl.DataFrame) else len(df)
+        return df.height if _is_polars_df(df) else len(df)
 
     @property
     def empty(self):
         """Check if the DataFrame is empty (compatible with both pandas and polars)"""
-        if isinstance(self._df, pl.DataFrame):
+        if _is_polars_df(self._df):
             return self._df.is_empty()
         else:
             return self._df.empty
@@ -456,8 +534,9 @@ class Bars:
             self._df = target_df
         return target_df
 
-    def _convert_pandas_to_polars(self, pandas_df: pd.DataFrame) -> pl.DataFrame:
+    def _convert_pandas_to_polars(self, pandas_df: pd.DataFrame):
         """Convert a pandas DataFrame (possibly with datetime index) to Polars."""
+        pl = _get_polars_module()
         df_to_convert = pandas_df.copy()
         if isinstance(df_to_convert.index, pd.DatetimeIndex):
             df_to_convert = df_to_convert.reset_index()
@@ -468,6 +547,7 @@ class Bars:
 
     @classmethod
     def parse_bar_list(cls, bar_list, source, asset):
+        pl = _get_polars_module()
         raw = []
         for bar in bar_list:
             raw.append(bar)
@@ -502,7 +582,8 @@ class Bars:
         """
         result = []
         # Use appropriate DataFrame for iteration
-        if isinstance(self._df, pl.DataFrame):
+        pl = _get_polars_module()
+        if _is_polars_df(self._df):
             underlying_df = self._df
         else:
             underlying_df = pl.from_pandas(self._df.reset_index() if hasattr(self._df, 'index') else self._df)
@@ -586,6 +667,7 @@ class Bars:
         Bars object
         """
         # Get polars DataFrame for operations
+        pl = _get_polars_module()
         df_copy = self.polars_df
         # Find datetime column
         dt_col = None
@@ -659,6 +741,7 @@ class Bars:
         Ensures the datetime column is a proper polars Datetime, coercing from integer epoch seconds
         (or milliseconds) and common string formats.
         """
+        pl = _get_polars_module()
         underlying_df = self.polars_df
 
         # Identify datetime column
@@ -690,13 +773,13 @@ class Bars:
                 .drop(dt_col)
                 .rename({tmp_name: dt_col})
             )
-            if isinstance(self._df, pl.DataFrame):
+            if _is_polars_df(self._df):
                 self._df = underlying_df
         elif early_dtype == pl.Utf8:
             underlying_df = underlying_df.with_columns(
                 pl.col(dt_col).str.strptime(pl.Datetime, strict=False, format=None).alias(dt_col)
             )
-            if isinstance(self._df, pl.DataFrame):
+            if _is_polars_df(self._df):
                 self._df = underlying_df
 
         # Frequency normalization

--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -1,13 +1,9 @@
 import datetime
 from decimal import Decimal
+from importlib import import_module
+from types import ModuleType
 from typing import Optional, Union
 
-import numpy as np
-
-import pandas as pd
-
-from lumibot.constants import LUMIBOT_DEFAULT_PYTZ as DEFAULT_PYTZ
-from lumibot.tools.helpers import parse_timestep_qty_and_unit, to_datetime_aware
 from lumibot.tools.lumibot_logger import get_logger
 
 from .asset import Asset
@@ -45,13 +41,179 @@ _DATA_QUOTE_FIELDS = {
 
 # PERF: module-level sentinel used to avoid eager-evaluating fallbacks in `getattr()` hot paths.
 _MISSING = object()
+_LAZY_PANDAS_SLICE_FRAME_CLASS = None
+_DEFAULT_PYTZ = None
+_PARSE_TIMESTEP_QTY_AND_UNIT = None
+_TO_DATETIME_AWARE = None
 
-# Set the option to raise an error if downcasting is not possible (if available in this pandas version)
-try:
-    pd.set_option('future.no_silent_downcasting', True)
-except (pd._config.config.OptionError, AttributeError):
-    # Option not available in this pandas version, skip it
-    pass
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module_name = self._module_name
+            module = import_module(module_name)
+            if module_name == "pandas":
+                try:
+                    module.set_option('future.no_silent_downcasting', True)
+                except (module._config.config.OptionError, AttributeError):
+                    pass
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+np = _LazyModule("numpy")
+pd = _LazyModule("pandas")
+
+
+def _default_pytz():
+    global _DEFAULT_PYTZ
+    if _DEFAULT_PYTZ is None:
+        from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
+
+        _DEFAULT_PYTZ = LUMIBOT_DEFAULT_PYTZ
+    return _DEFAULT_PYTZ
+
+
+def parse_timestep_qty_and_unit(*args, **kwargs):
+    global _PARSE_TIMESTEP_QTY_AND_UNIT
+    if _PARSE_TIMESTEP_QTY_AND_UNIT is None:
+        from lumibot.tools.helpers import parse_timestep_qty_and_unit as _parse_timestep_qty_and_unit
+
+        _PARSE_TIMESTEP_QTY_AND_UNIT = _parse_timestep_qty_and_unit
+    return _PARSE_TIMESTEP_QTY_AND_UNIT(*args, **kwargs)
+
+
+def to_datetime_aware(*args, **kwargs):
+    global _TO_DATETIME_AWARE
+    if _TO_DATETIME_AWARE is None:
+        from lumibot.tools.helpers import to_datetime_aware as _to_datetime_aware
+
+        _TO_DATETIME_AWARE = _to_datetime_aware
+    return _TO_DATETIME_AWARE(*args, **kwargs)
+
+
+def _lazy_pandas_slice_frame_class():
+    global _LAZY_PANDAS_SLICE_FRAME_CLASS
+    if _LAZY_PANDAS_SLICE_FRAME_CLASS is not None:
+        return _LAZY_PANDAS_SLICE_FRAME_CLASS
+
+    class _LazyPandasSliceFrame(pd.DataFrame):
+        """Pandas-compatible lazy row slice for hot backtesting bars.
+
+        It is still a ``pd.DataFrame`` instance for compatibility, but defers the
+        expensive BlockManager slice until strategy code actually uses DataFrame
+        operations. This keeps no-op historical-price calls cheap without changing
+        the public ``bars.df`` surface.
+        """
+
+        _metadata = [
+            "_lumibot_source_df",
+            "_lumibot_slice",
+            "_lumibot_len",
+            "_lumibot_real_df",
+            "_lumibot_virtual_return",
+        ]
+
+        def __init__(self, source_df, slice_obj, length, virtual_return=False):
+            object.__setattr__(self, "_lumibot_source_df", source_df)
+            object.__setattr__(self, "_lumibot_slice", slice_obj)
+            object.__setattr__(self, "_lumibot_len", int(length))
+            object.__setattr__(self, "_lumibot_real_df", None)
+            object.__setattr__(self, "_lumibot_virtual_return", bool(virtual_return))
+
+        def _lumibot_return_values(self):
+            source_df = object.__getattribute__(self, "_lumibot_source_df")
+            slice_obj = object.__getattribute__(self, "_lumibot_slice")
+            start = 0 if slice_obj.start is None else int(slice_obj.start)
+            stop = len(source_df.index) if slice_obj.stop is None else int(slice_obj.stop)
+            close = source_df["close"].to_numpy(dtype="float64", copy=False)
+            values = np.empty(max(0, stop - start), dtype="float64")
+            values[:] = np.nan
+            if len(values) == 0:
+                return values
+            prev_start = max(0, start - 1)
+            window = close[prev_start:stop]
+            if start > 0 and len(window) > 1:
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    values[:] = (window[1:] - window[:-1]) / window[:-1]
+            elif len(window) > 1:
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    values[1:] = (window[1:] - window[:-1]) / window[:-1]
+            return values
+
+        def _lumibot_materialize(self):
+            df = object.__getattribute__(self, "_lumibot_real_df")
+            if df is None:
+                source_df = object.__getattribute__(self, "_lumibot_source_df")
+                slice_obj = object.__getattribute__(self, "_lumibot_slice")
+                try:
+                    mgr = source_df._mgr.get_slice(slice_obj, axis=1)
+                    df = source_df._constructor_from_mgr(mgr, axes=mgr.axes)
+                except Exception:
+                    df = source_df._slice(slice_obj)
+                if object.__getattribute__(self, "_lumibot_virtual_return") and "return" not in df.columns:
+                    df = df.copy(deep=False)
+                    df["return"] = self._lumibot_return_values()
+                object.__setattr__(self, "_lumibot_real_df", df)
+            return df
+
+        @property
+        def _mgr(self):
+            return self._lumibot_materialize()._mgr
+
+        @_mgr.setter
+        def _mgr(self, value):
+            object.__setattr__(self, "_lumibot_real_df", pd.DataFrame._from_mgr(value, axes=value.axes))
+
+        @property
+        def _constructor(self):
+            return pd.DataFrame
+
+        def __len__(self):
+            return object.__getattribute__(self, "_lumibot_len")
+
+        @property
+        def empty(self):
+            return object.__getattribute__(self, "_lumibot_len") == 0
+
+        @property
+        def columns(self):
+            columns = object.__getattribute__(self, "_lumibot_source_df").columns
+            if object.__getattribute__(self, "_lumibot_virtual_return") and "return" not in columns:
+                return columns.append(pd.Index(["return"]))
+            return columns
+
+        @property
+        def index(self):
+            return self._lumibot_materialize().index
+
+        @property
+        def attrs(self):
+            return self._lumibot_materialize().attrs
+
+        def __getitem__(self, key):
+            if isinstance(key, str) and key == "return" and object.__getattribute__(self, "_lumibot_virtual_return"):
+                index = self._lumibot_materialize().index
+                return pd.Series(self._lumibot_return_values(), index=index, name="return")
+            return self._lumibot_materialize().__getitem__(key)
+
+        def __getattr__(self, name):
+            return getattr(self._lumibot_materialize(), name)
+
+        def __repr__(self):
+            return repr(self._lumibot_materialize())
+
+    _LAZY_PANDAS_SLICE_FRAME_CLASS = _LazyPandasSliceFrame
+    return _LAZY_PANDAS_SLICE_FRAME_CLASS
 
 
 class Data:
@@ -162,6 +324,7 @@ class Data:
         timestep="minute",
         quote=None,
         timezone=None,
+        assume_clean=False,
     ):
         self.asset = asset
         self.symbol = self.asset.symbol
@@ -188,6 +351,9 @@ class Data:
             )
 
         self.timestep = timestep
+
+        if assume_clean and self._initialize_clean_constructor_state(df, date_start, date_end, trading_hours_start, trading_hours_end):
+            return
 
         self.df = self.columns(df)
 
@@ -281,6 +447,54 @@ class Data:
         self._bars_has_dividend = "dividend" in self._bars_cols
         self._bars_required_cols = [c for c in ("open", "high", "low", "close") if c in self._bars_cols]
 
+    def _initialize_clean_constructor_state(
+        self,
+        df,
+        date_start=None,
+        date_end=None,
+        trading_hours_start=datetime.time(0, 0),
+        trading_hours_end=datetime.time(23, 59),
+    ) -> bool:
+        if not isinstance(df, pd.DataFrame):
+            return False
+        idx = df.index
+        if not isinstance(idx, pd.DatetimeIndex) or idx.tz is None:
+            return False
+        if not idx.is_monotonic_increasing:
+            return False
+        required = ("open", "high", "low", "close", "volume")
+        if any(col not in df.columns for col in required):
+            return False
+
+        self.df = df
+        if self.df.index.name != "datetime":
+            self.df.index.name = "datetime"
+        self._index_is_unique = bool(getattr(self.df.index, "is_unique", False))
+        self.trading_hours_start, self.trading_hours_end = self.set_times(trading_hours_start, trading_hours_end)
+        self.date_start, self.date_end = self.set_dates(date_start, date_end)
+        try:
+            self._data_len = int(len(self.df.index))
+        except Exception:
+            self._data_len = None
+
+        start_ts = self.df.index[0]
+        end_ts = self.df.index[-1]
+        self.datetime_start = start_ts.to_pydatetime() if isinstance(start_ts, pd.Timestamp) else start_ts
+        self.datetime_end = end_ts.to_pydatetime() if isinstance(end_ts, pd.Timestamp) else end_ts
+
+        self._ohlc_has_nan = False
+        self._volume_has_nan = False
+        self._dividend_has_nan = "dividend" in self.df.columns
+        bars_cols = ["open", "high", "low", "close", "volume"]
+        if "dividend" in self.df.columns:
+            bars_cols.append("dividend")
+        self._bars_cols = [c for c in bars_cols if c in self.df.columns]
+        self._bars_df = None
+        self._bars_has_volume = True
+        self._bars_has_dividend = "dividend" in self._bars_cols
+        self._bars_required_cols = ["open", "high", "low", "close"]
+        return True
+
     def set_times(self, trading_hours_start, trading_hours_end):
         """Set the start and end times for the data. The default is 0001 hrs to 2359 hrs.
 
@@ -321,9 +535,9 @@ class Data:
         df.index.name = "datetime"
         df.index = pd.to_datetime(df.index)
         if not df.index.tzinfo:
-            df.index = pd.to_datetime(df.index).tz_localize(DEFAULT_PYTZ)
-        elif df.index.tzinfo != DEFAULT_PYTZ:
-            df.index = df.index.tz_convert(DEFAULT_PYTZ)
+            df.index = pd.to_datetime(df.index).tz_localize(_default_pytz())
+        elif df.index.tzinfo != _default_pytz():
+            df.index = df.index.tz_convert(_default_pytz())
         return df
 
     def set_dates(self, date_start, date_end):
@@ -379,11 +593,17 @@ class Data:
         idx = idx[start_pos:end_pos]
 
         # OPTIMIZATION: More efficient duplicate removal
-        if self.df.index.has_duplicates:
+        has_duplicates = bool(self.df.index.has_duplicates)
+        if has_duplicates:
             self.df = self.df[~self.df.index.duplicated(keep='first')]
 
-        # Reindex the DataFrame with the new index and forward-fill missing values.
-        df = self.df.reindex(idx, method="ffill")
+        # Reindex the DataFrame with the new index and forward-fill missing values. Lazy-loaded
+        # backtesting data frequently passes its existing clean index here; avoid an identical
+        # reindex/copy and keep the downstream normalization work unchanged.
+        if (not has_duplicates) and len(idx) == len(self.df.index) and idx.equals(self.df.index):
+            df = self.df.copy(deep=False)
+        else:
+            df = self.df.reindex(idx, method="ffill")
 
         # Check if we have a volume column, if not then add it and fill with 0 or NaN.
         if "volume" in df.columns:
@@ -525,14 +745,15 @@ class Data:
             self._data_len = None
 
         # Set up iter_index and iter_index_dict for later use.
-        iter_index = pd.Series(df.index)
-        self.iter_index = pd.Series(iter_index.index, index=iter_index)
+        idx_values = df.index
+        self.iter_index = None
         # PERF: `to_dict()` produces keys as `pd.Timestamp`, which do not hash-equal to
         # `datetime.datetime` objects. Many hot paths pass python datetimes, causing dictionary
         # misses and forcing an expensive `Series.asof()` fallback.
         #
         # Store a second mapping keyed by python datetimes so `dt in iter_index_dict` is fast.
-        self.iter_index_dict = {ts.to_pydatetime(): int(pos) for ts, pos in self.iter_index.items()}
+        self.iter_index_dict = dict(zip(idx_values.to_pydatetime(), range(len(idx_values))))
+        self._iter_index_dict_get = self.iter_index_dict.get
 
         # PERF: Precompute an integer nanoseconds view of the datetime index so `get_iter_count()`
         # can use NumPy search/forward cursors without triggering pandas datetime scalar validation.
@@ -598,6 +819,86 @@ class Data:
         except Exception:
             self._bars_df = None
 
+    def _initialize_clean_repaired_state(self) -> bool:
+        """Initialize datalines/caches for already-clean OHLCV data without full repair."""
+        df = self.df
+        required = ("open", "high", "low", "close", "volume")
+        if any(col not in df.columns for col in required):
+            return False
+        if any(col in df.columns for col in ("bid", "ask", "bid_size", "ask_size")):
+            return False
+        if bool(getattr(df.index, "has_duplicates", False)):
+            return False
+        if getattr(self, "_ohlc_has_nan", True) or getattr(self, "_volume_has_nan", True):
+            return False
+
+        defer_returns = bool(getattr(self, "_defer_clean_returns", False))
+        if "return" not in df.columns and not defer_returns:
+            close_series = df["close"]
+            try:
+                close = close_series.to_numpy(dtype="float64", copy=False)
+            except Exception:
+                close = pd.to_numeric(close_series, errors="coerce").to_numpy(dtype="float64", copy=False)
+
+            returns = np.empty(len(close), dtype="float64")
+            returns[:] = np.nan
+            if len(close) > 1:
+                prev = close[:-1]
+                curr = close[1:]
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    returns[1:] = (curr - prev) / prev
+            df = df.copy(deep=False)
+            df["return"] = returns
+            self.df = df
+        self._return_is_deferred = bool(defer_returns and "return" not in self.df.columns)
+
+        try:
+            self._data_len = int(len(self.df.index))
+        except Exception:
+            self._data_len = None
+
+        idx_values = self.df.index
+        self.iter_index = None
+        self.iter_index_dict = dict(zip(idx_values.to_pydatetime(), range(len(idx_values))))
+        self._iter_index_dict_get = self.iter_index_dict.get
+
+        try:
+            idx = idx_values
+            try:
+                idx = idx.as_unit("ns")
+            except (AttributeError, TypeError):
+                pass
+            self._index_values_ns = idx.asi8
+        except Exception:
+            self._index_values_ns = None
+
+        self._iter_count_cursor_ns = None
+        self._iter_count_cursor_i = 0
+        self._iter_count_last_dt_key = None
+
+        self.datalines = {}
+        if getattr(self, "_skip_clean_datalines", False):
+            # IBKR native daily bars are used for direct slicing/last-price reads; full Dataline
+            # wrappers add load-time CPU/RSS with no benefit on that path.
+            self.datetime = idx_values.to_numpy()
+            for column in self.df.columns:
+                setattr(self, column, self.df[column].to_numpy())
+            self._quote_required_cols_present = False
+            self._quote_missing_cols = list(_DATA_QUOTE_COLS)
+            self._quote_presence_logged = False
+        else:
+            self.to_datalines()
+
+        bars_cols = ["open", "high", "low", "close", "volume"]
+        if "return" in self.df.columns:
+            bars_cols.append("return")
+        self._bars_cols = [c for c in bars_cols if c in self.df.columns]
+        self._bars_has_volume = "volume" in self._bars_cols
+        self._bars_has_dividend = False
+        self._bars_required_cols = [c for c in ("open", "high", "low", "close") if c in self._bars_cols]
+        self._bars_df = self.df[self._bars_cols].copy(deep=False) if self._bars_cols else None
+        return True
+
     def to_datalines(self):
         self.datalines.update(
             {
@@ -636,14 +937,18 @@ class Data:
         # known data (this speeds up the process)
         i = None
 
-        # Check if we have the iter_index_dict, if not then repair the times and fill (which will create the iter_index_dict)
-        if getattr(self, "iter_index_dict", None) is None:
-            self.repair_times_and_fill(self.df.index)
+        iter_index_get = getattr(self, "_iter_index_dict_get", None)
+        if iter_index_get is None:
+            # Check if we have the iter_index_dict, if not then repair the times and fill (which will create the iter_index_dict)
+            if getattr(self, "iter_index_dict", None) is None:
+                self.repair_times_and_fill(self.df.index)
+            iter_index_get = self.iter_index_dict.get
+            self._iter_index_dict_get = iter_index_get
 
         # Normalize dt to a python datetime for fast dict lookups.
         # Callers can pass `pd.Timestamp` (common in pandas-heavy code paths); mixing Timestamp and
         # datetime keys leads to misses and forces an expensive `asof()` fallback.
-        dt_key = dt.to_pydatetime() if isinstance(dt, pd.Timestamp) else dt
+        dt_key = dt.to_pydatetime() if dt.__class__ is pd.Timestamp else dt
 
         # PERF: repeated calls in the same iteration commonly ask for the same `(data, dt)`.
         # Short-circuit before any dict membership/search work.
@@ -651,10 +956,10 @@ class Data:
         if last_dt_key == dt_key:
             cursor_i = getattr(self, "_iter_count_cursor_i", None)
             if cursor_i is not None:
-                return int(cursor_i)
+                return cursor_i
 
         # Fast-path: exact bar timestamp lookup.
-        i = self.iter_index_dict.get(dt_key)
+        i = iter_index_get(dt_key)
         if i is not None:
             index_ns = getattr(self, "_index_values_ns", None)
             if index_ns is not None:
@@ -854,6 +1159,190 @@ class Data:
             pass
 
         return price
+
+    def get_last_price_fast(self, dt) -> Union[float, Decimal, None]:
+        """Fast current-bar last price read for already-validated backtesting data."""
+        iter_count = self.get_iter_count(dt)
+        if iter_count < 0:
+            return None
+
+        lines = getattr(self, "_last_price_fast_lines", None)
+        if lines is None:
+            open_line = getattr(self, "open", None)
+            close_line = getattr(self, "close", None)
+            datetime_line = getattr(self, "datetime", None)
+            if open_line is None or close_line is None or datetime_line is None:
+                open_line = self.datalines["open"].dataline
+                close_line = self.datalines["close"].dataline
+                datetime_line = self.datalines["datetime"].dataline
+            lines = (open_line, close_line, datetime_line)
+            self._last_price_fast_lines = lines
+        else:
+            open_line, close_line, datetime_line = lines
+
+        open_price = open_line[iter_count]
+        close_price = close_line[iter_count]
+        if self.timestep == "day":
+            price = close_price
+        else:
+            price = close_price if dt > datetime_line[iter_count] else open_price
+
+        if price is None:
+            return None
+        try:
+            if price != price:
+                return None
+        except (TypeError, ValueError):
+            try:
+                if pd.isna(price):
+                    return None
+            except (TypeError, ValueError):
+                pass
+        return price
+
+    def get_previous_bar_close_fast(self, dt) -> Union[float, Decimal, None]:
+        """Fast previous-bar close for exact-clock backtesting reads."""
+        iter_index_get = getattr(self, "_iter_index_dict_get", None)
+        if iter_index_get is None:
+            return None
+        dt_key = dt.to_pydatetime() if dt.__class__ is pd.Timestamp else dt
+        i = iter_index_get(dt_key)
+        if i is None or i <= 0:
+            return None
+
+        lines = getattr(self, "_last_price_fast_lines", None)
+        if lines is None:
+            open_line = getattr(self, "open", None)
+            close_line = getattr(self, "close", None)
+            datetime_line = getattr(self, "datetime", None)
+            if open_line is None or close_line is None or datetime_line is None:
+                open_line = self.datalines["open"].dataline
+                close_line = self.datalines["close"].dataline
+                datetime_line = self.datalines["datetime"].dataline
+            lines = (open_line, close_line, datetime_line)
+            self._last_price_fast_lines = lines
+        else:
+            _, close_line, _ = lines
+
+        price = close_line[int(i) - 1]
+        if price is None:
+            return None
+        try:
+            if price != price:
+                return None
+        except (TypeError, ValueError):
+            try:
+                if pd.isna(price):
+                    return None
+            except (TypeError, ValueError):
+                pass
+        return price
+
+    def get_native_bars_fast(self, dt, length=1, timestep=MIN_TIMESTEP, mark_timezone=True):
+        """Fast native minute/day bar slice for warm-cache backtesting paths."""
+        if (
+            not self._index_is_unique
+            or timestep not in {"minute", "day"}
+            or timestep != self.timestep
+        ):
+            return self.get_bars(dt, length=length, timestep=timestep, timeshift=None)
+
+        if timestep == "day":
+            try:
+                dt_date = dt.date()
+            except Exception:
+                dt_date = None
+            day_cache = getattr(self, "_native_day_bars_fast_cache", None)
+            if day_cache is not None and day_cache[0] == dt_date and day_cache[1] == int(length):
+                cached_df = day_cache[2]
+                if cached_df is not None and len(cached_df) != 0:
+                    return cached_df
+
+        iter_count = self.get_iter_count(dt)
+        if iter_count is None:
+            iter_count = 0
+
+        df_source = getattr(self, "_bars_df", None)
+        if df_source is None:
+            bars_cols = getattr(self, "_bars_cols", None)
+            df_source = self.df[bars_cols].copy(deep=False) if bars_cols else self.df
+            if bars_cols:
+                self._bars_df = df_source
+
+        if timestep == "minute" and iter_count > 0:
+            end_row = int(iter_count)
+            start_row = end_row - int(length)
+            if start_row < 0:
+                start_row = 0
+        else:
+            end_row = int(iter_count) + 1 if timestep == "day" else int(iter_count)
+            data_len = getattr(self, "_data_len", None)
+            if data_len is None:
+                data_len = int(len(df_source.index))
+                self._data_len = data_len
+            end_row = max(0, min(end_row, data_len))
+            start_row = max(0, end_row - int(length))
+            if start_row > end_row:
+                start_row = end_row
+            if start_row == end_row and end_row > 0:
+                start_row = max(0, end_row - 1)
+
+        cache_key = None
+        if timestep == "day":
+            cache_key = ("native_fast", timestep, int(length), int(start_row), int(end_row))
+            if getattr(self, "_get_bars_slice_cache_key", None) == cache_key:
+                cached_df = getattr(self, "_get_bars_slice_cache_df", None)
+                if cached_df is not None and len(cached_df) != 0:
+                    return cached_df
+
+        slice_obj = slice(start_row, end_row)
+        if (
+            not mark_timezone
+            and timestep in {"minute", "day"}
+            and not getattr(self, "_ohlc_has_nan", True)
+            and not getattr(self, "_volume_has_nan", False)
+            and not getattr(self, "_dividend_has_nan", False)
+        ):
+            df = _lazy_pandas_slice_frame_class()(
+                df_source,
+                slice_obj,
+                end_row - start_row,
+                virtual_return=getattr(self, "_return_is_deferred", False),
+            )
+            if cache_key is not None:
+                self._get_bars_slice_cache_key = cache_key
+                self._get_bars_slice_cache_df = df
+            return df
+
+        try:
+            mgr = df_source._mgr.get_slice(slice_obj, axis=1)
+            df = df_source._constructor_from_mgr(mgr, axes=mgr.axes)
+        except Exception:
+            df = df_source._slice(slice_obj)
+        if df is None or len(df) == 0:
+            return None
+        if mark_timezone:
+            df.attrs["_lumibot_skip_timezone"] = True
+
+        if (
+            (getattr(self, "_bars_has_volume", False) and getattr(self, "_volume_has_nan", False))
+            or (getattr(self, "_bars_has_dividend", False) and getattr(self, "_dividend_has_nan", False))
+        ):
+            df = df.copy()
+            if getattr(self, "_bars_has_volume", False) and getattr(self, "_volume_has_nan", False):
+                df["volume"] = df["volume"].fillna(0)
+            if getattr(self, "_bars_has_dividend", False) and getattr(self, "_dividend_has_nan", False):
+                df["dividend"] = df["dividend"].fillna(0)
+
+        required = getattr(self, "_bars_required_cols", None)
+        if required and getattr(self, "_ohlc_has_nan", True):
+            df = df.dropna(subset=required)
+
+        self._get_bars_slice_cache_key = cache_key
+        self._get_bars_slice_cache_df = df
+        if timestep == "day":
+            self._native_day_bars_fast_cache = (dt_date, int(length), df)
+        return df
 
     @check_data
     def get_price_snapshot(self, dt, length=1, timeshift=0):
@@ -1086,7 +1575,10 @@ class Data:
         if timeshift is None:
             timeshift = 0
         # Parse the timestep
-        quantity, timestep = parse_timestep_qty_and_unit(timestep)
+        if timestep in {"minute", "hour", "day"}:
+            quantity = 1
+        else:
+            quantity, timestep = parse_timestep_qty_and_unit(timestep)
         num_periods = length
 
         if timestep == "minute" and self.timestep in {"day", "hour"}:
@@ -1118,7 +1610,7 @@ class Data:
         ):
             try:
                 iter_count = self.get_iter_count(dt)
-                if pd.isna(iter_count):
+                if iter_count is None:
                     iter_count = 0
             except Exception:
                 iter_count = self.get_iter_count(dt)
@@ -1163,15 +1655,16 @@ class Data:
             cached_key = getattr(self, "_get_bars_slice_cache_key", None)
             if cached_key == cache_key:
                 cached_df = getattr(self, "_get_bars_slice_cache_df", None)
-                if cached_df is not None and cached_df.shape[0] != 0:
+                if cached_df is not None and len(cached_df) != 0:
                     return cached_df
 
             # PERF: `.iloc[start:end]` goes through the indexer stack (`_iLocIndexer`) which
             # performs validation on every call. In backtesting we already operate on integer
             # row bounds; `_slice()` is the internal fast-path that avoids the indexer overhead.
             df = df_source._slice(slice(start_row, end_row))
-            if df is None or df.shape[0] == 0:
+            if df is None or len(df) == 0:
                 return None
+            df.attrs["_lumibot_skip_timezone"] = True
 
             # PERF: avoid `col in df.columns` membership checks (`Index.__contains__`) on every call.
             has_volume = getattr(self, "_bars_has_volume", _MISSING)
@@ -1233,7 +1726,7 @@ class Data:
             # row bounds in O(1) and return a stable OHLCV schema.
             try:
                 iter_count = self.get_iter_count(dt)
-                if pd.isna(iter_count):
+                if iter_count is None:
                     iter_count = 0
             except Exception:
                 iter_count = self.get_iter_count(dt)
@@ -1286,15 +1779,16 @@ class Data:
             cached_key = getattr(self, "_get_bars_slice_cache_key", None)
             if cached_key == cache_key:
                 cached_df = getattr(self, "_get_bars_slice_cache_df", None)
-                if cached_df is not None and cached_df.shape[0] != 0:
+                if cached_df is not None and len(cached_df) != 0:
                     return cached_df
 
             # PERF: `.iloc[start:end]` goes through the indexer stack (`_iLocIndexer`) which
             # performs validation on every call. In backtesting we already operate on integer
             # row bounds; `_slice()` is the internal fast-path that avoids the indexer overhead.
             df = df_source._slice(slice(start_row, end_row))
-            if df is None or df.shape[0] == 0:
+            if df is None or len(df) == 0:
                 return None
+            df.attrs["_lumibot_skip_timezone"] = True
 
             # PERF: avoid `col in df.columns` membership checks (`Index.__contains__`) on every call.
             has_volume = getattr(self, "_bars_has_volume", _MISSING)

--- a/lumibot/entities/data_polars.py
+++ b/lumibot/entities/data_polars.py
@@ -1,26 +1,75 @@
+from __future__ import annotations
+
 import datetime
 from decimal import Decimal
+from importlib import import_module
 from typing import Optional, Union
 
-import pandas as pd
-import polars as pl
-
-from lumibot.constants import LUMIBOT_DEFAULT_PYTZ as DEFAULT_PYTZ
 import pytz
-from lumibot.tools.helpers import parse_timestep_qty_and_unit, to_datetime_aware
 from lumibot.tools.lumibot_logger import get_logger
 
 from .asset import Asset
 from .dataline import Dataline
 
 logger = get_logger(__name__)
+_DEFAULT_PYTZ = None
+_PARSE_TIMESTEP_QTY_AND_UNIT = None
+_TO_DATETIME_AWARE = None
 
-# Set the option to raise an error if downcasting is not possible (if available in this pandas version)
-try:
-    pd.set_option('future.no_silent_downcasting', True)
-except (pd._config.config.OptionError, AttributeError):
-    # Option not available in this pandas version, skip it
-    pass
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module_name = object.__getattribute__(self, "_module_name")
+            module = import_module(module_name)
+            if module_name == "pandas":
+                try:
+                    module.set_option('future.no_silent_downcasting', True)
+                except (module._config.config.OptionError, AttributeError):
+                    pass
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+pl = _LazyModule("polars")
+
+
+def _default_pytz():
+    global _DEFAULT_PYTZ
+    if _DEFAULT_PYTZ is None:
+        from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
+
+        _DEFAULT_PYTZ = LUMIBOT_DEFAULT_PYTZ
+    return _DEFAULT_PYTZ
+
+
+def parse_timestep_qty_and_unit(*args, **kwargs):
+    global _PARSE_TIMESTEP_QTY_AND_UNIT
+    if _PARSE_TIMESTEP_QTY_AND_UNIT is None:
+        from lumibot.tools.helpers import parse_timestep_qty_and_unit as _parse_timestep_qty_and_unit
+
+        _PARSE_TIMESTEP_QTY_AND_UNIT = _parse_timestep_qty_and_unit
+    return _PARSE_TIMESTEP_QTY_AND_UNIT(*args, **kwargs)
+
+
+def to_datetime_aware(*args, **kwargs):
+    global _TO_DATETIME_AWARE
+    if _TO_DATETIME_AWARE is None:
+        from lumibot.tools.helpers import to_datetime_aware as _to_datetime_aware
+
+        _TO_DATETIME_AWARE = _to_datetime_aware
+    return _TO_DATETIME_AWARE(*args, **kwargs)
 
 
 class DataPolars:
@@ -218,9 +267,9 @@ class DataPolars:
                     self._pandas_df.index = self._localize_or_convert_index(self._pandas_df.index, polars_tz)
 
                 if not getattr(self._pandas_df.index, "tz", None):
-                    self._pandas_df.index = self._localize_or_convert_index(self._pandas_df.index, DEFAULT_PYTZ)
-                elif str(self._pandas_df.index.tz) != str(DEFAULT_PYTZ):
-                    self._pandas_df.index = self._pandas_df.index.tz_convert(DEFAULT_PYTZ)
+                    self._pandas_df.index = self._localize_or_convert_index(self._pandas_df.index, _default_pytz())
+                elif str(self._pandas_df.index.tz) != str(_default_pytz()):
+                    self._pandas_df.index = self._pandas_df.index.tz_convert(_default_pytz())
 
         return self._pandas_df
 

--- a/lumibot/entities/dataline.py
+++ b/lumibot/entities/dataline.py
@@ -1,4 +1,6 @@
 class Dataline:
+    __slots__ = ("asset", "name", "dataline", "dtype")
+
     def __init__(self, asset, name, dataline, dtype):
         self.asset = asset
         self.name = name

--- a/lumibot/tools/bitunix_helpers.py
+++ b/lumibot/tools/bitunix_helpers.py
@@ -2,9 +2,14 @@ import os
 import time
 from typing import Dict, Any, Optional
 import hashlib
-import requests
 import json
 from lumibot.tools.lumibot_logger import get_logger
+
+
+def _requests():
+    import requests
+
+    return requests
 
 class BitUnixClient:
     """
@@ -90,7 +95,7 @@ class BitUnixClient:
         url = self.BASE_URL + endpoint
         # Use custom serialization for POST bodies so that the sent JSON matches the signature body exactly
         if method.upper() == "GET":
-            resp = requests.request(
+            resp = _requests().request(
                 method=method.upper(),
                 url=url,
                 headers=headers,
@@ -100,7 +105,7 @@ class BitUnixClient:
         else:
             # Serialize body without spaces to match signature
             body_str = json.dumps(json_body, separators=(',', ':'), ensure_ascii=False) if json_body is not None else ""
-            resp = requests.request(
+            resp = _requests().request(
                 method=method.upper(),
                 url=url,
                 headers=headers,

--- a/lumibot/tools/black_scholes.py
+++ b/lumibot/tools/black_scholes.py
@@ -1,13 +1,23 @@
-from math import e, log
-import numpy as np
+from math import e, erf, exp, log, pi, sqrt
 
 import warnings
 warnings.filterwarnings("ignore", category=RuntimeWarning)
 
-try:
-    from scipy.stats import norm
-except ImportError:
-    print("Mibian requires scipy to work properly")
+_SQRT_TWO = sqrt(2.0)
+_INV_SQRT_TWO_PI = 1.0 / sqrt(2.0 * pi)
+
+
+class _NormalDistribution:
+    @staticmethod
+    def cdf(value):
+        return 0.5 * (1.0 + erf(value / _SQRT_TWO))
+
+    @staticmethod
+    def pdf(value):
+        return exp(-0.5 * value * value) * _INV_SQRT_TWO_PI
+
+
+norm = _NormalDistribution()
 
 # WARNING: All numbers should be floats -> x = 1.0
 
@@ -37,7 +47,7 @@ def impliedVolatility(className, args, callPrice=None, putPrice=None, high=500.0
             estimate = eval(className)(args, volatility=mid, performance=True).callPrice
         if putPrice:
             estimate = eval(className)(args, volatility=mid, performance=True).putPrice
-        if np.round(estimate, decimals) == target:
+        if round(estimate, decimals) == target:
             break
         elif estimate > target:
             high = mid

--- a/lumibot/tools/ccxt_data_store.py
+++ b/lumibot/tools/ccxt_data_store.py
@@ -1,19 +1,42 @@
+from __future__ import annotations
+
 import time
-import duckdb
 import os
 import uuid
-import ccxt
 from datetime import datetime
-from tabulate import tabulate
-import pandas as pd
-from pandas import DataFrame
+from importlib import import_module
 from ..constants import LUMIBOT_CACHE_FOLDER
 from lumibot.tools.lumibot_logger import get_logger
 import math
-import numpy as np
-from typing import Union
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+duckdb = _LazyModule("duckdb")
+pd = _LazyModule("pandas")
+np = _LazyModule("numpy")
 
 class CcxtCacheDB:
     """A ccxt data cache class using duckdb.
@@ -46,6 +69,8 @@ class CcxtCacheDB:
 
         """
         self.logger = get_logger(self.__class__.__name__)
+        import ccxt
+
         try:
             exchange_class = getattr(ccxt, exchange_id)
         except:
@@ -457,6 +482,8 @@ class CcxtCacheDB:
 
 
     def _table_str(self, df, headers="keys"):
+        from tabulate import tabulate
+
         return tabulate(df, headers=headers, tablefmt='psql')
 
 if __name__ == "__main__":

--- a/lumibot/tools/data_downloader_queue_client.py
+++ b/lumibot/tools/data_downloader_queue_client.py
@@ -23,13 +23,33 @@ import random
 import threading
 import time
 from dataclasses import dataclass, field
+from importlib import import_module
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
-import requests
-from requests import exceptions as requests_exceptions
-
 logger = logging.getLogger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+requests = _LazyModule("requests")
+requests_exceptions = _LazyModule("requests.exceptions")
 
 # Lightweight, non-secret telemetry for backtest audit/debugging.
 #

--- a/lumibot/tools/databento_helper.py
+++ b/lumibot/tools/databento_helper.py
@@ -1,33 +1,96 @@
+from __future__ import annotations
+
 # This file contains helper functions for getting data from DataBento
 import os
-import re
 from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
+from importlib.util import find_spec
 from pathlib import Path
 from typing import Optional, List, Dict, Tuple, Union
 from decimal import Decimal
 
-import pandas as pd
 from lumibot import LUMIBOT_CACHE_FOLDER
 from lumibot.entities import Asset
-from lumibot.tools import futures_roll
-from termcolor import colored
 
-# Set up module-specific logger
-from lumibot.tools.lumibot_logger import get_logger
-logger = get_logger(__name__)
+_COLORED_FN = None
 
 
 class DataBentoAuthenticationError(RuntimeError):
     """Raised when DataBento rejects authentication credentials."""
     pass
 
-# DataBento imports (will be installed as dependency)
-try:
-    import databento as db
-    from databento import Historical
-    DATABENTO_AVAILABLE = True
-except ImportError:
-    DATABENTO_AVAILABLE = False
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+class _LazyDatabentoHistorical:
+    def __call__(self, *args, **kwargs):
+        return getattr(import_module("databento"), "Historical")(*args, **kwargs)
+
+
+pd = _LazyModule("pandas")
+futures_roll = _LazyModule("lumibot.tools.futures_roll")
+db = _LazyModule("databento")
+Historical = _LazyDatabentoHistorical()
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        object.__setattr__(self, "_logger", None)
+
+    def _load(self):
+        logger = object.__getattribute__(self, "_logger")
+        if logger is None:
+            from lumibot.tools.lumibot_logger import get_logger
+
+            logger = get_logger(__name__)
+            object.__setattr__(self, "_logger", logger)
+        return logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _colored
+
+        _COLORED_FN = _colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+DATABENTO_AVAILABLE = find_spec("databento") is not None
+if not DATABENTO_AVAILABLE:
     logger.warning("DataBento package not available. Please install with: pip install databento")
 
 # Cache settings

--- a/lumibot/tools/databento_helper_polars.py
+++ b/lumibot/tools/databento_helper_polars.py
@@ -1,19 +1,19 @@
+from __future__ import annotations
+
 # This file contains helper functions for getting data from DataBento - POLARS VERSION
 # This is a FULL COPY of databento_helper.py that will be incrementally optimized to leverage polars
 # for filtering operations while maintaining pandas compatibility at the boundaries.
 
 import os
-import re
 from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
+from importlib.util import find_spec
 from pathlib import Path
 from typing import Optional, List, Dict, Tuple, Union
 from decimal import Decimal
 
-import pandas as pd
-import polars as pl
 from lumibot import LUMIBOT_CACHE_FOLDER
 from lumibot.entities import Asset
-from lumibot.tools import futures_roll
 from termcolor import colored
 
 # Set up module-specific logger
@@ -25,13 +25,46 @@ class DataBentoAuthenticationError(RuntimeError):
     """Raised when DataBento rejects authentication credentials."""
     pass
 
-# DataBento imports (will be installed as dependency)
-try:
-    import databento as db
-    from databento import Historical
-    DATABENTO_AVAILABLE = True
-except ImportError:
-    DATABENTO_AVAILABLE = False
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+class _LazyDatabentoHistorical:
+    def __call__(self, *args, **kwargs):
+        return getattr(import_module("databento"), "Historical")(*args, **kwargs)
+
+
+pd = _LazyModule("pandas")
+pl = _LazyModule("polars")
+futures_roll = _LazyModule("lumibot.tools.futures_roll")
+db = _LazyModule("databento")
+Historical = _LazyDatabentoHistorical()
+DATABENTO_AVAILABLE = find_spec("databento") is not None
+if not DATABENTO_AVAILABLE:
     logger.warning("DataBento package not available. Please install with: pip install databento")
 
 # Cache settings - CRITICAL: Use separate cache from pandas version to avoid contamination

--- a/lumibot/tools/helpers.py
+++ b/lumibot/tools/helpers.py
@@ -7,16 +7,68 @@ import time
 import weakref
 from functools import lru_cache
 from decimal import Decimal, ROUND_HALF_EVEN
+from importlib import import_module
+from types import ModuleType
 
 import pytz
 import datetime as dt
 
-import pandas as pd
-import pandas_market_calendars as mcal
-from pandas_market_calendars.market_calendar import MarketCalendar
 from termcolor import colored
 
-from ..constants import LUMIBOT_DEFAULT_PYTZ, LUMIBOT_DEFAULT_TIMEZONE
+LUMIBOT_DEFAULT_TIMEZONE = "America/New_York"
+LUMIBOT_DEFAULT_PYTZ = pytz.timezone(LUMIBOT_DEFAULT_TIMEZONE)
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+
+
+class _PandasMarketCalendarsProxy:
+    def _module(self):
+        import pandas_market_calendars as _mcal
+
+        return _mcal
+
+    @property
+    def __version__(self):
+        return getattr(self._module(), "__version__", "unknown")
+
+    def get_calendar(self, *args, **kwargs):
+        return self._module().get_calendar(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._module(), name)
+
+
+mcal = _PandasMarketCalendarsProxy()
+_TWENTY_FOUR_SEVEN_CALENDAR_CLASS = None
+
+
+def __getattr__(name):
+    if name == "MarketCalendar":
+        from pandas_market_calendars.market_calendar import MarketCalendar
+
+        globals()["MarketCalendar"] = MarketCalendar
+        return MarketCalendar
+    if name == "TwentyFourSevenCalendar":
+        return _twenty_four_seven_calendar_class()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 # ============================================================================
 # PERFORMANCE CACHES - Critical for backtesting performance
@@ -69,7 +121,7 @@ def _get_trading_days_disk_cache_path(market: str, start_day, end_day, tz_name: 
     if not cache_dir:
         return None
 
-    market_cal_version = getattr(mcal, "__version__", "unknown")
+    market_cal_version = "24/7" if market == "24/7" else getattr(mcal, "__version__", "unknown")
     cache_key = "|".join(
         (
             _TRADING_CALENDAR_DISK_CACHE_VERSION,
@@ -110,7 +162,7 @@ def _get_trading_schedule_for_year(market: str, year: int, tz_name: str) -> pd.D
     year_end = pd.Timestamp(year=year, month=12, day=31)
 
     if market == "24/7":
-        cal = TwentyFourSevenCalendar(tzinfo=tzinfo)
+        cal = _twenty_four_seven_calendar_class()(tzinfo=tzinfo)
     else:
         cal = mcal.get_calendar(market)
 
@@ -144,59 +196,81 @@ def deduplicate_sequence(seq, key=""):
     return seq
 
 
-class TwentyFourSevenCalendar(MarketCalendar):
-    """
-    Calendar for markets that trade 24/7, like crypto markets.
-    Market open is set to midnight (00:00) and close to 23:59 for each day.
-    """
+def _twenty_four_seven_calendar_class():
+    global _TWENTY_FOUR_SEVEN_CALENDAR_CLASS
+    if _TWENTY_FOUR_SEVEN_CALENDAR_CLASS is not None:
+        return _TWENTY_FOUR_SEVEN_CALENDAR_CLASS
 
-    regular_market_times = {
-        'market_open': [(None, dt.time(0, 0))],
-        'market_close': [(None, dt.time(23, 59, 59, 999999))],
-    }
+    from pandas_market_calendars.market_calendar import MarketCalendar
 
-    def __init__(self, tzinfo: str | pytz.BaseTzInfo = 'UTC'):
-        self._tzinfo = pytz.timezone(tzinfo) if isinstance(tzinfo, str) else tzinfo
-        super().__init__()
+    class TwentyFourSevenCalendar(MarketCalendar):
+        """
+        Calendar for markets that trade 24/7, like crypto markets.
+        Market open is set to midnight (00:00) and close to 23:59 for each day.
+        """
 
-    @property
-    def name(self):
-        return "24/7"
+        regular_market_times = {
+            'market_open': [(None, dt.time(0, 0))],
+            'market_close': [(None, dt.time(23, 59, 59, 999999))],
+        }
 
-    @property
-    def tz(self):
-        return self._tzinfo
+        def __init__(self, tzinfo: str | pytz.BaseTzInfo = 'UTC'):
+            self._tzinfo = pytz.timezone(tzinfo) if isinstance(tzinfo, str) else tzinfo
+            super().__init__()
 
-    @property
-    def open_time_default(self):
-        return dt.time(0, 0)
+        @property
+        def name(self):
+            return "24/7"
 
-    @property
-    def close_time_default(self):
-        return dt.time(23, 59)
+        @property
+        def tz(self):
+            return self._tzinfo
 
-    @property
-    def regular_holidays(self):
-        return []
+        @property
+        def open_time_default(self):
+            return dt.time(0, 0)
 
-    @property
-    def special_closes(self):
-        return []
+        @property
+        def close_time_default(self):
+            return dt.time(23, 59)
 
-    @property
-    def special_closes_adherence(self):
-        return []
+        @property
+        def regular_holidays(self):
+            return []
 
-    @property
-    def special_opens(self):
-        return []
+        @property
+        def special_closes(self):
+            return []
 
-    @property
-    def special_opens_adherence(self):
-        return []
+        @property
+        def special_closes_adherence(self):
+            return []
 
-    def valid_days(self, start_date, end_date, tz=None):
-        return pd.date_range(start=start_date, end=end_date, freq='D')
+        @property
+        def special_opens(self):
+            return []
+
+        @property
+        def special_opens_adherence(self):
+            return []
+
+        def valid_days(self, start_date, end_date, tz=None):
+            return pd.date_range(start=start_date, end=end_date, freq='D', tz=tz or self._tzinfo)
+
+        def schedule(self, start_date, end_date, tz=None):
+            tzinfo = tz or self._tzinfo
+            idx = self.valid_days(start_date, end_date, tz=tzinfo)
+            return pd.DataFrame(
+                {
+                    "market_open": idx,
+                    "market_close": idx + pd.Timedelta(days=1) - pd.Timedelta(microseconds=1),
+                },
+                index=idx,
+            )
+
+    _TWENTY_FOUR_SEVEN_CALENDAR_CLASS = TwentyFourSevenCalendar
+    globals()["TwentyFourSevenCalendar"] = TwentyFourSevenCalendar
+    return TwentyFourSevenCalendar
 
 
 def get_trading_days(
@@ -305,7 +379,7 @@ def get_trading_days(
     span_days = int((schedule_end_day - start_day).days)
     if span_days >= 365:
         if market == "24/7":
-            cal = TwentyFourSevenCalendar(tzinfo=tzinfo)
+            cal = _twenty_four_seven_calendar_class()(tzinfo=tzinfo)
         else:
             cal = mcal.get_calendar(market)
 
@@ -668,34 +742,9 @@ def to_datetime_aware(dt_in):
 
 
 def parse_symbol(symbol):
-    """
-    Parse the given symbol and determine if it's an option or a stock.
-    For options, extract and return the stock symbol, expiration date (as a datetime.date object),
-    type (call or put), and strike price.
-    For stocks, simply return the stock symbol.
-    TODO: Crypto and Forex support
-    """
-    # Check that the symbol is a string
-    if not isinstance(symbol, str):
-        return {"type": None}
-    
-    # Pattern to match the option symbol format
-    option_pattern = r"([A-Z]+)(\d{6})([CP])(\d+)"
+    from lumibot.tools.symbol_parser import parse_symbol as _parse_symbol
 
-    match = re.match(option_pattern, symbol)
-    if match:
-        stock_symbol, expiration, option_type, strike_price = match.groups()
-        expiration_date = dt.datetime.strptime(expiration, "%y%m%d").date()
-        option_type = "CALL" if option_type == "C" else "PUT"
-        return {
-            "type": "option",
-            "stock_symbol": stock_symbol,
-            "expiration_date": expiration_date,
-            "option_type": option_type,
-            "strike_price": round(float(strike_price) / 1000, 3),  # assuming strike price is in thousandths
-        }
-    else:
-        return {"type": "stock", "stock_symbol": symbol}
+    return _parse_symbol(symbol)
 
 
 def create_options_symbol(stock_symbol, expiration_date, option_type, strike_price):

--- a/lumibot/tools/ibkr_helper.py
+++ b/lumibot/tools/ibkr_helper.py
@@ -6,22 +6,91 @@ import os
 import time
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Dict, Optional, Tuple
-
-import pandas as pd
 
 from lumibot.constants import LUMIBOT_CACHE_FOLDER, LUMIBOT_DEFAULT_PYTZ
 from lumibot.entities import Asset
-from lumibot.tools.backtest_cache import CacheMode, get_backtest_cache
-from lumibot.tools.data_downloader_queue_client import queue_request
 from lumibot.tools.ibkr_secdef import (
     IbkrFuturesExchangeAmbiguousError,
     select_futures_exchange_from_secdef_search_payload,
 )
-from lumibot.tools.parquet_series_cache import ParquetSeriesCache
 
 logger = logging.getLogger(__name__)
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_BACKTEST_CACHE_MODE = None
+_BACKTEST_CACHE_GETTER = None
+_QUEUE_REQUEST = None
+_PARQUET_SERIES_CACHE = None
+
+
+class _LazyCacheMode:
+    def __getattr__(self, name):
+        global _BACKTEST_CACHE_MODE
+        if _BACKTEST_CACHE_MODE is None:
+            from lumibot.tools.backtest_cache import CacheMode as _CacheMode
+
+            _BACKTEST_CACHE_MODE = _CacheMode
+        return getattr(_BACKTEST_CACHE_MODE, name)
+
+
+class _LazyParquetSeriesCache:
+    def _load(self):
+        global _PARQUET_SERIES_CACHE
+        if _PARQUET_SERIES_CACHE is None:
+            from lumibot.tools.parquet_series_cache import ParquetSeriesCache as _ParquetSeriesCache
+
+            _PARQUET_SERIES_CACHE = _ParquetSeriesCache
+        return _PARQUET_SERIES_CACHE
+
+    def __call__(self, *args, **kwargs):
+        return self._load()(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+CacheMode = _LazyCacheMode()
+ParquetSeriesCache = _LazyParquetSeriesCache()
+
+
+def get_backtest_cache():
+    global _BACKTEST_CACHE_GETTER
+    if _BACKTEST_CACHE_GETTER is None:
+        from lumibot.tools.backtest_cache import get_backtest_cache as _get_backtest_cache
+
+        _BACKTEST_CACHE_GETTER = _get_backtest_cache
+    return _BACKTEST_CACHE_GETTER()
+
+
+def queue_request(*args, **kwargs):
+    global _QUEUE_REQUEST
+    if _QUEUE_REQUEST is None:
+        from lumibot.tools.data_downloader_queue_client import queue_request as _queue_request
+
+        _QUEUE_REQUEST = _queue_request
+    return _QUEUE_REQUEST(*args, **kwargs)
 
 CACHE_SUBFOLDER = "ibkr"
 

--- a/lumibot/tools/indicators.py
+++ b/lumibot/tools/indicators.py
@@ -1,34 +1,135 @@
+from __future__ import annotations
+
 import contextlib
 import json
 import math
 import os
-import webbrowser
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
+from importlib import import_module
 
-import pandas as pd
-import numpy as np
-import plotly.graph_objects as go
 import pytz
-import quantstats_lumi as qs
-from plotly.subplots import make_subplots
 
 from ..constants import LUMIBOT_DEFAULT_TIMEZONE
 from lumibot.tools import to_datetime_aware
 
-from .yahoo_helper import YahooHelper as yh
 
-from lumibot.tools.lumibot_logger import get_logger
-from lumibot.tools.parquet_utils import (
-    coerce_object_columns_to_json_strings,
-    is_parquet_required,
-    write_parquet_with_logging,
-)
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
 
-logger = get_logger(__name__)
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+np = _LazyModule("numpy")
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        object.__setattr__(self, "_logger", None)
+
+    def _load(self):
+        logger = object.__getattribute__(self, "_logger")
+        if logger is None:
+            from lumibot.tools.lumibot_logger import get_logger
+
+            logger = get_logger(__name__)
+            object.__setattr__(self, "_logger", logger)
+        return logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
 
 _TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 _FALSE_ENV_VALUES = {"0", "false", "no", "off"}
+
+
+def _get_quantstats_lumi():
+    import quantstats_lumi as qs
+
+    globals()["qs"] = qs
+    return qs
+
+
+def _get_plotly_imports():
+    go = globals().get("go")
+    make_subplots = globals().get("make_subplots")
+    if go is None:
+        import plotly.graph_objects as go
+
+        globals()["go"] = go
+    if make_subplots is None:
+        from plotly.subplots import make_subplots
+
+        globals()["make_subplots"] = make_subplots
+
+    return go, make_subplots
+
+
+def _get_webbrowser():
+    module = globals().get("webbrowser")
+    if module is None:
+        module = import_module("webbrowser")
+        globals()["webbrowser"] = module
+    return module
+
+
+def _parquet_utils():
+    from lumibot.tools.parquet_utils import (
+        coerce_object_columns_to_json_strings,
+        is_parquet_required,
+        write_parquet_with_logging,
+    )
+
+    return coerce_object_columns_to_json_strings, is_parquet_required, write_parquet_with_logging
+
+
+def coerce_object_columns_to_json_strings(*args, **kwargs):
+    fn, _, _ = _parquet_utils()
+    return fn(*args, **kwargs)
+
+
+def is_parquet_required(*args, **kwargs):
+    _, fn, _ = _parquet_utils()
+    return fn(*args, **kwargs)
+
+
+def write_parquet_with_logging(*args, **kwargs):
+    _, _, fn = _parquet_utils()
+    return fn(*args, **kwargs)
+
+
+def __getattr__(name):
+    if name == "qs":
+        return _get_quantstats_lumi()
+    if name == "yh":
+        from .yahoo_helper import YahooHelper as yh
+
+        globals()["yh"] = yh
+        return yh
+    if name in {"go", "make_subplots"}:
+        go, make_subplots = _get_plotly_imports()
+        return go if name == "go" else make_subplots
+    if name == "webbrowser":
+        return _get_webbrowser()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 TERMINAL_TRADE_STATUSES_FOR_MARKERS = {
     "fill",
@@ -567,6 +668,8 @@ def get_symbol_returns(symbol, start=datetime(1900, 1, 1), end=datetime.now()):
 
     """
     # Fetch the symbol data
+    from .yahoo_helper import YahooHelper as yh
+
     returns_df = yh.get_symbol_data(symbol)
 
     if returns_df is None:
@@ -706,6 +809,7 @@ def plot_indicators(
         return
 
     logger.info("\nCreating indicators plot...")
+    go, make_subplots = _get_plotly_imports()
 
     # Assign "default_plot" as plot_name for markers and lines that don't have one
     if chart_markers_df is not None and not chart_markers_df.empty:
@@ -1131,6 +1235,8 @@ def plot_returns(
     if not show_plot:
         logger.info("show_plot is False; trades CSV/parquet written, skipping HTML plot.")
         return
+
+    go, make_subplots = _get_plotly_imports()
 
     dfs_concat = []
 
@@ -1745,6 +1851,8 @@ def create_tearsheet(
     # Set the name of the benchmark column so that quantstats can use it in the report
     df_final["benchmark"].name = str(benchmark_asset)
 
+    qs = _get_quantstats_lumi()
+
     # Run quantstats reports surpressing any logs because it can be noisy for no reason
     try:
         with open(os.devnull, "w") as f, contextlib.redirect_stdout(f), contextlib.redirect_stderr(f):
@@ -1879,7 +1987,7 @@ def create_tearsheet(
                 return f"{float(value) * 100.0:.2f}%"
 
             try:
-                import quantstats_lumi as _qs
+                _qs = qs
 
                 strat_returns = _qs.utils._prepare_returns(df_final["strategy"].astype(float))
                 bench_returns = _qs.utils._prepare_returns(df_final["benchmark"].astype(float))
@@ -2009,13 +2117,15 @@ def create_tearsheet(
 
     if show_tearsheet and not disable_ui:
         url = "file://" + os.path.abspath(str(tearsheet_file))
-        webbrowser.open(url)
+        _get_webbrowser().open(url)
 
     return result
 
 
 def get_risk_free_rate(dt: datetime = None):
     try:
+        from .yahoo_helper import YahooHelper as yh
+
         result = yh.get_risk_free_rate(dt=dt)
     except Exception as e:
         logger.error(f"Error getting the risk free rate: {e}")

--- a/lumibot/tools/lumibot_logger.py
+++ b/lumibot/tools/lumibot_logger.py
@@ -50,14 +50,10 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Tuple, Optional
+from typing import Dict, Tuple
 from enum import Enum
 
-# Import LUMIWEALTH_API_KEY from credentials
-try:
-    from ..credentials import LUMIWEALTH_API_KEY
-except ImportError:
-    LUMIWEALTH_API_KEY = None
+LUMIWEALTH_API_KEY = os.environ.get("LUMIWEALTH_API_KEY")
 
 class CSVErrorHandler(logging.Handler):
     """

--- a/lumibot/tools/pandas.py
+++ b/lumibot/tools/pandas.py
@@ -1,8 +1,31 @@
+from __future__ import annotations
+
 from datetime import time
 from decimal import Decimal
 
-import pandas as pd
-import numpy as np
+
+def _pd():
+    import pandas as pd
+
+    return pd
+
+
+def _np():
+    import numpy as np
+
+    return np
+
+
+def __getattr__(name):
+    if name == "pd":
+        module = _pd()
+        globals()["pd"] = module
+        return module
+    if name == "np":
+        module = _np()
+        globals()["np"] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def day_deduplicate(df_):
@@ -13,6 +36,7 @@ def day_deduplicate(df_):
 
 
 def is_daily_data(df_):
+    pd = _pd()
     times = pd.Series(df_.index).apply(lambda x: x.time()).unique()
     if len(times) == 1 and times[0] == time(0, 0):
         return True
@@ -20,6 +44,7 @@ def is_daily_data(df_):
 
 
 def fill_void(df_, interval, end):
+    pd = _pd()
     n_rows = len(df_.index)
     missing_lines = pd.DataFrame()
     for index, row in df_.iterrows():
@@ -50,6 +75,7 @@ def print_full_pandas_dataframes():
     """
     Show the whole dataframe when printing pandas dataframes
     """
+    pd = _pd()
     pd.set_option('display.max_columns', None)
     pd.set_option('display.max_colwidth', None)
     pd.set_option('display.max_rows', None)
@@ -57,11 +83,14 @@ def print_full_pandas_dataframes():
 
 
 def set_pandas_float_display_precision(precision: int = 5):
+    pd = _pd()
     format_str = '{:.' + str(precision) + 'f}'
     pd.set_option('display.float_format', format_str.format)
 
 
-def prettify_dataframe_with_decimals(df: pd.DataFrame, decimal_places: int = 5) -> str:
+def prettify_dataframe_with_decimals(df, decimal_places: int = 5) -> str:
+    np = _np()
+
     def decimal_formatter(x):
         if isinstance(x, (Decimal, float, int, np.float64, np.int64)):
             return f"{x:.{decimal_places}f}"

--- a/lumibot/tools/parquet_series_cache.py
+++ b/lumibot/tools/parquet_series_cache.py
@@ -2,15 +2,35 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from importlib import import_module
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
-
-import pandas as pd
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.tools.backtest_cache import get_backtest_cache
 
 logger = logging.getLogger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
 
 
 @dataclass(frozen=True)

--- a/lumibot/tools/parquet_utils.py
+++ b/lumibot/tools/parquet_utils.py
@@ -4,11 +4,31 @@ import json
 import os
 import time
 from dataclasses import dataclass
+from importlib import import_module
 from typing import Any, Callable, Optional
 
-import pandas as pd
-
 _TRUTHY = {"required", "require", "strict", "1", "true", "yes"}
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
 
 
 @dataclass(frozen=True)

--- a/lumibot/tools/polars_utils.py
+++ b/lumibot/tools/polars_utils.py
@@ -4,7 +4,22 @@ from __future__ import annotations
 
 from typing import Iterable, Optional, Sequence, Set
 
-import polars as pl
+
+class _LazyPolars:
+    _module = None
+
+    def _load(self):
+        if self._module is None:
+            import polars as pl
+
+            self._module = pl
+        return self._module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pl = _LazyPolars()
 
 
 class PolarsResampleError(Exception):

--- a/lumibot/tools/polygon_helper.py
+++ b/lumibot/tools/polygon_helper.py
@@ -1,29 +1,101 @@
+from __future__ import annotations
+
 # This file contains helper functions for getting data from Polygon.io
 import os
 import time
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
 from pathlib import Path
-from typing import Iterator, List, Optional
+from typing import TYPE_CHECKING, Iterator, List, Optional
 from urllib.parse import urlparse, urlunparse
 
-import pandas as pd
-import pandas_market_calendars as mcal
-from polygon.exceptions import BadResponse
-
-# noinspection PyPackageRequirements
-from polygon.rest import RESTClient
-from termcolor import colored
-from tqdm import tqdm
-from urllib3.exceptions import MaxRetryError
-
-from lumibot.constants import LUMIBOT_CACHE_FOLDER, LUMIBOT_DEFAULT_PYTZ
-from lumibot.credentials import POLYGON_API_KEY
+from lumibot import LUMIBOT_CACHE_FOLDER
 from lumibot.entities import Asset
-from lumibot.tools.lumibot_logger import get_logger
 
-logger = get_logger(__name__)
+if TYPE_CHECKING:
+    from polygon.rest import RESTClient
+
+_POLYGON_CLIENT_CLASSES = {}
+_COLORED_FN = None
+_DEFAULT_PYTZ = None
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_TQDM_FUNC = None
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        object.__setattr__(self, "_logger", None)
+
+    def _load(self):
+        logger = object.__getattribute__(self, "_logger")
+        if logger is None:
+            from lumibot.tools.lumibot_logger import get_logger
+
+            logger = get_logger(__name__)
+            object.__setattr__(self, "_logger", logger)
+        return logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _colored
+
+        _COLORED_FN = _colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _default_pytz():
+    global _DEFAULT_PYTZ
+    if _DEFAULT_PYTZ is None:
+        from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
+
+        _DEFAULT_PYTZ = LUMIBOT_DEFAULT_PYTZ
+    return _DEFAULT_PYTZ
+
+
+def _polygon_api_key():
+    from lumibot.credentials import POLYGON_API_KEY
+
+    return POLYGON_API_KEY
+
+
+def tqdm(*args, **kwargs):
+    global _TQDM_FUNC
+    if _TQDM_FUNC is None:
+        from tqdm import tqdm as _real_tqdm
+
+        _TQDM_FUNC = _real_tqdm
+    return _TQDM_FUNC(*args, **kwargs)
 
 # Adjust as desired, in days. We'll reuse any existing chain file
 # that is not older than RECENT_FILE_TOLERANCE_DAYS.
@@ -35,6 +107,16 @@ MAX_POLYGON_DAYS = 30
 # Define a cache dictionary to store schedules and a global dictionary for buffered schedules
 schedule_cache = {}
 buffered_schedules = {}
+_PANDAS_MARKET_CALENDARS = None
+
+
+def _get_market_calendars():
+    global _PANDAS_MARKET_CALENDARS
+    if _PANDAS_MARKET_CALENDARS is None:
+        import pandas_market_calendars as mcal
+
+        _PANDAS_MARKET_CALENDARS = mcal
+    return _PANDAS_MARKET_CALENDARS
 
 
 def get_cached_schedule(cal, start_date, end_date, buffer_days=30):
@@ -213,6 +295,8 @@ def get_price_data_from_polygon(
             limit=50000,
         )
 
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_to_range = {executor.submit(fetch_chunk, cstart, cend): (cstart, cend)
                            for (cstart, cend) in chunks}
@@ -373,11 +457,13 @@ def get_trading_dates(asset: Asset, start: datetime, end: datetime):
         or asset.asset_type == Asset.AssetType.STOCK
         or asset.asset_type == Asset.AssetType.OPTION
     ):
+        mcal = _get_market_calendars()
         cal = mcal.get_calendar("NYSE")
 
     # Forex Asset for Backtesting - Forex trades weekdays, 24hrs starting Sunday 5pm EST
     # Calendar: "CME_FX"
     elif asset.asset_type == Asset.AssetType.FOREX:
+        mcal = _get_market_calendars()
         cal = mcal.get_calendar("CME_FX")
 
     else:
@@ -633,7 +719,7 @@ def update_cache(
         if d not in cached_dates:
             # Create a datetime at the start of the day using the default timezone,
             # then convert to UTC.
-            dt = datetime(year=d.year, month=d.month, day=d.day, tzinfo=LUMIBOT_DEFAULT_PYTZ)
+            dt = datetime(year=d.year, month=d.month, day=d.day, tzinfo=_default_pytz())
             dt_utc = dt.astimezone(timezone.utc)
             dummy_rows.append((dt_utc, {"missing": True}))
     # If any dummy rows were created, add them to the DataFrame.
@@ -871,10 +957,29 @@ def get_chains_cached(
     return option_contracts
 
 
-class PolygonClient(RESTClient):
+def _polygon_client_class(facade_cls):
+    client_class = _POLYGON_CLIENT_CLASSES.get(facade_cls)
+    if client_class is not None:
+        return client_class
+
+    from polygon.rest import RESTClient
+
+    client_class = type(
+        "_RateLimitedPolygonClient",
+        (facade_cls, RESTClient),
+        {"__module__": __name__},
+    )
+    _POLYGON_CLIENT_CLASSES[facade_cls] = client_class
+    return client_class
+
+
+class PolygonClient:
     ''' Rate Limited RESTClient with factory method '''
 
     WAIT_SECONDS_RETRY = 60
+
+    def __new__(cls, *args, **kwargs):
+        return object.__new__(_polygon_client_class(cls))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -916,7 +1021,7 @@ class PolygonClient(RESTClient):
 
         """
         if 'api_key' not in kwargs or kwargs.get('api_key') is None:
-            kwargs['api_key'] = POLYGON_API_KEY
+            kwargs['api_key'] = _polygon_api_key()
 
         return cls(*args, **kwargs)
 
@@ -925,6 +1030,9 @@ class PolygonClient(RESTClient):
         Override to handle rate-limits by sleeping 60s, but *throttle*
         the log message so it isn't repeated too frequently.
         """
+        from polygon.exceptions import BadResponse
+        from urllib3.exceptions import MaxRetryError
+
         max_attempts = int(os.environ.get("POLYGON_MAX_RETRY_ATTEMPTS", "0") or "0")
         max_total_sleep = int(os.environ.get("POLYGON_MAX_RETRY_SLEEP_SECONDS", "0") or "0")
         wait_seconds = int(os.environ.get("POLYGON_WAIT_SECONDS_RETRY", str(PolygonClient.WAIT_SECONDS_RETRY)) or "0")

--- a/lumibot/tools/polygon_helper_async.py
+++ b/lumibot/tools/polygon_helper_async.py
@@ -1,16 +1,11 @@
 # Async implementation for Polygon data downloads - significantly faster than sync version
-import asyncio
+from __future__ import annotations
+
 import time
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional
+from importlib import import_module
+from typing import Any, Dict, List, Optional
 
-import aiohttp
-import polars as pl
-
-try:
-    from tqdm.asyncio import tqdm
-except ImportError:
-    from tqdm import tqdm
 from lumibot.entities import Asset
 from lumibot.tools.lumibot_logger import get_logger
 
@@ -20,9 +15,54 @@ logger = get_logger(__name__)
 MAX_CONCURRENT_REQUESTS = 50  # Much higher than sync version
 MAX_POLYGON_DAYS = 7  # Smaller chunks for better parallelization
 RATE_LIMIT_PER_MINUTE = 100  # Polygon rate limit
-CONNECTION_TIMEOUT = aiohttp.ClientTimeout(total=60, connect=10, sock_read=30)
 MAX_RETRIES = 3
 RETRY_DELAY = 0.5
+
+_AIOHTTP = None
+_ASYNCIO = None
+_POLARS = None
+_TQDM = None
+
+
+def _asyncio():
+    global _ASYNCIO
+    if _ASYNCIO is None:
+        _ASYNCIO = import_module("asyncio")
+    return _ASYNCIO
+
+
+def _aiohttp():
+    global _AIOHTTP
+    if _AIOHTTP is None:
+        import aiohttp
+
+        _AIOHTTP = aiohttp
+    return _AIOHTTP
+
+
+def _pl():
+    global _POLARS
+    if _POLARS is None:
+        import polars as pl
+
+        _POLARS = pl
+    return _POLARS
+
+
+def _tqdm():
+    global _TQDM
+    if _TQDM is None:
+        try:
+            from tqdm.asyncio import tqdm
+        except ImportError:
+            from tqdm import tqdm
+
+        _TQDM = tqdm
+    return _TQDM
+
+
+def _connection_timeout():
+    return _aiohttp().ClientTimeout(total=60, connect=10, sock_read=30)
 
 class AsyncPolygonClient:
     """Async Polygon client for high-performance data downloads."""
@@ -30,11 +70,12 @@ class AsyncPolygonClient:
     def __init__(self, api_key: str):
         self.api_key = api_key
         self.base_url = "https://api.polygon.io"
-        self.session: Optional[aiohttp.ClientSession] = None
+        self.session = None
         self.rate_limiter = RateLimiter(RATE_LIMIT_PER_MINUTE)
 
     async def __aenter__(self):
         """Create session on context enter."""
+        aiohttp = _aiohttp()
         connector = aiohttp.TCPConnector(
             limit=100,
             limit_per_host=50,
@@ -43,7 +84,7 @@ class AsyncPolygonClient:
         )
         self.session = aiohttp.ClientSession(
             connector=connector,
-            timeout=CONNECTION_TIMEOUT,
+            timeout=_connection_timeout(),
             headers={"Authorization": f"Bearer {self.api_key}"}
         )
         return self
@@ -64,6 +105,7 @@ class AsyncPolygonClient:
     ) -> Optional[List[Dict]]:
         """Get aggregated bars data."""
         await self.rate_limiter.acquire()
+        asyncio = _asyncio()
 
         # Format dates
         from_str = from_date.strftime("%Y-%m-%d")
@@ -106,10 +148,11 @@ class RateLimiter:
         self.calls_per_minute = calls_per_minute
         self.min_interval = 60.0 / calls_per_minute
         self.last_call = 0
-        self.lock = asyncio.Lock()
+        self.lock = _asyncio().Lock()
 
     async def acquire(self):
         """Wait if necessary to respect rate limit."""
+        asyncio = _asyncio()
         async with self.lock:
             now = time.time()
             time_since_last = now - self.last_call
@@ -126,7 +169,7 @@ async def download_polygon_data_async(
     timespan: str = "minute",
     quote_asset: Optional[Asset] = None,
     symbol: Optional[str] = None
-) -> Optional[pl.DataFrame]:
+) -> Optional[Any]:
     """
     Download Polygon data using async/await for maximum performance.
     
@@ -178,8 +221,10 @@ async def download_polygon_data_async(
 
     # Download all chunks in parallel
     async with AsyncPolygonClient(api_key) as client:
+        asyncio = _asyncio()
+
         # Create progress bar
-        pbar = tqdm(
+        pbar = _tqdm()(
             total=len(chunks),
             desc=f"Async downloading {asset.symbol} {timespan}",
             dynamic_ncols=True
@@ -208,6 +253,7 @@ async def download_polygon_data_async(
         return None
 
     # Optimized DataFrame creation
+    pl = _pl()
     df = pl.DataFrame(results, schema_overrides={
         "o": pl.Float64,
         "h": pl.Float64,
@@ -238,7 +284,7 @@ def get_price_data_from_polygon_async(
     timespan: str = "minute",
     quote_asset: Optional[Asset] = None,
     force_cache_update: bool = False
-) -> Optional[pl.DataFrame]:
+) -> Optional[Any]:
     """
     Wrapper function to use async download in sync context.
     
@@ -260,7 +306,7 @@ def get_price_data_from_polygon_async(
     # Validate cache
     force_cache_update = validate_cache_polars(force_cache_update, asset, cache_file, api_key)
 
-    df_all: Optional[pl.DataFrame] = None
+    df_all: Optional[Any] = None
 
     # Load cached data if available
     if cache_file.exists() and not force_cache_update:
@@ -283,6 +329,7 @@ def get_price_data_from_polygon_async(
     end_dt = datetime.combine(poly_end, datetime.max.time(), tzinfo=timezone.utc)
 
     # Run async download
+    asyncio = _asyncio()
     try:
         loop = asyncio.get_event_loop()
     except RuntimeError:
@@ -300,6 +347,7 @@ def get_price_data_from_polygon_async(
         if df_all is None or len(df_all) == 0:
             df_all = new_data
         else:
+            pl = _pl()
             df_all = (
                 pl.concat([df_all.lazy(), new_data.lazy()])
                 .sort("datetime")
@@ -312,6 +360,7 @@ def get_price_data_from_polygon_async(
     df_all = update_cache_polars(cache_file, df_all, missing_dates)
 
     # Reload and clean cache
+    pl = _pl()
     df_all_full = load_cache_polars(cache_file)
     if "missing" in df_all_full.columns:
         df_all_output = df_all_full.filter(~pl.col("missing").cast(pl.Boolean))

--- a/lumibot/tools/polygon_helper_polars_optimized.py
+++ b/lumibot/tools/polygon_helper_polars_optimized.py
@@ -1,23 +1,38 @@
 # This file contains helper functions for getting data from Polygon.io optimized with Polars
+from __future__ import annotations
+
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Iterator, List, Optional
-
-import pandas_market_calendars as mcal
-import polars as pl
-
-# noinspection PyPackageRequirements
-from termcolor import colored
-from tqdm import tqdm
+from typing import TYPE_CHECKING, Iterator, List, Optional
 
 from lumibot.constants import LUMIBOT_CACHE_FOLDER
 from lumibot.entities import Asset
 from lumibot.tools.lumibot_logger import get_logger
 
+if TYPE_CHECKING:
+    from lumibot.tools.polygon_helper import PolygonClient
+
 logger = get_logger(__name__)
+
+
+class _LazyPolars:
+    _module = None
+
+    def _load(self):
+        if self._module is None:
+            import polars as pl
+
+            self._module = pl
+        return self._module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pl = _LazyPolars()
 
 # Adjust as desired, in days. We'll reuse any existing chain file
 # that is not older than RECENT_FILE_TOLERANCE_DAYS.
@@ -33,6 +48,16 @@ MAX_CONCURRENT_REQUESTS = 20
 # Define a cache dictionary to store schedules and a global dictionary for buffered schedules
 schedule_cache = {}
 buffered_schedules = {}
+_PANDAS_MARKET_CALENDARS = None
+
+
+def _get_market_calendars():
+    global _PANDAS_MARKET_CALENDARS
+    if _PANDAS_MARKET_CALENDARS is None:
+        import pandas_market_calendars as mcal
+
+        _PANDAS_MARKET_CALENDARS = mcal
+    return _PANDAS_MARKET_CALENDARS
 
 
 def get_cached_schedule(cal, start_date, end_date, buffer_days=30):
@@ -169,6 +194,8 @@ def get_price_data_from_polygon_polars(
         s_date = e_date + timedelta(days=1)
 
     # Download data in parallel with optimized batch processing
+    from tqdm import tqdm
+
     pbar = tqdm(total=total_queries,
             desc=f"Downloading and caching {asset} / {quote_asset.symbol if quote_asset else ''} '{timespan}'",
             dynamic_ncols=True)
@@ -322,11 +349,13 @@ def get_trading_dates(asset: Asset, start: datetime, end: datetime):
         or asset.asset_type == Asset.AssetType.STOCK
         or asset.asset_type == Asset.AssetType.OPTION
     ):
+        mcal = _get_market_calendars()
         cal = mcal.get_calendar("NYSE")
 
     # Forex Asset for Backtesting - Forex trades weekdays, 24hrs starting Sunday 5pm EST
     # Calendar: "CME_FX"
     elif asset.asset_type == Asset.AssetType.FOREX:
+        mcal = _get_market_calendars()
         cal = mcal.get_calendar("CME_FX")
 
     else:
@@ -395,6 +424,8 @@ def get_polygon_symbol(asset, polygon_client, quote_asset=None):
         )
 
         if len(contracts) == 0:
+            from termcolor import colored
+
             text = colored(f"Unable to find option contract for {asset}", "red")
             logger.debug(text)
             return

--- a/lumibot/tools/projectx_helpers.py
+++ b/lumibot/tools/projectx_helpers.py
@@ -4,15 +4,16 @@ ProjectX Helper Utilities for Lumibot Integration
 This module provides the core ProjectX API client and streaming functionality
 integrated into Lumibot's architecture based on the actual working Project X library.
 """
+from __future__ import annotations
 
 import time
 import warnings
 from datetime import datetime
+from importlib import import_module
+from importlib.util import find_spec
 from typing import Callable, Optional, Dict, List
 
-import pandas as pd
 import pytz
-import requests
 
 from lumibot.tools.lumibot_logger import get_logger
 
@@ -25,12 +26,45 @@ warnings.filterwarnings("ignore", category=DeprecationWarning, message="websocke
 
 logger = get_logger(__name__)
 
-# SignalR imports - will be imported when needed
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+requests = _LazyModule("requests")
+_SIGNALR_MODULE = _LazyModule("signalrcore.hub_connection_builder")
 try:
-    from signalrcore.hub_connection_builder import HubConnectionBuilder
-    SIGNALR_AVAILABLE = True
-except ImportError:
+    SIGNALR_AVAILABLE = find_spec("signalrcore.hub_connection_builder") is not None
+except ModuleNotFoundError:
     SIGNALR_AVAILABLE = False
+
+
+def _hub_connection_builder_class():
+    return _SIGNALR_MODULE.HubConnectionBuilder
 
 
 class ProjectXAuth:
@@ -129,7 +163,7 @@ class ProjectXStreaming:
             
             hub_url_with_auth = f"{self.user_hub_url}?access_token={self.token}"
             
-            self.user_connection = HubConnectionBuilder() \
+            self.user_connection = _hub_connection_builder_class()() \
                 .with_url(hub_url_with_auth) \
                 .with_automatic_reconnect({
                     "type": "raw",

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -1,4 +1,6 @@
 # This file contains helper functions for getting data from Polygon.io
+from __future__ import annotations
+
 import functools
 import hashlib
 import json
@@ -9,26 +11,124 @@ import re
 import signal
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlencode, urlparse
 
-import pandas as pd
-import pandas_market_calendars as mcal
 import pytz
-import requests
-from dateutil import parser as dateutil_parser
-from tqdm import tqdm
 
-from lumibot import LUMIBOT_CACHE_FOLDER, LUMIBOT_DEFAULT_PYTZ
+from lumibot import LUMIBOT_CACHE_FOLDER, LUMIBOT_DEFAULT_TIMEZONE
 from lumibot.entities import Asset
-from lumibot.tools.backtest_cache import CacheMode, get_backtest_cache
-from lumibot.tools.lumibot_logger import get_logger
 
-logger = get_logger(__name__)
+LUMIBOT_DEFAULT_PYTZ = pytz.timezone(LUMIBOT_DEFAULT_TIMEZONE)
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        if name in {"_module_name", "_module"}:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+mcal = _LazyModule("pandas_market_calendars")
+requests = _LazyModule("requests")
+_TQDM_FUNC = None
+_BACKTEST_CACHE_MODE = None
+_BACKTEST_CACHE_GETTER = None
+_DATEUTIL_PARSE = None
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        object.__setattr__(self, "_logger", None)
+
+    def _load(self):
+        logger = object.__getattribute__(self, "_logger")
+        if logger is None:
+            from lumibot.tools.lumibot_logger import get_logger
+
+            logger = get_logger(__name__)
+            object.__setattr__(self, "_logger", logger)
+        return logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
+
+
+def _dateutil_parse(value):
+    global _DATEUTIL_PARSE
+    if _DATEUTIL_PARSE is None:
+        from dateutil import parser as dateutil_parser
+
+        _DATEUTIL_PARSE = dateutil_parser.parse
+    return _DATEUTIL_PARSE(value)
+
+
+class _LazyCacheMode:
+    def __getattr__(self, name):
+        global _BACKTEST_CACHE_MODE
+        if _BACKTEST_CACHE_MODE is None:
+            from lumibot.tools.backtest_cache import CacheMode as _CacheMode
+
+            _BACKTEST_CACHE_MODE = _CacheMode
+        return getattr(_BACKTEST_CACHE_MODE, name)
+
+
+CacheMode = _LazyCacheMode()
+
+
+def get_backtest_cache():
+    global _BACKTEST_CACHE_GETTER
+    if _BACKTEST_CACHE_GETTER is None:
+        from lumibot.tools.backtest_cache import get_backtest_cache as _get_backtest_cache
+
+        _BACKTEST_CACHE_GETTER = _get_backtest_cache
+    return _BACKTEST_CACHE_GETTER()
+
+
+def _tqdm(*args, **kwargs):
+    global _TQDM_FUNC
+    if _TQDM_FUNC is None:
+        from tqdm import tqdm
+
+        _TQDM_FUNC = tqdm
+    return _TQDM_FUNC(*args, **kwargs)
+
+
+def tqdm(*args, **kwargs):
+    return _tqdm(*args, **kwargs)
 
 # ==============================================================================
 # Download Status Tracking
@@ -485,6 +585,16 @@ DIVIDEND_DATE_COLUMNS = ("ex_dividend_date", "ex_date", "ex_dividend", "executio
 SPLIT_NUMERATOR_COLUMNS = ("split_to", "to", "numerator", "ratio_to", "after_shares")
 SPLIT_DENOMINATOR_COLUMNS = ("split_from", "from", "denominator", "ratio_from", "before_shares")
 SPLIT_RATIO_COLUMNS = ("ratio", "split_ratio")
+
+
+def _corporate_action_horizon_date() -> date:
+    backtesting_end = os.environ.get("BACKTESTING_END")
+    if backtesting_end:
+        try:
+            return datetime.fromisoformat(backtesting_end).date()
+        except ValueError:
+            logger.debug("Ignoring unparseable BACKTESTING_END=%r for corporate actions", backtesting_end)
+    return date.today()
 
 OPTION_LIST_ENDPOINTS = {
     "expirations": "/v3/option/list/expirations",
@@ -1642,11 +1752,11 @@ def _get_option_query_strike(option_asset: Asset, sim_datetime: datetime = None)
     # Get the underlying stock asset
     underlying_asset = Asset(option_asset.symbol, asset_type="stock")
 
-    from datetime import date as date_type
-    today = date_type.today()
+    today = _corporate_action_horizon_date()
 
     # FIX (2025-12-12): Use sim_datetime as the reference date for split lookup.
-    # This ensures we catch all splits between the simulation date and today.
+    # This ensures we catch all splits between the simulation date and the
+    # corporate-action horizon (BACKTESTING_END for deterministic backtests, today otherwise).
     # Previously, we used option expiration, which missed splits that occurred
     # BEFORE the expiration but AFTER the sim_datetime.
     if sim_datetime is not None:
@@ -1795,9 +1905,7 @@ def _apply_corporate_actions_to_frame(
         if underlying_asset is None:
             underlying_asset = Asset(getattr(asset, "symbol", ""), asset_type="stock")
 
-        from datetime import date as date_type
-
-        today = date_type.today()
+        today = _corporate_action_horizon_date()
         splits = _get_theta_splits(underlying_asset, start_day, today, username, password)
 
         if splits is None or splits.empty:
@@ -1834,12 +1942,11 @@ def _apply_corporate_actions_to_frame(
         return frame
 
     dividends = _get_theta_dividends(asset, start_day, end_day, username, password)
-    # CRITICAL: Fetch splits up to TODAY, not the data's end date!
+    # CRITICAL: Fetch splits up to the corporate-action horizon, not the data's end date!
     # When fetching March 2020 data, we still need to know about the July 2022 split
     # so we can adjust historical prices to be comparable to current prices.
     # This matches Yahoo Finance behavior where Adj Close always reflects current splits.
-    from datetime import date as date_type
-    today = date_type.today()
+    today = _corporate_action_horizon_date()
     splits = _get_theta_splits(asset, start_day, today, username, password)
     if "dividend" not in frame.columns:
         frame["dividend"] = 0.0
@@ -1869,7 +1976,7 @@ def _apply_corporate_actions_to_frame(
             # Sort splits by date (oldest first)
             sorted_splits = splits.sort_values("event_date")
 
-            # IMPORTANT: Apply ALL splits up to TODAY's date, not the data's end date.
+            # IMPORTANT: Apply ALL splits up to the corporate-action horizon, not the data's end date.
             # When we fetch March 2020 data in 2025, we need to apply the July 2022 split
             # so that historical prices are comparable to current split-adjusted prices.
             # This matches how Yahoo Finance calculates Adj Close - it always reflects
@@ -3344,6 +3451,8 @@ def get_price_data(
             result_df=result_df,
         )
     else:
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
         with ThreadPoolExecutor(max_workers=chunk_workers) as executor:
             future_map: Dict[Any, Tuple[datetime, datetime, float]] = {}
             for chunk_start, chunk_end in chunk_ranges:
@@ -5756,7 +5865,7 @@ def get_historical_eod_data(
             ts = pd.to_datetime(value, errors="coerce")
             if ts is None or pd.isna(ts):
                 try:
-                    parsed = dateutil_parser.parse(str(value))
+                    parsed = _dateutil_parse(str(value))
                 except Exception:
                     return None
                 if parsed.tzinfo is None:
@@ -6756,9 +6865,8 @@ def build_historical_chain(
     # - Without this fix, the strategy tries to buy $1320 strike (wrong!)
     # - With this fix, strikes are adjusted: $1320 / 20 = $66 (correct!)
     #
-    # We fetch splits from as_of_date to TODAY and apply the cumulative ratio.
-    from datetime import date as date_type
-    today = date_type.today()
+    # We fetch splits from as_of_date to the corporate-action horizon and apply the cumulative ratio.
+    today = _corporate_action_horizon_date()
 
     # Fetch splits that occurred AFTER the backtest date
     splits = _get_theta_splits(asset, as_of_date, today)

--- a/lumibot/tools/yahoo_helper.py
+++ b/lumibot/tools/yahoo_helper.py
@@ -1,22 +1,87 @@
+from __future__ import annotations
+
 import os
 import pickle
 import time
 import random
-from pathlib import Path
+from importlib import import_module
 from datetime import datetime, timedelta
+from pathlib import Path
 
-import pandas as pd
-import yfinance as yf
-from fp.fp import FreeProxy
+from lumibot import LUMIBOT_CACHE_FOLDER
 
-from ..constants import LUMIBOT_CACHE_FOLDER, LUMIBOT_DEFAULT_PYTZ
-from .lumibot_logger import get_logger
-from .helpers import get_lumibot_datetime
-
-logger = get_logger(__name__)
+_DEFAULT_PYTZ = None
+_GET_LUMIBOT_DATETIME = None
 
 INFO_DATA = "info"
 INVALID_SYMBOLS = set()
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+
+
+class _LazyLogger:
+    __slots__ = ("_logger",)
+
+    def __init__(self):
+        object.__setattr__(self, "_logger", None)
+
+    def _load(self):
+        logger = object.__getattribute__(self, "_logger")
+        if logger is None:
+            from .lumibot_logger import get_logger
+
+            logger = get_logger(__name__)
+            object.__setattr__(self, "_logger", logger)
+        return logger
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+logger = _LazyLogger()
+
+
+def _default_pytz():
+    global _DEFAULT_PYTZ
+    if _DEFAULT_PYTZ is None:
+        from ..constants import LUMIBOT_DEFAULT_PYTZ
+
+        _DEFAULT_PYTZ = LUMIBOT_DEFAULT_PYTZ
+    return _DEFAULT_PYTZ
+
+
+def _get_lumibot_datetime():
+    global _GET_LUMIBOT_DATETIME
+    if _GET_LUMIBOT_DATETIME is None:
+        from .helpers import get_lumibot_datetime
+
+        _GET_LUMIBOT_DATETIME = get_lumibot_datetime
+    return _GET_LUMIBOT_DATETIME()
+
+
+def _get_yfinance():
+    import yfinance as yf
+
+    return yf
 
 
 class _YahooData:
@@ -28,7 +93,7 @@ class _YahooData:
 
     def is_up_to_date(self, last_needed_datetime=None):
         if last_needed_datetime is None:
-            last_needed_datetime = get_lumibot_datetime()
+            last_needed_datetime = _get_lumibot_datetime()
 
         if self.type == '1d':
             last_needed_date = last_needed_datetime.date()
@@ -76,6 +141,8 @@ class YahooHelper:
         time.sleep(random.uniform(2, 5))
 
         if YahooHelper.YAHOO_FREE_PROXY_ENABLED:
+            from fp.fp import FreeProxy
+
             return FreeProxy(timeout=5).get()
         return None
 
@@ -169,9 +236,9 @@ class YahooHelper:
         df.sort_index(inplace=True)
 
         if df.index.tzinfo is None:
-            df.index = pd.to_datetime(df.index).tz_localize(LUMIBOT_DEFAULT_PYTZ)
+            df.index = pd.to_datetime(df.index).tz_localize(_default_pytz())
         else:
-            df.index = df.index.tz_convert(LUMIBOT_DEFAULT_PYTZ)
+            df.index = df.index.tz_convert(_default_pytz())
 
         return df
 
@@ -179,6 +246,7 @@ class YahooHelper:
 
     @staticmethod
     def download_symbol_info(symbol):
+        yf = _get_yfinance()
         proxy = YahooHelper.sleep_and_get_proxy()
         if proxy:
             yf.set_config(proxy=proxy)
@@ -191,20 +259,21 @@ class YahooHelper:
             logger.debug(e)
             return {
                 "ticker": symbol,
-                "last_update": get_lumibot_datetime(),
+                "last_update": _get_lumibot_datetime(),
                 "error": True,
                 "info": None,
             }
 
         return {
             "ticker": ticker.ticker,
-            "last_update": get_lumibot_datetime(),
+            "last_update": _get_lumibot_datetime(),
             "error": False,
             "info": info,
         }
 
     @staticmethod
     def get_symbol_info(symbol):
+        yf = _get_yfinance()
         proxy = YahooHelper.sleep_and_get_proxy()
         if proxy:
             yf.set_config(proxy=proxy)
@@ -213,6 +282,7 @@ class YahooHelper:
 
     @staticmethod
     def get_symbol_last_price(symbol):
+        yf = _get_yfinance()
         proxy = YahooHelper.sleep_and_get_proxy()
         if proxy:
             yf.set_config(proxy=proxy)
@@ -239,6 +309,7 @@ class YahooHelper:
             logger.debug(f"{symbol} is already marked invalid. Skipping yfinance calls.")
             return None
 
+        yf = _get_yfinance()
         ticker = yf.Ticker(symbol)
 
         # --- HISTORICAL DATA RETRY LOGIC ---
@@ -254,13 +325,13 @@ class YahooHelper:
                 if interval == "1m":
                     df = ticker.history(
                         interval=interval,
-                        start=get_lumibot_datetime() - timedelta(days=7),
+                        start=_get_lumibot_datetime() - timedelta(days=7),
                         auto_adjust=False
                     )
                 elif interval == "15m":
                     df = ticker.history(
                         interval=interval,
-                        start=get_lumibot_datetime() - timedelta(days=60),
+                        start=_get_lumibot_datetime() - timedelta(days=60),
                         auto_adjust=False
                     )
                 else:
@@ -337,6 +408,7 @@ class YahooHelper:
             return {symbols[0]: item}
 
         result = {}
+        yf = _get_yfinance()
         proxy = YahooHelper.sleep_and_get_proxy()
         if proxy:
             yf.set_config(proxy=proxy)

--- a/lumibot/tools/yahoo_helper_polars_optimized.py
+++ b/lumibot/tools/yahoo_helper_polars_optimized.py
@@ -1,16 +1,37 @@
 """Optimized Yahoo finance helper using pure polars with minimal conversions."""
+from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from importlib import import_module
 from pathlib import Path
 from typing import Any, Dict, Optional
-
-import polars as pl
-import yfinance as yf
 
 from lumibot.constants import LUMIBOT_CACHE_FOLDER
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pl = _LazyModule("polars")
+yf = _LazyModule("yfinance")
 
 
 class YahooHelperPolarsOptimized:

--- a/tests/test_data_entity.py
+++ b/tests/test_data_entity.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
+import pytest
 import pytz
 
 from lumibot.entities import Asset
@@ -159,3 +160,90 @@ class TestDataGetLastPriceTradeOnly:
         tz = pytz.timezone("America/New_York")
         dt = tz.localize(datetime(2024, 1, 3, 9, 30))
         assert data.get_last_price(dt) == 5.0
+
+
+def test_native_minute_bars_fast_returns_lazy_pandas_slice_until_used():
+    asset = Asset("SPY")
+    tz = pytz.timezone("America/New_York")
+    idx = pd.date_range(tz.localize(datetime(2024, 1, 2, 9, 30)), periods=20, freq="1min")
+    df = pd.DataFrame(
+        {
+            "open": range(20),
+            "high": range(1, 21),
+            "low": range(20),
+            "close": range(2, 22),
+            "volume": [100] * 20,
+        },
+        index=idx,
+    )
+    data = Data(asset, df, timestep="minute")
+
+    bars_df = data.get_native_bars_fast(idx[10].to_pydatetime(), length=5, timestep="minute", mark_timezone=False)
+
+    assert isinstance(bars_df, pd.DataFrame)
+    assert len(bars_df) == 5
+    assert getattr(bars_df, "_lumibot_real_df", None) is None
+    assert bars_df["close"].iloc[-1] == 11
+    assert getattr(bars_df, "_lumibot_real_df", None) is not None
+
+
+def test_native_minute_bars_fast_lazy_slice_matches_common_pandas_ops():
+    asset = Asset("SPY")
+    tz = pytz.timezone("America/New_York")
+    idx = pd.date_range(tz.localize(datetime(2024, 1, 2, 9, 30)), periods=20, freq="1min")
+    df = pd.DataFrame(
+        {
+            "open": range(20),
+            "high": range(1, 21),
+            "low": range(20),
+            "close": range(2, 22),
+            "volume": [100] * 20,
+        },
+        index=idx,
+    )
+    data = Data(asset, df, timestep="minute")
+
+    fast_df = data.get_native_bars_fast(idx[10].to_pydatetime(), length=5, timestep="minute", mark_timezone=False)
+    slow_df = data.get_bars(idx[10].to_pydatetime(), length=5, timestep="minute", timeshift=None)
+
+    ops = {
+        "shape": lambda x: x.shape,
+        "dtypes": lambda x: tuple(map(str, x.dtypes)),
+        "iloc": lambda x: float(x.iloc[-1]["close"]),
+        "tail": lambda x: float(x.tail(1)["close"].iloc[0]),
+        "copy": lambda x: float(x.copy()["close"].iloc[-1]),
+        "reset_index": lambda x: x.reset_index().shape,
+        "to_numpy": lambda x: x.to_numpy().shape,
+        "describe": lambda x: round(float(x.describe().loc["mean", "close"]), 4),
+        "iterrows": lambda x: sum(1 for _ in x.iterrows()),
+    }
+
+    for op_name, op in ops.items():
+        assert op(fast_df) == op(slow_df), op_name
+
+
+def test_native_minute_bars_fast_lazy_slice_can_defer_return_column():
+    asset = Asset("SPY")
+    tz = pytz.timezone("America/New_York")
+    idx = pd.date_range(tz.localize(datetime(2024, 1, 2, 9, 30)), periods=20, freq="1min")
+    df = pd.DataFrame(
+        {
+            "open": range(20),
+            "high": range(1, 21),
+            "low": range(20),
+            "close": range(2, 22),
+            "volume": [100] * 20,
+        },
+        index=idx,
+    )
+    data = Data(asset, df, timestep="minute", assume_clean=True)
+    data._defer_clean_returns = True
+    data._initialize_clean_repaired_state()
+
+    bars_df = data.get_native_bars_fast(idx[10].to_pydatetime(), length=5, timestep="minute", mark_timezone=False)
+
+    assert getattr(bars_df, "_lumibot_real_df", None) is None
+    assert "return" in bars_df.columns
+    assert getattr(bars_df, "_lumibot_real_df", None) is None
+    assert bars_df["return"].iloc[0] == pytest.approx(1 / 6)
+    assert bars_df["return"].iloc[-1] == pytest.approx(0.1)

--- a/tests/test_ibkr_futures_daily_series.py
+++ b/tests/test_ibkr_futures_daily_series.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import date, datetime, timezone
 
 import pandas as pd
-import pytest
 
 from lumibot.entities import Asset
 
@@ -23,7 +22,7 @@ def test_ibkr_futures_daily_bars_are_session_aligned_not_midnight(monkeypatch):
     close_local = pd.Timestamp(sess["market_close"]).tz_convert("America/New_York")
     assert open_local < close_local
 
-    idx = pd.date_range(open_local, close_local, freq="1H", tz="America/New_York")
+    idx = pd.date_range(open_local, close_local, freq="1h", tz="America/New_York")
     intraday = pd.DataFrame(
         {
             "open": [100.0 for _ in idx],
@@ -61,4 +60,3 @@ def test_ibkr_futures_daily_bars_are_session_aligned_not_midnight(monkeypatch):
     # Futures "day" bar should be timestamped at the session close, not midnight.
     assert out.index[0].tz is not None
     assert out.index[0].hour != 0
-


### PR DESCRIPTION
Stacked on #1015. Split from #1013.

Scope:
- Add faster `Data`/`Bars` slicing and last-price paths.
- Optimize data source adapters and market-data helper modules.
- Keep IBKR/ThetaData corporate-action and timestep fixes with the data layer that needs them.

Validation:
- `uv run pytest -q tests/test_data_entity.py tests/test_ibkr_futures_daily_series.py tests/test_split_adjustment.py`