### PR TITLE
[codex] Optimize backtest execution hot paths

### DIFF
--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import math
@@ -8,26 +10,75 @@ import threading
 from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta
 from decimal import Decimal
+from importlib import import_module
+from types import ModuleType
 from typing import Any, Optional, Union
 
-import numpy as np
-import pandas as pd
-import polars as pl
-import pytz
-
 from lumibot.brokers import Broker
-from lumibot.data_sources import DataSourceBacktesting
-from lumibot.entities import Asset, Order, Position, SmartLimitConfig, TradingFee
-from lumibot.tools.smart_limit_utils import build_price_ladder, compute_final_price, compute_mid, expected_fill_price, infer_tick_size, round_to_tick
+from lumibot.brokers.broker import _FAST_TRADE_EVENT_MARKER, _FAST_TRADE_PAIR_EVENT_MARKER
+from lumibot.entities import Asset, Order, Position, SmartLimitConfig
+from lumibot.tools.smart_limit_utils import compute_final_price, compute_mid, expected_fill_price, infer_tick_size, round_to_tick
 from lumibot.tools.lumibot_logger import get_logger
 from lumibot.trading_builtins import CustomStream
 
-try:
-    from lumibot.backtesting.thetadata_backtesting_pandas import ThetaDataBacktestingPandas
-except Exception:  # pragma: no cover - optional dependency
-    ThetaDataBacktestingPandas = None
+ThetaDataBacktestingPandas = None
+_THETADATA_BACKTESTING_PANDAS_IMPORT_ATTEMPTED = False
+_POLARS_MODULE = None
+_NO_SIMPLE_POSITION = object()
+DataSourceBacktesting = None
 
 logger = get_logger(__name__)
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+np = _LazyModule("numpy")
+pd = _LazyModule("pandas")
+
+
+def _get_thetadata_backtesting_pandas_cls():
+    """Load ThetaDataBacktestingPandas only when a Theta-specific branch needs it."""
+    global ThetaDataBacktestingPandas, _THETADATA_BACKTESTING_PANDAS_IMPORT_ATTEMPTED
+    if not _THETADATA_BACKTESTING_PANDAS_IMPORT_ATTEMPTED:
+        _THETADATA_BACKTESTING_PANDAS_IMPORT_ATTEMPTED = True
+        try:
+            from lumibot.backtesting.thetadata_backtesting_pandas import ThetaDataBacktestingPandas as cls
+        except Exception:  # pragma: no cover - optional dependency
+            cls = None
+        ThetaDataBacktestingPandas = cls
+    return ThetaDataBacktestingPandas
+
+
+def _get_polars_module():
+    global _POLARS_MODULE
+    if _POLARS_MODULE is None:
+        import polars as pl
+
+        _POLARS_MODULE = pl
+    return _POLARS_MODULE
+
+
+def _data_source_backtesting_class():
+    global DataSourceBacktesting
+    if DataSourceBacktesting is None:
+        from lumibot.data_sources import DataSourceBacktesting
+
+    return DataSourceBacktesting
 
 
 # Typical initial margin requirements for common futures contracts
@@ -157,7 +208,7 @@ class BacktestingBroker(Broker):
         # self._config = config
 
         # Check if data source is a backtesting data source
-        if not (isinstance(self.data_source, DataSourceBacktesting) or
+        if not (isinstance(self.data_source, _data_source_backtesting_class()) or
                 (hasattr(self.data_source, 'IS_BACKTESTING_DATA_SOURCE') and
                  self.data_source.IS_BACKTESTING_DATA_SOURCE)):
             raise ValueError("Must provide a backtesting data_source to run with a BacktestingBroker")
@@ -380,6 +431,7 @@ class BacktestingBroker(Broker):
         performance bottleneck, so this method sources active orders directly from the
         broker's active-order buckets.
         """
+        strategy_name = self._strategy_name_from_input(strategy)
         active_orders: list[Order] = []
         try:
             buckets = (
@@ -389,7 +441,7 @@ class BacktestingBroker(Broker):
             )
         except Exception:
             # Fallback to the slower path if internal buckets are unavailable.
-            orders = self.get_tracked_orders(strategy=strategy)
+            orders = self.get_tracked_orders(strategy=strategy_name)
             if not orders:
                 return []
             return [
@@ -397,9 +449,15 @@ class BacktestingBroker(Broker):
                 if o.is_active() and (asset is None or getattr(o, "asset", None) == asset)
             ]
 
+        simple_by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+        if simple_by_strategy:
+            for order in simple_by_strategy.get(strategy_name, ()):
+                if asset is None or getattr(order, "asset", None) == asset:
+                    active_orders.append(order)
+
         for bucket in buckets:
             for order in bucket:
-                if getattr(order, "strategy", None) != strategy:
+                if getattr(order, "strategy", None) != strategy_name:
                     continue
                 if asset is not None and getattr(order, "asset", None) != asset:
                     continue
@@ -429,26 +487,27 @@ class BacktestingBroker(Broker):
         orders : list, optional
             List of minimal order dicts from Order.to_minimal_dict()
         """
-        tz = self.datetime.tzinfo
-        is_pytz = isinstance(tz, (pytz.tzinfo.StaticTzInfo, pytz.tzinfo.DstTzInfo))
+        current_datetime = self.data_source.get_datetime()
+        tz = current_datetime.tzinfo
+        normalize_tz = getattr(tz, "normalize", None)
 
-        previous_datetime = self.datetime
+        previous_datetime = current_datetime
 
         if isinstance(update_dt, timedelta):
-            new_datetime = self.datetime + update_dt
+            new_datetime = current_datetime + update_dt
         elif isinstance(update_dt, int) or isinstance(update_dt, float):
-            new_datetime = self.datetime + timedelta(seconds=update_dt)
+            new_datetime = current_datetime + timedelta(seconds=update_dt)
         else:
             new_datetime = update_dt
 
         # This is needed to handle Daylight Savings Time changes
-        new_datetime = tz.normalize(new_datetime) if is_pytz else new_datetime
+        new_datetime = normalize_tz(new_datetime) if callable(normalize_tz) else new_datetime
 
         # Guard against non-advancing timestamps (e.g., DST ambiguity)
         if new_datetime <= previous_datetime:
             new_datetime = previous_datetime + timedelta(minutes=1)
-            if is_pytz:
-                new_datetime = tz.normalize(new_datetime)
+            if callable(normalize_tz):
+                new_datetime = normalize_tz(new_datetime)
 
         self.data_source._update_datetime(
             new_datetime,
@@ -1004,9 +1063,17 @@ class BacktestingBroker(Broker):
         # Currently perfect fill price in backtesting!
         order.avg_fill_price = price
 
-        position = super()._process_filled_order(order, price, quantity)
+        self._new_orders.remove(order.identifier, key="identifier")
+        self._unprocessed_orders.remove(order.identifier, key="identifier")
+        self._partially_filled_orders.remove(order.identifier, key="identifier")
+        order.add_transaction(price, quantity)
+        order.status = self.FILLED_ORDER
+        order.set_filled()
+        self._track_filled_order(order)
+
         if existing_position:
-            position.add_order(order, quantity)  # Add will update quantity, but not double count the order
+            position = existing_position
+            position.add_order(order, quantity)
             if position.quantity == 0:
                 logger.info(f"Position {position} liquidated")
                 self._filled_positions.remove(position)
@@ -1032,7 +1099,14 @@ class BacktestingBroker(Broker):
                         cancel_sides=cancel_sides,
                     )
         else:
+            position = order.to_position(quantity)
+            if position is None:
+                logger.error(f"Skipping filled order processing - could not create position from order {order.identifier}")
+                return
             self._filled_positions.append(position)  # New position, add it to the tracker
+
+        if order.asset and "crypto" == order.asset.asset_type and not getattr(order, "_simple_is_crypto_forex", False):
+            self._process_crypto_quote(order, quantity, price)
 
         # If this is a child order, update the parent order status if all children are filled or cancelled.
         if order.parent_identifier:
@@ -1058,6 +1132,24 @@ class BacktestingBroker(Broker):
             return
         filled_ids.add(identifier)
         self._filled_orders.append(order)
+
+    def _track_unique_simple_filled_order(self, order: Order) -> None:
+        """Record a monotonic-ID simple backtest order without a duplicate-id side set."""
+        self._filled_orders.append(order)
+
+    def _finalize_fast_trade_pair_row(self, order: Order, pair_row) -> None:
+        """Freeze a filled pair row and remove temporary private order references."""
+        try:
+            row_index = order._fast_trade_event_pair_row_index
+            if self._trade_event_log_rows[row_index] is pair_row:
+                self._trade_event_log_rows[row_index] = tuple(pair_row)
+            del order._fast_trade_event_pair_row
+            del order._fast_trade_event_pair_row_index
+            del order._fast_trade_event_static
+        except AttributeError:
+            return
+        except Exception:
+            return
 
     def _process_partially_filled_order(self, order, price, quantity):
         """
@@ -1124,15 +1216,19 @@ class BacktestingBroker(Broker):
             self._unprocessed_orders.remove(order.identifier, key="identifier")
             self._partially_filled_orders.remove(order.identifier, key="identifier")
 
-            self._track_filled_order(order)
+            self._track_unique_simple_filled_order(order)
 
     def _submit_order(self, order):
         """Submit an order for an asset"""
+        if getattr(order, "_simple_is_option", None):
+            self._backtest_has_option_lifecycle_exposure = True
+        elif self._is_option_asset(getattr(order, "asset", None)):
+            self._backtest_has_option_lifecycle_exposure = True
 
         # Optional audit trail (submission-time context).
         #
         # Invariant: audit collection must never break backtests; any errors must be swallowed.
-        audit_enabled = self._audit_enabled()
+        audit_enabled = getattr(self, "_backtest_audit_enabled", False)
         if audit_enabled:
             try:
                 self._audit_merge(order, self._audit_submit_fields(order), overwrite=False)
@@ -1144,12 +1240,93 @@ class BacktestingBroker(Broker):
         # submitted below. Bracket/OTO orders will be submitted here, but their child orders will not be submitted
         # until the parent order is filled
         if order.order_class is not Order.OrderClass.OCO:
-            order.update_raw(order)
-            self.stream.dispatch(
-                self.NEW_ORDER,
-                wait_until_complete=True,
-                order=order,
-            )
+            actions = getattr(getattr(self, "stream", None), "_actions_mapping", None)
+            default_action = getattr(self, "_default_new_order_stream_action", None)
+            if actions is not None and actions.get(self.NEW_ORDER) is default_action and not audit_enabled:
+                try:
+                    if getattr(order, "_simple_backtest_order", False):
+                        order._transmitted = True
+                        order._raw = order
+                        order._status = self.NEW_ORDER
+                        if order._new_event is not None:
+                            order._new_event.set()
+                        by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+                        if by_strategy is None:
+                            by_strategy = {}
+                            self._simple_new_orders_by_strategy = by_strategy
+                        by_strategy.setdefault(order.strategy, []).append(order)
+                        self._simple_new_orders_revision = getattr(self, "_simple_new_orders_revision", 0) + 1
+                        processed_order = order
+                    else:
+                        order.update_raw(order)
+                        processed_order = self._process_new_order(order)
+                    if processed_order and not (
+                        getattr(order, "_simple_backtest_order", False)
+                        and self._should_skip_default_new_callback(order)
+                    ):
+                        self._on_new_order(processed_order)
+                    if getattr(order, "_simple_backtest_order", False) and getattr(self, "_trade_event_log_enabled", True):
+                        static = getattr(order, "_fast_trade_event_static", None)
+                        if static is not None:
+                            (
+                                strategy_name,
+                                identifier,
+                                symbol,
+                                side,
+                                order_type,
+                                trade_slippage,
+                                time_in_force,
+                                asset_multiplier,
+                                asset_type,
+                            ) = static
+                        else:
+                            asset = order.asset
+                            strategy_name = order.strategy
+                            identifier = order._identifier
+                            symbol = order.symbol
+                            side = order.side
+                            order_type = order.order_type
+                            trade_slippage = getattr(order, "trade_slippage", None)
+                            time_in_force = order.time_in_force
+                            asset_multiplier = asset.multiplier if asset is not None else None
+                            asset_type = asset.asset_type if asset is not None else None
+                        pair_row = [
+                            _FAST_TRADE_PAIR_EVENT_MARKER,
+                            self.data_source.get_datetime(),
+                            None,
+                            strategy_name,
+                            identifier,
+                            symbol,
+                            side,
+                            order_type,
+                            order._status,
+                            None,
+                            None,
+                            None,
+                            1,
+                            None,
+                            trade_slippage,
+                            time_in_force,
+                            asset_multiplier,
+                            asset_type,
+                            None,
+                        ]
+                        order._fast_trade_event_pair_row = pair_row
+                        order._fast_trade_event_pair_row_index = len(self._trade_event_log_rows)
+                        self._trade_event_log_rows.append(pair_row)
+                        if self._trade_event_log_df_cache is not None:
+                            self._trade_event_log_df_cache = None
+                    else:
+                        self._record_fast_backtest_trade_event(order, None, None, 1)
+                except Exception:
+                    logger.error(traceback.format_exc())
+            else:
+                order.update_raw(order)
+                self.stream.dispatch(
+                    self.NEW_ORDER,
+                    wait_until_complete=True,
+                    order=order,
+                )
 
         # Only an OCO order submits the child orders immediately. Bracket/OTO child orders are not submitted until
         # the parent order is filled
@@ -1176,6 +1353,81 @@ class BacktestingBroker(Broker):
                     wait_until_complete=True,
                     order=child,
                 )
+
+        return order
+
+    def _submit_simple_backtest_order(self, order):
+        """Submit a validated simple backtest order without the general broker dispatch path."""
+        if getattr(order, "_simple_is_option", None):
+            self._backtest_has_option_lifecycle_exposure = True
+            return self._submit_order(order)
+
+        actions = getattr(getattr(self, "stream", None), "_actions_mapping", None)
+        default_action = getattr(self, "_default_new_order_stream_action", None)
+        if actions is None or actions.get(self.NEW_ORDER) is not default_action or getattr(self, "_backtest_audit_enabled", False):
+            return self._submit_order(order)
+
+        try:
+            order._transmitted = True
+            order._raw = order
+            order._status = self.NEW_ORDER
+            if order._new_event is not None:
+                order._new_event.set()
+
+            by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+            if by_strategy is None:
+                by_strategy = {}
+                self._simple_new_orders_by_strategy = by_strategy
+            by_strategy.setdefault(order.strategy, []).append(order)
+            self._simple_new_orders_revision = getattr(self, "_simple_new_orders_revision", 0) + 1
+
+            skip_new_cache = getattr(self, "_skip_default_new_callback_by_strategy", None)
+            skip_new_callback = None if skip_new_cache is None else skip_new_cache.get(order.strategy)
+            if skip_new_callback is None:
+                skip_new_callback = self._should_skip_default_new_callback(order)
+            if not skip_new_callback:
+                self._on_new_order(order)
+
+            if getattr(self, "_trade_event_log_enabled", True):
+                (
+                    strategy_name,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                ) = order._fast_trade_event_static
+                pair_row = [
+                    _FAST_TRADE_PAIR_EVENT_MARKER,
+                    getattr(order, "_date_created", None) or self.data_source.get_datetime(),
+                    None,
+                    strategy_name,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    order._status,
+                    None,
+                    None,
+                    None,
+                    1,
+                    None,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                    None,
+                ]
+                order._fast_trade_event_pair_row = pair_row
+                order._fast_trade_event_pair_row_index = len(self._trade_event_log_rows)
+                self._trade_event_log_rows.append(pair_row)
+                if self._trade_event_log_df_cache is not None:
+                    self._trade_event_log_df_cache = None
+        except Exception:
+            logger.error(traceback.format_exc())
 
         return order
 
@@ -1535,6 +1787,9 @@ class BacktestingBroker(Broker):
         return option_price
 
     def _run_backtest_option_lifecycle_tasks(self, strategy) -> None:
+        if not getattr(self, "_backtest_has_option_lifecycle_exposure", False):
+            return
+
         # Run conservative early-assignment checks near close.
         self.process_early_assignment_contracts(strategy)
 
@@ -1784,8 +2039,437 @@ class BacktestingBroker(Broker):
         if not trade_cost:
             return
 
-        current_cash = strategy.cash
+        current_cash = self._get_strategy_cash_fast(strategy)
         strategy._set_cash_position(current_cash - float(trade_cost))
+
+    @staticmethod
+    def _get_strategy_cash_fast(strategy) -> float:
+        cash_position = getattr(strategy, "_cash_position", None)
+        if cash_position is None:
+            get_cash_position = getattr(strategy, "_get_cash_position", None)
+            cash_position = get_cash_position() if callable(get_cash_position) else None
+
+        quantity = getattr(cash_position, "quantity", None) if cash_position is not None else None
+        if type(quantity) is Decimal:
+            return float(quantity)
+        if quantity is None:
+            cash_value = getattr(strategy, "cash", None)
+            if cash_value is not None:
+                try:
+                    return float(cash_value)
+                except Exception:
+                    pass
+            return 0.0
+        return quantity
+
+    @staticmethod
+    def _set_strategy_cash_fast(strategy, cash: float) -> None:
+        cash_position = getattr(strategy, "_cash_position", None)
+        if cash_position is not None:
+            try:
+                cash_f = float(cash)
+                cash_position._quantity_float = cash_f
+            except Exception:
+                cash_position.quantity = cash
+            return
+        strategy._set_cash_position(cash)
+
+    def _execute_simple_market_fast_fill(
+        self,
+        order: Order,
+        price: float,
+        filled_quantity: Decimal,
+        strategy,
+        price_source=None,
+    ) -> None:
+        """Direct fill for narrow zero-fee IBKR market orders with no user fill callback."""
+        order.trade_cost = 0.0
+        asset_type = getattr(order, "_simple_asset_type", None)
+        if asset_type is None:
+            asset_type = getattr(order.asset, "asset_type", None)
+        quote_asset_type = getattr(order, "_simple_quote_asset_type", None)
+        if quote_asset_type is None and getattr(order, "quote", None):
+            quote_asset_type = getattr(order.quote, "asset_type", None)
+
+        filled_quantity_f = getattr(order, "_simple_quantity_float", None)
+        if filled_quantity_f is None:
+            filled_quantity_f = filled_quantity
+        if filled_quantity_f is not None and type(filled_quantity_f) is not float:
+            filled_quantity_f = float(filled_quantity_f)
+
+        if asset_type in (Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE):
+            self._process_futures_fill(strategy, order, float(price), filled_quantity_f)
+        elif asset_type == Asset.AssetType.CRYPTO and quote_asset_type == Asset.AssetType.FOREX:
+            trade_amount = filled_quantity_f * price
+            multiplier = getattr(order, "_simple_multiplier", None)
+            if multiplier and multiplier != 1:
+                trade_amount *= multiplier
+            current_cash = self._get_strategy_cash_fast(strategy)
+            is_buy_order = getattr(order, "_simple_is_buy", None)
+            if is_buy_order is None:
+                is_buy_order = order.is_buy_order()
+            new_cash = current_cash - trade_amount if is_buy_order else current_cash + trade_amount
+            self._set_strategy_cash_fast(strategy, new_cash)
+
+        multiplier = getattr(order, "_simple_multiplier", None) or getattr(order.asset, "multiplier", None) or 1
+        try:
+            if getattr(order, "_simple_backtest_order", False):
+                self._process_simple_market_filled_order(order, price, filled_quantity_f)
+            else:
+                self._process_filled_order(order, price, filled_quantity_f)
+            self._record_fast_backtest_trade_event(
+                order,
+                price,
+                filled_quantity_f,
+                multiplier,
+                price_source=price_source,
+            )
+        except Exception:
+            logger.error(traceback.format_exc())
+
+    def _execute_simple_backtest_market_fast_fill(self, order: Order, price: float, strategy, price_source=None) -> None:
+        """Tighter direct fill for Order.simple_market_backtest orders."""
+        order.trade_cost = 0.0
+        quantity = order._simple_quantity_float
+
+        if order._simple_is_future:
+            self._process_futures_fill(strategy, order, float(price), quantity)
+        elif order._simple_is_crypto_forex:
+            trade_amount = quantity * price
+            multiplier = order._simple_multiplier
+            if multiplier != 1:
+                trade_amount *= multiplier
+            cash_delta = -trade_amount if order._simple_is_buy else trade_amount
+            cash_position = getattr(strategy, "_cash_position", None)
+            if cash_position is not None:
+                current_quantity = getattr(cash_position, "_quantity_float", None)
+                if current_quantity is None:
+                    current_quantity = getattr(cash_position, "quantity", None)
+                    if type(current_quantity) is Decimal:
+                        current_quantity = float(current_quantity)
+                new_cash = (current_quantity or 0.0) + cash_delta
+                try:
+                    cash_position._quantity_float = float(new_cash)
+                except Exception:
+                    cash_position.quantity = new_cash
+            else:
+                current_cash = self._get_strategy_cash_fast(strategy)
+                strategy._set_cash_position(current_cash + cash_delta)
+
+        try:
+            self._process_simple_market_filled_order(order, price, quantity)
+            self._record_fast_backtest_trade_event(
+                order,
+                price,
+                quantity,
+                order._simple_multiplier,
+                price_source=price_source,
+            )
+        except Exception:
+            logger.error(traceback.format_exc())
+
+    def _execute_simple_futures_backtest_fast_fill(
+        self,
+        order: Order,
+        price: float,
+        strategy,
+        price_source=None,
+        event_dt=None,
+    ) -> None:
+        """Direct fill for simple futures market orders."""
+        try:
+            order.trade_cost = 0.0
+            quantity = order._simple_quantity_float
+            price_f = float(price)
+
+            margin_per_contract = getattr(order.asset, "_lumibot_margin_requirement_cache", None)
+            if margin_per_contract is None:
+                margin_per_contract = get_futures_margin_requirement(order.asset)
+                try:
+                    setattr(order.asset, "_lumibot_margin_requirement_cache", margin_per_contract)
+                except Exception:
+                    pass
+            key = getattr(order, "_simple_futures_ledger_key", None)
+            if key is None:
+                key = self._get_futures_ledger_key(strategy, order.asset)
+            ledger = self._futures_lot_ledgers[key]
+            signed_fill_qty = quantity if order._simple_is_buy else -quantity
+            current_cash = self._get_strategy_cash_fast(strategy)
+            new_cash = current_cash
+
+            if not ledger:
+                ledger.append({"qty": signed_fill_qty, "price": price_f})
+                new_cash -= margin_per_contract * quantity
+            elif len(ledger) == 1:
+                lot = ledger[0]
+                lot_qty = lot["qty"]
+                if lot_qty and signed_fill_qty and lot_qty * signed_fill_qty < 0:
+                    closing_qty = min(abs(lot_qty), quantity)
+                    entry_price = lot["price"]
+                    multiplier = order._simple_multiplier
+                    if lot_qty > 0:
+                        realized_pnl = (price_f - entry_price) * closing_qty * multiplier
+                        lot["qty"] -= closing_qty
+                    else:
+                        realized_pnl = (entry_price - price_f) * closing_qty * multiplier
+                        lot["qty"] += closing_qty
+                    new_cash += margin_per_contract * closing_qty
+                    new_cash += realized_pnl
+                    if abs(lot["qty"]) < 1e-9:
+                        ledger.pop(0)
+                    opening_qty = quantity - closing_qty
+                    if opening_qty > 0:
+                        opening_sign = 1 if signed_fill_qty > 0 else -1
+                        ledger.append({"qty": opening_sign * opening_qty, "price": price_f})
+                        new_cash -= margin_per_contract * opening_qty
+                else:
+                    ledger.append({"qty": signed_fill_qty, "price": price_f})
+                    new_cash -= margin_per_contract * quantity
+            else:
+                self._process_futures_fill(strategy, order, price_f, quantity)
+                new_cash = None
+
+            if new_cash is not None:
+                if not ledger:
+                    self._futures_lot_ledgers.pop(key, None)
+                self._set_strategy_cash_fast(strategy, new_cash)
+
+            simple_positions = getattr(self, "_simple_positions_by_strategy_asset", None)
+            if simple_positions is None:
+                simple_positions = {}
+                self._simple_positions_by_strategy_asset = simple_positions
+            position_key = (order.strategy, id(order.asset))
+            existing_position = simple_positions.get(position_key)
+            if existing_position is _NO_SIMPLE_POSITION:
+                existing_position = None
+            elif existing_position is None:
+                existing_position = self.get_tracked_position(order.strategy, order.asset)
+                if existing_position is not None:
+                    simple_positions[position_key] = existing_position
+                else:
+                    simple_positions[position_key] = _NO_SIMPLE_POSITION
+
+            order._avg_fill_price = round(float(price), 2) if price is not None else None
+            order.transactions = [order.Transaction(quantity, price)]
+            order._status = self.FILLED_ORDER
+            filled_event = order._filled_event
+            if filled_event is not None:
+                filled_event.set()
+            closed_event = order._closed_event
+            if closed_event is not None:
+                closed_event.set()
+            self._track_unique_simple_filled_order(order)
+
+            qty_decimal = order._quantity
+            if existing_position:
+                new_qty = existing_position._quantity + (qty_decimal if order._simple_is_buy else -qty_decimal)
+                if new_qty == 0:
+                    self._filled_positions.remove(existing_position)
+                    simple_positions[position_key] = _NO_SIMPLE_POSITION
+                else:
+                    existing_position._quantity = new_qty
+                    existing_position._quantity_float = float(new_qty)
+                    existing_position.orders.append(order)
+            else:
+                position_qty = qty_decimal
+                if order._simple_is_sell:
+                    position_qty = -position_qty
+                position = Position.simple_backtest(
+                    order.strategy,
+                    order.asset,
+                    position_qty,
+                    order,
+                    avg_fill_price=order._avg_fill_price,
+                )
+                self._filled_positions.append(position)
+                simple_positions[position_key] = position
+
+            if getattr(self, "_trade_event_log_enabled", True):
+                pair_row = getattr(order, "_fast_trade_event_pair_row", None)
+                if pair_row is not None:
+                    pair_row[2] = event_dt if event_dt is not None else self.data_source.get_datetime()
+                    pair_row[9] = order._status
+                    pair_row[10] = price
+                    pair_row[11] = quantity
+                    pair_row[12] = order._simple_multiplier
+                    pair_row[13] = order.trade_cost
+                    pair_row[18] = price_source
+                    if self._trade_event_log_df_cache is not None:
+                        self._trade_event_log_df_cache = None
+                    self._finalize_fast_trade_pair_row(order, pair_row)
+                else:
+                    self._record_fast_backtest_trade_event(
+                        order,
+                        price,
+                        quantity,
+                        order._simple_multiplier,
+                        price_source=price_source,
+                    )
+        except Exception:
+            logger.error(traceback.format_exc())
+
+    def _execute_simple_crypto_forex_backtest_fast_fill(
+        self,
+        order: Order,
+        price: float,
+        strategy,
+        price_source=None,
+        event_dt=None,
+    ) -> None:
+        """Direct fill for simple crypto/forex market orders."""
+        try:
+            quantity = order._simple_quantity_float
+            order.trade_cost = 0.0
+
+            trade_amount = quantity * price
+            multiplier = order._simple_multiplier
+            if multiplier != 1:
+                trade_amount *= multiplier
+            cash_delta = -trade_amount if order._simple_is_buy else trade_amount
+            cash_position = getattr(strategy, "_cash_position", None)
+            if cash_position is not None:
+                current_quantity = getattr(cash_position, "_quantity_float", None)
+                if current_quantity is None:
+                    current_quantity = getattr(cash_position, "quantity", None)
+                    if type(current_quantity) is Decimal:
+                        current_quantity = float(current_quantity)
+                new_cash = (current_quantity or 0.0) + cash_delta
+                try:
+                    cash_position._quantity_float = float(new_cash)
+                except Exception:
+                    cash_position.quantity = new_cash
+            else:
+                current_cash = self._get_strategy_cash_fast(strategy)
+                strategy._set_cash_position(current_cash + cash_delta)
+
+            simple_positions = getattr(self, "_simple_positions_by_strategy_asset", None)
+            if simple_positions is None:
+                simple_positions = {}
+                self._simple_positions_by_strategy_asset = simple_positions
+            position_key = (order.strategy, id(order.asset))
+            existing_position = simple_positions.get(position_key)
+            if existing_position is _NO_SIMPLE_POSITION:
+                existing_position = None
+            elif existing_position is None:
+                existing_position = self.get_tracked_position(order.strategy, order.asset)
+                if existing_position is not None:
+                    simple_positions[position_key] = existing_position
+                else:
+                    simple_positions[position_key] = _NO_SIMPLE_POSITION
+
+            order._avg_fill_price = round(float(price), 2) if price is not None else None
+            order.transactions = [order.Transaction(quantity, price)]
+            order._status = self.FILLED_ORDER
+            filled_event = getattr(order, "_filled_event", None)
+            if filled_event is not None:
+                filled_event.set()
+            closed_event = getattr(order, "_closed_event", None)
+            if closed_event is not None:
+                closed_event.set()
+            self._track_unique_simple_filled_order(order)
+
+            qty_decimal = order._quantity
+            if existing_position:
+                new_qty = existing_position._quantity + (qty_decimal if order._simple_is_buy else -qty_decimal)
+                if new_qty == 0:
+                    self._filled_positions.remove(existing_position)
+                    simple_positions[position_key] = _NO_SIMPLE_POSITION
+                else:
+                    existing_position._quantity = new_qty
+                    existing_position._quantity_float = float(new_qty)
+                    existing_position.orders.append(order)
+            else:
+                if order._simple_is_sell:
+                    qty_decimal = -qty_decimal
+                position = Position.simple_backtest(
+                    order.strategy,
+                    order.asset,
+                    qty_decimal,
+                    order,
+                    avg_fill_price=order._avg_fill_price,
+                )
+                self._filled_positions.append(position)
+                simple_positions[position_key] = position
+
+            if getattr(self, "_trade_event_log_enabled", True):
+                pair_row = getattr(order, "_fast_trade_event_pair_row", None)
+                if pair_row is not None:
+                    pair_row[2] = event_dt if event_dt is not None else self.data_source.get_datetime()
+                    pair_row[9] = order._status
+                    pair_row[10] = price
+                    pair_row[11] = quantity
+                    pair_row[12] = order._simple_multiplier
+                    pair_row[13] = order.trade_cost
+                    pair_row[18] = price_source
+                    if self._trade_event_log_df_cache is not None:
+                        self._trade_event_log_df_cache = None
+                    self._finalize_fast_trade_pair_row(order, pair_row)
+                else:
+                    self._record_fast_backtest_trade_event(
+                        order,
+                        price,
+                        quantity,
+                        order._simple_multiplier,
+                        price_source=price_source,
+                    )
+        except Exception:
+            logger.error(traceback.format_exc())
+
+    def _process_simple_market_filled_order(self, order: Order, price, quantity):
+        """Minimal bookkeeping for simple direct market orders proven by the fast lane."""
+        simple_positions = getattr(self, "_simple_positions_by_strategy_asset", None)
+        if simple_positions is None:
+            simple_positions = {}
+            self._simple_positions_by_strategy_asset = simple_positions
+        position_key = (order.strategy, id(order.asset))
+        existing_position = simple_positions.get(position_key)
+        if existing_position is _NO_SIMPLE_POSITION:
+            existing_position = None
+        elif existing_position is None:
+            existing_position = self.get_tracked_position(order.strategy, order.asset)
+            if existing_position is not None:
+                simple_positions[position_key] = existing_position
+            else:
+                simple_positions[position_key] = _NO_SIMPLE_POSITION
+        order._avg_fill_price = round(float(price), 2) if price is not None else None
+
+        order.transactions = [order.Transaction(quantity, price)]
+        order._status = self.FILLED_ORDER
+        filled_event = order._filled_event
+        if filled_event is not None:
+            filled_event.set()
+        closed_event = order._closed_event
+        if closed_event is not None:
+            closed_event.set()
+        self._track_unique_simple_filled_order(order)
+
+        qty_decimal = order._quantity
+
+        if existing_position:
+            new_qty = existing_position._quantity + (qty_decimal if order._simple_is_buy else -qty_decimal)
+            if new_qty == 0:
+                self._filled_positions.remove(existing_position)
+                simple_positions[position_key] = _NO_SIMPLE_POSITION
+            else:
+                existing_position._quantity = new_qty
+                existing_position._quantity_float = float(new_qty)
+                existing_position.orders.append(order)
+        else:
+            position_qty = qty_decimal
+            if order._simple_is_sell:
+                position_qty = -position_qty
+            position = Position.simple_backtest(
+                order.strategy,
+                order.asset,
+                position_qty,
+                order,
+                avg_fill_price=order._avg_fill_price,
+            )
+            self._filled_positions.append(position)
+            simple_positions[position_key] = position
+
+        if not order._simple_is_crypto_forex and order._simple_asset_type_value == "crypto":
+            self._process_crypto_quote(order, quantity, price)
 
     def _execute_filled_order(
         self,
@@ -1835,7 +2519,7 @@ class BacktestingBroker(Broker):
             if hasattr(order.asset, 'multiplier') and order.asset.multiplier:
                 trade_amount *= order.asset.multiplier
 
-            current_cash = strategy.cash
+            current_cash = self._get_strategy_cash_fast(strategy)
 
             if order.is_buy_order():
                 # Deduct cash for buy orders (trade amount + fees)
@@ -1856,15 +2540,32 @@ class BacktestingBroker(Broker):
         if filled_quantity_f is not None and not isinstance(filled_quantity_f, float):
             filled_quantity_f = float(filled_quantity_f)
 
-        self.stream.dispatch(
-            self.FILLED_ORDER,
-            wait_until_complete=True,
-            order=order,
-            price=price,
-            filled_quantity=filled_quantity_f,
-            quantity=filled_quantity_f,
-            multiplier=multiplier,
-        )
+        # PERF: In backtests the FILLED_ORDER stream action is normally the broker's own
+        # `_process_trade_event()` wrapper. When that default action is still installed, call the
+        # filled-order work directly and skip the generic trade-event router/payload path.
+        actions = getattr(getattr(self, "stream", None), "_actions_mapping", None)
+        default_action = getattr(self, "_default_filled_order_stream_action", None)
+        audit_enabled = getattr(self, "_backtest_audit_enabled", None)
+        if audit_enabled is None:
+            audit_enabled = self._truthy_env(os.environ.get("LUMIBOT_BACKTEST_AUDIT"))
+        if actions is not None and actions.get(self.FILLED_ORDER) is default_action and not audit_enabled:
+            try:
+                position = self._process_filled_order(order, price, filled_quantity_f)
+                if position and not self._should_skip_default_filled_callback(order):
+                    self._on_filled_order(position, order, price, filled_quantity_f, multiplier)
+                self._record_fast_backtest_trade_event(order, price, filled_quantity_f, multiplier)
+            except Exception:
+                logger.error(traceback.format_exc())
+        else:
+            self.stream.dispatch(
+                self.FILLED_ORDER,
+                wait_until_complete=True,
+                order=order,
+                price=price,
+                filled_quantity=filled_quantity_f,
+                quantity=filled_quantity_f,
+                multiplier=multiplier,
+            )
 
         # Only apply trade cost if it's not crypto with forex quote (already handled above)
         if (
@@ -1886,6 +2587,176 @@ class BacktestingBroker(Broker):
                 parent_order.set_filled()
                 if parent_order not in self._filled_orders:
                     self._filled_orders.append(parent_order)
+
+    def _should_skip_default_new_callback(self, order: Order) -> bool:
+        strategy_name = getattr(order, "strategy", None)
+        cache = getattr(self, "_skip_default_new_callback_by_strategy", None)
+        if cache is None:
+            cache = {}
+            self._skip_default_new_callback_by_strategy = cache
+        if strategy_name in cache:
+            return cache[strategy_name]
+
+        subscriber = self._get_subscriber(strategy_name)
+        if not subscriber:
+            cache[strategy_name] = False
+            return False
+
+        try:
+            strategy_obj = getattr(subscriber, "strategy", None)
+            handler = getattr(strategy_obj, "on_new_order", None)
+            func = getattr(handler, "__func__", handler)
+            result = getattr(func, "__qualname__", "") == "Strategy.on_new_order"
+        except Exception:
+            result = False
+        cache[strategy_name] = result
+        return result
+
+    def _should_skip_default_filled_callback(self, order: Order) -> bool:
+        asset_type = getattr(getattr(order, "asset", None), "asset_type", None)
+        if asset_type not in (Asset.AssetType.CRYPTO, Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE):
+            return False
+
+        strategy_name = getattr(order, "strategy", None)
+        cache = getattr(self, "_skip_default_filled_callback_by_strategy", None)
+        if cache is None:
+            cache = {}
+            self._skip_default_filled_callback_by_strategy = cache
+        if strategy_name in cache:
+            return cache[strategy_name]
+
+        subscriber = self._get_subscriber(strategy_name)
+        if not subscriber:
+            cache[strategy_name] = False
+            return False
+
+        try:
+            strategy_obj = getattr(subscriber, "strategy", None)
+            handler = getattr(strategy_obj, "on_filled_order", None)
+            func = getattr(handler, "__func__", handler)
+            executor_handler = getattr(subscriber, "_on_filled_order", None)
+            executor_func = getattr(executor_handler, "__func__", executor_handler)
+            result = (
+                getattr(func, "__qualname__", "") == "Strategy.on_filled_order"
+                and getattr(executor_func, "__qualname__", "") == "StrategyExecutor._on_filled_order"
+                and not callable(getattr(strategy_obj, "_filled_order_callback", None))
+            )
+        except Exception:
+            result = False
+        cache[strategy_name] = result
+        return result
+
+    def _record_fast_backtest_trade_event(
+        self,
+        order: Order,
+        price,
+        filled_quantity,
+        multiplier=1,
+        price_source=None,
+    ):
+        """Append the non-audit trade log row for a direct backtest fill."""
+        if price_source is None:
+            price_source = getattr(order, "_price_source", None)
+        if getattr(self, "_trade_event_log_enabled", True):
+            static = getattr(order, "_fast_trade_event_static", None)
+            if static is not None:
+                (
+                    strategy_name,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                ) = static
+            else:
+                asset = order.asset
+                strategy_name = order.strategy
+                identifier = order._identifier
+                symbol = order.symbol
+                side = order.side
+                order_type = order.order_type
+                trade_slippage = getattr(order, "trade_slippage", None)
+                time_in_force = order.time_in_force
+                asset_multiplier = asset.multiplier if asset is not None else None
+                asset_type = asset.asset_type if asset is not None else None
+            pair_row = getattr(order, "_fast_trade_event_pair_row", None)
+            if pair_row is not None and price is not None:
+                pair_row[2] = self.data_source.get_datetime()
+                pair_row[9] = order._status
+                pair_row[10] = price
+                pair_row[11] = filled_quantity
+                pair_row[12] = multiplier
+                pair_row[13] = order.trade_cost
+                pair_row[18] = price_source
+                if self._trade_event_log_df_cache is not None:
+                    self._trade_event_log_df_cache = None
+                self._finalize_fast_trade_pair_row(order, pair_row)
+                return
+            if (
+                getattr(order, "_simple_backtest_order", False)
+                and price is None
+                and filled_quantity is None
+                and order._status == self.NEW_ORDER
+            ):
+                pair_row = [
+                    _FAST_TRADE_PAIR_EVENT_MARKER,
+                    self.data_source.get_datetime(),
+                    None,
+                    strategy_name,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    order._status,
+                    None,
+                    None,
+                    None,
+                    1,
+                    None,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                    None,
+                ]
+                order._fast_trade_event_pair_row = pair_row
+                order._fast_trade_event_pair_row_index = len(self._trade_event_log_rows)
+                self._trade_event_log_rows.append(pair_row)
+                if self._trade_event_log_df_cache is not None:
+                    self._trade_event_log_df_cache = None
+                return
+            self._trade_event_log_rows.append(
+                (
+                    _FAST_TRADE_EVENT_MARKER,
+                    self.data_source.get_datetime(),
+                    strategy_name,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    order._status,
+                    price,
+                    filled_quantity,
+                    multiplier,
+                    order.trade_cost,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                    price_source,
+                )
+            )
+            if self._trade_event_log_df_cache is not None:
+                self._trade_event_log_df_cache = None
+
+        if price_source and getattr(order, "_price_source", None) is not None:
+            try:
+                delattr(order, "_price_source")
+            except AttributeError:
+                pass
 
     def _process_crypto_quote(self, order, quantity, price):
         """Override to skip quote processing for assets that use direct cash updates or margin-based trading."""
@@ -1946,13 +2817,41 @@ class BacktestingBroker(Broker):
 
     def _process_futures_fill(self, strategy, order, price, filled_quantity):
         multiplier = getattr(order.asset, "multiplier", 1)
-        margin_per_contract = get_futures_margin_requirement(order.asset)
+        margin_per_contract = getattr(order.asset, "_lumibot_margin_requirement_cache", None)
+        if margin_per_contract is None:
+            margin_per_contract = get_futures_margin_requirement(order.asset)
+            try:
+                setattr(order.asset, "_lumibot_margin_requirement_cache", margin_per_contract)
+            except Exception:
+                pass
 
-        key = self._get_futures_ledger_key(strategy, order.asset)
+        key = getattr(order, "_simple_futures_ledger_key", None)
+        if key is None:
+            strategy_name = getattr(strategy, "_name", None) or getattr(strategy, "name", "unknown_strategy")
+            key_cache = getattr(order.asset, "_lumibot_futures_ledger_key_cache", None)
+            if key_cache is None:
+                key_cache = {}
+                try:
+                    setattr(order.asset, "_lumibot_futures_ledger_key_cache", key_cache)
+                except Exception:
+                    key_cache = None
+            key = key_cache.get(strategy_name) if key_cache is not None else None
+            if key is None:
+                key = self._get_futures_ledger_key(strategy, order.asset)
+                if key_cache is not None:
+                    key_cache[strategy_name] = key
         ledger = self._futures_lot_ledgers[key]
 
-        net_before = sum(lot["qty"] for lot in ledger)
-        signed_fill_qty = filled_quantity if order.is_buy_order() else -filled_quantity
+        if not ledger:
+            net_before = 0.0
+        elif len(ledger) == 1:
+            net_before = ledger[0]["qty"]
+        else:
+            net_before = sum(lot["qty"] for lot in ledger)
+        is_buy_order = getattr(order, "_simple_is_buy", None)
+        if is_buy_order is None:
+            is_buy_order = order.is_buy_order()
+        signed_fill_qty = filled_quantity if is_buy_order else -filled_quantity
 
         closing_qty = 0.0
         if net_before and signed_fill_qty and net_before * signed_fill_qty < 0:
@@ -1960,11 +2859,20 @@ class BacktestingBroker(Broker):
 
         opening_qty = filled_quantity - closing_qty
 
-        current_cash = strategy.cash or 0.0
+        current_cash = self._get_strategy_cash_fast(strategy)
         new_cash = current_cash
 
         if closing_qty > 0:
-            realized_pnl = self._realize_futures_pnl(ledger, closing_qty, price, multiplier)
+            if len(ledger) == 1 and abs(abs(ledger[0]["qty"]) - closing_qty) < 1e-9:
+                lot = ledger[0]
+                entry_price = lot["price"]
+                if lot["qty"] > 0:
+                    realized_pnl = (price - entry_price) * closing_qty * multiplier
+                else:
+                    realized_pnl = (entry_price - price) * closing_qty * multiplier
+                ledger.pop(0)
+            else:
+                realized_pnl = self._realize_futures_pnl(ledger, closing_qty, price, multiplier)
             new_cash += margin_per_contract * closing_qty
             new_cash += realized_pnl
 
@@ -1979,7 +2887,7 @@ class BacktestingBroker(Broker):
         if not ledger:
             self._futures_lot_ledgers.pop(key, None)
 
-        strategy._set_cash_position(new_cash)
+        self._set_strategy_cash_fast(strategy, new_cash)
 
     def calculate_trade_cost(self, order: Order, strategy, price: float):
         """Calculate the trade cost of an order for a given strategy"""
@@ -2014,7 +2922,7 @@ class BacktestingBroker(Broker):
                 trade_cost += Decimal(str(order.quantity)) * trading_fee.per_contract_fee
 
         return trade_cost
-        
+
 
     def process_pending_orders(self, strategy):
         """Used to evaluate and execute open orders in backtesting.
@@ -2031,40 +2939,293 @@ class BacktestingBroker(Broker):
 
         # This function is called once per bar (minute-level: ~100k/year). Avoid allocating lists
         # or copying buckets when there are no pending orders.
-        strategy_name = strategy.name
+        strategy_name = getattr(strategy, "_name", None)
+        if strategy_name is None:
+            strategy_name = strategy.name
 
         unprocessed_bucket = getattr(self, "_unprocessed_orders", None)
         new_bucket = getattr(self, "_new_orders", None)
-        if not unprocessed_bucket and not new_bucket:
-            self._run_backtest_option_lifecycle_tasks(strategy)
+        simple_by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+        if not unprocessed_bucket and not new_bucket and not simple_by_strategy:
+            if getattr(self, "_backtest_has_option_lifecycle_exposure", False):
+                self._run_backtest_option_lifecycle_tasks(strategy)
             return
 
-        def _iter_bucket(bucket):
-            if not bucket:
-                return ()
-            get_list = getattr(bucket, "get_list", None)
-            if callable(get_list):
-                return get_list()
-            return bucket
-
-        pending_orders: list[Order] = []
-        for order in _iter_bucket(unprocessed_bucket):
-            if getattr(order, "strategy", None) == strategy_name:
-                pending_orders.append(order)
-        for order in _iter_bucket(new_bucket):
-            if getattr(order, "strategy", None) == strategy_name:
-                pending_orders.append(order)
+        simple_pending = simple_by_strategy.pop(strategy_name, None) if simple_by_strategy else None
+        if simple_pending and not unprocessed_bucket and not new_bucket:
+            self._simple_new_orders_revision = getattr(self, "_simple_new_orders_revision", 0) + 1
+            pending_orders = simple_pending
+        else:
+            pending_orders: list[Order] = []
+            if simple_pending:
+                self._simple_new_orders_revision = getattr(self, "_simple_new_orders_revision", 0) + 1
+                pending_orders.extend(simple_pending)
+            if unprocessed_bucket:
+                get_list = getattr(unprocessed_bucket, "get_list", None)
+                for order in get_list() if callable(get_list) else unprocessed_bucket:
+                    if getattr(order, "strategy", None) == strategy_name:
+                        pending_orders.append(order)
+            if new_bucket:
+                get_list = getattr(new_bucket, "get_list", None)
+                for order in get_list() if callable(get_list) else new_bucket:
+                    if getattr(order, "strategy", None) == strategy_name:
+                        pending_orders.append(order)
 
         if not pending_orders:
-            self._run_backtest_option_lifecycle_tasks(strategy)
+            self._requeue_simple_pending(strategy_name, simple_pending)
+            if getattr(self, "_backtest_has_option_lifecycle_exposure", False):
+                self._run_backtest_option_lifecycle_tasks(strategy)
             return
 
-        # Prefetching: Track assets and schedule prefetch
-        current_dt = self.datetime
-        audit_enabled = self._audit_enabled()
+        audit_enabled = getattr(self, "_backtest_audit_enabled", False)
         # PERF: Used in multiple branches below; avoid recomputing per order.
-        data_source_name = str(getattr(self.data_source, "SOURCE", "") or "").upper()
+        data_source = self.data_source
+        data_source_source = getattr(data_source, "SOURCE", "") or ""
+        is_ibkr_rest_source = data_source_source in ("InteractiveBrokersREST", "INTERACTIVEBROKERSREST")
+        data_source_name = "INTERACTIVEBROKERSREST" if is_ibkr_rest_source else str(data_source_source).upper()
 
+        if (
+            not audit_enabled
+            and is_ibkr_rest_source
+            and not self.hybrid_prefetcher
+            and not self.prefetcher
+            and not (getattr(strategy, "buy_trading_fees", None) or getattr(strategy, "sell_trading_fees", None))
+        ):
+            actions = getattr(getattr(self, "stream", None), "_actions_mapping", None)
+            default_action = getattr(self, "_default_filled_order_stream_action", None)
+            can_use_direct_fill = actions is not None and actions.get(self.FILLED_ORDER) is default_action
+            if can_use_direct_fill:
+                first_order = pending_orders[0]
+                skip_filled_cache = getattr(self, "_skip_default_filled_callback_by_strategy", None)
+                skip_default_filled_callback = (
+                    None if skip_filled_cache is None else skip_filled_cache.get(getattr(first_order, "strategy", None))
+                )
+                if skip_default_filled_callback is None:
+                    skip_default_filled_callback = self._should_skip_default_filled_callback(first_order)
+            else:
+                skip_default_filled_callback = False
+            if can_use_direct_fill and skip_default_filled_callback and simple_pending and not unprocessed_bucket and not new_bucket:
+                all_simple_filled = True
+                fast_open_data_source = self.data_source
+                fast_open_now = getattr(fast_open_data_source, "_datetime", None)
+                if fast_open_now is None:
+                    fast_open_now = fast_open_data_source.get_datetime()
+                fast_open_exchange = getattr(fast_open_data_source, "exchange", None)
+                exchange_cache = getattr(self, "_fast_open_exchange_key_cache", None)
+                exchange_cache_key = (id(fast_open_data_source), fast_open_exchange)
+                if exchange_cache is not None and exchange_cache[0] == exchange_cache_key:
+                    fast_open_exchange_key = exchange_cache[1]
+                else:
+                    try:
+                        fast_open_exchange_key = fast_open_data_source._normalize_exchange_key(fast_open_exchange)
+                    except Exception:
+                        fast_open_exchange_key = (str(fast_open_exchange or "").strip().upper() or "AUTO")
+                    self._fast_open_exchange_key_cache = (exchange_cache_key, fast_open_exchange_key)
+                fast_open_cache = getattr(self, "_fast_market_open_data_cache", None)
+                if fast_open_cache is None:
+                    fast_open_cache = {}
+                    self._fast_market_open_data_cache = fast_open_cache
+                no_bid_ask = getattr(self, "_simple_no_bid_ask_fill_keys", None)
+                no_bid_open_cache = getattr(self, "_simple_no_bid_ask_open_cache", None)
+                if no_bid_open_cache is None:
+                    no_bid_open_cache = {}
+                    self._simple_no_bid_ask_open_cache = no_bid_open_cache
+                coerce_price = self._coerce_price
+                fast_open_cache_get = fast_open_cache.get
+                terminal_statuses = (self.FILLED_ORDER, self.CANCELED_ORDER, self.ERROR_ORDER)
+                for order in simple_pending:
+                    order_asset = order.asset
+                    is_buy_order = getattr(order, "_simple_is_buy", False)
+                    order_status = getattr(order, "_status", None)
+                    if (
+                        order_status in terminal_statuses
+                        or not getattr(order, "_simple_direct_fill_eligible", False)
+                    ):
+                        all_simple_filled = False
+                        break
+
+                    order_exchange = getattr(order, "exchange", None)
+                    order_quote = order.quote
+                    order_asset_id = id(order_asset)
+                    order_quote_id = id(order_quote)
+                    no_bid_ask_key = (order_asset_id, order_quote_id, order_exchange)
+                    price = None
+                    price_source = "quote"
+                    no_bid_ask_hit = no_bid_ask_key in no_bid_ask if no_bid_ask else False
+                    if no_bid_ask_hit and order_exchange is None:
+                        cached_open_entry = no_bid_open_cache.get(no_bid_ask_key)
+                        if cached_open_entry is not None and cached_open_entry[0] == fast_open_exchange_key:
+                            open_line = cached_open_entry[1]
+                            exact_i = cached_open_entry[2]
+                        else:
+                            cached_open = fast_open_cache_get((order_asset_id, order_quote_id, "minute", fast_open_exchange_key))
+                            if cached_open is not None:
+                                _, cached_open_line, exact_i = cached_open
+                                open_line = getattr(cached_open_line, "dataline", cached_open_line)
+                                no_bid_open_cache[no_bid_ask_key] = (fast_open_exchange_key, open_line, exact_i)
+                            else:
+                                open_line = None
+                                exact_i = None
+                        if open_line is not None:
+                            try:
+                                i = exact_i.get(fast_open_now) if exact_i is not None else None
+                                if i is not None:
+                                    price = float(open_line[int(i)])
+                                    price_source = "ohlc_fast_open"
+                            except Exception:
+                                price = None
+                    if not no_bid_ask_hit:
+                        fast_bid, fast_ask = self._fast_get_bid_ask_for_fill(order_asset, order_quote, order_exchange)
+                        fast_bid = coerce_price(fast_bid)
+                        fast_ask = coerce_price(fast_ask)
+                        price = fast_ask if is_buy_order else fast_bid
+                        if fast_bid is None and fast_ask is None:
+                            if no_bid_ask is None:
+                                no_bid_ask = set()
+                                self._simple_no_bid_ask_fill_keys = no_bid_ask
+                            no_bid_ask.add(no_bid_ask_key)
+                    if price is None or price <= 0 or price != price:
+                        price = None
+                        if order_exchange is None:
+                            cached_open_entry = no_bid_open_cache.get(no_bid_ask_key)
+                            if cached_open_entry is not None and cached_open_entry[0] == fast_open_exchange_key:
+                                open_line = cached_open_entry[1]
+                                exact_i = cached_open_entry[2]
+                            else:
+                                cached_open = fast_open_cache_get(
+                                    (order_asset_id, order_quote_id, "minute", fast_open_exchange_key)
+                                )
+                                if cached_open is not None:
+                                    _, cached_open_line, exact_i = cached_open
+                                    open_line = getattr(cached_open_line, "dataline", cached_open_line)
+                                    no_bid_open_cache[no_bid_ask_key] = (fast_open_exchange_key, open_line, exact_i)
+                                else:
+                                    open_line = None
+                                    exact_i = None
+                            if open_line is not None:
+                                try:
+                                    i = exact_i.get(fast_open_now) if exact_i is not None else None
+                                    if i is not None:
+                                        price = float(open_line[int(i)])
+                                except Exception:
+                                    price = None
+                        if price is None or price <= 0 or price != price:
+                            price = coerce_price(
+                                self._fast_get_market_open_for_fill(
+                                    order_asset,
+                                    order_quote,
+                                    order_exchange,
+                                    _data_source=fast_open_data_source,
+                                    _now=fast_open_now,
+                                    _cache=fast_open_cache,
+                                )
+                            )
+                        price_source = "ohlc_fast_open"
+                    if price is None or price <= 0 or price != price:
+                        all_simple_filled = False
+                        break
+
+                    if getattr(order, "_simple_is_crypto_forex", False):
+                        self._execute_simple_crypto_forex_backtest_fast_fill(
+                            order,
+                            price,
+                            strategy,
+                            price_source,
+                            event_dt=fast_open_now,
+                        )
+                    elif getattr(order, "_simple_is_future", False):
+                        self._execute_simple_futures_backtest_fast_fill(
+                            order,
+                            price,
+                            strategy,
+                            price_source,
+                            event_dt=fast_open_now,
+                        )
+                    else:
+                        self._execute_simple_backtest_market_fast_fill(order, price, strategy, price_source)
+                if all_simple_filled:
+                    if getattr(self, "_backtest_has_option_lifecycle_exposure", False):
+                        self._run_backtest_option_lifecycle_tasks(strategy)
+                    return
+
+            fast_fills = []
+            can_fast_fill_all = can_use_direct_fill
+            for order in pending_orders:
+                order_asset = order.asset
+                asset_type = getattr(order_asset, "asset_type", None)
+                is_market_order = order.order_type == Order.OrderType.MARKET
+                is_buy_order = getattr(order, "_simple_is_buy", None)
+                if is_buy_order is None:
+                    is_buy_order = order.is_buy_order()
+                is_sell_order = getattr(order, "_simple_is_sell", None)
+                if is_sell_order is None:
+                    is_sell_order = order.is_sell_order()
+                if (
+                    not order.is_active()
+                    or order.dependent_order_filled
+                    or getattr(order, "dependent_order", None) is not None
+                    or getattr(order, "parent_identifier", None) is not None
+                    or order.order_class is Order.OrderClass.OCO
+                    or order.order_class is Order.OrderClass.MULTILEG
+                    or getattr(order, "_smart_limit_managed_by_parent", False)
+                    or not is_market_order
+                    or not (is_buy_order or is_sell_order)
+                    or (
+                        asset_type in (Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE)
+                        and not getattr(order, "_simple_backtest_order", False)
+                    )
+                    or asset_type not in (Asset.AssetType.CRYPTO, Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE)
+                    or getattr(order, "_simple_is_option", None)
+                    or (not getattr(order, "_simple_backtest_order", False) and self._is_option_asset(order_asset))
+                    or self._should_force_day_fill_timestep(order)
+                    or not skip_default_filled_callback
+                ):
+                    can_fast_fill_all = False
+                    break
+
+                order_exchange = getattr(order, "exchange", None)
+                no_bid_ask_key = (id(order_asset), id(order.quote), order_exchange)
+                no_bid_ask = getattr(self, "_simple_no_bid_ask_fill_keys", None)
+                price = None
+                price_source = "quote"
+                if not (no_bid_ask and no_bid_ask_key in no_bid_ask):
+                    fast_bid, fast_ask = self._fast_get_bid_ask_for_fill(order_asset, order.quote, order_exchange)
+                    fast_bid = self._coerce_price(fast_bid)
+                    fast_ask = self._coerce_price(fast_ask)
+                    price = fast_ask if is_buy_order else fast_bid
+                    if fast_bid is None and fast_ask is None:
+                        if no_bid_ask is None:
+                            no_bid_ask = set()
+                            self._simple_no_bid_ask_fill_keys = no_bid_ask
+                        no_bid_ask.add(no_bid_ask_key)
+                if price is None or self._is_invalid_price(price):
+                    price = self._coerce_price(
+                        self._fast_get_market_open_for_fill(
+                            order_asset,
+                            order.quote,
+                            order_exchange,
+                        )
+                    )
+                    price_source = "ohlc_fast_open"
+                if price is None or self._is_invalid_price(price):
+                    can_fast_fill_all = False
+                    break
+                fast_fills.append((order, price, price_source))
+
+            if can_fast_fill_all and fast_fills:
+                for order, price, price_source in fast_fills:
+                    self._execute_simple_market_fast_fill(
+                        order=order,
+                        price=price,
+                        filled_quantity=order.quantity,
+                        strategy=strategy,
+                        price_source=price_source,
+                    )
+                if getattr(self, "_backtest_has_option_lifecycle_exposure", False):
+                    self._run_backtest_option_lifecycle_tasks(strategy)
+                return
+
+        current_dt = self.datetime
         if self.hybrid_prefetcher:
             # Use advanced hybrid prefetcher
             try:
@@ -2209,18 +3370,24 @@ class BacktestingBroker(Broker):
             fast_bid = None
             fast_ask = None
             force_day_fill_timestep = self._should_force_day_fill_timestep(order)
+            order_asset = order.asset
+            is_buy_order = order.is_buy_order()
+            is_sell_order = order.is_sell_order()
+            is_buy_or_sell = is_buy_order or is_sell_order
+            is_option_order = self._is_option_asset(order_asset)
+            is_market_order = order.order_type == Order.OrderType.MARKET
 
             # PERF: MARKET orders dominate many warm-cache backtests (minute strategies, speed-burner).
             # When bid/ask are already present in the cached Data series, we can fill immediately
             # without constructing a `Quote` object or running the full quote normalization stack.
             if (
                 not audit_enabled
-                and order.order_type == Order.OrderType.MARKET
-                and (order.is_buy_order() or order.is_sell_order())
-                and not self._is_option_asset(getattr(order, "asset", None))
+                and is_market_order
+                and is_buy_or_sell
+                and not is_option_order
             ):
                 fast_bid, fast_ask = self._fast_get_bid_ask_for_fill(
-                    order.asset,
+                    order_asset,
                     order.quote,
                     getattr(order, "exchange", None),
                 )
@@ -2231,7 +3398,7 @@ class BacktestingBroker(Broker):
                 if fast_ask is not None and self._is_invalid_price(fast_ask):
                     fast_ask = None
 
-                required_price = fast_ask if order.is_buy_order() else fast_bid
+                required_price = fast_ask if is_buy_order else fast_bid
                 if required_price is not None and not self._is_invalid_price(required_price):
                     setattr(order, "_price_source", "quote")
                     self._execute_filled_order(
@@ -2248,9 +3415,9 @@ class BacktestingBroker(Broker):
             skip_quote_fills = (
                 (not audit_enabled)
                 and data_source_name in {"INTERACTIVEBROKERSREST"}
-                and order.order_type == Order.OrderType.MARKET
-                and (order.is_buy_order() or order.is_sell_order())
-                and not self._is_option_asset(getattr(order, "asset", None))
+                and is_market_order
+                and is_buy_or_sell
+                and not is_option_order
                 and fast_bid is None
                 and fast_ask is None
             )
@@ -2258,27 +3425,51 @@ class BacktestingBroker(Broker):
                 not skip_quote_fills
                 and not audit_enabled
                 and force_day_fill_timestep
-                and order.order_type == Order.OrderType.MARKET
-                and (order.is_buy_order() or order.is_sell_order())
+                and is_market_order
+                and is_buy_or_sell
             ):
                 skip_quote_fills = True
+
+            if (
+                skip_quote_fills
+                and not audit_enabled
+                and is_market_order
+                and is_buy_or_sell
+                and not force_day_fill_timestep
+                and not is_option_order
+            ):
+                fast_open = self._fast_get_market_open_for_fill(
+                    order_asset,
+                    order.quote,
+                    getattr(order, "exchange", None),
+                )
+                fast_open = self._coerce_price(fast_open)
+                if fast_open is not None and not self._is_invalid_price(fast_open):
+                    setattr(order, "_price_source", "ohlc_fast_open")
+                    self._execute_filled_order(
+                        order=order,
+                        price=fast_open,
+                        filled_quantity=filled_quantity,
+                        strategy=strategy,
+                    )
+                    continue
 
             # PERFORMANCE: Prefer quote-based fills when bid/ask are present so we avoid
             # fetching trade-only OHLC bars (which can be sparse/missing, especially for
             # options). When bid/ask are unavailable we fall back to the OHLC-based model.
             should_try_quote_first = not (
-                force_day_fill_timestep and order.order_type == Order.OrderType.MARKET
+                force_day_fill_timestep and is_market_order
             )
             if (
                 should_try_quote_first
                 and
                 order.order_type in (Order.OrderType.MARKET, Order.OrderType.LIMIT)
-                and (order.is_buy_order() or order.is_sell_order())
+                and is_buy_or_sell
             ):
                 quote = None
                 if not skip_quote_fills:
                     try:
-                        quote = self.get_quote(order.asset, quote=order.quote)
+                        quote = self.get_quote(order_asset, quote=order.quote)
                     except Exception:
                         quote = None
 
@@ -2296,12 +3487,12 @@ class BacktestingBroker(Broker):
                 # to sparse trade-only OHLC (which can leave orders unfilled and canceled at EOD).
                 if (
                     (bid is None or ask is None)
-                    and getattr(order.asset, "asset_type", None) == Asset.AssetType.OPTION
+                    and getattr(order_asset, "asset_type", None) == Asset.AssetType.OPTION
                     and self.data_source is not None
                     and self.data_source.__class__.__name__ == "ThetaDataBacktestingPandas"
                 ):
                     try:
-                        snap = self.data_source.get_quote(order.asset, quote=order.quote, snapshot_only=True)
+                        snap = self.data_source.get_quote(order_asset, quote=order.quote, snapshot_only=True)
                     except TypeError:
                         snap = None
                     except Exception:
@@ -2314,10 +3505,8 @@ class BacktestingBroker(Broker):
                         if ask is None and snap_ask is not None and not self._is_invalid_price(snap_ask):
                             ask = snap_ask
 
-                is_buy = order.is_buy_order()
-
                 if order.order_type == Order.OrderType.MARKET:
-                    required_price = ask if is_buy else bid
+                    required_price = ask if is_buy_order else bid
                     if required_price is not None and not self._is_invalid_price(required_price):
                         if audit_enabled:
                             payload: dict[str, Any] = {
@@ -2346,7 +3535,7 @@ class BacktestingBroker(Broker):
                     limit_price = self._coerce_price(order.limit_price)
                     crossed = False
                     if limit_price is not None:
-                        if is_buy:
+                        if is_buy_order:
                             if limit_price >= ask:
                                 fill_price = ask
                                 crossed = True
@@ -2360,7 +3549,7 @@ class BacktestingBroker(Broker):
                                 fill_price = limit_price
 
                     if fill_price is not None and not self._is_invalid_price(fill_price):
-                        spread_key = "max_spread_buy_pct" if is_buy else "max_spread_sell_pct"
+                        spread_key = "max_spread_buy_pct" if is_buy_order else "max_spread_sell_pct"
                         spread_limit = self._get_spread_limit(strategy, spread_key)
                         if spread_limit is None:
                             spread_limit = self._get_spread_limit(strategy, "max_spread_pct")
@@ -2609,6 +3798,7 @@ class BacktestingBroker(Broker):
                             if df_check is not None and hasattr(df_check, "index"):
                                 last_dt = df_check.index.max()
                             elif df_check is not None and hasattr(df_check, "columns"):
+                                pl = _get_polars_module()
                                 dt_col = None
                                 for col in df_check.columns:
                                     try:
@@ -2805,6 +3995,7 @@ class BacktestingBroker(Broker):
 
                 # Handle both pandas and polars DataFrames
                 if hasattr(df_original, 'select'):  # Polars DataFrame
+                    pl = _get_polars_module()
                     # Find datetime column
                     dt_col = None
                     for col in df_original.columns:
@@ -3140,7 +4331,25 @@ class BacktestingBroker(Broker):
                     )
                 continue
 
-        self._run_backtest_option_lifecycle_tasks(strategy)
+        self._requeue_simple_pending(strategy_name, simple_pending)
+        if getattr(self, "_backtest_has_option_lifecycle_exposure", False):
+            self._run_backtest_option_lifecycle_tasks(strategy)
+
+    def _requeue_simple_pending(self, strategy_name, simple_pending) -> None:
+        if not simple_pending:
+            return
+        active_simple = [order for order in simple_pending if order.is_active()]
+        if not active_simple:
+            return
+        by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+        if by_strategy is None:
+            by_strategy = {}
+            self._simple_new_orders_by_strategy = by_strategy
+        existing = by_strategy.get(strategy_name)
+        if existing:
+            active_simple.extend(existing)
+        by_strategy[strategy_name] = active_simple
+        self._simple_new_orders_revision = getattr(self, "_simple_new_orders_revision", 0) + 1
 
     def _coerce_price(self, value):
         """Convert numeric inputs to float when possible for safe comparisons."""
@@ -3215,7 +4424,7 @@ class BacktestingBroker(Broker):
         if data_source is None or data_source.__class__.__name__ != "InteractiveBrokersRESTBacktesting":
             return None, None
 
-        now = getattr(self, "datetime", None)
+        now = data_source.get_datetime()
         if now is None:
             return None, None
 
@@ -3301,6 +4510,122 @@ class BacktestingBroker(Broker):
 
         return bid, ask
 
+    def _fast_get_market_open_for_fill(
+        self,
+        asset: Asset,
+        quote: Optional[Asset],
+        exchange: Optional[str] = None,
+        *,
+        _data_source=None,
+        _now=None,
+        _cache=None,
+    ) -> Optional[float]:
+        """Fast exact-bar MARKET fill from loaded IBKR OHLC data.
+
+        This is intentionally narrow: if the current simulation timestamp is not an exact bar
+        timestamp in the cached Data object, return None and let the canonical OHLC path enforce
+        its broader gap/fabrication guards.
+        """
+        data_source = _data_source if _data_source is not None else getattr(self, "data_source", None)
+        if data_source is None or data_source.__class__.__name__ != "InteractiveBrokersRESTBacktesting":
+            return None
+
+        now = _now if _now is not None else data_source.get_datetime()
+        if now is None:
+            return None
+
+        timestep = getattr(data_source, "_timestep", None) or "minute"
+        if str(timestep) != "minute":
+            return None
+
+        cache = _cache if _cache is not None else getattr(self, "_fast_market_open_data_cache", None)
+        if cache is None:
+            cache = {}
+            setattr(self, "_fast_market_open_data_cache", cache)
+
+        effective_exchange = exchange if exchange is not None else getattr(data_source, "exchange", None)
+        try:
+            exchange_key = data_source._normalize_exchange_key(effective_exchange)  # type: ignore[attr-defined]
+        except Exception:
+            exchange_key = (str(effective_exchange or "").strip().upper() or "AUTO")
+
+        cache_key = (id(asset), id(quote), str(timestep), exchange_key)
+        if cache_key in cache:
+            cached = cache[cache_key]
+            if len(cached) == 3:
+                data_obj, open_line, exact_i = cached
+            else:
+                data_obj, open_line = cached
+                exact_i = getattr(data_obj, "iter_index_dict", None) if data_obj is not None else None
+        else:
+            quote_asset = quote if quote is not None else Asset("USD", asset_type=Asset.AssetType.FOREX)
+            data_obj = None
+            open_line = None
+            exact_i = None
+            store = getattr(data_source, "_data_store", None)
+            if isinstance(store, dict):
+                try:
+                    canonical_key, legacy_key = data_source._build_dataset_keys(  # type: ignore[attr-defined]
+                        asset,
+                        quote_asset,
+                        str(timestep),
+                        effective_exchange,
+                    )
+                except Exception:
+                    canonical_key = (asset, quote_asset, str(timestep), exchange_key)
+                    legacy_key = (asset, quote_asset, exchange_key)
+
+                data_obj = store.get(canonical_key)
+                if data_obj is None:
+                    data_obj = store.get(legacy_key)
+
+            if data_obj is not None:
+                try:
+                    open_line_obj = getattr(data_obj, "datalines", {}).get("open")
+                    open_line = getattr(open_line_obj, "dataline", None) if open_line_obj is not None else getattr(data_obj, "open", None)
+                    exact_i = getattr(data_obj, "iter_index_dict", None)
+                    if exact_i is None:
+                        data_obj.repair_times_and_fill(data_obj.df.index)
+                        exact_i = getattr(data_obj, "iter_index_dict", None)
+                except Exception:
+                    open_line = None
+                    exact_i = None
+
+            cache[cache_key] = (data_obj, open_line, exact_i)
+
+        if data_obj is None or open_line is None:
+            return None
+
+        if exact_i is not None:
+            i = exact_i.get(now)
+            if i is not None:
+                try:
+                    return open_line[int(i)]
+                except Exception:
+                    return None
+
+        try:
+            now_ts = pd.Timestamp(now)
+            index = getattr(getattr(data_obj, "df", None), "index", None)
+            if index is None or len(index) == 0:
+                return None
+            i = data_obj.get_iter_count(now)
+            if int(i) < 0 or int(i) >= len(index):
+                return None
+            selected_ts = pd.Timestamp(index[int(i)])
+            if getattr(selected_ts, "tz", None) is not None:
+                if now_ts.tz is None:
+                    now_ts = now_ts.tz_localize(selected_ts.tz)
+                else:
+                    now_ts = now_ts.tz_convert(selected_ts.tz)
+            elif now_ts.tz is not None:
+                now_ts = now_ts.tz_localize(None)
+            if selected_ts != now_ts:
+                return None
+            return open_line[int(i)]
+        except Exception:
+            return None
+
     def _resolve_provider_key_for_asset(self, asset: Asset) -> Optional[str]:
         """Resolve a routing provider key for an asset when exposed by the data source."""
         if asset is None:
@@ -3329,6 +4654,9 @@ class BacktestingBroker(Broker):
     def _should_force_day_fill_timestep(self, order: Order) -> bool:
         """Whether market fills should bypass minute quote paths and use daily bars."""
         if order is None:
+            return False
+
+        if getattr(order, "_simple_backtest_order", False) and not getattr(order, "_simple_is_option", False):
             return False
 
         asset = getattr(order, "asset", None)
@@ -3379,9 +4707,12 @@ class BacktestingBroker(Broker):
         return timestep == "day"
 
     def _is_thetadata_source(self) -> bool:
-        if ThetaDataBacktestingPandas is None:
+        if self.data_source.__class__.__name__ != "ThetaDataBacktestingPandas":
             return False
-        return isinstance(self.data_source, ThetaDataBacktestingPandas)
+        theta_cls = _get_thetadata_backtesting_pandas_cls()
+        if theta_cls is None:
+            return False
+        return isinstance(self.data_source, theta_cls)
 
     def _get_spread_limit(self, strategy, key: str) -> Optional[float]:
         if strategy is None or not key:
@@ -4313,6 +5644,8 @@ class BacktestingBroker(Broker):
             except:
                 logger.error(traceback.format_exc())
 
+        broker._default_new_order_stream_action = on_trade_event
+
         @broker.stream.add_action(broker.PLACEHOLDER_ORDER)
         def on_trade_event(order):
             try:
@@ -4337,6 +5670,8 @@ class BacktestingBroker(Broker):
                 return True
             except:
                 logger.error(traceback.format_exc())
+
+        broker._default_filled_order_stream_action = on_trade_event
 
         @broker.stream.add_action(broker.CANCELED_ORDER)
         def on_trade_event(order, **payload):

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -1,29 +1,73 @@
-import asyncio
+from __future__ import annotations
+
 import datetime
 import time
 import traceback
-from asyncio import CancelledError
 from collections import Counter
 from datetime import timezone
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
-import pandas_market_calendars as mcal
-from alpaca.trading.client import TradingClient
-from alpaca.trading.enums import ActivityType, QueryOrderStatus, PositionSide
-from alpaca.trading.requests import GetOrdersRequest, ReplaceOrderRequest
-from alpaca.trading.stream import TradingStream
-from dateutil import tz
-from termcolor import colored
-
-from lumibot.data_sources import AlpacaData
-from lumibot.entities import Asset, CashEvent, Order, Position, Quote
-from lumibot.tools.helpers import has_more_than_n_decimal_places
+from lumibot.entities import Asset, Order
 from lumibot.tools.lumibot_logger import get_logger
-from lumibot.trading_builtins import PollingStream
 
 from .broker import Broker
 
+if TYPE_CHECKING:
+    from lumibot.entities import CashEvent, Quote
+
 logger = get_logger(__name__)
+
+TradingClient = None
+TradingStream = None
+_HAS_MORE_THAN_N_DECIMAL_PLACES = None
+_CASH_EVENT_CLASS = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _cash_event_class():
+    global _CASH_EVENT_CLASS
+    if _CASH_EVENT_CLASS is None:
+        from lumibot.entities import CashEvent
+
+        _CASH_EVENT_CLASS = CashEvent
+    return _CASH_EVENT_CLASS
+
+
+def _has_more_than_n_decimal_places(*args, **kwargs):
+    global _HAS_MORE_THAN_N_DECIMAL_PLACES
+    if _HAS_MORE_THAN_N_DECIMAL_PLACES is None:
+        from lumibot.tools.helpers import has_more_than_n_decimal_places
+
+        _HAS_MORE_THAN_N_DECIMAL_PLACES = has_more_than_n_decimal_places
+    return _HAS_MORE_THAN_N_DECIMAL_PLACES(*args, **kwargs)
+
+
+def _get_trading_client_class():
+    global TradingClient
+    if TradingClient is None:
+        from alpaca.trading.client import TradingClient as _TradingClient
+
+        TradingClient = _TradingClient
+    return TradingClient
+
+
+def _get_trading_stream_class():
+    global TradingStream
+    if TradingStream is None:
+        from alpaca.trading.stream import TradingStream as _TradingStream
+
+        TradingStream = _TradingStream
+    return TradingStream
 
 
 # Create our own OrderData class to pass to the API because this is easier to work with
@@ -114,7 +158,12 @@ class Alpaca(Broker):
         forex=[],
         crypto=["crypto", "CRYPTO"],  # Added support for crypto asset class names
     )
-    CASH_ACTIVITY_TYPES = tuple(activity.value for activity in ActivityType if activity != ActivityType.FILL)
+    CASH_ACTIVITY_TYPES = (
+        "ACATC", "ACATS", "CFEE", "CIL", "CSD", "CSW", "DIV", "DIVCGL", "DIVCGS", "DIVNRA",
+        "DIVROC", "DIVTXEX", "DIVWH", "EXTRD", "FEE", "FXTRD", "INT", "INTPNL", "JNLC", "JNLS",
+        "MA", "MEM", "NC", "OCT", "OPASN", "OPCSH", "OPEXC", "OPEXP", "OPTRD", "PTC", "REORG",
+        "SPIN", "SPLIT", "SWP", "VOF", "WH",
+    )
     DIVIDEND_ACTIVITY_TYPES = {
         "DIV",
         "DIVCGL",
@@ -167,6 +216,8 @@ class Alpaca(Broker):
         logger.debug(f"Alpaca Broker Init: is_oauth_only={self.is_oauth_only}")
 
         if not data_source:
+            from lumibot.data_sources import AlpacaData
+
             data_source = AlpacaData(config, max_workers=max_workers, chunk_size=chunk_size)
 
         super().__init__(
@@ -179,10 +230,12 @@ class Alpaca(Broker):
 
         # Initialize TradingClient based on available authentication method (API keys have precedence)
         try:
+            trading_client_class = _get_trading_client_class()
+
             if self.api_key and self.api_secret:
-                self.api = TradingClient(self.api_key, self.api_secret, paper=self.is_paper)
+                self.api = trading_client_class(self.api_key, self.api_secret, paper=self.is_paper)
             elif self.oauth_token:
-                self.api = TradingClient(oauth_token=self.oauth_token, paper=self.is_paper)
+                self.api = trading_client_class(oauth_token=self.oauth_token, paper=self.is_paper)
             else:
                 raise ValueError("Either OAuth token or API key/secret must be provided for Alpaca authentication")
         except Exception as e:
@@ -299,9 +352,11 @@ class Alpaca(Broker):
 
             open_time = self.utc_to_local(self.market_hours(close=False))
             close_time = self.utc_to_local(self.market_hours(close=True))
-            current_time = datetime.datetime.now().astimezone(tz=tz.tzlocal())
+            current_time = datetime.datetime.now().astimezone()
 
             # Check if it is a holiday or weekend using pandas_market_calendars
+            import pandas_market_calendars as mcal
+
             market_cal = mcal.get_calendar(self.market)
             schedule = market_cal.schedule(start_date=open_time, end_date=close_time)
             if schedule.empty:
@@ -437,10 +492,14 @@ class Alpaca(Broker):
         except (ValueError, TypeError):
             avg_fill_price = None
 
+        from lumibot.entities import Position
+
         position = Position(strategy, asset, quantity, orders=orders, avg_fill_price=avg_fill_price)
 
         position.pnl = float(broker_position.unrealized_pl) if broker_position.unrealized_pl else None
         position.current_price = float(broker_position.current_price) if broker_position.current_price else None
+        from alpaca.trading.enums import PositionSide
+
         position.side = Position.PositionSide.LONG if broker_position.side == PositionSide.LONG else Position.PositionSide.SHORT
         position.market_value = float(broker_position.market_value) if broker_position.market_value else None
         
@@ -656,6 +715,9 @@ class Alpaca(Broker):
         """Get the broker orders"""
         # Use GetOrdersRequest with status="all" to get both open and filled orders
         # This is crucial for OAuth polling since orders can be filled quickly
+        from alpaca.trading.enums import QueryOrderStatus
+        from alpaca.trading.requests import GetOrdersRequest
+
         request = GetOrdersRequest(status=QueryOrderStatus.ALL, limit=100)
         return self.api.get_orders(filter=request)
 
@@ -943,7 +1005,7 @@ class Alpaca(Broker):
                 if order.is_stop_order() and order.stop_price is not None:
                     orig_stop = order.stop_price
                     conformed = False
-                    if has_more_than_n_decimal_places(order.stop_price, 2):
+                    if _has_more_than_n_decimal_places(order.stop_price, 2):
                         order.stop_price = round(order.stop_price, 2)
                         conformed = True
                     if conformed:
@@ -958,7 +1020,7 @@ class Alpaca(Broker):
                 if order.order_type == Order.OrderType.STOP_LIMIT and order.stop_limit_price is not None:
                     orig_stop_limit = order.stop_limit_price
                     conformed = False
-                    if has_more_than_n_decimal_places(order.stop_limit_price, 2):
+                    if _has_more_than_n_decimal_places(order.stop_limit_price, 2):
                         order.stop_limit_price = round(order.stop_limit_price, 2)
                         conformed = True
                     if conformed:
@@ -1025,10 +1087,10 @@ class Alpaca(Broker):
             """
             orig_price = order.limit_price
             conformed = False
-            if order.limit_price >= 1.0 and has_more_than_n_decimal_places(order.limit_price, 2):
+            if order.limit_price >= 1.0 and _has_more_than_n_decimal_places(order.limit_price, 2):
                     order.limit_price = round(order.limit_price, 2)
                     conformed = True
-            elif order.limit_price < 1.0 and has_more_than_n_decimal_places(order.limit_price, 4):
+            elif order.limit_price < 1.0 and _has_more_than_n_decimal_places(order.limit_price, 4):
                 order.limit_price = round(order.limit_price, 4)
                 conformed = True
 
@@ -1095,6 +1157,8 @@ class Alpaca(Broker):
                 return
 
             # Build the replace request
+            from alpaca.trading.requests import ReplaceOrderRequest
+
             replace_req = ReplaceOrderRequest(**update_kwargs)
 
             # Try to replace the order on Alpaca, handle APIError for accepted status
@@ -1211,12 +1275,14 @@ class Alpaca(Broker):
 
     @classmethod
     def _normalize_activity_to_cash_event(cls, activity: dict) -> CashEvent | None:
+        CashEvent = _cash_event_class()
+
         activity = cls._coerce_activity_dict(activity)
         if activity is None:
             return None
 
         raw_type = str(activity.get("activity_type") or "").upper().strip()
-        if not raw_type or raw_type == ActivityType.FILL.value or raw_type in cls.TRADE_LIKE_ACTIVITY_TYPES:
+        if not raw_type or raw_type == "FILL" or raw_type in cls.TRADE_LIKE_ACTIVITY_TYPES:
             return None
 
         amount = CashEvent.coerce_amount(activity.get("net_amount"))
@@ -1256,6 +1322,8 @@ class Alpaca(Broker):
         since: datetime.datetime | None = None,
         limit: int | None = 100,
     ) -> list[CashEvent]:
+        CashEvent = _cash_event_class()
+
         normalized_limit = max(int(limit or 100), 1)
         page_size = min(max(normalized_limit * 10, normalized_limit), 100)
         normalized_events = []
@@ -1347,12 +1415,15 @@ class Alpaca(Broker):
         """
         if self.is_oauth_only:
             # OAuth-only configurations use polling since TradingStream doesn't support OAuth tokens
+            from lumibot.trading_builtins import PollingStream
+
             logger.debug("Alpaca Stream: Using PollingStream for OAuth-only configuration")
             return PollingStream(self.polling_interval)
         elif self.api_key and self.api_secret:
             # Traditional API key/secret authentication
             logger.debug("Alpaca Stream: Using TradingStream for API key/secret authentication")
-            return TradingStream(self.api_key, self.api_secret, paper=self.is_paper)
+            trading_stream_class = _get_trading_stream_class()
+            return trading_stream_class(self.api_key, self.api_secret, paper=self.is_paper)
         else:
             raise ValueError("Either OAuth token or API key/secret must be provided for Alpaca authentication")
 
@@ -1364,7 +1435,7 @@ class Alpaca(Broker):
             logger.debug("Alpaca Stream: Registering OAuth polling events")
             broker = self
 
-            @broker.stream.add_action(PollingStream.POLL_EVENT)
+            @broker.stream.add_action("poll")
             def on_trade_event_poll():
                 logger.debug("Alpaca Stream: Polling event triggered, calling do_polling()")
                 self.do_polling()
@@ -1651,6 +1722,9 @@ class Alpaca(Broker):
                     return True
                 except ValueError:
                     logger.error(traceback.format_exc())
+
+            import asyncio
+            from asyncio import CancelledError
 
             self.stream.loop = asyncio.new_event_loop()
             loop = self.stream.loop

--- a/lumibot/brokers/bitunix.py
+++ b/lumibot/brokers/bitunix.py
@@ -1,19 +1,62 @@
+from __future__ import annotations
+
 import os
 import time
 import traceback
 from decimal import Decimal
-from typing import Any, Dict, List, Optional, Tuple
-
-import pandas as pd
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from .broker import Broker, LumibotBrokerAPIError
-from lumibot.data_sources.bitunix_data import BitunixData
-from lumibot.entities import Asset, Order, Position
-from lumibot.tools.bitunix_helpers import BitUnixClient
+from lumibot.entities import Asset, Order
 from lumibot.tools.lumibot_logger import get_logger
-from lumibot.trading_builtins import PollingStream
+
+if TYPE_CHECKING:
+    from lumibot.entities import Position
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+BitUnixClient = None
+BitunixData = None
+
+
+def _bitunix_client_class():
+    global BitUnixClient
+    if BitUnixClient is None:
+        from lumibot.tools.bitunix_helpers import BitUnixClient as _BitUnixClient
+
+        BitUnixClient = _BitUnixClient
+    return BitUnixClient
+
+
+def _bitunix_data_class():
+    global BitunixData
+    if BitunixData is None:
+        from lumibot.data_sources.bitunix_data import BitunixData as _BitunixData
+
+        BitunixData = _BitunixData
+    return BitunixData
+
 
 class Bitunix(Broker):
     """
@@ -75,7 +118,7 @@ class Bitunix(Broker):
             raise ValueError("API_KEY and API_SECRET must be provided in config")
 
         # Initialize API client and WS attributes BEFORE calling super().__init__
-        self.api = BitUnixClient(api_key=api_key, secret_key=api_secret)
+        self.api = _bitunix_client_class()(api_key=api_key, secret_key=api_secret)
         self.api_secret = api_secret  # needed for signing
         # Private-channel URL per BitUnix docs (used for authenticated account streams)
         self.ws_url = "wss://fapi.bitunix.com/private/"
@@ -98,7 +141,7 @@ class Bitunix(Broker):
             logger.debug(traceback.format_exc())
 
         if not data_source:
-            data_source = BitunixData(config, max_workers=max_workers, chunk_size=chunk_size)
+            data_source = _bitunix_data_class()(config, max_workers=max_workers, chunk_size=chunk_size)
             # Share the client instance with the data source if it was just created
             data_source.client = self.api
             # Share the client_symbols set with the broker for WebSocket subscriptions
@@ -194,6 +237,8 @@ class Bitunix(Broker):
                     # entry price is avgOpenPrice (fallback to entryValue)
                     entry = Decimal(str(p.get("avgOpenPrice", p.get("entryValue", "0"))))
                     if qty != 0 and sym:
+                        from lumibot.entities import Position
+
                         asset = Asset(sym, Asset.AssetType.CRYPTO_FUTURE)
                         pos = Position(strategy_name, asset, qty)
                         pos.avg_fill_price = entry
@@ -606,13 +651,15 @@ class Bitunix(Broker):
 
     def _get_stream_object(self):
         """Returns the polling stream object."""
+        from lumibot.trading_builtins import PollingStream
+
         return PollingStream(self.poll_interval)
 
     def _register_stream_events(self):
         """Register polling event for Bitunix."""
         broker = self
 
-        @broker.stream.add_action(PollingStream.POLL_EVENT)
+        @broker.stream.add_action("poll")
         def on_trade_event_poll():
             self.do_polling()
 

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import json
 import os
@@ -5,33 +7,75 @@ import time
 import threading
 from collections import deque
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from queue import Queue
+from importlib import import_module
 from threading import RLock, Thread
-from typing import Union
-
-import pandas as pd
-import pandas_market_calendars as mcal
-from dateutil import tz
-from termcolor import colored
+from typing import TYPE_CHECKING, Union
 
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
 
 from lumibot.tools.lumibot_logger import get_logger, get_strategy_logger
-from lumibot.tools.parquet_utils import (
-    coerce_object_columns_to_json_strings,
-    is_parquet_required,
-    write_parquet_with_logging,
-)
 from lumibot.tools.symbol_normalization import normalize_symbol_for_broker, normalize_symbol_for_internal
-from ..data_sources import DataSource
-from ..entities import Asset, CashEvent, Order, Position, Quote
+from ..entities import Asset, Order
 from ..entities.chains import normalize_option_chains
 from ..trading_builtins import SafeList, SafeOrderDict
+
+if TYPE_CHECKING:
+    from ..data_sources import DataSource
+    from ..entities import CashEvent, Position, Quote
+    from ..strategies.strategy import Strategy
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_PARQUET_UTILS = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _get_parquet_utils():
+    global _PARQUET_UTILS
+    if _PARQUET_UTILS is None:
+        from lumibot.tools.parquet_utils import (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+
+        _PARQUET_UTILS = (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+    return _PARQUET_UTILS
 
 DEFAULT_CLEANUP_CONFIG = {
     "enabled": True,
@@ -99,6 +143,8 @@ TRADE_EVENT_LOG_COLUMNS = (
     "cash_event_broker_name",
     "cash_event_broker_event_id",
 )
+_FAST_TRADE_EVENT_MARKER = "__fast_trade__"
+_FAST_TRADE_PAIR_EVENT_MARKER = "__fast_trade_pair__"
 
 # Consolidate errors from different brokers into a single class that can be easily caught even
 # if the user decides to switch brokers.
@@ -169,6 +215,8 @@ class Broker(ABC):
         the existing trade-event stream so downstream artifacts can render them without requiring a
         separate cash-event file.
         """
+        from ..entities import CashEvent
+
         if not getattr(self, "_trade_event_log_enabled", True):
             return
         if not isinstance(cash_event, CashEvent):
@@ -302,7 +350,7 @@ class Broker(ABC):
         self._trade_event_log_rows = (
             deque(maxlen=self._trade_event_log_max_rows) if self._trade_event_log_max_rows else []
         )
-        self._trade_event_log_df_cache = pd.DataFrame()
+        self._trade_event_log_df_cache = None
         self._trade_event_log_columns = TRADE_EVENT_LOG_COLUMNS
         self._hold_trade_events = False
         self._held_trades = []
@@ -351,6 +399,8 @@ class Broker(ABC):
 
         # setting the orders queue and threads
         if not self.IS_BACKTESTING_BROKER:
+            from queue import Queue
+
             self._orders_queue = Queue()
             self._orders_thread = None
             self._start_orders_thread()
@@ -942,6 +992,7 @@ class Broker(ABC):
             getattr(self._error_orders, "revision", 0),
             getattr(self._canceled_orders, "revision", 0),
             getattr(self._placeholder_orders, "revision", 0),
+            getattr(self, "_simple_new_orders_revision", 0),
         )
         if self._tracked_orders_cache_key == cache_key:
             return self._tracked_orders_cache_value
@@ -949,6 +1000,10 @@ class Broker(ABC):
         orders: list[Order] = []
         orders.extend(self._unprocessed_orders.get_list())
         orders.extend(self._new_orders.get_list())
+        simple_by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+        if simple_by_strategy:
+            for strategy_orders in simple_by_strategy.values():
+                orders.extend(strategy_orders)
         orders.extend(self._partially_filled_orders.get_list())
         orders.extend(self._filled_orders.get_list())
         orders.extend(self._error_orders.get_list())
@@ -1390,6 +1445,41 @@ class Broker(ABC):
     def _process_new_order(self, order):
         # Don't duplicate orders in the new orders tracker. Check if an order with the same identifier already exists
         # in the tracked orders.
+        if self.IS_BACKTESTING_BROKER:
+            order_identifier = order.identifier
+
+            def _find_in_bucket(bucket):
+                if order_identifier not in bucket:
+                    return None
+                getter = getattr(bucket, "get", None)
+                if getter is not None:
+                    existing = getter(order_identifier)
+                    if existing is not None:
+                        return existing
+                for existing in bucket.get_list():
+                    if getattr(existing, "_identifier", getattr(existing, "identifier", None)) == order_identifier:
+                        return existing
+                return None
+
+            existing_order = _find_in_bucket(self._new_orders)
+            if existing_order is not None:
+                return existing_order
+
+            existing_order = _find_in_bucket(self._unprocessed_orders)
+            if existing_order is not None:
+                order = existing_order
+            else:
+                for bucket in (self._partially_filled_orders, self._placeholder_orders):
+                    existing_order = _find_in_bucket(bucket)
+                    if existing_order is not None:
+                        return existing_order
+
+            self._unprocessed_orders.remove(order_identifier, key="identifier")
+            order.status = self.NEW_ORDER
+            order.set_new()
+            self._new_orders.append(order)
+            return order
+
         existing_order = self.get_tracked_order(order.identifier)
         if existing_order:
             # Check if this order already exists in self._new_orders based on the identifier - Do nothing
@@ -1580,6 +1670,8 @@ class Broker(ABC):
             quote_quantity = -quote_quantity
         position = self.get_tracked_position(order.strategy, order.quote)
         if position is None:
+            from ..entities import Position
+
             position = Position(
                 order.strategy,
                 order.quote,
@@ -1592,7 +1684,7 @@ class Broker(ABC):
     # =========Clock functions=====================
 
     def utc_to_local(self, utc_dt):
-        return utc_dt.replace(tzinfo=timezone.utc).astimezone(tz=tz.tzlocal())
+        return utc_dt.replace(tzinfo=timezone.utc).astimezone()
 
     def market_hours(self, market="NASDAQ", close=True, next=False, date=None):
         """[summary]
@@ -1616,6 +1708,8 @@ class Broker(ABC):
         """
 
         market = self.market if self.market is not None else market
+        import pandas_market_calendars as mcal
+
         mkt_cal = mcal.get_calendar(market)
 
         # Get the current datetime in UTC (because the market hours are in UTC)
@@ -1739,7 +1833,7 @@ class Broker(ABC):
             
             return True
             
-        current_time = datetime.now().astimezone(tz=tz.tzlocal())
+        current_time = datetime.now().astimezone()
 
         # For ANY market, check both today's and tomorrow's sessions since trading sessions 
         # can span multiple calendar days (futures: 6pm Thu -> 6pm Fri, forex: Sun 5pm -> Fri 5pm, 
@@ -1773,7 +1867,7 @@ class Broker(ABC):
         open_time_next_day = self.utc_to_local(self.market_hours(close=False, next=True))
         now = self.utc_to_local(datetime.now())
         open_time = open_time_this_day if open_time_this_day > now else open_time_next_day
-        current_time = datetime.now().astimezone(tz=tz.tzlocal())
+        current_time = datetime.now().astimezone()
         if self.is_market_open():
             return 0
         else:
@@ -1784,7 +1878,7 @@ class Broker(ABC):
         """Return the remaining time for the market to close in seconds"""
         market_hours = self.market_hours(close=True)
         close_time = self.utc_to_local(market_hours)
-        current_time = datetime.now().astimezone(tz=tz.tzlocal())
+        current_time = datetime.now().astimezone()
         if self.is_market_open():
             result = close_time.timestamp() - current_time.timestamp()
             return result
@@ -1832,7 +1926,10 @@ class Broker(ABC):
             return cached
 
         for position in self._filled_positions:
-            if position.asset == asset and (strategy_name is None or position.strategy == strategy_name):
+            position_asset = position.asset
+            if (position_asset is asset or position_asset == asset) and (
+                strategy_name is None or position.strategy == strategy_name
+            ):
                 self._cache_result(self._tracked_position_cache, cache_key, position)
                 return position
         self._cache_result(self._tracked_position_cache, cache_key, None)
@@ -1895,6 +1992,7 @@ class Broker(ABC):
             getattr(self._new_orders, "revision", 0),
             getattr(self._partially_filled_orders, "revision", 0),
             getattr(self._placeholder_orders, "revision", 0),
+            getattr(self, "_simple_new_orders_revision", 0),
             strategy_name,
             asset,
         )
@@ -1913,6 +2011,19 @@ class Broker(ABC):
                 if not order.is_active():
                     continue
                 if strategy_name is not None and order.strategy != strategy_name:
+                    continue
+                if asset is not None and order.asset != asset:
+                    continue
+                result.append(order)
+        simple_by_strategy = getattr(self, "_simple_new_orders_by_strategy", None)
+        if simple_by_strategy:
+            strategy_orders = (
+                simple_by_strategy.get(strategy_name, ())
+                if strategy_name is not None
+                else (order for orders in simple_by_strategy.values() for order in orders)
+            )
+            for order in strategy_orders:
+                if not order.is_active():
                     continue
                 if asset is not None and order.asset != asset:
                     continue
@@ -2050,6 +2161,8 @@ class Broker(ABC):
             if kwargs.get('is_multileg') and kwargs.get('order_type') == Order.OrderType.LIMIT:
                 raise NotImplementedError("Multileg limit orders are not supported by this broker")
 
+            from concurrent.futures import ThreadPoolExecutor, as_completed
+
             with ThreadPoolExecutor(
                 max_workers=self.max_workers,
                 thread_name_prefix=f"{self.name}_submitting_orders",
@@ -2083,6 +2196,8 @@ class Broker(ABC):
 
     def cancel_orders(self, orders):
         """cancel orders"""
+        from concurrent.futures import ThreadPoolExecutor
+
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             tasks = []
             for order in orders:
@@ -2230,13 +2345,6 @@ class Broker(ABC):
 
         return None
 
-    def _resolve_subscriber(self, strategy_name):
-        """Get subscriber by name, falling back to the sole registered subscriber when strategy_name is falsy."""
-        subscriber = self._get_subscriber(strategy_name)
-        if subscriber is None and not strategy_name and len(self._subscribers) == 1:
-            subscriber = self._subscribers[0]
-        return subscriber
-
     def _on_new_order(self, order):
         """notify relevant subscriber/strategy about
         new order event"""
@@ -2245,7 +2353,7 @@ class Broker(ABC):
             self.logger.info(colored(f"New order was created: {order}", color="green"))
 
         payload = dict(order=order)
-        subscriber = self._resolve_subscriber(order.strategy)
+        subscriber = self._get_subscriber(order.strategy)
         if subscriber:
             # PERF: Many strategies do not override `Strategy.on_new_order()` (base impl is `pass`).
             # Avoid enqueueing/processing a no-op event in high-churn backtests.
@@ -2267,7 +2375,7 @@ class Broker(ABC):
             self.logger.info(colored(f"Order was canceled: {order}", color="green"))
 
         payload = dict(order=order)
-        subscriber = self._resolve_subscriber(order.strategy)
+        subscriber = self._get_subscriber(order.strategy)
         if subscriber:
             # PERF: Many strategies do not override `Strategy.on_canceled_order()` (base impl is `pass`).
             # Avoid enqueueing/processing a no-op event in high-churn backtests.
@@ -2295,7 +2403,7 @@ class Broker(ABC):
             quantity=quantity,
             multiplier=multiplier,
         )
-        subscriber = self._resolve_subscriber(order.strategy)
+        subscriber = self._get_subscriber(order.strategy)
         if subscriber:
             subscriber.add_event(subscriber.PARTIALLY_FILLED_ORDER, payload)
         else:
@@ -2315,8 +2423,26 @@ class Broker(ABC):
             quantity=quantity,
             multiplier=multiplier,
         )
-        subscriber = self._resolve_subscriber(order.strategy)
+        subscriber = self._get_subscriber(order.strategy)
         if subscriber:
+            # Futures/crypto cash and position effects are handled before the strategy executor
+            # event. If the user did not override the callback, avoid enqueueing a no-op.
+            try:
+                asset_type = getattr(getattr(order, "asset", None), "asset_type", None)
+                if asset_type in (Asset.AssetType.CRYPTO, Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE):
+                    strategy_obj = getattr(subscriber, "strategy", None)
+                    handler = getattr(strategy_obj, "on_filled_order", None)
+                    func = getattr(handler, "__func__", handler)
+                    executor_handler = getattr(subscriber, "_on_filled_order", None)
+                    executor_func = getattr(executor_handler, "__func__", executor_handler)
+                    if (
+                        getattr(func, "__qualname__", "") == "Strategy.on_filled_order"
+                        and getattr(executor_func, "__qualname__", "") == "StrategyExecutor._on_filled_order"
+                        and not callable(getattr(strategy_obj, "_filled_order_callback", None))
+                    ):
+                        return
+            except Exception:
+                pass
             subscriber.add_event(subscriber.FILLED_ORDER, payload)
         else:
             self.logger.error(colored(f"Subscriber {order.strategy} not found", color="red"))
@@ -2343,9 +2469,180 @@ class Broker(ABC):
                     cache = pd.DataFrame(list(rows))
                 else:
                     cols = getattr(self, "_trade_event_log_columns", None) or None
-                    cache = pd.DataFrame(list(rows), columns=list(cols) if cols else None)
+                    normalized_rows = self._expand_trade_event_rows(rows)
+                    cache = pd.DataFrame(normalized_rows, columns=list(cols) if cols else None)
             self._trade_event_log_df_cache = cache
         return cache
+
+    def _expand_trade_event_rows(self, rows):
+        expanded = []
+        for row in rows:
+            if (
+                isinstance(row, (tuple, list))
+                and len(row) == 19
+                and row[0] == _FAST_TRADE_PAIR_EVENT_MARKER
+            ):
+                (
+                    _marker,
+                    new_time,
+                    fill_time,
+                    strategy,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    new_status,
+                    fill_status,
+                    price,
+                    filled_quantity,
+                    multiplier,
+                    trade_cost,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                    price_source,
+                ) = row
+
+                expanded.append(
+                    (
+                        new_time,
+                        strategy,
+                        None,
+                        identifier,
+                        symbol,
+                        side,
+                        order_type,
+                        new_status,
+                        None,
+                        None,
+                        1,
+                        None,
+                        trade_slippage,
+                        time_in_force,
+                        None,
+                        None,
+                        asset_multiplier,
+                        None,
+                        asset_type,
+                        None,
+                        "trade",
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
+                )
+                if fill_time is not None:
+                    expanded.append(
+                        (
+                            fill_time,
+                            strategy,
+                            None,
+                            identifier,
+                            symbol,
+                            side,
+                            order_type,
+                            fill_status,
+                            price,
+                            filled_quantity,
+                            multiplier,
+                            trade_cost,
+                            trade_slippage,
+                            time_in_force,
+                            None,
+                            None,
+                            asset_multiplier,
+                            None,
+                            asset_type,
+                            price_source,
+                            "trade",
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
+                    )
+            elif (
+                isinstance(row, tuple)
+                and len(row) == 17
+                and row[0] == _FAST_TRADE_EVENT_MARKER
+            ):
+                (
+                    _marker,
+                    event_time,
+                    strategy,
+                    identifier,
+                    symbol,
+                    side,
+                    order_type,
+                    status,
+                    price,
+                    filled_quantity,
+                    multiplier,
+                    trade_cost,
+                    trade_slippage,
+                    time_in_force,
+                    asset_multiplier,
+                    asset_type,
+                    price_source,
+                ) = row
+                expanded.append(
+                    (
+                        event_time,
+                        strategy,
+                        None,
+                        identifier,
+                        symbol,
+                        side,
+                        order_type,
+                        status,
+                        price,
+                        filled_quantity,
+                        multiplier,
+                        trade_cost,
+                        trade_slippage,
+                        time_in_force,
+                        None,
+                        None,
+                        asset_multiplier,
+                        None,
+                        asset_type,
+                        price_source,
+                        "trade",
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
+                )
+            else:
+                expanded.append(row)
+        return expanded
 
     @_trade_event_log_df.setter
     def _trade_event_log_df(self, value) -> None:
@@ -2465,7 +2762,7 @@ class Broker(ABC):
             elif type_event == self.ERROR_ORDER:
                 order = self._process_error_order(stored_order, error or LumibotBrokerAPIError("Unknown order error"))
                 if order:
-                    subscriber = self._resolve_subscriber(order.strategy)
+                    subscriber = self._get_subscriber(order.strategy)
                     if subscriber:
                         payload = dict(order=order, error=error)
                         subscriber.add_event(subscriber.ERROR_ORDER, payload)
@@ -2510,7 +2807,7 @@ class Broker(ABC):
                 order = self._process_error_order(stored_order, error or LumibotBrokerAPIError("Unknown order error"))
                 if order:
                     # Notify subscriber about the error event
-                    subscriber = self._resolve_subscriber(order.strategy)
+                    subscriber = self._get_subscriber(order.strategy)
                     if subscriber:
                         payload = dict(order=order, error=error)
                         subscriber.add_event(subscriber.ERROR_ORDER, payload)
@@ -2546,7 +2843,7 @@ class Broker(ABC):
         # method call overhead in the hot-path trade-event logger, but fall back to `get_datetime()`
         # for stubbed sources used in unit tests.
         if is_backtesting:
-            current_dt = getattr(self.data_source, "_datetime", None) or self.data_source.get_datetime()
+            current_dt = self.datetime
         else:
             current_dt = self.data_source.get_datetime()
         # Cache the audit-enabled flag when available (BacktestingBroker sets this in __init__).
@@ -2730,6 +3027,11 @@ class Broker(ABC):
         parquet_filename = (
             filename[:-4] + ".parquet" if str(filename).lower().endswith(".csv") else str(filename) + ".parquet"
         )
+        (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        ) = _get_parquet_utils()
         required = bool(self.IS_BACKTESTING_BROKER) and is_parquet_required()
         write_parquet_with_logging(
             df=df,

--- a/lumibot/brokers/ccxt.py
+++ b/lumibot/brokers/ccxt.py
@@ -1,17 +1,36 @@
+from __future__ import annotations
+
 import datetime
 import os
 from decimal import ROUND_DOWN, Decimal, getcontext
 from typing import Union
 
-from termcolor import colored
-
-from lumibot.data_sources import CcxtData
-from lumibot.entities import Asset, Order, Position
+from lumibot.entities import Asset, Order
 from lumibot.tools.lumibot_logger import get_logger
 
 from .broker import Broker
 
 logger = get_logger(__name__)
+_CCXT_DATA_CLASS = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _ccxt_data_class():
+    global _CCXT_DATA_CLASS
+    if _CCXT_DATA_CLASS is None:
+        from lumibot.data_sources import CcxtData
+
+        _CCXT_DATA_CLASS = CcxtData
+    return _CCXT_DATA_CLASS
 
 
 class Ccxt(Broker):
@@ -19,7 +38,8 @@ class Ccxt(Broker):
     Crypto broker using CCXT.
     """
 
-    def __init__(self, config, data_source: CcxtData = None, max_workers=20, chunk_size=100, **kwargs):
+    def __init__(self, config, data_source=None, max_workers=20, chunk_size=100, **kwargs):
+        CcxtData = _ccxt_data_class()
         if data_source is None:
             data_source = CcxtData(config, max_workers=max_workers, chunk_size=chunk_size)
         super().__init__(name="ccxt", config=config, data_source=data_source, max_workers=max_workers, **kwargs)
@@ -200,6 +220,8 @@ class Ccxt(Broker):
             asset_type="crypto",
             precision=precision,
         )
+
+        from lumibot.entities import Position
 
         position_return = Position(strategy, asset, quantity, hold=hold, available=available, orders=orders)
         return position_return

--- a/lumibot/brokers/example_broker.py
+++ b/lumibot/brokers/example_broker.py
@@ -1,13 +1,25 @@
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from termcolor import colored
 
 from .broker import Broker
-from lumibot.data_sources import ExampleBrokerData
 from lumibot.entities import Asset, Order, Position
 from lumibot.tools.lumibot_logger import get_logger
 
+if TYPE_CHECKING:
+    from lumibot.strategies.strategy import Strategy
+
 logger = get_logger(__name__)
+_EXAMPLE_BROKER_DATA_CLASS = None
+
+
+def _example_broker_data_class():
+    global _EXAMPLE_BROKER_DATA_CLASS
+    if _EXAMPLE_BROKER_DATA_CLASS is None:
+        from lumibot.data_sources import ExampleBrokerData
+
+        _EXAMPLE_BROKER_DATA_CLASS = ExampleBrokerData
+    return _EXAMPLE_BROKER_DATA_CLASS
 
 class ExampleBroker(Broker):
     """
@@ -20,10 +32,10 @@ class ExampleBroker(Broker):
             self,
             config=None,
             data_source=None,
-    ):
+        ):
         # Check if the user has provided a data source, if not, create one
         if data_source is None:
-            data_source = ExampleBrokerData()
+            data_source = _example_broker_data_class()()
 
         super().__init__(
             name=self.NAME,

--- a/lumibot/brokers/interactive_brokers.py
+++ b/lumibot/brokers/interactive_brokers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import math
 import os
@@ -10,21 +12,38 @@ from sys import exit
 from threading import Thread
 from typing import Union
 
-from dateutil import tz
 from ibapi.client import *
 from ibapi.contract import *
 from ibapi.order import *
 from ibapi.wrapper import *
-from termcolor import colored
 
-from lumibot.data_sources import InteractiveBrokersData
 from lumibot.tools.lumibot_logger import get_logger
 from lumibot.tools.symbol_normalization import normalize_symbol_for_broker
 
 logger = get_logger(__name__)
+_INTERACTIVE_BROKERS_DATA_CLASS = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _interactive_brokers_data_class():
+    global _INTERACTIVE_BROKERS_DATA_CLASS
+    if _INTERACTIVE_BROKERS_DATA_CLASS is None:
+        from lumibot.data_sources import InteractiveBrokersData
+
+        _INTERACTIVE_BROKERS_DATA_CLASS = InteractiveBrokersData
+    return _INTERACTIVE_BROKERS_DATA_CLASS
 
 # Naming conflict on Order between IB and Lumibot.
-from lumibot.entities import Asset, Position
+from lumibot.entities import Asset
 from lumibot.entities import Order as OrderLum
 
 from .broker import Broker
@@ -58,7 +77,7 @@ class InteractiveBrokers(Broker):
 
     def __init__(self, config, max_workers=20, chunk_size=100, data_source=None, **kwargs):
         if data_source is None:
-            data_source = InteractiveBrokersData(config, max_workers=max_workers, chunk_size=chunk_size)
+            data_source = _interactive_brokers_data_class()(config, max_workers=max_workers, chunk_size=chunk_size)
 
         super().__init__(
             name="interactive_brokers",
@@ -115,7 +134,7 @@ class InteractiveBrokers(Broker):
         if not self.ib:
             self.ib = IBApp(ip_address=self.ip, socket_port=self.socket_port, client_id=self.client_id, subaccount=self.subaccount, ib_broker=self)
 
-        if isinstance(self.data_source, InteractiveBrokersData):
+        if isinstance(self.data_source, _interactive_brokers_data_class()):
             if not self.data_source.ib:
                 self.data_source.ib = self.ib
 
@@ -168,6 +187,8 @@ class InteractiveBrokers(Broker):
             )
 
         quantity = broker_position["position"]
+        from lumibot.entities import Position
+
         position = Position(strategy, asset, quantity, orders=orders)
         return position
 
@@ -825,7 +846,7 @@ class IBWrapper(EWrapper):
         if not hasattr(self, "realtimeBar"):
             self.init_realtimeBar()
         rtb = dict(
-            datetime=datetime.datetime.fromtimestamp(time).astimezone(tz=tz.tzlocal()),
+            datetime=datetime.datetime.fromtimestamp(time).astimezone(),
             open=open_,
             high=high,
             low=low,

--- a/lumibot/brokers/interactive_brokers_rest.py
+++ b/lumibot/brokers/interactive_brokers_rest.py
@@ -1,21 +1,42 @@
+from __future__ import annotations
+
 import datetime
 import os
 import re
 import traceback
 from decimal import Decimal
 from math import gcd
-from typing import Union
-
-from termcolor import colored
+from typing import TYPE_CHECKING, Union
 
 from lumibot.tools.lumibot_logger import get_logger
 
 from ..brokers import Broker
-from ..data_sources import InteractiveBrokersRESTData
-from ..entities import Asset, Order, Position
-from ..trading_builtins import PollingStream
+from ..entities import Asset, Order
+
+if TYPE_CHECKING:
+    from ..entities import Position
 
 logger = get_logger(__name__)
+_INTERACTIVE_BROKERS_REST_DATA_CLASS = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _interactive_brokers_rest_data_class():
+    global _INTERACTIVE_BROKERS_REST_DATA_CLASS
+    if _INTERACTIVE_BROKERS_REST_DATA_CLASS is None:
+        from ..data_sources import InteractiveBrokersRESTData
+
+        _INTERACTIVE_BROKERS_REST_DATA_CLASS = InteractiveBrokersRESTData
+    return _INTERACTIVE_BROKERS_REST_DATA_CLASS
 
 TYPE_MAP = dict(
     stock="STK",
@@ -68,7 +89,7 @@ class InteractiveBrokersREST(Broker):
     Broker that connects to the Interactive Brokers REST API.
     """
 
-    POLL_EVENT = PollingStream.POLL_EVENT
+    POLL_EVENT = "poll"
     NAME = "InteractiveBrokersREST"
 
     def __init__(self, config, data_source=None, poll_interval=5.0):
@@ -76,7 +97,7 @@ class InteractiveBrokersREST(Broker):
         self.polling_interval = poll_interval
 
         if data_source is None:
-            data_source = InteractiveBrokersRESTData(config)
+            data_source = _interactive_brokers_rest_data_class()(config)
 
         super().__init__(
             name=self.NAME,
@@ -139,6 +160,8 @@ class InteractiveBrokersREST(Broker):
                 quantity = balances["cashbalance"]
 
                 if quantity != 0:
+                    from ..entities import Position
+
                     position = Position(
                         strategy=strategy_name,
                         asset=asset,
@@ -381,6 +404,8 @@ class InteractiveBrokersREST(Broker):
             )
 
         quantity = broker_position["position"]
+        from ..entities import Position
+
         position = Position(strategy, asset, quantity, orders=orders)
         return position
 
@@ -399,6 +424,8 @@ class InteractiveBrokersREST(Broker):
         for pos in result:
             if pos.asset == asset:
                 return pos
+        from ..entities import Position
+
         return Position(strategy, asset, 0)
 
     def _pull_broker_positions(self, strategy=None):
@@ -562,6 +589,8 @@ class InteractiveBrokersREST(Broker):
                 continue
 
             # Create the Position object
+            from ..entities import Position
+
             position_obj = Position(
                 strategy=strategy,
                 asset=asset,
@@ -1149,6 +1178,8 @@ class InteractiveBrokersREST(Broker):
 
     def _get_stream_object(self):
         """Create polling stream"""
+        from ..trading_builtins import PollingStream
+
         return PollingStream(self.polling_interval)
 
     def _close_connection(self):

--- a/lumibot/brokers/projectx.py
+++ b/lumibot/brokers/projectx.py
@@ -5,38 +5,105 @@ Provides futures trading functionality through ProjectX broker integration.
 Supports multiple underlying brokers (TSX, TOPONE, etc.) via ProjectX gateway.
 """
 
+from __future__ import annotations
+
 import threading
 from datetime import datetime, timedelta
-from typing import Dict, List
-
-import pandas as pd
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict, List
 
 from lumibot.brokers.broker import Broker
-from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
-from lumibot.data_sources import DataSource
-from lumibot.entities import Asset, Order, Position
+from lumibot.entities import Asset, Order
 from lumibot.tools.lumibot_logger import get_logger
-from lumibot.tools.projectx_helpers import (
-    ProjectXClient,
-    create_bracket_meta,
-    normalize_bracket_entry_tag,
-    build_unique_order_tag,
-    select_effective_prices,
-    bracket_child_tag,
-    derive_base_tag,
-    early_store_bracket_meta,
-    restore_bracket_meta_if_needed,
-    should_spawn_bracket_children,
-    build_bracket_child_spec,
-)
-from termcolor import colored
 # PollingStream usage was removed to align with centralized lifecycle in core Broker
-import traceback
+
+if TYPE_CHECKING:
+    from lumibot.entities import Position
 
 # Import moved to avoid circular dependency
 # from lumibot.credentials import PROJECTX_CONFIG
 
 logger = get_logger(__name__)
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+_projectx_helpers = _LazyModule("lumibot.tools.projectx_helpers")
+ProjectXClient = None
+
+
+def _projectx_client_class():
+    global ProjectXClient
+    if ProjectXClient is None:
+        ProjectXClient = _projectx_helpers.ProjectXClient
+    return ProjectXClient
+
+
+def create_bracket_meta(*args, **kwargs):
+    return _projectx_helpers.create_bracket_meta(*args, **kwargs)
+
+
+def normalize_bracket_entry_tag(*args, **kwargs):
+    return _projectx_helpers.normalize_bracket_entry_tag(*args, **kwargs)
+
+
+def build_unique_order_tag(*args, **kwargs):
+    return _projectx_helpers.build_unique_order_tag(*args, **kwargs)
+
+
+def select_effective_prices(*args, **kwargs):
+    return _projectx_helpers.select_effective_prices(*args, **kwargs)
+
+
+def bracket_child_tag(*args, **kwargs):
+    return _projectx_helpers.bracket_child_tag(*args, **kwargs)
+
+
+def derive_base_tag(*args, **kwargs):
+    return _projectx_helpers.derive_base_tag(*args, **kwargs)
+
+
+def early_store_bracket_meta(*args, **kwargs):
+    return _projectx_helpers.early_store_bracket_meta(*args, **kwargs)
+
+
+def restore_bracket_meta_if_needed(*args, **kwargs):
+    return _projectx_helpers.restore_bracket_meta_if_needed(*args, **kwargs)
+
+
+def should_spawn_bracket_children(*args, **kwargs):
+    return _projectx_helpers.should_spawn_bracket_children(*args, **kwargs)
+
+
+def build_bracket_child_spec(*args, **kwargs):
+    return _projectx_helpers.build_bracket_child_spec(*args, **kwargs)
 
 
 class ProjectX(Broker):
@@ -101,7 +168,7 @@ class ProjectX(Broker):
         2: "short",
     }
 
-    def __init__(self, config: dict = None, data_source: DataSource = None,
+    def __init__(self, config: dict = None, data_source = None,
                  connect_stream: bool = True, max_workers: int = 20, firm: str = None):
         """
         Initialize ProjectX broker.
@@ -142,7 +209,7 @@ class ProjectX(Broker):
         self.firm = config.get("firm")
 
         # Initialize ProjectX client
-        self.client = ProjectXClient(config)
+        self.client = _projectx_client_class()(config)
 
         # Account management
         self.account_id = None
@@ -600,6 +667,8 @@ class ProjectX(Broker):
 
             # Get orders from last 30 days to catch filled/cancelled orders
             # Note: Orders may disappear quickly after being filled
+            from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
+
             end_date = datetime.now(LUMIBOT_DEFAULT_PYTZ).replace(hour=23, minute=59, second=59)
             start_date = end_date.replace(hour=0, minute=0, second=0) - timedelta(days=self.order_lookback_days)
 
@@ -762,6 +831,8 @@ class ProjectX(Broker):
         """Get all orders from broker, including recently filled ones via trades."""
         try:
             # Get all orders from today to catch any recent activity
+            from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
+
             end_date = datetime.now(LUMIBOT_DEFAULT_PYTZ).replace(hour=23, minute=59, second=59)
             start_date = end_date.replace(hour=0, minute=0, second=0)
 
@@ -1071,6 +1142,8 @@ class ProjectX(Broker):
 
             # Try both field names: avgPrice and averagePrice
             avg_price = broker_position.get("avgPrice") or broker_position.get("averagePrice", 0.0)
+
+            from lumibot.entities import Position
 
             position = Position(
                 strategy="",  # Will be set by strategy

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import json
 import os
@@ -5,33 +7,55 @@ import re
 import traceback
 from datetime import datetime, timedelta
 from threading import Thread
-from typing import List, Optional, Union
-
-import dotenv
-from pytz import timezone
-
-# Import Schwab specific libraries
-from schwab.client import Client
-from schwab.streaming import StreamClient
-from termcolor import colored
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from .broker import Broker
-from lumibot.data_sources import SchwabData  # Import YahooData
-from lumibot.entities import Asset, Order, Position
+from lumibot.entities import Asset, Order
 from lumibot.tools.lumibot_logger import get_logger
+
+if TYPE_CHECKING:
+    from lumibot.entities import Position
+    from lumibot.strategies.strategy import Strategy
 
 logger = get_logger(__name__)
 
-# Import PollingStream class
 import time
 from pathlib import Path
-
-from lumibot.tools import SchwabHelper
-from lumibot.trading_builtins import PollingStream
 
 # ---- Lumiwealth default Schwab app configuration ----
 LUMI_DEFAULT_APP_KEY = "RfUVxotUc8p6CbeCwFmophgNZSat0TLv"
 LUMI_DEFAULT_CALLBACK = "https://api.botspot.trade/broker_oauth/schwab"
+_SCHWAB_DATA_CLASS = None
+SchwabHelper = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _schwab_data_class():
+    global _SCHWAB_DATA_CLASS
+    if _SCHWAB_DATA_CLASS is None:
+        from lumibot.data_sources import SchwabData
+
+        _SCHWAB_DATA_CLASS = SchwabData
+    return _SCHWAB_DATA_CLASS
+
+
+def _schwab_helper():
+    global SchwabHelper
+    if SchwabHelper is None:
+        from lumibot.tools import SchwabHelper as _helper
+
+        SchwabHelper = _helper
+    return SchwabHelper
+
 
 class Schwab(Broker):
     """
@@ -46,7 +70,7 @@ class Schwab(Broker):
     """
 
     NAME = "Schwab"
-    POLL_EVENT = PollingStream.POLL_EVENT
+    POLL_EVENT = "poll"
 
     def __init__(
             self,
@@ -60,6 +84,7 @@ class Schwab(Broker):
 
         # === Prepare Data Source ===
         # Determine if SchwabData is intended or if a specific one was passed
+        SchwabData = _schwab_data_class()
         is_schwab_data_intended = data_source is None or isinstance(data_source, SchwabData)
         final_data_source = data_source
 
@@ -106,6 +131,8 @@ class Schwab(Broker):
         self.market = (config.get("MARKET") if config else None) or os.environ.get("MARKET") or "NASDAQ"
 
         # Load environment variables (still useful for fallback if config is missing keys)
+        import dotenv
+
         dotenv.load_dotenv()
         logger.warning("==== [DEBUG] Schwab Broker Initialization (New OAuth Flow) ====")
         config = config or {}
@@ -173,10 +200,10 @@ class Schwab(Broker):
         if token_payload_env:
             logger.info("[Schwab] SCHWAB_TOKEN environment variable found. Processing it.")
             try:
-                SchwabHelper._save_payload_str_to_token_file(token_payload_env, token_path)
-                if SchwabHelper._is_token_valid_for_schwab_py(token_path):
-                    SchwabHelper._ensure_token_metadata(token_path)
-                    if SchwabHelper._is_token_valid_for_schwab_py(token_path):
+                _schwab_helper()._save_payload_str_to_token_file(token_payload_env, token_path)
+                if _schwab_helper()._is_token_valid_for_schwab_py(token_path):
+                    _schwab_helper()._ensure_token_metadata(token_path)
+                    if _schwab_helper()._is_token_valid_for_schwab_py(token_path):
                         token_available_and_valid = True
                         logger.info(f"[Schwab] Token from SCHWAB_TOKEN env var processed, validated, and saved to {token_path}")
                     else:
@@ -192,8 +219,8 @@ class Schwab(Broker):
         if not token_available_and_valid and token_path.exists() and token_path.stat().st_size > 0:
             logger.info(f"[Schwab] Existing token file found at {token_path}. Validating...")
             try:
-                SchwabHelper._ensure_token_metadata(token_path)
-                if SchwabHelper._is_token_valid_for_schwab_py(token_path):
+                _schwab_helper()._ensure_token_metadata(token_path)
+                if _schwab_helper()._is_token_valid_for_schwab_py(token_path):
                     token_available_and_valid = True
                     logger.info(f"[Schwab] Existing token file {token_path} is valid after metadata check.")
                 else:
@@ -205,7 +232,7 @@ class Schwab(Broker):
 
         if not token_available_and_valid:
             logger.info("[Schwab] No valid token found. Initiating user authorization flow to obtain token payload.")
-            auth_success = SchwabHelper._initiate_schwab_auth_and_get_token_payload(api_key, schwab_backend_redirect_uri, token_path)
+            auth_success = _schwab_helper()._initiate_schwab_auth_and_get_token_payload(api_key, schwab_backend_redirect_uri, token_path)
             if not auth_success:
                 self.schwab_authorization_error = True
                 raise ConnectionError(
@@ -213,9 +240,9 @@ class Schwab(Broker):
                     "Please check logs, ensure SCHWAB_APP_KEY and SCHWAB_BACKEND_CALLBACK_URL are correct, "
                     "and that the backend OAuth flow is functioning. Restart to try again."
                 )
-            if SchwabHelper._is_token_valid_for_schwab_py(token_path):
-                SchwabHelper._ensure_token_metadata(token_path)
-                if SchwabHelper._is_token_valid_for_schwab_py(token_path):
+            if _schwab_helper()._is_token_valid_for_schwab_py(token_path):
+                _schwab_helper()._ensure_token_metadata(token_path)
+                if _schwab_helper()._is_token_valid_for_schwab_py(token_path):
                     token_available_and_valid = True
                 else:
                     logger.error(f"[Schwab] Token became invalid after SchwabHelper._ensure_token_metadata post-auth. Deleting {token_path}.")
@@ -285,6 +312,8 @@ class Schwab(Broker):
             # Passing it raises: TypeError: BaseClient.__init__() got an unexpected keyword argument 'app_secret'.
             # The secret is only needed when REFRESHING a token via the auth helpers, not when we already
             # have a full token dict and build the OAuth2Session ourselves, so we can safely omit it here.
+            from schwab.client import Client
+
             self.client = Client(api_key=api_key, session=oauth_session)
             logger.info(f"[Schwab] Successfully initialized Schwab client from {token_path} (app_secret not used).")
             # Check if SCHWAB_APP_SECRET is available for auto-refresh warning
@@ -478,7 +507,7 @@ class Schwab(Broker):
                 elif asset_type == 'OPTION':
                     # Parse option details
                     option_symbol = instrument.get('symbol')
-                    option_parts = SchwabHelper._parse_option_symbol(option_symbol)
+                    option_parts = _schwab_helper()._parse_option_symbol(option_symbol)
 
                     if option_parts is None:
                         logger.error(colored(f"Failed to parse option symbol: {option_symbol}", "red"))
@@ -561,6 +590,8 @@ class Schwab(Broker):
                             existing_position.market_value += market_value
                     else:
                         # Create a new Position object
+                        from lumibot.entities import Position
+
                         pos_dict[key] = Position(
                             strategy_name,
                             asset=asset,
@@ -658,6 +689,8 @@ class Schwab(Broker):
 
         try:
             # Get orders from last 7 days
+            from pytz import timezone
+
             seek_start = datetime.now(timezone('UTC')) - timedelta(days=7)
 
             response = self.client.get_orders_for_account(
@@ -964,7 +997,7 @@ class Schwab(Broker):
                     )
                 elif asset_type == Asset.AssetType.OPTION:
                     option_symbol = instrument.get("symbol", "")
-                    option_parts = SchwabHelper._parse_option_symbol(option_symbol)
+                    option_parts = _schwab_helper()._parse_option_symbol(option_symbol)
 
                     if not option_parts:
                         logger.error(colored(f"Failed to parse option symbol: {option_symbol} for order ID: {order_id}", "red"))
@@ -1025,6 +1058,8 @@ class Schwab(Broker):
         # Only create stream client if client exists
         if self.client:
             try:
+                from schwab.streaming import StreamClient
+
                 self.stream_client = StreamClient(self.client, account_id=account_number)
             except Exception as e:
                 logger.error(colored(f"Failed to create Schwab StreamClient: {e}", "red"))
@@ -1036,7 +1071,7 @@ class Schwab(Broker):
         # === Configure Data Source Client ===
         # The data_source passed here is the one set in self.data_source by super().__init__
         # self.data_source should already be the correct instance (either passed in or created in __init__)
-        if self._is_schwab_data_intended and isinstance(self.data_source, SchwabData):
+        if self._is_schwab_data_intended and isinstance(self.data_source, _schwab_data_class()):
             if self.client:
                 # Set the client on the existing SchwabData instance
                 if not hasattr(self.data_source, 'client') or self.data_source.client is None:
@@ -1070,6 +1105,8 @@ class Schwab(Broker):
     # Unimplemented methods with stubs
     def _get_stream_object(self):
         """Get the broker stream connection"""
+        from lumibot.trading_builtins import PollingStream
+
         stream = PollingStream(5.0)  # 5 seconds polling interval
         return stream
 
@@ -1198,7 +1235,7 @@ class Schwab(Broker):
 
             # Import Schwab order templates
             try:
-                from schwab.orders.common import Duration, OrderType, Session
+                from schwab.orders.common import Duration, Session
                 from schwab.orders.equities import (
                     equity_buy_limit,
                     equity_buy_market,

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import traceback
@@ -8,23 +10,121 @@ import threading
 import datetime
 import inspect
 from collections import Counter
-from typing import Union
-
-import pandas as pd
-import requests
-from lumiwealth_tradier import Tradier as _Tradier
-from lumiwealth_tradier.base import TradierApiError
-from lumiwealth_tradier.orders import OrderLeg
-from termcolor import colored
+from importlib import import_module
+from typing import TYPE_CHECKING, Union
 
 from .broker import Broker, LumibotBrokerAPIError
-from lumibot.data_sources.tradier_data import TradierData
-from lumibot.entities import Asset, CashEvent, Order, Position
-from lumibot.tools.helpers import create_options_symbol
+from lumibot.entities import Asset, Order
 from lumibot.tools.lumibot_logger import get_logger
-from lumibot.trading_builtins import PollingStream
+
+if TYPE_CHECKING:
+    from lumibot.entities import CashEvent
 
 logger = get_logger(__name__)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        if name in {"_module_name", "_module"}:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+requests = _LazyModule("requests")
+_TRADIER_CLASS = None
+_TRADIER_API_ERROR_CLASS = None
+_ORDER_LEG_CLASS = None
+_TRADIER_DATA_CLASS = None
+_CREATE_OPTIONS_SYMBOL = None
+_CASH_EVENT_CLASS = None
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _cash_event_class():
+    global _CASH_EVENT_CLASS
+    if _CASH_EVENT_CLASS is None:
+        from lumibot.entities import CashEvent
+
+        _CASH_EVENT_CLASS = CashEvent
+    return _CASH_EVENT_CLASS
+
+
+def _tradier_class():
+    global _TRADIER_CLASS
+    if _TRADIER_CLASS is None:
+        from lumiwealth_tradier import Tradier
+
+        _TRADIER_CLASS = Tradier
+    return _TRADIER_CLASS
+
+
+def _tradier_api_error_class():
+    global _TRADIER_API_ERROR_CLASS
+    if _TRADIER_API_ERROR_CLASS is None:
+        from lumiwealth_tradier.base import TradierApiError
+
+        _TRADIER_API_ERROR_CLASS = TradierApiError
+    return _TRADIER_API_ERROR_CLASS
+
+
+def _order_leg_class():
+    global _ORDER_LEG_CLASS
+    if _ORDER_LEG_CLASS is None:
+        from lumiwealth_tradier.orders import OrderLeg
+
+        _ORDER_LEG_CLASS = OrderLeg
+    return _ORDER_LEG_CLASS
+
+
+def _tradier_data_class():
+    global _TRADIER_DATA_CLASS
+    if _TRADIER_DATA_CLASS is None:
+        from lumibot.data_sources.tradier_data import TradierData
+
+        _TRADIER_DATA_CLASS = TradierData
+    return _TRADIER_DATA_CLASS
+
+
+def _create_options_symbol(*args, **kwargs):
+    global _CREATE_OPTIONS_SYMBOL
+    if _CREATE_OPTIONS_SYMBOL is None:
+        from lumibot.tools.helpers import create_options_symbol
+
+        _CREATE_OPTIONS_SYMBOL = create_options_symbol
+    return _CREATE_OPTIONS_SYMBOL(*args, **kwargs)
 
 
 class Tradier(Broker):
@@ -39,7 +139,7 @@ class Tradier(Broker):
     ***Note: Tradier does not support Trailing StopLoss orders.
     """
 
-    POLL_EVENT = PollingStream.POLL_EVENT
+    POLL_EVENT = "poll"
     CASH_ACTIVITY_TYPES = (
         "ach",
         "wire",
@@ -216,7 +316,7 @@ class Tradier(Broker):
                 self._refresh_oauth_token(force=False)
                 try:
                     return orig_request(*args, **kwargs)
-                except TradierApiError as e:
+                except _tradier_api_error_class() as e:
                     # Retry once on auth errors after forcing a refresh.
                     if self._is_auth_error(e) and self._refresh_oauth_token(force=True):
                         return orig_request(*args, **kwargs)
@@ -336,11 +436,11 @@ class Tradier(Broker):
         self._refresh_oauth_token(force=False)
 
         # Create the Tradier object
-        self.tradier = _Tradier(account_number, self._tradier_access_token, paper)
+        self.tradier = _tradier_class()(account_number, self._tradier_access_token, paper)
 
         # Check if the user has provided a data source, if not, create one
         if data_source is None:
-            data_source = TradierData(
+            data_source = _tradier_data_class()(
                 account_number=account_number,
                 access_token=self._tradier_access_token,
                 paper=paper,
@@ -422,7 +522,7 @@ class Tradier(Broker):
                 limit_price=limit_price,
                 stop_price=stop_price,
             )
-        except TradierApiError as e:
+        except _tradier_api_error_class() as e:
             raise LumibotBrokerAPIError(f"Unable to modify order at broker. {e}") from e
 
     def _submit_orders(self, orders, is_multileg=False, order_type=None, duration="day", price=None):
@@ -525,12 +625,12 @@ class Tradier(Broker):
         legs = []
         for order in orders:
             # Create the options symbol
-            option_symbol = create_options_symbol(
+            option_symbol = _create_options_symbol(
                 order.asset.symbol, order.asset.expiration, order.asset.right, order.asset.strike
             )
 
             # Example leg: leg1 = OrderLeg(option_symbol=option_symbol_1, quantity=1, side='buy_to_open')
-            leg = OrderLeg(
+            leg = _order_leg_class()(
                 option_symbol=option_symbol,
                 quantity=int(order.quantity), # Quantity for Tradier must be a positive integer
                 side=self._lumi_side2tradier(order),
@@ -602,14 +702,14 @@ class Tradier(Broker):
                 legs = []
                 if order.order_class != Order.OrderClass.OCO:
                     # Create the stock/options symbol
-                    parent_option_symbol = create_options_symbol(
+                    parent_option_symbol = _create_options_symbol(
                         order.asset.symbol, order.asset.expiration, order.asset.right, order.asset.strike
                     ) if order.asset.asset_type == Asset.AssetType.OPTION else None
                     parent_stock_symbol = self._normalize_symbol_for_broker(order.asset.symbol, asset_type=order.asset.asset_type) \
                         if order.asset.asset_type != Asset.AssetType.OPTION else None
 
                     # Add the parent order to the legs list
-                    legs.append(OrderLeg(
+                    legs.append(_order_leg_class()(
                         stock_symbol=parent_stock_symbol,  # None if option order
                         option_symbol=parent_option_symbol,  # None if stock order
                         quantity=int(order.quantity),
@@ -630,14 +730,14 @@ class Tradier(Broker):
                         if child_order.order_type != Order.OrderType.STOP_LIMIT else child_order.stop_limit_price
 
                     # Create the stock/options symbol
-                    child_option_symbol = create_options_symbol(
+                    child_option_symbol = _create_options_symbol(
                         order.asset.symbol, order.asset.expiration, order.asset.right, order.asset.strike
                     ) if child_order.asset.asset_type == Asset.AssetType.OPTION else None
                     child_stock_symbol = self._normalize_symbol_for_broker(order.asset.symbol, asset_type=order.asset.asset_type) \
                         if child_order.asset.asset_type != Asset.AssetType.OPTION else None
 
                     # Create the leg
-                    leg = OrderLeg(
+                    leg = _order_leg_class()(
                         stock_symbol=child_stock_symbol,  # None if option order
                         option_symbol=child_option_symbol,  # None if stock order
                         quantity=int(child_order.quantity),
@@ -658,7 +758,7 @@ class Tradier(Broker):
                         legs=legs,
                         tag=tag,
                     )
-                except TradierApiError as e:
+                except _tradier_api_error_class() as e:
                     msg = colored(f"Error submitting order {order}: {e}", color="red")
                     self._safe_stream_dispatch(self.ERROR_ORDER, order=order, error_msg=msg)
                     return None
@@ -681,7 +781,7 @@ class Tradier(Broker):
             elif order.asset is not None and order.asset.asset_type == Asset.AssetType.OPTION:
                 tradier_side = self._lumi_side2tradier(order)
                 stock_symbol = self._normalize_symbol_for_broker(order.asset.symbol, asset_type=order.asset.asset_type)
-                option_symbol = create_options_symbol(
+                option_symbol = _create_options_symbol(
                     order.asset.symbol, order.asset.expiration, order.asset.right, order.asset.strike
                 )
 
@@ -711,7 +811,7 @@ class Tradier(Broker):
             self._unprocessed_orders.append(order)
             self._safe_stream_dispatch(self.NEW_ORDER, order=order)
 
-        except TradierApiError as e:
+        except _tradier_api_error_class() as e:
             msg = colored(f"Error submitting order {order}: {e}", color="red")
             self._safe_stream_dispatch(self.ERROR_ORDER, order=order, error_msg=msg)
 
@@ -720,7 +820,7 @@ class Tradier(Broker):
     def _get_balances_at_broker(self, quote_asset: Asset, strategy):
         try:
             df = self.tradier.account.get_account_balance()
-        except TradierApiError as e:
+        except _tradier_api_error_class() as e:
             # Check if the error is a 401 or 403, if so, the access token is invalid
             error = str(e)
             if "401" in error or "403" in error:
@@ -761,6 +861,8 @@ class Tradier(Broker):
 
     @staticmethod
     def _extract_history_amount(row: dict) -> float:
+        CashEvent = _cash_event_class()
+
         for key in ("amount", "net_amount", "total", "cash", "value"):
             if key in row and row.get(key) not in (None, ""):
                 return CashEvent.coerce_amount(row.get(key))
@@ -833,6 +935,8 @@ class Tradier(Broker):
 
     @classmethod
     def _normalize_history_row_to_cash_event(cls, row: dict) -> CashEvent | None:
+        CashEvent = _cash_event_class()
+
         if not isinstance(row, dict):
             return None
 
@@ -977,6 +1081,8 @@ class Tradier(Broker):
         since: datetime.datetime | None = None,
         limit: int | None = 100,
     ) -> list[CashEvent]:
+        CashEvent = _cash_event_class()
+
         start_date = CashEvent.coerce_datetime(since).date() if since is not None else None
         end_date = datetime.datetime.now(datetime.timezone.utc).date()
         per_type_limit = max(int(limit or 100), 1)
@@ -1044,7 +1150,7 @@ class Tradier(Broker):
     def _pull_positions(self, strategy):
         try:
             positions_df = self.tradier.account.get_positions()
-        except TradierApiError as e:
+        except _tradier_api_error_class() as e:
             # Check if the error is a 401 or 403, if so, the access token is invalid
             error = str(e)
             if "401" in error or "403" in error:
@@ -1079,6 +1185,8 @@ class Tradier(Broker):
             asset = Asset.symbol2asset(symbol)  # Parse the symbol. Handles 'stock' and 'option' types
 
             # Create the position
+            from lumibot.entities import Position
+
             position = Position(
                 strategy=strategy_name,
                 asset=asset,
@@ -1431,11 +1539,8 @@ class Tradier(Broker):
         except Exception:
             pass
         stored_orders = {x.identifier: x for x in self.get_all_orders()}
-        strategy_name = self._strategy_name
-        if not strategy_name and len(self._subscribers) == 1:
-            strategy_name = self._subscribers[0].name
         for order_row in raw_orders:
-            order = self._parse_broker_order_dict(order_row, strategy_name=strategy_name)
+            order = self._parse_broker_order_dict(order_row, strategy_name=self._strategy_name)
             # Process child orders first so they are tracked in the Lumi system before the parent order
             all_orders = [child for child in order.child_orders] + [order]
 
@@ -1460,21 +1565,6 @@ class Tradier(Broker):
                     # Always Update Quantity and Children. Children can change as they are assigned an identifier
                     # for the first time.
                     stored_order = stored_orders[order.identifier]
-
-                    # Repair missing strategy using tag field (mirrors fix in projectx.py).
-                    # Tradier stores the order tag as the strategy name with underscores replaced by hyphens.
-                    if not stored_order.strategy:
-                        tag = getattr(stored_order, 'tag', None) or getattr(order, 'tag', None)
-                        if tag and hasattr(self, '_subscribers') and self._subscribers:
-                            for sub in self._subscribers:
-                                sub_name = getattr(sub, 'name', '') or str(sub)
-                                if re.sub(r'[^a-zA-Z0-9-]', '-', sub_name) == tag or sub_name == tag:
-                                    stored_order.strategy = sub_name
-                                    break
-                        if not stored_order.strategy and hasattr(self, '_subscribers') and len(self._subscribers) == 1:
-                            only_sub = self._subscribers[0]
-                            stored_order.strategy = getattr(only_sub, 'name', '') or str(only_sub)
-
                     stored_order.quantity = order.quantity  # Update the quantity in case it has changed
                     stored_order.broker_create_date = order.broker_create_date
                     stored_order.broker_update_date = order.broker_update_date
@@ -1580,6 +1670,8 @@ class Tradier(Broker):
 
     def _get_stream_object(self):
         """get the broker stream connection"""
+        from lumibot.trading_builtins import PollingStream
+
         stream = PollingStream(self.polling_interval)
         return stream
 
@@ -1682,7 +1774,7 @@ class Tradier(Broker):
         # Try to run the stream
         try:
             self.stream._run()
-        except TradierApiError as e:
+        except _tradier_api_error_class() as e:
             # Check if the error is a 401 or 403, if so, the access token is invalid
             error = str(e)
             if "401" in error or "403" in error:

--- a/lumibot/brokers/tradovate.py
+++ b/lumibot/brokers/tradovate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import re
 import threading
@@ -5,20 +7,56 @@ import time
 import traceback
 from collections import deque
 from datetime import datetime, timezone
-from typing import Optional, Union
-
-import requests
-from termcolor import colored
+from importlib import import_module
+from typing import TYPE_CHECKING, Optional, Union
 
 from .broker import Broker
-from lumibot.data_sources import TradovateData
-from lumibot.entities import Asset, Order, Position
-from lumibot.trading_builtins import PollingStream
+from lumibot.entities import Asset, Order
+
+if TYPE_CHECKING:
+    from lumibot.entities import Position
 
 # Set up module-specific logger for enhanced logging
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+_COLORED_FN = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+requests = _LazyModule("requests")
+
+
+def _tradovate_data_class():
+    from lumibot.data_sources import TradovateData
+
+    return TradovateData
 
 class TradovateAPIError(Exception):
     """Exception raised for errors in the Tradovate API."""
@@ -33,7 +71,7 @@ class Tradovate(Broker):
     Tradovate broker that implements connection to the Tradovate API.
     """
     NAME = "Tradovate"
-    POLL_EVENT = PollingStream.POLL_EVENT
+    POLL_EVENT = "poll"
 
     def __init__(self, config=None, data_source=None):
         if config is None:
@@ -84,7 +122,7 @@ class Tradovate(Broker):
                 # Update config with API URLs for consistency
                 config["TRADING_API_URL"] = self.trading_api_url
                 config["MD_URL"] = self.market_data_url
-                data_source = TradovateData(
+                data_source = _tradovate_data_class()(
                     config=config,
                     trading_token=self.trading_token,
                     market_token=self.market_token
@@ -530,6 +568,8 @@ class Tradovate(Broker):
 
     def _get_stream_object(self):
         """Return a polling stream to monitor Tradovate orders."""
+        from lumibot.trading_builtins import PollingStream
+
         return PollingStream(self.polling_interval)
 
     def check_token_expiry(self):
@@ -695,6 +735,8 @@ class Tradovate(Broker):
                 net_price = pos.get("netPrice", 0)
                 hold = 0
                 available = 0
+                from lumibot.entities import Position
+
                 position_obj = Position(
                     strategy,
                     asset,

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -1,4 +1,5 @@
 import datetime
+import itertools
 import uuid
 from collections import namedtuple
 from decimal import Decimal
@@ -19,6 +20,7 @@ from lumibot.tools.types import check_positive, check_price
 logger = get_logger(__name__)
 
 _LAZY_EVENT_LOCK = Lock()
+_SIMPLE_BACKTEST_IDENTIFIER_COUNTER = itertools.count(1)
 
 
 class _LazyEvent:
@@ -64,6 +66,7 @@ class _LazyEvent:
                         event.set()
                     self._event = event
         return bool(event.wait(timeout=timeout))
+
 
 
 # Custom string enum implementation for Python 3.9 compatibility
@@ -152,6 +155,41 @@ NONE_TYPE = type(None)  # Order is shadowing 'type' parameter, this is a workaro
 
 class Order:
     Transaction = namedtuple("Transaction", ["quantity", "price"])
+    good_till_date = None
+    position_filled = None
+    limit_price = None
+    stop_price = None
+    stop_limit_price = None
+    trail_price = None
+    trail_percent = None
+    price_triggered = False
+    take_profit_price = None
+    stop_loss_price = None
+    stop_loss_limit_price = None
+    parent_identifier = None
+    dependent_order = None
+    dependent_order_filled = False
+    smart_limit = None
+    trade_cost = None
+    trade_slippage = 0.0
+    custom_params = None
+    pair = None
+    tag = ""
+    broker_create_date = None
+    broker_update_date = None
+    exchange = None
+    error_message = None
+    transactions = ()
+    _trail_stop_price = None
+    _avg_fill_price = None
+    _new_event = None
+    _canceled_event = None
+    _partial_filled_event = None
+    _filled_event = None
+    _closed_event = None
+    _raw = None
+    _transmitted = False
+    _error = None
 
     class OrderClass(StrEnum):
         SIMPLE = "simple"
@@ -510,14 +548,14 @@ class Order:
         self._quantity = quantity
 
         try:
-            self.side = side if isinstance(side, (self.OrderSide, NONE_TYPE)) else self.OrderSide(side)
+            self.side = side if (side is None or isinstance(side, self.OrderSide)) else self.OrderSide(side)
         except ValueError:
             raise ValueError(f"Order: Invalid side {side}. Must be one of:"
                              f" {', '.join([str(s.value) for s in self.OrderSide])}") from None
 
         try:
             self.order_class = order_class \
-                if isinstance(order_class, (self.OrderClass, NONE_TYPE)) else self.OrderClass(order_class)
+                if (order_class is None or isinstance(order_class, self.OrderClass)) else self.OrderClass(order_class)
         except ValueError:
             raise ValueError(f"Order: Invalid order_class '{order_class}'. Must be one of:"
                              f" {', '.join([str(oc.value) for oc in self.OrderClass])}") from None
@@ -612,7 +650,7 @@ class Order:
 
         try:
             self.order_type = order_type \
-                if isinstance(order_type, (self.OrderType, NONE_TYPE)) else self.OrderType(order_type)
+                if (order_type is None or isinstance(order_type, self.OrderType)) else self.OrderType(order_type)
         except ValueError:
             raise ValueError(f"Order: Invalid order_type {order_type}. Must be one of:"
                              f" {', '.join([str(t.value) for t in self.OrderType])}") from None
@@ -667,6 +705,107 @@ class Order:
             secondary_trail_price,
             secondary_trail_percent,
         )
+
+    @classmethod
+    def simple_market_backtest(
+        cls,
+        strategy,
+        asset,
+        quantity,
+        side,
+        *,
+        quote=None,
+        time_in_force="gtc",
+        date_created=None,
+        identifier=None,
+    ):
+        """Construct a normal simple MARKET order for hot backtest paths."""
+        obj = cls.__new__(cls)
+        obj.child_orders = []
+        obj.strategy = strategy
+        obj.asset = asset
+        obj.quote = quote
+        obj.symbol = asset.symbol if asset else None
+        obj._identifier = identifier if identifier else f"bt-{next(_SIMPLE_BACKTEST_IDENTIFIER_COUNTER):x}"
+        obj._status = "unprocessed"
+        obj._date_created = date_created
+        obj.side = side if (side is None or side.__class__ is cls.OrderSide) else cls.OrderSide(side)
+        obj.time_in_force = time_in_force
+        obj.order_class = cls.OrderClass.SIMPLE
+        obj.order_type = cls.OrderType.MARKET
+        asset_type = getattr(asset, "asset_type", None)
+        quote_asset_type = getattr(quote, "asset_type", None) if quote is not None else None
+        asset_type_value = getattr(asset, "_cached_asset_type_key", None)
+        if asset_type_value is None:
+            asset_type_value = str.__str__(asset_type) if isinstance(asset_type, str) else str(asset_type or "")
+        quote_asset_type_value = getattr(quote, "_cached_asset_type_key", None) if quote is not None else ""
+        if quote_asset_type_value is None:
+            quote_asset_type_value = (
+                str.__str__(quote_asset_type) if isinstance(quote_asset_type, str) else str(quote_asset_type or "")
+            )
+
+        if asset and asset_type_value == "crypto" and quote:
+            pair_cache = getattr(asset, "_lumibot_quote_pair_cache", None)
+            if pair_cache is None:
+                pair_cache = {}
+                try:
+                    setattr(asset, "_lumibot_quote_pair_cache", pair_cache)
+                except Exception:
+                    pair_cache = None
+            quote_symbol = quote.symbol
+            if pair_cache is not None:
+                pair = pair_cache.get(quote_symbol)
+                if pair is None:
+                    pair = f"{asset.symbol}/{quote_symbol}"
+                    pair_cache[quote_symbol] = pair
+                obj.pair = pair
+            else:
+                obj.pair = f"{asset.symbol}/{quote_symbol}"
+        obj._simple_asset_type_value = asset_type_value
+        obj._simple_is_crypto_forex = asset_type_value == "crypto" and quote_asset_type_value == "forex"
+        obj._simple_is_future = asset_type_value in ("future", "cont_future")
+        obj._simple_multiplier = getattr(asset, "multiplier", None) or 1
+        obj._simple_is_option = asset_type_value == "option"
+        if obj._simple_is_future:
+            obj._simple_futures_ledger_key = (obj.strategy, obj.symbol, asset_type, getattr(asset, "expiration", None))
+        obj._quantity = quantity if isinstance(quantity, Decimal) else Decimal(quantity)
+        obj._simple_quantity_float = float(obj._quantity)
+        obj._simple_backtest_order = True
+        side_obj = obj.side
+        if side_obj is cls.OrderSide.BUY:
+            obj._simple_is_buy = True
+            obj._simple_is_sell = False
+        elif side_obj is cls.OrderSide.SELL:
+            obj._simple_is_buy = False
+            obj._simple_is_sell = True
+        else:
+            obj._simple_is_buy = (
+                side_obj is cls.OrderSide.BUY_TO_OPEN
+                or side_obj is cls.OrderSide.BUY_TO_COVER
+                or side_obj is cls.OrderSide.BUY_TO_CLOSE
+            )
+            obj._simple_is_sell = (
+                side_obj is cls.OrderSide.SELL_SHORT
+                or side_obj is cls.OrderSide.SELL_TO_OPEN
+                or side_obj is cls.OrderSide.SELL_TO_CLOSE
+            )
+        obj._simple_direct_fill_eligible = (
+            (obj._simple_is_buy or obj._simple_is_sell)
+            and asset_type_value in ("crypto", "future", "cont_future")
+        )
+        obj._fast_trade_event_static = (
+            obj.strategy,
+            obj._identifier,
+            obj.symbol,
+            obj.side,
+            obj.order_type,
+            obj.trade_slippage,
+            obj.time_in_force,
+            obj._simple_multiplier,
+            asset_type,
+        )
+        return obj
+
     def is_advanced_order(self):
         order_class = self.order_class
         return (
@@ -1167,7 +1306,19 @@ class Order:
 
     def add_transaction(self, price, quantity):
         transaction = self.Transaction(price=price, quantity=quantity)
-        self.transactions.append(transaction)
+        transactions = self.transactions
+        if type(transactions) is list:
+            transactions.append(transaction)
+        else:
+            self.transactions = [transaction]
+
+    def add_transaction_fast(self, price, quantity):
+        transaction = self.Transaction(quantity=quantity, price=price)
+        transactions = self.transactions
+        if type(transactions) is list:
+            transactions.append(transaction)
+        else:
+            self.transactions = [transaction]
 
     def cash_pending(self, strategy):
         # Returns the impact to cash of any unfilled shares.
@@ -1346,28 +1497,50 @@ class Order:
     # ======Setting the events methods===========
 
     def set_new(self):
+        if self._new_event is None:
+            self._new_event = _LazyEvent()
         self._new_event.set()
 
     def set_canceled(self):
+        if self._canceled_event is None:
+            self._canceled_event = _LazyEvent()
         self._canceled_event.set()
+        if self._closed_event is None:
+            self._closed_event = _LazyEvent()
         self._closed_event.set()
 
     def set_partially_filled(self):
+        if self._partial_filled_event is None:
+            self._partial_filled_event = _LazyEvent()
         self._partial_filled_event.set()
 
     def set_filled(self):
+        if self._filled_event is None:
+            self._filled_event = _LazyEvent()
         self._filled_event.set()
+        if self._closed_event is None:
+            self._closed_event = _LazyEvent()
         self._closed_event.set()
 
     # =========Waiting methods==================
 
     def wait_to_be_registered(self):
         logger.info("Waiting for order %r to be registered" % self)
+        if self._new_event is None:
+            if self.status != "unprocessed":
+                logger.info("Order %r registered" % self)
+                return
+            self._new_event = _LazyEvent()
         self._new_event.wait()
         logger.info("Order %r registered" % self)
 
     def wait_to_be_closed(self):
         logger.info("Waiting for broker to execute order %r" % self)
+        if self._closed_event is None:
+            if self.status in {"filled", "canceled", "error"}:
+                logger.info("Order %r executed by broker" % self)
+                return
+            self._closed_event = _LazyEvent()
         self._closed_event.wait()
         logger.info("Order %r executed by broker" % self)
 

--- a/lumibot/entities/position.py
+++ b/lumibot/entities/position.py
@@ -106,6 +106,30 @@ class Position:
                     )
             self.orders = orders
 
+    @classmethod
+    def simple_backtest(cls, strategy, asset, quantity, order, avg_fill_price=None):
+        """Create a Position for the validated simple backtest fill hot path."""
+        position = cls.__new__(cls)
+        position.strategy = strategy
+        position.asset = asset
+        position.symbol = asset.symbol
+        position.orders = [order]
+        position.avg_fill_price = avg_fill_price
+        position._quantity = quantity if type(quantity) is Decimal else Decimal(quantity)
+        position._quantity_float = float(position._quantity)
+        asset_type_value = getattr(order, "_simple_asset_type_value", None)
+        if asset_type_value is None:
+            asset_type = getattr(asset, "asset_type", None)
+            asset_type_value = str.__str__(asset_type) if isinstance(asset_type, str) else str(asset_type or "")
+        if asset_type_value == "crypto":
+            position._hold = Decimal("0")
+            position._available = Decimal("0")
+        else:
+            position._hold = 0
+            position._available = 0
+        position._raw = None
+        return position
+
     def __repr__(self):
         return f"{self.strategy} Position: {self.quantity} shares of {self.asset} ({len(self.orders)} orders)"
 
@@ -221,6 +245,12 @@ class Position:
         self._quantity_float = float(self._quantity)
         if order not in self.orders:
             self.orders.append(order)
+
+    def add_simple_order(self, order: entities.Order, quantity: Decimal, is_buy: bool):
+        qty = Decimal(quantity)
+        self._quantity += qty if is_buy else -qty
+        self._quantity_float = float(self._quantity)
+        self.orders.append(order)
 
     # ========= Serialization methods ===========
     def to_minimal_dict(self) -> dict:

--- a/lumibot/indicators/indicators.py
+++ b/lumibot/indicators/indicators.py
@@ -43,14 +43,43 @@ are missing when they hand-roll indicator code inside ``on_trading_iteration``.
 from __future__ import annotations
 
 import logging
+from importlib import import_module
 from typing import Any, Callable, Optional
-
-import numpy as np
-import pandas as pd
 
 logger = logging.getLogger(__name__)
 
 _TA_MODULE: Any = None
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+np = _LazyModule("numpy")
+pd = _LazyModule("pandas")
 
 
 def _get_ta_module():

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import io
 import json
@@ -10,78 +12,344 @@ import traceback
 import uuid
 from collections import deque
 from decimal import Decimal
-from typing import Dict, List, Union
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict, List, Union
 
-import matplotlib.dates as mdates
-import matplotlib.pyplot as plt
-import matplotlib.ticker as ticker
-import pandas as pd
-import polars as pl
-import requests
-from sqlalchemy import create_engine, inspect, text
-from sqlalchemy.exc import OperationalError
-from termcolor import colored
-
-from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.tools.lumibot_logger import get_logger, get_strategy_logger
-from lumibot.tools.parquet_utils import (
-    coerce_object_columns_to_json_strings,
-    is_parquet_required,
-    write_parquet_with_logging,
-)
 
-from ..backtesting import (
-    AlpacaBacktesting,
-    BacktestingBroker,
-    CcxtBacktesting,
-    DataBentoDataBacktesting,
-    InteractiveBrokersRESTBacktesting,
-    PolygonDataBacktesting,
-    RoutedBacktestingPandas,
-    ThetaDataBacktesting,
-    ThetaDataBacktestingPandas,
-    YahooDataBacktesting,
-)
-from ..components.agents import AgentManager
-from ..credentials import (
-    BACKTESTING_END,
-    BACKTESTING_SHOW_PROGRESS_BAR,
-    BACKTESTING_START,
-    BROKER,
-    DATA_SOURCE,
-    DB_CONNECTION_STR,
-    DISCORD_WEBHOOK_URL,
-    HIDE_POSITIONS,
-    HIDE_TRADES,
-    LIVE_CONFIG,
-    LOG_BACKTEST_PROGRESS_TO_FILE,
-    LUMIWEALTH_API_KEY,
-    MARKET,
-    POLYGON_API_KEY,
-    POLYGON_MAX_MEMORY_BYTES,
-    SHOW_INDICATORS,
-    SHOW_PLOT,
-    SHOW_TEARSHEET,
-    STRATEGY_NAME,
-    THETADATA_CONFIG,
-)
-from ..entities import Asset, CashEvent, Data, Order, Position
-from ..tools import (
-    cash_flow_adjusted_returns,
-    create_tearsheet,
-    cumulative_to_period_flows,
-    day_deduplicate,
-    get_symbol_returns,
-    plot_indicators,
-    plot_returns,
-    stats_summary,
-    to_datetime_aware,
-)
-from ..traders import Trader
-from .strategy_executor import StrategyExecutor
+from ..entities import Asset, Order
+
+if TYPE_CHECKING:
+    from ..entities import CashEvent, Data
 
 # Set the stats table name for when storing stats in a database, defined by db_connection_str
 STATS_TABLE_NAME = "strategy_tracker"
+_COMPAT_SENTINEL = object()
+_BACKTESTING_IMPORTS_READY = False
+_REQUESTS_MODULE = None
+_SQLALCHEMY_IMPORTS = None
+_POLARS_MODULE = None
+_TOOL_FUNC_CACHE = {}
+_PARQUET_UTILS = None
+_STRATEGY_EXECUTOR_CLASS = None
+_TRADER_CLASS = None
+_LUMIBOT_DEFAULT_PYTZ = None
+_CREDENTIALS_MODULE = None
+_COLORED_FN = None
+Trader = _COMPAT_SENTINEL
+BROKER = _COMPAT_SENTINEL
+DATA_SOURCE = _COMPAT_SENTINEL
+STRATEGY_NAME = _COMPAT_SENTINEL
+HIDE_POSITIONS = _COMPAT_SENTINEL
+HIDE_TRADES = _COMPAT_SENTINEL
+MARKET = _COMPAT_SENTINEL
+LIVE_CONFIG = _COMPAT_SENTINEL
+DISCORD_WEBHOOK_URL = _COMPAT_SENTINEL
+DB_CONNECTION_STR = _COMPAT_SENTINEL
+LUMIWEALTH_API_KEY = _COMPAT_SENTINEL
+BACKTESTING_START = _COMPAT_SENTINEL
+BACKTESTING_END = _COMPAT_SENTINEL
+SHOW_PLOT = _COMPAT_SENTINEL
+SHOW_TEARSHEET = _COMPAT_SENTINEL
+SHOW_INDICATORS = _COMPAT_SENTINEL
+POLYGON_API_KEY = _COMPAT_SENTINEL
+THETADATA_CONFIG = _COMPAT_SENTINEL
+BACKTESTING_SHOW_PROGRESS_BAR = _COMPAT_SENTINEL
+POLYGON_MAX_MEMORY_BYTES = _COMPAT_SENTINEL
+LOG_BACKTEST_PROGRESS_TO_FILE = _COMPAT_SENTINEL
+AlpacaBacktesting = None
+BacktestingBroker = None
+CcxtBacktesting = None
+DataBentoDataBacktesting = None
+InteractiveBrokersRESTBacktesting = None
+PolygonDataBacktesting = None
+RoutedBacktestingPandas = None
+ThetaDataBacktesting = None
+ThetaDataBacktestingPandas = None
+YahooDataBacktesting = None
+
+
+def colored(*args, **kwargs):
+    global _COLORED_FN
+    if _COLORED_FN is None:
+        from termcolor import colored as _termcolor_colored
+
+        _COLORED_FN = _termcolor_colored
+    return _COLORED_FN(*args, **kwargs)
+
+
+def _strategy_executor_class():
+    global _STRATEGY_EXECUTOR_CLASS
+    if _STRATEGY_EXECUTOR_CLASS is None:
+        from .strategy_executor import StrategyExecutor
+
+        _STRATEGY_EXECUTOR_CLASS = StrategyExecutor
+    return _STRATEGY_EXECUTOR_CLASS
+
+
+def _trader_class():
+    global _TRADER_CLASS, Trader
+    if Trader is not _COMPAT_SENTINEL:
+        return Trader
+    if _TRADER_CLASS is None:
+        from ..traders import Trader as _Trader
+
+        _TRADER_CLASS = _Trader
+    return _TRADER_CLASS
+
+
+def _default_pytz():
+    global _LUMIBOT_DEFAULT_PYTZ
+    if _LUMIBOT_DEFAULT_PYTZ is None:
+        from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
+
+        _LUMIBOT_DEFAULT_PYTZ = LUMIBOT_DEFAULT_PYTZ
+    return _LUMIBOT_DEFAULT_PYTZ
+
+
+def _credential(name):
+    override = globals().get(name, _COMPAT_SENTINEL)
+    if override is not _COMPAT_SENTINEL:
+        return override
+    global _CREDENTIALS_MODULE
+    if _CREDENTIALS_MODULE is None:
+        from .. import credentials
+
+        _CREDENTIALS_MODULE = credentials
+    return getattr(_CREDENTIALS_MODULE, name)
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        if name in {"_module_name", "_module"}:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+
+
+def _call_tool_func(name, *args, **kwargs):
+    fn = _TOOL_FUNC_CACHE.get(name)
+    if fn is None:
+        tools = import_module("lumibot.tools")
+        fn = getattr(tools, name)
+        _TOOL_FUNC_CACHE[name] = fn
+    return fn(*args, **kwargs)
+
+
+def _get_parquet_utils():
+    global _PARQUET_UTILS
+    if _PARQUET_UTILS is None:
+        from lumibot.tools.parquet_utils import (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+
+        _PARQUET_UTILS = (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+    return _PARQUET_UTILS
+
+
+def cash_flow_adjusted_returns(*args, **kwargs):
+    return _call_tool_func("cash_flow_adjusted_returns", *args, **kwargs)
+
+
+def create_tearsheet(*args, **kwargs):
+    return _call_tool_func("create_tearsheet", *args, **kwargs)
+
+
+def cumulative_to_period_flows(*args, **kwargs):
+    return _call_tool_func("cumulative_to_period_flows", *args, **kwargs)
+
+
+def day_deduplicate(*args, **kwargs):
+    return _call_tool_func("day_deduplicate", *args, **kwargs)
+
+
+def get_symbol_returns(*args, **kwargs):
+    return _call_tool_func("get_symbol_returns", *args, **kwargs)
+
+
+def plot_indicators(*args, **kwargs):
+    return _call_tool_func("plot_indicators", *args, **kwargs)
+
+
+def plot_returns(*args, **kwargs):
+    return _call_tool_func("plot_returns", *args, **kwargs)
+
+
+def stats_summary(*args, **kwargs):
+    return _call_tool_func("stats_summary", *args, **kwargs)
+
+
+def to_datetime_aware(*args, **kwargs):
+    return _call_tool_func("to_datetime_aware", *args, **kwargs)
+
+
+def _get_requests_module():
+    global _REQUESTS_MODULE
+    if _REQUESTS_MODULE is None:
+        import requests as _requests
+
+        _REQUESTS_MODULE = _requests
+    return _REQUESTS_MODULE
+
+
+def _get_sqlalchemy_imports():
+    global _SQLALCHEMY_IMPORTS
+    if _SQLALCHEMY_IMPORTS is None:
+        from sqlalchemy import create_engine, inspect, text
+        from sqlalchemy.exc import OperationalError
+
+        _SQLALCHEMY_IMPORTS = (create_engine, inspect, text, OperationalError)
+    return _SQLALCHEMY_IMPORTS
+
+
+def _get_polars_module():
+    global _POLARS_MODULE
+    if _POLARS_MODULE is None:
+        import polars as _pl
+
+        _POLARS_MODULE = _pl
+    return _POLARS_MODULE
+
+
+class _LazyAgentManager:
+    """Import and construct AgentManager only when strategy code uses agents."""
+
+    __slots__ = ("_strategy", "_manager")
+
+    def __init__(self, strategy):
+        self._strategy = strategy
+        self._manager = None
+
+    def _get_manager(self):
+        manager = self._manager
+        if manager is None:
+            from ..components.agents import AgentManager
+
+            manager = AgentManager(self._strategy)
+            self._manager = manager
+            try:
+                self._strategy.agents = manager
+            except Exception:
+                pass
+        return manager
+
+    def __getattr__(self, name):
+        return getattr(self._get_manager(), name)
+
+    def __getitem__(self, key):
+        return self._get_manager()[key]
+
+    def __contains__(self, key):
+        return key in self._get_manager()
+
+    def __iter__(self):
+        return iter(self._get_manager())
+
+    def __len__(self):
+        return len(self._get_manager())
+
+    def __repr__(self):
+        manager = self._manager
+        if manager is None:
+            return "<LazyAgentManager unloaded>"
+        return repr(manager)
+
+
+class _LazyIndicators:
+    """Import and construct Indicators only when strategy code uses indicators."""
+
+    __slots__ = ("_strategy", "_indicators")
+
+    def __init__(self, strategy):
+        self._strategy = strategy
+        self._indicators = None
+
+    def _get_indicators(self):
+        indicators = self._indicators
+        if indicators is None:
+            from lumibot.indicators import Indicators
+
+            indicators = Indicators(self._strategy)
+            self._indicators = indicators
+            try:
+                self._strategy.indicators = indicators
+            except Exception:
+                pass
+        return indicators
+
+    def __getattr__(self, name):
+        return getattr(self._get_indicators(), name)
+
+    def __repr__(self):
+        indicators = self._indicators
+        if indicators is None:
+            return "<LazyIndicators unloaded>"
+        return repr(indicators)
+
+
+def _ensure_backtesting_imports():
+    global _BACKTESTING_IMPORTS_READY
+    global AlpacaBacktesting, BacktestingBroker, CcxtBacktesting, DataBentoDataBacktesting
+    global InteractiveBrokersRESTBacktesting, PolygonDataBacktesting, RoutedBacktestingPandas
+    global ThetaDataBacktesting, ThetaDataBacktestingPandas, YahooDataBacktesting
+
+    if _BACKTESTING_IMPORTS_READY:
+        return
+
+    backtesting = import_module("lumibot.backtesting")
+
+    if AlpacaBacktesting is None:
+        AlpacaBacktesting = backtesting.AlpacaBacktesting
+    if BacktestingBroker is None:
+        BacktestingBroker = backtesting.BacktestingBroker
+    if CcxtBacktesting is None:
+        CcxtBacktesting = backtesting.CcxtBacktesting
+    if DataBentoDataBacktesting is None:
+        DataBentoDataBacktesting = backtesting.DataBentoDataBacktesting
+    if InteractiveBrokersRESTBacktesting is None:
+        InteractiveBrokersRESTBacktesting = backtesting.InteractiveBrokersRESTBacktesting
+    if PolygonDataBacktesting is None:
+        PolygonDataBacktesting = backtesting.PolygonDataBacktesting
+    if RoutedBacktestingPandas is None:
+        RoutedBacktestingPandas = backtesting.RoutedBacktestingPandas
+    if ThetaDataBacktesting is None:
+        ThetaDataBacktesting = backtesting.ThetaDataBacktesting
+    if ThetaDataBacktestingPandas is None:
+        ThetaDataBacktestingPandas = backtesting.ThetaDataBacktestingPandas
+    if YahooDataBacktesting is None:
+        YahooDataBacktesting = backtesting.YahooDataBacktesting
+    _BACKTESTING_IMPORTS_READY = True
 
 class SafeJSONEncoder(json.JSONEncoder):
     """Custom JSON encoder for Lumibot objects.
@@ -150,7 +418,7 @@ class _Strategy:
             if tzinfo is None or tzinfo.utcoffset(value) is None:
                 return to_datetime_aware(value)
             if not hasattr(tzinfo, "zone"):
-                return value.astimezone(LUMIBOT_DEFAULT_PYTZ)
+                return value.astimezone(_default_pytz())
         return value
 
     @property
@@ -306,6 +574,8 @@ class _Strategy:
         self.sell_trading_slippages = sell_trading_slippages
         self.save_logfile = save_logfile
         self.broker = broker
+        if getattr(broker, "IS_BACKTESTING_BROKER", False):
+            _ensure_backtesting_imports()
 
         # initialize cash variables
         self._position_value = None
@@ -345,8 +615,8 @@ class _Strategy:
         if name is not None:
             self._name = name
 
-        elif STRATEGY_NAME is not None:
-            self._name = STRATEGY_NAME
+        elif _credential("STRATEGY_NAME") is not None:
+            self._name = _credential("STRATEGY_NAME")
 
         else:
             self._name = self.__class__.__name__
@@ -362,12 +632,12 @@ class _Strategy:
         self._logged_get_historical_prices_assets = set()
 
         if self.broker == None:
-            self.broker = BROKER
+            self.broker = _credential("BROKER")
 
         # Handle data source initialization
         self._data_source = data_source
         if self._data_source is None:
-            self._data_source = DATA_SOURCE
+            self._data_source = _credential("DATA_SOURCE")
 
         # If we have a custom data source, attach it to the broker
         if self._data_source is not None and self.broker is not None:
@@ -377,19 +647,20 @@ class _Strategy:
             # Set the custom data source
             self.broker.data_source = self._data_source
 
-        self.hide_positions = HIDE_POSITIONS
-        self.hide_trades = HIDE_TRADES
+        self.hide_positions = _credential("HIDE_POSITIONS")
+        self.hide_trades = _credential("HIDE_TRADES")
         self.include_cash_positions = include_cash_positions
 
         # If the MARKET env variable is set, use it as the market
-        if MARKET:
+        market = _credential("MARKET")
+        if market:
             # Log the market being used
-            colored_message = colored(f"Using market from environment variables: {MARKET}", "green")
+            colored_message = colored(f"Using market from environment variables: {market}", "green")
             self.logger.info(colored_message)
-            self.set_market(MARKET)
+            self.set_market(market)
 
-        self.live_config = LIVE_CONFIG
-        self.discord_webhook_url = discord_webhook_url if discord_webhook_url is not None else DISCORD_WEBHOOK_URL
+        self.live_config = _credential("LIVE_CONFIG")
+        self.discord_webhook_url = discord_webhook_url if discord_webhook_url is not None else _credential("DISCORD_WEBHOOK_URL")
 
         if account_history_db_connection_str:
             self.db_connection_str = account_history_db_connection_str
@@ -397,7 +668,8 @@ class _Strategy:
         elif db_connection_str:
             self.db_connection_str = db_connection_str
         else:
-            self.db_connection_str = DB_CONNECTION_STR if DB_CONNECTION_STR else None
+            env_db_connection_str = _credential("DB_CONNECTION_STR")
+            self.db_connection_str = env_db_connection_str if env_db_connection_str else None
 
         self.discord_account_summary_footer = discord_account_summary_footer
         self.backup_table_name="vars_backup"
@@ -406,7 +678,7 @@ class _Strategy:
         if lumiwealth_api_key:
             self.lumiwealth_api_key = lumiwealth_api_key
         else:
-            self.lumiwealth_api_key = LUMIWEALTH_API_KEY
+            self.lumiwealth_api_key = _credential("LUMIWEALTH_API_KEY")
 
         if strategy_id is None:
             self.strategy_id = self._name
@@ -482,6 +754,8 @@ class _Strategy:
             # Create initial starting positions.
             self.starting_positions = starting_positions
             if self.starting_positions is not None and len(self.starting_positions) > 0:
+                from ..entities import Position
+
                 for asset, quantity in self.starting_positions.items():
                     position = Position(
                         self._name,
@@ -587,7 +861,7 @@ class _Strategy:
         self._minutes_after_closing = minutes_after_closing
         self._sleeptime = sleeptime
         self._risk_free_rate = risk_free_rate
-        self._executor = StrategyExecutor(self)
+        self._executor = _strategy_executor_class()(self)
         self.broker._add_subscriber(self._executor)
 
         # Stats related variables
@@ -602,10 +876,9 @@ class _Strategy:
         self.should_send_summary_to_discord = should_send_summary_to_discord
         self._last_backup_state = None
         self.vars = Vars()
-        self.agents = AgentManager(self)
+        self.agents = _LazyAgentManager(self)
 
-        from lumibot.indicators import Indicators
-        self.indicators = Indicators(self)
+        self.indicators = _LazyIndicators(self)
 
         # Storing parameters for the initialize method
         if not hasattr(self, "parameters") or not isinstance(self.parameters, dict) or self.parameters is None:
@@ -727,6 +1000,8 @@ class _Strategy:
                 return
 
         # If not in positions, create a new position for cash
+        from ..entities import Position
+
         position = Position(
             self._name,
             self._quote_asset,
@@ -740,9 +1015,10 @@ class _Strategy:
 
     def _get_cash_position(self):
         cash_position = getattr(self, "_cash_position", None)
+        cash_asset = getattr(cash_position, "asset", None) if cash_position is not None else None
         if (
             cash_position is not None
-            and getattr(cash_position, "asset", None) == self._quote_asset
+            and (cash_asset is self._quote_asset or cash_asset == self._quote_asset)
             and getattr(cash_position, "strategy", None) == self._name
         ):
             return cash_position
@@ -909,6 +1185,8 @@ class _Strategy:
             return
 
         try:
+            from ..entities import CashEvent
+
             cash_event = CashEvent(
                 broker_name="backtesting",
                 event_type=event_type,
@@ -1119,9 +1397,9 @@ class _Strategy:
             if isinstance(broker_dt, datetime.datetime):
                 try:
                     if broker_dt.tzinfo is None:
-                        option_mark_time_local = LUMIBOT_DEFAULT_PYTZ.localize(broker_dt)
+                        option_mark_time_local = _default_pytz().localize(broker_dt)
                     else:
-                        option_mark_time_local = broker_dt.astimezone(LUMIBOT_DEFAULT_PYTZ)
+                        option_mark_time_local = broker_dt.astimezone(_default_pytz())
                 except Exception:
                     option_mark_time_local = None
 
@@ -1304,8 +1582,10 @@ class _Strategy:
         if base_asset_type is None:
             base_asset_type = getattr(base_asset, "asset_type", None)
             base_asset_type = getattr(base_asset_type, "value", base_asset_type)
-            base_asset_type = str(base_asset_type).lower()
+        base_asset_type = str(base_asset_type).lower()
         is_option_asset = base_asset_type == "option"
+        if self.is_backtesting and is_option_asset:
+            _ensure_backtesting_imports()
         is_thetadata_option_backtest = (
             self.is_backtesting
             and is_option_asset
@@ -1539,7 +1819,7 @@ class _Strategy:
 
         now = self._normalize_snapshot_datetime(getattr(self.broker, "datetime", None))
         if now is None:
-            now = self._normalize_snapshot_datetime(datetime.datetime.now(LUMIBOT_DEFAULT_PYTZ))
+            now = self._normalize_snapshot_datetime(datetime.datetime.now(_default_pytz()))
 
         trade_time = self._normalize_snapshot_datetime(snapshot.get("last_trade_time"))
         bid_time = self._normalize_snapshot_datetime(snapshot.get("last_bid_time"))
@@ -1622,10 +1902,10 @@ class _Strategy:
         if isinstance(dt_value, datetime.datetime):
             if dt_value.tzinfo is None:
                 try:
-                    return LUMIBOT_DEFAULT_PYTZ.localize(dt_value)
+                    return _default_pytz().localize(dt_value)
                 except ValueError:
-                    return dt_value.replace(tzinfo=LUMIBOT_DEFAULT_PYTZ)
-            return dt_value.astimezone(LUMIBOT_DEFAULT_PYTZ)
+                    return dt_value.replace(tzinfo=_default_pytz())
+            return dt_value.astimezone(_default_pytz())
         return None
 
     @staticmethod
@@ -1816,6 +2096,11 @@ class _Strategy:
                 stats_parquet_file = (
                     self._stats_file[:-4] + ".parquet" if self._stats_file.lower().endswith(".csv") else self._stats_file + ".parquet"
                 )
+                (
+                    coerce_object_columns_to_json_strings,
+                    is_parquet_required,
+                    write_parquet_with_logging,
+                ) = _get_parquet_utils()
                 required = bool(self.is_backtesting) and is_parquet_required()
                 write_parquet_with_logging(
                     df=self._stats,
@@ -1840,6 +2125,8 @@ class _Strategy:
         if not self.is_backtesting or not self._benchmark_asset:
             return
         if self._backtesting_start is not None and self._backtesting_end is not None:
+            _ensure_backtesting_imports()
+
             # Need to adjust the backtesting end date because the data from Yahoo
             # is at the start of the day, so the graph cuts short. This may be needed
             # for other timeframes as well
@@ -1872,6 +2159,7 @@ class _Strategy:
 
                 # Add returns column
                 if hasattr(df, 'select'):  # Polars DataFrame
+                    pl = _get_polars_module()
                     df = df.with_columns(pl.col("close").pct_change().alias("return"))
                     # Add the symbol_cumprod column for polars
                     df = df.with_columns((1 + pl.col("return")).cum_prod().alias("symbol_cumprod"))
@@ -2078,6 +2366,7 @@ class _Strategy:
                     return
                 df = df.loc[self._backtesting_start:self._backtesting_end].copy()
                 if hasattr(df, 'select'):  # Polars DataFrame
+                    pl = _get_polars_module()
                     df = df.with_columns(pl.col("close").pct_change().alias("return"))
                     df = df.with_columns((1 + pl.col("return")).cumprod().alias("symbol_cumprod"))
                 else:  # Pandas DataFrame
@@ -2390,7 +2679,7 @@ class _Strategy:
         use_quote_data = False,
         show_progress_bar = True,
         quiet_logs = False,
-        trader_class = Trader,
+        trader_class = None,
         include_cash_positions=False,
         save_stats_file = True,
         **kwargs,
@@ -2522,6 +2811,8 @@ class _Strategy:
 
         if name is None:
             name = self.__name__
+        if trader_class is None:
+            trader_class = _trader_class()
 
         self._name = name
         self._analyze_backtest = analyze_backtest
@@ -2529,8 +2820,8 @@ class _Strategy:
         # Set backtesting_start: priority 1 - passed argument, 2 - BACKTESTING_START env var, 3 - default to 1 year ago
         if backtesting_start is not None:
             pass
-        elif BACKTESTING_START is not None:
-            backtesting_start = BACKTESTING_START
+        elif _credential("BACKTESTING_START") is not None:
+            backtesting_start = _credential("BACKTESTING_START")
         else:
             backtesting_start = datetime.datetime.now() - datetime.timedelta(days=365)
             get_logger(__name__).warning(
@@ -2543,8 +2834,8 @@ class _Strategy:
         # Set backtesting_end: priority 1 - passed argument, 2 - BACKTESTING_END env var, 3 - default to yesterday
         if backtesting_end is not None:
             pass
-        elif BACKTESTING_END is not None:
-            backtesting_end = BACKTESTING_END
+        elif _credential("BACKTESTING_END") is not None:
+            backtesting_end = _credential("BACKTESTING_END")
         else:
             backtesting_end = datetime.datetime.now() - datetime.timedelta(days=1)
             get_logger(__name__).warning(
@@ -2560,17 +2851,18 @@ class _Strategy:
 
         # If show_plot is None, then set it to True
         if show_plot is None:
-            show_plot = SHOW_PLOT
+            show_plot = _credential("SHOW_PLOT")
 
         # If show_tearsheet is None, then set it to True
         if show_tearsheet is None:
-            show_tearsheet = SHOW_TEARSHEET
+            show_tearsheet = _credential("SHOW_TEARSHEET")
 
         # If show_indicators is None, then set it to True
         if show_indicators is None:
-            show_indicators = SHOW_INDICATORS
+            show_indicators = _credential("SHOW_INDICATORS")
 
         from lumibot.credentials import BACKTESTING_DATA_SOURCE as _DEFAULT_BACKTESTING_DATA_SOURCE
+        _ensure_backtesting_imports()
 
         # Determine whether an environment override exists. When BACKTESTING_DATA_SOURCE
         # is set (and not blank/\"none\"), it should take precedence even if a
@@ -2659,7 +2951,7 @@ class _Strategy:
             )
 
         # Make sure polygon_api_key is set if using PolygonDataBacktesting
-        polygon_api_key = polygon_api_key if polygon_api_key is not None else POLYGON_API_KEY
+        polygon_api_key = polygon_api_key if polygon_api_key is not None else _credential("POLYGON_API_KEY")
         if datasource_class.__name__ == 'PolygonDataBacktesting' and polygon_api_key is None:
             raise ValueError(
                 "Please set `POLYGON_API_KEY` to your API key from polygon.io as an environment variable if "
@@ -2670,8 +2962,9 @@ class _Strategy:
         # Make sure thetadata_username and thetadata_password are set if using ThetaDataBacktesting
         if thetadata_username is None or thetadata_password is None:
             # Try getting the Theta Data credentials from credentials
-            thetadata_username = THETADATA_CONFIG.get('THETADATA_USERNAME')
-            thetadata_password = THETADATA_CONFIG.get('THETADATA_PASSWORD')
+            thetadata_config = _credential("THETADATA_CONFIG")
+            thetadata_username = thetadata_config.get('THETADATA_USERNAME')
+            thetadata_password = thetadata_config.get('THETADATA_PASSWORD')
 
             # Check again if theta data username and pass are set (before checking dict)
             if datasource_class.__name__ == 'ThetaDataBacktesting' and (thetadata_username is None or thetadata_password is None):
@@ -2752,7 +3045,7 @@ class _Strategy:
 
         show_progress_env = os.environ.get("BACKTESTING_SHOW_PROGRESS_BAR")
         if show_progress_env is not None:
-            show_progress_bar = BACKTESTING_SHOW_PROGRESS_BAR
+            show_progress_bar = _credential("BACKTESTING_SHOW_PROGRESS_BAR")
 
         previous_backtesting_env = {
             "IS_BACKTESTING": os.environ.get("IS_BACKTESTING"),
@@ -2783,8 +3076,8 @@ class _Strategy:
                     api_key=polygon_api_key,
                     pandas_data=pandas_data,
                     show_progress_bar=show_progress_bar,
-                    max_memory=POLYGON_MAX_MEMORY_BYTES,
-                    log_backtest_progress_to_file=LOG_BACKTEST_PROGRESS_TO_FILE,
+                    max_memory=_credential("POLYGON_MAX_MEMORY_BYTES"),
+                    log_backtest_progress_to_file=_credential("LOG_BACKTEST_PROGRESS_TO_FILE"),
                     **kwargs,
                 )
             elif issubclass(datasource_class, ThetaDataBacktestingPandas) or (
@@ -2800,7 +3093,7 @@ class _Strategy:
                     pandas_data=pandas_data,
                     use_quote_data=use_quote_data,
                     show_progress_bar=show_progress_bar,
-                    log_backtest_progress_to_file=LOG_BACKTEST_PROGRESS_TO_FILE,
+                    log_backtest_progress_to_file=_credential("LOG_BACKTEST_PROGRESS_TO_FILE"),
                     **kwargs,
                 )
             elif datasource_class == InteractiveBrokersRESTBacktesting:
@@ -2811,7 +3104,7 @@ class _Strategy:
                     auto_adjust=auto_adjust,
                     pandas_data=pandas_data,
                     show_progress_bar=show_progress_bar,
-                    log_backtest_progress_to_file=LOG_BACKTEST_PROGRESS_TO_FILE,
+                    log_backtest_progress_to_file=_credential("LOG_BACKTEST_PROGRESS_TO_FILE"),
                     **kwargs,
                 )
             else:
@@ -2822,7 +3115,7 @@ class _Strategy:
                     auto_adjust=auto_adjust,
                     pandas_data=pandas_data,
                     show_progress_bar=show_progress_bar,
-                    log_backtest_progress_to_file=LOG_BACKTEST_PROGRESS_TO_FILE,
+                    log_backtest_progress_to_file=_credential("LOG_BACKTEST_PROGRESS_TO_FILE"),
                     **kwargs,
                 )
 
@@ -3139,6 +3432,8 @@ class _Strategy:
         }
 
         normalized_events = []
+        from ..entities import CashEvent
+
         for event in fetched_events or []:
             if not isinstance(event, CashEvent):
                 continue
@@ -3286,6 +3581,7 @@ class _Strategy:
         # Apply to your data dictionary
         data = replace_nan(data)
 
+        requests = _get_requests_module()
         try:
             # Send the data to the cloud
             json_data = json.dumps(data, default=str)
@@ -3430,6 +3726,7 @@ class _Strategy:
         if silent:
             payload["flags"] = [4096]
 
+        requests = _get_requests_module()
         # Check if we have an image
         if image_buf is not None:
             # The files that you want to send
@@ -3450,6 +3747,13 @@ class _Strategy:
             )
 
     def send_spark_chart_to_discord(self, stats_df, portfolio_value, now, days=1095):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.dates as mdates
+        import matplotlib.pyplot as plt
+        import matplotlib.ticker as ticker
+
         # Check if we are in backtesting mode, if so, don't send the message
         if self.is_backtesting:
             return
@@ -3676,7 +3980,7 @@ class _Strategy:
         cash = self.get_cash()
 
         # # Get the datetime
-        now = pd.Timestamp(datetime.datetime.now()).tz_localize(LUMIBOT_DEFAULT_PYTZ)
+        now = pd.Timestamp(datetime.datetime.now()).tz_localize(_default_pytz())
 
         # Get the returns
         returns_text, stats_df = self.calculate_returns()
@@ -3688,6 +3992,7 @@ class _Strategy:
         self.send_result_text_to_discord(returns_text, portfolio_value, cash)
 
     def get_stats_from_database(self, stats_table_name, retries=5, delay=5):
+        create_engine, inspect, text, OperationalError = _get_sqlalchemy_imports()
         attempt = 0
         while attempt < retries:
             try:
@@ -3705,7 +4010,7 @@ class _Strategy:
                     self.logger.info(f"Table {stats_table_name} does not exist. Creating it now.")
 
                     # Get the current time in New York
-                    ny_tz = LUMIBOT_DEFAULT_PYTZ
+                    ny_tz = _default_pytz()
                     now = datetime.datetime.now(ny_tz)
 
                     # Create an empty stats dataframe
@@ -3741,6 +4046,7 @@ class _Strategy:
                     raise
 
     def to_sql(self, stats_df, stats_table_name, if_exists='replace', index=True, retries=5, delay=5):
+        create_engine, _inspect, _text, OperationalError = _get_sqlalchemy_imports()
         attempt = 0
         while attempt < retries:
             try:
@@ -3764,12 +4070,13 @@ class _Strategy:
         if not hasattr(self, "db_connection_str") or self.db_connection_str is None or self.db_connection_str == "" or not self.should_backup_variables_to_database:
             return
 
+        create_engine, inspect, text, _OperationalError = _get_sqlalchemy_imports()
         # Ensure we have a self.db_engine
         if not hasattr(self, 'db_engine') or not self.db_engine:
             self.db_engine = create_engine(self.db_connection_str)
 
         # Get the current time in New York
-        ny_tz = LUMIBOT_DEFAULT_PYTZ
+        ny_tz = _default_pytz()
         now = datetime.datetime.now(ny_tz)
 
         if not inspect(self.db_engine).has_table(self.backup_table_name):
@@ -3850,6 +4157,7 @@ class _Strategy:
             return
     
         try:
+            create_engine, inspect, text, _OperationalError = _get_sqlalchemy_imports()
             if not hasattr(self, 'db_engine') or not self.db_engine:
                 self.db_engine = create_engine(self.db_connection_str)
     
@@ -3923,7 +4231,7 @@ class _Strategy:
         # Calculate the return over the past 24 hours, 7 days, and 30 days using the stats dataframe
 
         # Get the current time in New York
-        ny_tz = LUMIBOT_DEFAULT_PYTZ
+        ny_tz = _default_pytz()
 
         # Get the datetime
         now = datetime.datetime.now(ny_tz)
@@ -3940,11 +4248,11 @@ class _Strategy:
         # Check if the datetime column is timezone-aware
         if stats_df['datetime'].dt.tz is None:
             # If the datetime is timezone-naive, directly localize it to "America/New_York"
-            stats_df["datetime"] = stats_df["datetime"].dt.tz_localize(LUMIBOT_DEFAULT_PYTZ, ambiguous='infer')
+            stats_df["datetime"] = stats_df["datetime"].dt.tz_localize(_default_pytz(), ambiguous='infer')
         else:
             # If the datetime is already timezone-aware, first remove timezone and then localize
             stats_df["datetime"] = stats_df["datetime"].dt.tz_localize(None)
-            stats_df["datetime"] = stats_df["datetime"].dt.tz_localize(LUMIBOT_DEFAULT_PYTZ, ambiguous='infer')
+            stats_df["datetime"] = stats_df["datetime"].dt.tz_localize(_default_pytz(), ambiguous='infer')
 
         # Get the stats
         stats_new = pd.DataFrame(
@@ -3964,7 +4272,7 @@ class _Strategy:
         stats_df = pd.concat([stats_df, stats_new])
 
         # # Convert the datetime column to eastern time
-        stats_df["datetime"] = stats_df["datetime"].dt.tz_convert(LUMIBOT_DEFAULT_PYTZ)
+        stats_df["datetime"] = stats_df["datetime"].dt.tz_convert(_default_pytz())
 
         # Remove any duplicate rows
         stats_df = stats_df[~stats_df["datetime"].duplicated(keep="last")]

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import datetime
 import inspect
+from importlib import import_module
 import logging
 import math
 import os
@@ -8,20 +11,12 @@ import time
 import uuid
 import warnings
 from decimal import Decimal
-from typing import Callable, List, Type, Union, Optional
+from types import ModuleType
+from typing import TYPE_CHECKING, Callable, List, Optional, Type, Union
 
-import jsonpickle
-import matplotlib
-from matplotlib.colors import is_color_like
-import numpy as np
-import pandas as pd
-import pandas_market_calendars as mcal
-from apscheduler.triggers.cron import CronTrigger
 from termcolor import colored, COLORS
 
-from ..data_sources import DataSource
-from ..entities import Asset, Data, Order, Position, Quote, TradingFee, TradingSlippage, SmartLimitConfig
-from ..tools import get_risk_free_rate
+from ..entities import Asset, Order, Quote, SmartLimitConfig
 from ..tools.smart_limit_utils import (
     build_price_ladder,
     compute_final_price,
@@ -30,13 +25,101 @@ from ..tools.smart_limit_utils import (
     infer_tick_size,
     round_to_tick,
 )
-from ..tools.polars_utils import PolarsResampleError, resample_polars_ohlc
-from ..traders import Trader
-from ..credentials import IS_BACKTESTING
 from ._strategy import _Strategy
-from ..constants import LUMIBOT_DEFAULT_TIMEZONE, LUMIBOT_DEFAULT_PYTZ
 
-matplotlib.use("Agg")
+if TYPE_CHECKING:
+    from ..data_sources import DataSource
+    from ..entities import Data, Position, TradingFee, TradingSlippage
+
+_FAST_LAST_PRICE_MISS = object()
+_PANDAS_MARKET_CALENDARS = None
+_TRADER_CLASS = None
+_COMPAT_SENTINEL = object()
+IS_BACKTESTING = _COMPAT_SENTINEL
+_IS_BACKTESTING = None
+_LUMIBOT_DEFAULT_TIMEZONE = None
+_LUMIBOT_DEFAULT_PYTZ = None
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        if name in {"_module_name", "_module"}:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+np = _LazyModule("numpy")
+
+
+def _get_market_calendars():
+    global _PANDAS_MARKET_CALENDARS
+    if _PANDAS_MARKET_CALENDARS is None:
+        import pandas_market_calendars as mcal
+
+        _PANDAS_MARKET_CALENDARS = mcal
+    return _PANDAS_MARKET_CALENDARS
+
+
+def _trader_class():
+    global _TRADER_CLASS
+    if _TRADER_CLASS is None:
+        from ..traders import Trader
+
+        _TRADER_CLASS = Trader
+    return _TRADER_CLASS
+
+
+def _is_backtesting_env():
+    global _IS_BACKTESTING, IS_BACKTESTING
+    if IS_BACKTESTING is not _COMPAT_SENTINEL:
+        return IS_BACKTESTING
+    if _IS_BACKTESTING is None:
+        from ..credentials import IS_BACKTESTING as _credentials_is_backtesting
+
+        _IS_BACKTESTING = _credentials_is_backtesting
+    return _IS_BACKTESTING
+
+
+def _default_timezone():
+    global _LUMIBOT_DEFAULT_TIMEZONE
+    if _LUMIBOT_DEFAULT_TIMEZONE is None:
+        from ..constants import LUMIBOT_DEFAULT_TIMEZONE
+
+        _LUMIBOT_DEFAULT_TIMEZONE = LUMIBOT_DEFAULT_TIMEZONE
+    return _LUMIBOT_DEFAULT_TIMEZONE
+
+
+def _default_pytz():
+    global _LUMIBOT_DEFAULT_PYTZ
+    if _LUMIBOT_DEFAULT_PYTZ is None:
+        from ..constants import LUMIBOT_DEFAULT_PYTZ
+
+        _LUMIBOT_DEFAULT_PYTZ = LUMIBOT_DEFAULT_PYTZ
+    return _LUMIBOT_DEFAULT_PYTZ
+
 
 class Strategy(_Strategy):
     @property
@@ -352,6 +435,8 @@ class Strategy(_Strategy):
             return self._risk_free_rate
         else:
             # Use the yahoo data to get the risk free rate, or 0 if None is returned
+            from ..tools import get_risk_free_rate
+
             now = self.get_datetime()
             return get_risk_free_rate(now) or 0.0
 
@@ -737,6 +822,54 @@ class Strategy(_Strategy):
         >>> order = self.create_order(base, 0.05, "buy", limit_price=41000,  quote=quote)
         >>> self.submit_order(order)
         """
+        broker = self.broker
+        if (
+            isinstance(asset, Asset)
+            and getattr(asset, "asset_type", None) not in (Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE)
+            and quote is None
+            and order_type is Order.OrderType.MARKET
+            and time_in_force == "gtc"
+            and getattr(broker, "IS_BACKTESTING_BROKER", False)
+            and (
+                order_class,
+                type,
+                smart_limit,
+                custom_params,
+                pair,
+                limit_price,
+                stop_price,
+                stop_limit_price,
+                trail_price,
+                trail_percent,
+                secondary_limit_price,
+                secondary_stop_price,
+                secondary_stop_limit_price,
+                secondary_trail_price,
+                secondary_trail_percent,
+                take_profit_price,
+                stop_loss_price,
+                stop_loss_limit_price,
+                position_filled,
+                exchange,
+                good_till_date,
+            ) == (None,) * 21
+        ):
+            seq = getattr(broker, "_backtest_order_seq", 0) + 1
+            setattr(broker, "_backtest_order_seq", seq)
+            ds = getattr(broker, "data_source", None)
+            date_created = getattr(ds, "_datetime", None)
+            if date_created is None:
+                date_created = broker.datetime
+            return Order.simple_market_backtest(
+                self._name,
+                asset,
+                quantity,
+                side,
+                time_in_force=time_in_force,
+                date_created=date_created,
+                quote=self._quote_asset,
+                identifier=f"bt_{seq}",
+            )
 
         if quote is None:
             quote = self.quote_asset
@@ -748,10 +881,17 @@ class Strategy(_Strategy):
         # PERF: uuid4() generation is a measurable hot path in high-churn backtests (1 order per bar per asset).
         # Backtests only need identifiers to be unique within the run, so use a cheap monotonic counter.
         identifier = None
-        if getattr(self.broker, "IS_BACKTESTING_BROKER", False):
-            seq = getattr(self.broker, "_backtest_order_seq", 0) + 1
-            setattr(self.broker, "_backtest_order_seq", seq)
+        is_backtesting_broker = getattr(broker, "IS_BACKTESTING_BROKER", False)
+        if is_backtesting_broker:
+            seq = getattr(broker, "_backtest_order_seq", 0) + 1
+            setattr(broker, "_backtest_order_seq", seq)
             identifier = f"bt_{seq}"
+            ds = getattr(broker, "data_source", None)
+            date_created = getattr(ds, "_datetime", None)
+            if date_created is None:
+                date_created = broker.datetime
+        else:
+            date_created = self.get_datetime()
 
         order = Order(
             self.name,
@@ -775,7 +915,7 @@ class Strategy(_Strategy):
             secondary_trail_percent=secondary_trail_percent,
             exchange=exchange,
             position_filled=position_filled,
-            date_created=self.get_datetime(),
+            date_created=date_created,
             quote=quote,
             pair=pair,
             type=type,
@@ -1703,6 +1843,13 @@ class Strategy(_Strategy):
         >>> order2 = self.create_order((asset_ETH, asset_quote), 10, "buy")
         >>> self.submit_order([order1, order2])
         """
+        if getattr(order, "_simple_backtest_order", False):
+            broker = self.broker
+            if getattr(broker, "IS_BACKTESTING_BROKER", False):
+                submit_simple = getattr(broker, "_submit_simple_backtest_order", None)
+                if submit_simple is not None:
+                    return submit_simple(order)
+                return broker._submit_order(order)
 
         if isinstance(order, list):
             # Submit multiple orders
@@ -1808,7 +1955,7 @@ class Strategy(_Strategy):
             if not self._validate_order(order):
                 return
 
-            if order.order_type == Order.OrderType.SMART_LIMIT:
+            if order.order_type is Order.OrderType.SMART_LIMIT:
                 if self.broker.IS_BACKTESTING_BROKER:
                     return self.broker.submit_order(order)
 
@@ -2404,6 +2551,54 @@ class Strategy(_Strategy):
             results.append(self.close_position(asset))
         return results
 
+    def _get_ibkr_backtest_last_price_fast(self, asset, quote=None, exchange=None, *, allow_source_fallback=False):
+        if not isinstance(asset, Asset) or quote is not None or exchange is not None:
+            return _FAST_LAST_PRICE_MISS
+
+        broker = getattr(self, "broker", None)
+        ds = getattr(broker, "data_source", None)
+        asset_type = getattr(asset, "asset_type", None)
+        asset_type_value = getattr(asset, "_cached_asset_type_key", None)
+        if asset_type_value is None:
+            asset_type_value = str.__str__(asset_type) if isinstance(asset_type, str) else str(asset_type or "")
+        if (
+            not getattr(broker, "IS_BACKTESTING_BROKER", False)
+            or getattr(ds, "SOURCE", None) != "InteractiveBrokersREST"
+            or asset_type_value not in ("crypto", "future", "cont_future")
+        ):
+            return _FAST_LAST_PRICE_MISS
+
+        quote_asset = self._quote_asset
+        now = getattr(ds, "_datetime", None)
+        if now is not None:
+            exchange_key = "AUTO" if getattr(ds, "exchange", None) is None else ds._normalize_exchange_key(ds.exchange)
+            data_cache = getattr(self, "_ibkr_last_price_data_cache", None)
+            if data_cache is None:
+                data_cache = {}
+                self._ibkr_last_price_data_cache = data_cache
+            cache_key = (id(asset), id(quote_asset), exchange_key)
+            data = data_cache.get(cache_key)
+            if data is None:
+                data = getattr(ds, "_data_store", {}).get((asset, quote_asset, "minute", exchange_key))
+                if data is not None:
+                    data_cache[cache_key] = data
+            if data is not None:
+                try:
+                    if asset_type_value in ("future", "cont_future"):
+                        price = data.get_previous_bar_close_fast(now)
+                        if price is not None:
+                            return price
+                        now = getattr(ds, "_datetime_minus_microsecond", None) or now - datetime.timedelta(
+                            microseconds=1
+                        )
+                    return data.get_last_price_fast(now)
+                except Exception:
+                    pass
+
+        if allow_source_fallback:
+            return ds.get_last_price(asset, quote=quote_asset, exchange=None)
+        return _FAST_LAST_PRICE_MISS
+
     def get_last_price(self, asset: Union[Asset, str], quote=None, exchange=None) -> Union[float, Decimal, None]:
         """Takes an asset and returns the last known price
 
@@ -2458,6 +2653,103 @@ class Strategy(_Strategy):
         >>> )
         >>> price = self.get_last_price(asset=self.base, exchange="CME")
         """
+        if isinstance(asset, Asset) and quote is None and exchange is None:
+            quote_asset = getattr(self, "_quote_asset", None)
+            fast_ctx_cache = getattr(self, "_ibkr_last_price_fast_context_cache", None) if quote_asset is not None else None
+            if fast_ctx_cache is not None:
+                ctx = fast_ctx_cache.get((id(asset), id(quote_asset)))
+                if ctx is not None:
+                    ds_for_cache, data, asset_type_value = ctx
+                    now = getattr(ds_for_cache, "_datetime", None)
+                    if now is not None:
+                        if asset_type_value in ("future", "cont_future"):
+                            price = data.get_previous_bar_close_fast(now)
+                            if price is not None:
+                                return price
+                            now = getattr(ds_for_cache, "_datetime_minus_microsecond", None) or now - datetime.timedelta(microseconds=1)
+                        try:
+                            return data.get_last_price_fast(now)
+                        except Exception:
+                            pass
+            broker = getattr(self, "broker", None)
+            ds = getattr(broker, "data_source", None)
+            last_price_ctx_cache = getattr(self, "_ibkr_last_price_context_cache", None)
+            if last_price_ctx_cache is not None and getattr(ds, "SOURCE", None) == "InteractiveBrokersREST":
+                effective_exchange = getattr(ds, "exchange", None)
+                try:
+                    exchange_key = "AUTO" if effective_exchange is None else ds._normalize_exchange_key(effective_exchange)
+                except Exception:
+                    exchange_key = str(effective_exchange or "").strip().upper() or "AUTO"
+                ctx = last_price_ctx_cache.get((id(ds), id(asset), id(quote_asset), exchange_key))
+                if ctx is not None:
+                    data, asset_type_value = ctx
+                    now = getattr(ds, "_datetime", None)
+                    if now is not None:
+                        if asset_type_value in ("future", "cont_future"):
+                            price = data.get_previous_bar_close_fast(now)
+                            if price is not None:
+                                return price
+                            now = getattr(ds, "_datetime_minus_microsecond", None) or now - datetime.timedelta(microseconds=1)
+                        try:
+                            return data.get_last_price_fast(now)
+                        except Exception:
+                            pass
+            asset_type = getattr(asset, "asset_type", None)
+            asset_type_value = getattr(asset, "_cached_asset_type_key", None)
+            if asset_type_value is None:
+                asset_type_value = str.__str__(asset_type) if isinstance(asset_type, str) else str(asset_type or "")
+            if (
+                getattr(broker, "IS_BACKTESTING_BROKER", False)
+                and getattr(ds, "SOURCE", None) == "InteractiveBrokersREST"
+                and asset_type_value in ("crypto", "future", "cont_future")
+            ):
+                quote_asset = self._quote_asset
+                now = getattr(ds, "_datetime", None)
+                if now is not None:
+                    exchange_key = "AUTO" if getattr(ds, "exchange", None) is None else ds._normalize_exchange_key(ds.exchange)
+                    data_cache = getattr(self, "_ibkr_last_price_data_cache", None)
+                    if data_cache is None:
+                        data_cache = {}
+                        self._ibkr_last_price_data_cache = data_cache
+                    cache_key = (id(asset), id(quote_asset), exchange_key)
+                    data = data_cache.get(cache_key)
+                    if data is None:
+                        data = getattr(ds, "_data_store", {}).get((asset, quote_asset, "minute", exchange_key))
+                        if data is not None:
+                            data_cache[cache_key] = data
+                    if data is not None:
+                        try:
+                            last_price_ctx_cache = getattr(self, "_ibkr_last_price_context_cache", None)
+                            if last_price_ctx_cache is None:
+                                last_price_ctx_cache = {}
+                                self._ibkr_last_price_context_cache = last_price_ctx_cache
+                            last_price_ctx_cache[(id(ds), id(asset), id(quote_asset), exchange_key)] = (
+                                data,
+                                asset_type_value,
+                            )
+                            fast_ctx_cache = getattr(self, "_ibkr_last_price_fast_context_cache", None)
+                            if fast_ctx_cache is None:
+                                fast_ctx_cache = {}
+                                self._ibkr_last_price_fast_context_cache = fast_ctx_cache
+                            fast_ctx_cache[(id(asset), id(quote_asset))] = (
+                                ds,
+                                data,
+                                asset_type_value,
+                            )
+                            if asset_type_value in ("future", "cont_future"):
+                                price = data.get_previous_bar_close_fast(now)
+                                if price is not None:
+                                    return price
+                                now = getattr(ds, "_datetime_minus_microsecond", None) or now - datetime.timedelta(
+                                    microseconds=1
+                                )
+                            return data.get_last_price_fast(now)
+                        except Exception:
+                            pass
+        else:
+            fast_price = Strategy._get_ibkr_backtest_last_price_fast(self, asset, quote=quote, exchange=exchange)
+            if fast_price is not _FAST_LAST_PRICE_MISS:
+                return fast_price
 
         # Check if the asset is valid
         if asset is None or (isinstance(asset, Asset) and not asset.is_valid()):
@@ -2473,6 +2765,16 @@ class Strategy(_Strategy):
             )
             return None
 
+        fast_price = Strategy._get_ibkr_backtest_last_price_fast(
+            self,
+            asset,
+            quote=quote,
+            exchange=exchange,
+            allow_source_fallback=True,
+        )
+        if fast_price is not _FAST_LAST_PRICE_MISS:
+            return fast_price
+
         asset = self._sanitize_user_asset(asset)
 
         if quote is None:
@@ -2481,7 +2783,7 @@ class Strategy(_Strategy):
             quote_asset = quote
 
         is_backtesting_run = bool(
-            IS_BACKTESTING
+            _is_backtesting_env()
             or getattr(self, "is_backtesting", False)
             or getattr(getattr(self, "broker", None), "IS_BACKTESTING_BROKER", False)
         )
@@ -2500,6 +2802,27 @@ class Strategy(_Strategy):
                 return cache[cache_key]
 
         try:
+            asset_type_for_last = getattr(asset, "asset_type", "")
+            asset_type_for_last = getattr(asset_type_for_last, "value", asset_type_for_last)
+            asset_type_for_last = str(asset_type_for_last).lower()
+            if is_backtesting_run and asset_type_for_last in {"crypto", "future", "cont_future"}:
+                result = self.broker.data_source.get_last_price(
+                    asset,
+                    quote=quote_asset,
+                    exchange=exchange,
+                )
+                cache[cache_key] = result
+                return result
+
+            if is_backtesting_run and asset_type_for_last not in {"stock", "equity", "index"}:
+                result = self.broker.get_last_price(
+                    asset,
+                    quote=quote_asset,
+                    exchange=exchange,
+                )
+                cache[cache_key] = result
+                return result
+
             # For daily-cadence backtests, prefer day bars for sources where minute-level
             # fetches are expensive (ThetaData/IBKR/routed backtesting). Keep Yahoo/Polygon
             # on legacy behavior to preserve existing regression anchors.
@@ -2526,7 +2849,10 @@ class Strategy(_Strategy):
             # close) instead of the 2022-07-01 close of $90.98, polluting position sizing.
             # Regression coverage lives in `tests/test_get_last_price_sim_time_safety.py` and
             # explicitly replays a polluted frame so this exact failure mode cannot re-land.
-            should_use_daily = self._should_use_daily_last_price(asset)
+            should_use_daily = (
+                asset_type_for_last in {"stock", "equity", "index"}
+                and self._should_use_daily_last_price(asset)
+            )
             if is_backtesting_run and should_use_daily and self._supports_daily_last_price_optimization():
                 try:
                     bars = self.get_historical_prices(
@@ -2624,7 +2950,7 @@ class Strategy(_Strategy):
         if asset_type not in {"stock", "equity", "index"}:
             return False
         if not (
-            IS_BACKTESTING
+            _is_backtesting_env()
             or getattr(self, "is_backtesting", False)
             or getattr(getattr(self, "broker", None), "IS_BACKTESTING_BROKER", False)
         ):
@@ -2842,6 +3168,7 @@ class Strategy(_Strategy):
         """
 
         # Load the specified market calendar
+        mcal = _get_market_calendars()
         calendar = mcal.get_calendar(exchange)
 
         # Convert the input string date to pandas Timestamp
@@ -3129,6 +3456,7 @@ class Strategy(_Strategy):
                 break
 
         # Check if the market is open on the expiration date, if not then get the previous open day
+        mcal = _get_market_calendars()
         nyse = mcal.get_calendar("NYSE")
 
         # Get the schedule for all the days that the market is open between the given date and the proposed expiration date
@@ -3268,7 +3596,7 @@ class Strategy(_Strategy):
 
         # Hard default when tzinfo is missing
         if tz is None:
-            return LUMIBOT_DEFAULT_TIMEZONE
+            return _default_timezone()
 
         # Prefer canonical zone identifiers when available
         if hasattr(tz, "zone") and getattr(tz, "zone", None):
@@ -3285,7 +3613,7 @@ class Strategy(_Strategy):
             pass
 
         # Final fallback to configured default to ensure a str is returned
-        return LUMIBOT_DEFAULT_TIMEZONE
+        return _default_timezone()
 
     @property
     def pytz(self):
@@ -3303,7 +3631,7 @@ class Strategy(_Strategy):
         >>> self.log_message(f"pytz: {pytz}")
         """
         tz = getattr(self.broker.data_source, "tzinfo", None)
-        return tz or LUMIBOT_DEFAULT_PYTZ
+        return tz or _default_pytz()
 
     def get_datetime(self, adjust_for_delay: bool = False):
         """Returns the current datetime according to the data source. In a backtest this will be the current bar's datetime. In live trading this will be the current datetime on the exchange.
@@ -3374,6 +3702,8 @@ class Strategy(_Strategy):
             return job_id
 
         # Create a CronTrigger from the schedule string using the broker's timezone
+        from apscheduler.triggers.cron import CronTrigger
+
         trigger = CronTrigger.from_crontab(cron_schedule, timezone=self.pytz)
 
         # Add the job to the scheduler
@@ -3611,6 +3941,8 @@ class Strategy(_Strategy):
             return default
 
         try:
+            from matplotlib.colors import is_color_like
+
             valid = is_color_like(normalized)
         except Exception:
             valid = False
@@ -4199,6 +4531,8 @@ class Strategy(_Strategy):
         except Exception:
             pass
         os.makedirs(os.path.dirname(settings_file), exist_ok=True)
+        import jsonpickle
+
         with open(settings_file, "w") as outfile:
             json = jsonpickle.encode(settings)
             outfile.write(json)
@@ -4393,6 +4727,265 @@ class Strategy(_Strategy):
         >>> last_ohlc = df.iloc[-1] # Get the last row of the DataFrame (the most recent pricing data we have)
         >>> self.log_message(f"Last price of BTC in USD: {last_ohlc['close']}, and the open price was {last_ohlc['open']}")
         """
+        if (
+            timeshift is None
+            and exchange is None
+            and include_after_hours is True
+            and not args
+            and not kwargs
+            and isinstance(asset, Asset)
+            and isinstance(length, int)
+            and timestep in {"minute", "day"}
+        ):
+            quote_asset = self._quote_asset if quote is None else quote
+            if quote is None:
+                request_cache = getattr(self, "_ibkr_native_hist_request_cache_default_quote", None)
+                request_key = (id(asset), length, timestep)
+            else:
+                request_cache = getattr(self, "_ibkr_native_hist_request_cache", None)
+                request_key = (id(asset), id(quote_asset), length, timestep)
+            if request_cache is not None:
+                ctx = request_cache.get(request_key)
+                if ctx is not None:
+                    ds_for_cache, bars_from_pandas_fast, data = ctx
+                    current_dt = getattr(ds_for_cache, "_datetime", None)
+                    if current_dt is not None:
+                        try:
+                            if timestep == "day":
+                                day_bars_cache = getattr(self, "_ibkr_native_day_bars_cache", None)
+                                if day_bars_cache is not None:
+                                    day_key = (
+                                        id(asset),
+                                        id(quote_asset),
+                                        length,
+                                        getattr(ds_for_cache, "exchange", None),
+                                        current_dt.date(),
+                                    )
+                                    cached_bars = day_bars_cache.get(day_key)
+                                    if cached_bars is not None:
+                                        return cached_bars
+                                else:
+                                    day_key = None
+                            else:
+                                day_key = None
+                            response = data.get_native_bars_fast(
+                                current_dt,
+                                length=length,
+                                timestep=timestep,
+                                mark_timezone=False,
+                            )
+                            if response is not None and not isinstance(response, float):
+                                bars = bars_from_pandas_fast(
+                                    response,
+                                    ds_for_cache.SOURCE,
+                                    asset,
+                                    quote=quote_asset,
+                                    raw=response,
+                                )
+                                if day_key is not None:
+                                    day_bars_cache[day_key] = bars
+                                return bars
+                        except Exception:
+                            pass
+
+        if (
+            timestep == "minute"
+            and timeshift is None
+            and exchange is None
+            and include_after_hours is True
+            and not args
+            and not kwargs
+            and isinstance(asset, Asset)
+            and isinstance(length, int)
+        ):
+            minute_ctx_cache = getattr(self, "_ibkr_native_minute_bars_context_cache", None)
+            if minute_ctx_cache is not None:
+                broker_for_cache = getattr(self, "broker", None)
+                ds_for_cache = getattr(broker_for_cache, "data_source", None)
+                if getattr(ds_for_cache, "SOURCE", None) == "InteractiveBrokersREST":
+                    quote_asset = self._quote_asset if quote is None else quote
+                    effective_exchange = getattr(ds_for_cache, "exchange", None)
+                    ctx = minute_ctx_cache.get((id(ds_for_cache), id(asset), id(quote_asset), effective_exchange))
+                    if ctx is not None:
+                        Bars, data = ctx
+                        current_dt = getattr(ds_for_cache, "_datetime", None)
+                        if current_dt is None:
+                            current_dt = getattr(broker_for_cache, "datetime", None)
+                        if current_dt is not None:
+                            try:
+                                response = data.get_native_bars_fast(
+                                    current_dt,
+                                    length=length,
+                                    timestep="minute",
+                                    mark_timezone=False,
+                                )
+                                if response is not None and not isinstance(response, float):
+                                    return Bars.from_pandas_fast(
+                                        response,
+                                        ds_for_cache.SOURCE,
+                                        asset,
+                                        quote=quote_asset,
+                                        raw=response,
+                                    )
+                            except Exception:
+                                pass
+
+        if (
+            timestep == "day"
+            and timeshift is None
+            and exchange is None
+            and include_after_hours is True
+            and not args
+            and not kwargs
+            and isinstance(asset, Asset)
+            and isinstance(length, int)
+        ):
+            day_bars_cache = getattr(self, "_ibkr_native_day_bars_cache", None)
+            if day_bars_cache is not None:
+                broker_for_cache = getattr(self, "broker", None)
+                ds_for_cache = getattr(broker_for_cache, "data_source", None)
+                current_dt = getattr(ds_for_cache, "_datetime", None)
+                if current_dt is not None and getattr(ds_for_cache, "SOURCE", None) == "InteractiveBrokersREST":
+                    quote_asset = self._quote_asset if quote is None else quote
+                    cached_bars = day_bars_cache.get(
+                        (
+                            id(asset),
+                            id(quote_asset),
+                            length,
+                            getattr(ds_for_cache, "exchange", None),
+                            current_dt.date(),
+                        )
+                    )
+                    if cached_bars is not None:
+                        return cached_bars
+
+        broker = getattr(self, "broker", None)
+        ds = getattr(broker, "data_source", None)
+        if (
+            not args
+            and not kwargs
+            and isinstance(asset, Asset)
+            and isinstance(length, int)
+            and timestep in {"minute", "hour", "day"}
+            and timeshift is None
+            and exchange is None
+            and include_after_hours is True
+            and getattr(broker, "IS_BACKTESTING_BROKER", False)
+            and getattr(ds, "SOURCE", None) == "InteractiveBrokersREST"
+        ):
+            asset_type = getattr(asset, "asset_type", None)
+            asset_type_value = getattr(asset, "_cached_asset_type_key", None)
+            if asset_type_value is None:
+                asset_type_value = str.__str__(asset_type) if isinstance(asset_type, str) else str(asset_type or "")
+            if asset_type_value == "option":
+                return ds.get_historical_prices(
+                    asset,
+                    length,
+                    timestep=timestep,
+                    timeshift=None,
+                    exchange=None,
+                    include_after_hours=True,
+                    quote=self._quote_asset if quote is None else quote,
+                    return_polars=False,
+                )
+            quote_asset = self._quote_asset if quote is None else quote
+            if timestep in {"minute", "day"}:
+                try:
+                    effective_exchange = getattr(ds, "exchange", None)
+                    current_dt = getattr(ds, "_datetime", None)
+                    if current_dt is None:
+                        current_dt = broker.datetime
+                    if timestep == "day":
+                        try:
+                            day_key = (
+                                id(asset),
+                                id(quote_asset),
+                                int(length),
+                                effective_exchange,
+                                current_dt.date(),
+                            )
+                            day_bars_cache = getattr(self, "_ibkr_native_day_bars_cache", None)
+                            if day_bars_cache is not None:
+                                cached_bars = day_bars_cache.get(day_key)
+                                if cached_bars is not None:
+                                    return cached_bars
+                        except Exception:
+                            day_key = None
+                    else:
+                        day_key = None
+                    hist_cache_key = (id(asset), id(quote_asset), timestep, effective_exchange)
+                    hist_cache = getattr(self, "_ibkr_native_hist_data_cache", None)
+                    data = hist_cache.get(hist_cache_key) if hist_cache is not None else None
+                    if data is None:
+                        data = getattr(ds, "_fully_loaded_hot_data_cache", {}).get(hist_cache_key)
+                        if data is not None:
+                            if hist_cache is None:
+                                hist_cache = {}
+                                self._ibkr_native_hist_data_cache = hist_cache
+                            hist_cache[hist_cache_key] = data
+                    if data is not None:
+                        Bars = getattr(ds, "_native_bars_fast_cls", None)
+                        if Bars is None:
+                            from lumibot.entities.bars import Bars
+
+                            ds._native_bars_fast_cls = Bars
+                        if timestep == "minute":
+                            minute_ctx_cache = getattr(self, "_ibkr_native_minute_bars_context_cache", None)
+                            if minute_ctx_cache is None:
+                                minute_ctx_cache = {}
+                                self._ibkr_native_minute_bars_context_cache = minute_ctx_cache
+                            minute_ctx_cache[(id(ds), id(asset), id(quote_asset), effective_exchange)] = (Bars, data)
+                        request_cache = getattr(self, "_ibkr_native_hist_request_cache", None)
+                        if request_cache is None:
+                            request_cache = {}
+                            self._ibkr_native_hist_request_cache = request_cache
+                        request_cache[(id(asset), id(quote_asset), int(length), timestep)] = (
+                            ds,
+                            Bars.from_pandas_fast,
+                            data,
+                        )
+                        if quote is None:
+                            default_request_cache = getattr(
+                                self,
+                                "_ibkr_native_hist_request_cache_default_quote",
+                                None,
+                            )
+                            if default_request_cache is None:
+                                default_request_cache = {}
+                                self._ibkr_native_hist_request_cache_default_quote = default_request_cache
+                            default_request_cache[(id(asset), int(length), timestep)] = (
+                                ds,
+                                Bars.from_pandas_fast,
+                                data,
+                            )
+                        response = data.get_native_bars_fast(
+                            current_dt,
+                            length=length,
+                            timestep=timestep,
+                            mark_timezone=False,
+                        )
+                        if response is not None and not isinstance(response, float):
+                            bars = Bars.from_pandas_fast(response, ds.SOURCE, asset, quote=quote_asset, raw=response)
+                            if day_key is not None:
+                                day_bars_cache = getattr(self, "_ibkr_native_day_bars_cache", None)
+                                if day_bars_cache is None:
+                                    day_bars_cache = {}
+                                    self._ibkr_native_day_bars_cache = day_bars_cache
+                                day_bars_cache[day_key] = bars
+                            return bars
+                except Exception:
+                    pass
+            return ds.get_historical_prices(
+                asset,
+                length,
+                timestep=timestep,
+                timeshift=None,
+                exchange=None,
+                include_after_hours=True,
+                quote=quote_asset,
+                return_polars=False,
+            )
+
         if args:
             if len(args) != 1:
                 raise TypeError("get_historical_prices() accepts at most 1 extra positional argument (deprecated `return_polars`)")
@@ -4426,9 +5019,49 @@ class Strategy(_Strategy):
         if quote is None:
             quote = self.quote_asset
 
+        # PERF: native-bar backtest calls are the hottest historical-price path. When no
+        # resampling or live-source compatibility work is needed, go straight to the data source.
+        if (
+            timestep in {"minute", "hour", "day"}
+            and timeshift is None
+            and exchange is None
+            and include_after_hours is True
+            and not return_polars
+            and not return_polars_provided
+            and getattr(getattr(self, "broker", None), "IS_BACKTESTING_BROKER", False)
+        ):
+            asset = self._sanitize_user_asset(asset)
+            asset = self.crypto_assets_to_tuple(asset, quote)
+            ds = self.broker.data_source
+            if self.broker.option_source and getattr(asset, "asset_type", None) == "option":
+                ds = self.broker.option_source
+            if getattr(ds, "IS_BACKTESTING_DATA_SOURCE", False):
+                return ds.get_historical_prices(
+                    asset,
+                    length,
+                    timestep=timestep,
+                    timeshift=None,
+                    exchange=None,
+                    include_after_hours=True,
+                    quote=quote,
+                    return_polars=False,
+                )
+
         # Parse timestep to check if we need to aggregate
         original_timestep = timestep
-        parsed = self._parse_timestep(timestep) if timestep else None
+        if timestep in {"minute", "day", "hour"}:
+            parsed = (1, timestep)
+        elif timestep:
+            parse_cache = getattr(self, "_historical_timestep_parse_cache", None)
+            if parse_cache is None:
+                parse_cache = {}
+                self._historical_timestep_parse_cache = parse_cache
+            parsed = parse_cache.get(timestep)
+            if timestep not in parse_cache:
+                parsed = self._parse_timestep(timestep)
+                parse_cache[timestep] = parsed
+        else:
+            parsed = None
 
         # Determine the actual timestep to use for data fetching
         if parsed and parsed[0] > 1:
@@ -4466,52 +5099,27 @@ class Strategy(_Strategy):
         if not actual_timestep:
             actual_timestep = self.broker.data_source.get_timestep()
 
-        # Only log once per asset to reduce noise.
-        # PERF: avoid per-call f-string construction in hot loops; use a tuple key.
-        asset_key = (asset, int(length), original_timestep)
-        if asset_key not in self._logged_get_historical_prices_assets:
-            if needs_resampling:
-                self.logger.info(
-                    f"Getting historical prices for {asset}, {length} bars of {original_timestep} "
-                    f"(fetching {actual_length} {actual_timestep} bars)"
-                )
-            else:
-                self.logger.info(f"Getting historical prices for {asset}, {length} bars, {original_timestep}")
-            self._logged_get_historical_prices_assets.add(asset_key)
+        # Only log once per asset to reduce noise. In quiet backtests, skip the bookkeeping too.
+        if self.logger.isEnabledFor(logging.INFO):
+            asset_key = (asset, int(length), original_timestep)
+            if asset_key not in self._logged_get_historical_prices_assets:
+                if needs_resampling:
+                    self.logger.info(
+                        f"Getting historical prices for {asset}, {length} bars of {original_timestep} "
+                        f"(fetching {actual_length} {actual_timestep} bars)"
+                    )
+                else:
+                    self.logger.info(f"Getting historical prices for {asset}, {length} bars, {original_timestep}")
+                self._logged_get_historical_prices_assets.add(asset_key)
 
         effective_return_polars = return_polars
-
-        # Call through to the appropriate data source. Only pass `return_polars` if supported
-        # to maintain compatibility with live data sources that don't yet accept it.
-        #
-        # PERF: avoid per-call nested function creation/dict allocations; keep this inline and cache
-        # `return_polars` support per data source type.
-        supports_cache = getattr(self, "_get_hist_supports_return_polars_by_ds_type", None)
-        if supports_cache is None:
-            supports_cache = {}
-            setattr(self, "_get_hist_supports_return_polars_by_ds_type", supports_cache)
 
         ds = self.broker.data_source
         if self.broker.option_source and getattr(asset, "asset_type", None) == "option":
             ds = self.broker.option_source
 
-        ds_type = type(ds)
-        supports_return_polars = supports_cache.get(ds_type)
-        if supports_return_polars is None:
-            try:
-                params = inspect.signature(ds_type.get_historical_prices).parameters
-                supports_return_polars = (
-                    "return_polars" in params
-                    or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
-                )
-            except Exception:
-                # Conservative default: if we can't inspect, assume it does NOT support return_polars
-                # so we don't raise TypeError by passing an unknown kwarg.
-                supports_return_polars = False
-            supports_cache[ds_type] = bool(supports_return_polars)
-
         fn = ds.get_historical_prices
-        if supports_return_polars:
+        if getattr(ds, "IS_BACKTESTING_DATA_SOURCE", False):
             bars = fn(
                 asset,
                 actual_length,  # Use the actual length for fetching
@@ -4523,21 +5131,56 @@ class Strategy(_Strategy):
                 return_polars=effective_return_polars,
             )
         else:
-            bars = fn(
-                asset,
-                actual_length,  # Use the actual length for fetching
-                timestep=actual_timestep,
-                timeshift=timeshift,
-                exchange=exchange,
-                include_after_hours=include_after_hours,
-                quote=quote,
-            )
+            # Live data sources vary in whether they accept `return_polars`; inspect once per type.
+            supports_cache = getattr(self, "_get_hist_supports_return_polars_by_ds_type", None)
+            if supports_cache is None:
+                supports_cache = {}
+                setattr(self, "_get_hist_supports_return_polars_by_ds_type", supports_cache)
+
+            ds_type = type(ds)
+            supports_return_polars = supports_cache.get(ds_type)
+            if supports_return_polars is None:
+                try:
+                    params = inspect.signature(ds_type.get_historical_prices).parameters
+                    supports_return_polars = (
+                        "return_polars" in params
+                        or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+                    )
+                except Exception:
+                    # Conservative default: if we can't inspect, assume it does NOT support return_polars
+                    # so we don't raise TypeError by passing an unknown kwarg.
+                    supports_return_polars = False
+                supports_cache[ds_type] = bool(supports_return_polars)
+
+            if supports_return_polars:
+                bars = fn(
+                    asset,
+                    actual_length,  # Use the actual length for fetching
+                    timestep=actual_timestep,
+                    timeshift=timeshift,
+                    exchange=exchange,
+                    include_after_hours=include_after_hours,
+                    quote=quote,
+                    return_polars=effective_return_polars,
+                )
+            else:
+                bars = fn(
+                    asset,
+                    actual_length,  # Use the actual length for fetching
+                    timestep=actual_timestep,
+                    timeshift=timeshift,
+                    exchange=exchange,
+                    include_after_hours=include_after_hours,
+                    quote=quote,
+                )
 
         # If we need to resample the data
         if needs_resampling and bars and len(bars) > 0:
             resampled_with_polars = False
             if return_polars:
                 try:
+                    from ..tools.polars_utils import PolarsResampleError, resample_polars_ohlc
+
                     polars_frame = bars.polars_df
                     resampled_frame = resample_polars_ohlc(polars_frame, multiplier, base_unit, length)
                     if resampled_frame is not None and not resampled_frame.is_empty():
@@ -5428,7 +6071,7 @@ class Strategy(_Strategy):
         Returns:
             None
         """
-        trader = Trader()
+        trader = _trader_class()()
 
         trader.add_strategy(self)
         trader.run_all()
@@ -5475,7 +6118,7 @@ class Strategy(_Strategy):
         use_quote_data: bool = True,  # Changed to True for ThetaData options support
         show_progress_bar: bool = True,
         quiet_logs: bool = True,
-        trader_class: Type[Trader] = Trader,
+        trader_class = None,
         save_stats_file: bool = True,
         **kwargs,
     ):

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -7,20 +7,15 @@ import traceback
 from datetime import datetime, timedelta
 from decimal import Decimal
 from functools import wraps
+from importlib import import_module
 from queue import Empty, Queue
 from threading import Event, Lock, Thread
-
-import pandas as pd
+from types import ModuleType
 
 logger = logging.getLogger(__name__)
-import pandas_market_calendars as mcal
-from apscheduler.jobstores.memory import MemoryJobStore
-from apscheduler.schedulers.background import BackgroundScheduler
-from apscheduler.triggers.cron import CronTrigger
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.entities import Asset, Order
-from lumibot.entities import Asset
-from lumibot.tools import append_locals, get_trading_days, staticdecorator
+from lumibot.tools.decorators import append_locals, staticdecorator
 from lumibot.tools.smart_limit_utils import (
     build_price_ladder,
     compute_final_price,
@@ -31,6 +26,83 @@ from lumibot.tools.smart_limit_utils import (
 )
 
 SNAPSHOT_CAPTURE_THROTTLE_SECONDS = 1.9
+_SCHEDULER_IMPORTS = None
+_PANDAS_MARKET_CALENDARS = None
+_GET_TRADING_DAYS = None
+
+
+class _LazyModule(ModuleType):
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module = None
+
+    def _load(self):
+        module = self._module
+        if module is None:
+            module = import_module(self._module_name)
+            self._module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+
+
+def get_trading_days(*args, **kwargs):
+    global _GET_TRADING_DAYS
+    if _GET_TRADING_DAYS is None:
+        from lumibot.tools.helpers import get_trading_days as _func
+
+        _GET_TRADING_DAYS = _func
+    return _GET_TRADING_DAYS(*args, **kwargs)
+
+
+def _get_scheduler_imports():
+    global _SCHEDULER_IMPORTS
+    if _SCHEDULER_IMPORTS is None:
+        from apscheduler.jobstores.memory import MemoryJobStore
+        from apscheduler.schedulers.background import BackgroundScheduler
+        from apscheduler.triggers.cron import CronTrigger
+
+        _SCHEDULER_IMPORTS = (MemoryJobStore, BackgroundScheduler, CronTrigger)
+    return _SCHEDULER_IMPORTS
+
+
+def _get_market_calendars():
+    global _PANDAS_MARKET_CALENDARS
+    if _PANDAS_MARKET_CALENDARS is None:
+        import pandas_market_calendars as mcal
+
+        _PANDAS_MARKET_CALENDARS = mcal
+    return _PANDAS_MARKET_CALENDARS
+
+
+class _BacktestSchedulerStub:
+    """Cheap scheduler placeholder for backtests; creates real scheduler only if used."""
+
+    running = False
+
+    def __init__(self, executor):
+        self._executor = executor
+
+    def _materialize(self):
+        MemoryJobStore, BackgroundScheduler, _CronTrigger = _get_scheduler_imports()
+        job_stores = {"default": MemoryJobStore(), "On_Trading_Iteration": MemoryJobStore()}
+        scheduler = BackgroundScheduler(jobstores=job_stores)
+        self._executor.scheduler = scheduler
+        return scheduler
+
+    def add_job(self, *args, **kwargs):
+        return self._materialize().add_job(*args, **kwargs)
+
+    def get_jobs(self):
+        return []
+
+    def get_job(self, _job_id):
+        return None
 
 
 class StrategyExecutor(Thread):
@@ -51,20 +123,21 @@ class StrategyExecutor(Thread):
         self.strategy = strategy
         self._strategy_context = None
         self.broker = self.strategy.broker
+        self._is_backtesting_strategy = bool(getattr(self.strategy, "is_backtesting", False))
         self.result = {}
         self._in_trading_iteration = False
 
         # Store any exception that occurs during execution
         self.exception = None
 
-        # Create a dictionary of job stores. A job store is where the scheduler persists its jobs. In this case,
-        # we create an in-memory job store for "default" and "On_Trading_Iteration" which is the job store we will
-        # use to store jobs for the main on_trading_iteration method.
-        job_stores = {"default": MemoryJobStore(), "On_Trading_Iteration": MemoryJobStore()}
-
-        # Instantiate a BackgroundScheduler with the job stores we just defined. This scheduler will be used to store
-        # the jobs that we create later and execute them at the correct time.
-        self.scheduler = BackgroundScheduler(jobstores=job_stores)
+        # Backtests drive iterations synchronously and never need APScheduler. Live sessions create
+        # it lazily in _setup_live_trading_scheduler().
+        if self._is_backtesting_strategy:
+            self.scheduler = _BacktestSchedulerStub(self)
+        else:
+            MemoryJobStore, BackgroundScheduler, _CronTrigger = _get_scheduler_imports()
+            job_stores = {"default": MemoryJobStore(), "On_Trading_Iteration": MemoryJobStore()}
+            self.scheduler = BackgroundScheduler(jobstores=job_stores)
 
         # Initialize a target count and a current count for cron jobs to 0.
         # These are used to determine when to execute the on_trading_iteration method.
@@ -131,7 +204,7 @@ class StrategyExecutor(Thread):
                 self._market_type_cache[market_name] = True
                 return True
 
-            cal = mcal.get_calendar(market_name)
+            cal = _get_market_calendars().get_calendar(market_name)
 
             # Sample ~1.5 weeks so we can observe weekend gaps as well as daily spans.
             reference_day = pd.Timestamp('2025-01-13', tz='UTC')  # Monday
@@ -298,7 +371,6 @@ class StrategyExecutor(Thread):
         cash_broker_max_retries = 3
         cash_broker_retries = 0
         orders_broker = []
-        positions_broker = []
         while held_trades_len > 0:
             # Snapshot for the broker and lumibot:
             self.strategy
@@ -658,8 +730,14 @@ class StrategyExecutor(Thread):
             self.strategy.logger.error(f"Event {event} not recognized. Payload: {payload}")
 
     def process_queue(self):
-        while not self.queue.empty():
-            event, payload = self.queue.get()
+        queue = self.queue
+        if self._is_backtesting_strategy and not queue.queue:
+            return
+        while True:
+            try:
+                event, payload = queue.get_nowait()
+            except Empty:
+                break
             self.process_event(event, payload)
 
     def _process_smart_limit_orders(self):
@@ -1480,6 +1558,7 @@ class StrategyExecutor(Thread):
                 )
 
         # Return a CronTrigger object with the calculated settings.
+        _MemoryJobStore, _BackgroundScheduler, CronTrigger = _get_scheduler_imports()
         return CronTrigger(**kwargs)
 
     # TODO: speed up this function, it's a major bottleneck for backtesting
@@ -1692,8 +1771,13 @@ class StrategyExecutor(Thread):
 
     def _setup_live_trading_scheduler(self):
         """Set up the APScheduler for live trading sessions"""
+        MemoryJobStore, BackgroundScheduler, _CronTrigger = _get_scheduler_imports()
         # Ensure a scheduler exists (it may have been set to None during a previous graceful_exit)
-        if not hasattr(self, 'scheduler') or self.scheduler is None:
+        if (
+            not hasattr(self, 'scheduler')
+            or self.scheduler is None
+            or not isinstance(self.scheduler, BackgroundScheduler)
+        ):
             job_stores = {"default": MemoryJobStore(), "On_Trading_Iteration": MemoryJobStore()}
             self.scheduler = BackgroundScheduler(jobstores=job_stores)
 
@@ -1977,7 +2061,10 @@ class StrategyExecutor(Thread):
 
     def get_next_ap_scheduler_run_time(self):
         # Check if scheduler object exists.
-        if self.scheduler is None or not isinstance(self.scheduler, BackgroundScheduler):
+        if self.scheduler is None or isinstance(self.scheduler, _BacktestSchedulerStub):
+            return None
+        _MemoryJobStore, BackgroundScheduler, _CronTrigger = _get_scheduler_imports()
+        if not isinstance(self.scheduler, BackgroundScheduler):
             return None
 
         # Get the current jobs from the scheduler.

--- a/lumibot/trading_builtins/safe_list.py
+++ b/lumibot/trading_builtins/safe_list.py
@@ -300,6 +300,13 @@ class SafeOrderDict:
         with lock:
             return self._remove_unlocked(value, key=key)
 
+    def get(self, identifier, default=None):
+        lock = self.__lock
+        if lock is None:
+            return self.__items.get(str(identifier), default)
+        with lock:
+            return self.__items.get(str(identifier), default)
+
     def _remove_unlocked(self, value, key=None):
         if key is None:
             if isinstance(value, str):

--- a/scripts/bench_ibkr_speed_burner_stubbed.py
+++ b/scripts/bench_ibkr_speed_burner_stubbed.py
@@ -124,8 +124,13 @@ def main() -> int:
                 self.submit_order(order)
             self._i += 1
 
+    iterations = int(os.environ.get("LUMIBOT_BENCH_ITERATIONS", "1000"))
+
     tz = "America/New_York"
-    minute_index = pd.date_range("2025-12-08 09:30", periods=600, freq="1min", tz=tz)
+    # Keep enough minute bars for longer runs. A 200-iteration benchmark with a shared broker
+    # overweights one-time lazy series loads; 1000 iterations gives a steadier runtime signal.
+    minute_periods = max(4000, (iterations * 2) + 300)
+    minute_index = pd.date_range("2025-12-08 09:30", periods=minute_periods, freq="1min", tz=tz)
     # Provide enough daily history for `length=20` at the chosen intraday timestamps.
     day_index = pd.date_range("2025-09-01 00:00", periods=200, freq="1D", tz=tz)
 
@@ -197,7 +202,6 @@ def main() -> int:
     # Ensure multi-timeframe paths are exercised.
     _ = futures.get_historical_prices(fut_mes, length=10, timestep="15min")
 
-    iterations = 200
     t0 = perf_counter()
     for _ in range(iterations):
         futures.on_trading_iteration()

--- a/tests/backtest/performance_tracker.py
+++ b/tests/backtest/performance_tracker.py
@@ -4,7 +4,6 @@ Automatically records execution time and key metrics to CSV for long-term tracki
 """
 import csv
 import datetime
-import os
 from pathlib import Path
 
 
@@ -43,7 +42,7 @@ class PerformanceTracker:
         """Create CSV file with headers if it doesn't exist"""
         if not self.csv_path.exists():
             with open(self.csv_path, 'w', newline='') as f:
-                writer = csv.DictWriter(f, fieldnames=self.COLUMNS)
+                writer = csv.DictWriter(f, fieldnames=self.COLUMNS, lineterminator="\n")
                 writer.writeheader()
 
     def _get_git_commit(self):
@@ -111,7 +110,7 @@ class PerformanceTracker:
         }
 
         with open(self.csv_path, 'a', newline='') as f:
-            writer = csv.DictWriter(f, fieldnames=self.COLUMNS)
+            writer = csv.DictWriter(f, fieldnames=self.COLUMNS, lineterminator="\n")
             writer.writerow(row)
 
     def get_recent_performance(self, test_name=None, limit=10):

--- a/tests/test_backtesting_broker.py
+++ b/tests/test_backtesting_broker.py
@@ -4,7 +4,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 import pandas as pd
-from datetime import datetime as dt, time, timedelta # Renamed datetime to dt to avoid conflict
+from datetime import datetime as dt # Renamed datetime to dt to avoid conflict
 import pytz
 
 
@@ -238,6 +238,26 @@ class TestBacktestingBroker:
         broker._partially_filled_orders = MagicMock()
 
         orders = broker.get_active_tracked_orders(strategy="test", asset=asset)
+
+        assert orders == [matching]
+
+    def test_get_active_tracked_orders_normalizes_strategy_object_for_simple_pending(self):
+        broker = BacktestingBroker.__new__(BacktestingBroker)
+        asset = Asset("SPY")
+        strategy = SimpleNamespace(name="test")
+        matching = MagicMock()
+        matching.asset = asset
+        matching.strategy = "test"
+        matching.is_active.return_value = True
+        broker._simple_new_orders_by_strategy = {"test": [matching]}
+        broker._unprocessed_orders = MagicMock()
+        broker._unprocessed_orders.get_list.return_value = []
+        broker._new_orders = MagicMock()
+        broker._new_orders.get_list.return_value = []
+        broker._partially_filled_orders = MagicMock()
+        broker._partially_filled_orders.get_list.return_value = []
+
+        orders = broker.get_active_tracked_orders(strategy=strategy, asset=asset)
 
         assert orders == [matching]
 

--- a/tests/test_backtesting_futures_flips.py
+++ b/tests/test_backtesting_futures_flips.py
@@ -1,9 +1,11 @@
 from collections import defaultdict
+from decimal import Decimal
 
 import pytest
 
 from lumibot.backtesting.backtesting_broker import BacktestingBroker
 from lumibot.entities import Asset, Order
+from lumibot.trading_builtins import SafeList
 
 
 class DummyStrategy:
@@ -69,3 +71,57 @@ def test_futures_flip_releases_margin_and_creates_new_entry():
 
     assert strategy.cash == pytest.approx(100_700)
     assert key not in broker._futures_lot_ledgers
+
+
+def test_simple_futures_fast_fill_flip_matches_margin_and_position_semantics():
+    broker = make_broker()
+    broker._filled_positions = SafeList(None)
+    broker._filled_orders = SafeList(None)
+    broker._tracked_position_cache = {}
+    broker._trade_event_log_enabled = False
+    strategy = DummyStrategy()
+    asset = make_asset()
+
+    buy_order = Order.simple_market_backtest(
+        strategy.name,
+        asset,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+    )
+    broker._execute_simple_futures_backtest_fast_fill(buy_order, price=2000, strategy=strategy)
+
+    assert strategy.cash == pytest.approx(90_000)
+    position = broker.get_tracked_position(strategy.name, asset)
+    assert position is not None
+    assert position.quantity == pytest.approx(1)
+
+    reverse_order = Order.simple_market_backtest(
+        strategy.name,
+        asset,
+        Decimal("2"),
+        Order.OrderSide.SELL,
+    )
+    broker._execute_simple_futures_backtest_fast_fill(reverse_order, price=2005, strategy=strategy)
+
+    assert strategy.cash == pytest.approx(90_500)
+    position = broker.get_tracked_position(strategy.name, asset)
+    assert position is not None
+    assert position.quantity == pytest.approx(-1)
+    key = broker._get_futures_ledger_key(strategy, asset)
+    ledger = broker._futures_lot_ledgers[key]
+    assert len(ledger) == 1
+    assert ledger[0]["qty"] == pytest.approx(-1)
+    assert ledger[0]["price"] == pytest.approx(2005)
+
+    cover_order = Order.simple_market_backtest(
+        strategy.name,
+        asset,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+    )
+    broker._execute_simple_futures_backtest_fast_fill(cover_order, price=2003, strategy=strategy)
+
+    assert strategy.cash == pytest.approx(100_700)
+    assert key not in broker._futures_lot_ledgers
+    position = broker.get_tracked_position(strategy.name, asset)
+    assert position is None

--- a/tests/test_ibkr_crypto_backtesting_smoke_stubbed.py
+++ b/tests/test_ibkr_crypto_backtesting_smoke_stubbed.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import timedelta
 from decimal import Decimal
 
 import pandas as pd
@@ -20,6 +19,27 @@ class _DummyIbkrCryptoStrategy(Strategy):
 
     def on_trading_iteration(self):
         return
+
+
+class _CallbackIbkrCryptoStrategy(_DummyIbkrCryptoStrategy):
+    def initialize(self, parameters=None):
+        super().initialize(parameters=parameters)
+        self.filled_events = []
+
+    def on_filled_order(self, position, order, price, quantity, multiplier):
+        filled_events = getattr(self, "filled_events", None)
+        if filled_events is None:
+            filled_events = []
+            self.filled_events = filled_events
+        filled_events.append(
+            {
+                "symbol": order.asset.symbol,
+                "side": order.side,
+                "price": price,
+                "quantity": quantity,
+                "multiplier": multiplier,
+            }
+        )
 
 
 def test_ibkr_rest_backtesting_crypto_market_orders_fill_at_ask_and_bid(monkeypatch):
@@ -120,6 +140,85 @@ def test_ibkr_rest_backtesting_crypto_market_orders_fill_at_ask_and_bid(monkeypa
 
     assert sell.is_filled()
     assert sell.get_fill_price() == pytest.approx(expected_bid_1, rel=1e-12)
+
+
+def test_ibkr_rest_backtesting_crypto_market_fill_preserves_custom_callback(monkeypatch):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    idx = pd.date_range("2025-01-01 00:00", periods=3, freq="1min", tz="America/New_York")
+    df = pd.DataFrame(
+        {
+            "open": [20_000.0, 20_100.0, 20_200.0],
+            "high": [20_050.0, 20_150.0, 20_250.0],
+            "low": [19_900.0, 20_000.0, 20_100.0],
+            "close": [20_010.0, 20_120.0, 20_230.0],
+            "bid": [20_005.0, 20_115.0, 20_225.0],
+            "ask": [20_015.0, 20_125.0, 20_235.0],
+            "volume": [1_000, 1_000, 1_000],
+        },
+        index=idx,
+    )
+
+    def fake_get_price_data(*, asset, quote, timestep, start_dt, end_dt, exchange=None, include_after_hours=True, source=None):
+        return df
+
+    monkeypatch.setattr(ibkr_helper, "get_price_data", fake_get_price_data)
+
+    data_source = InteractiveBrokersRESTBacktesting(
+        datetime_start=idx[0].to_pydatetime(),
+        datetime_end=(idx[-1] + pd.Timedelta(minutes=1)).to_pydatetime(),
+        market="24/7",
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    data_source.load_data()
+
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+    broker._update_datetime(idx[0].to_pydatetime())
+
+    strategy = _CallbackIbkrCryptoStrategy(
+        broker=broker,
+        budget=100_000.0,
+        analyze_backtest=False,
+        parameters={},
+    )
+    strategy._first_iteration = False
+
+    base = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+    data_source.get_historical_prices_between_dates(
+        (base, quote),
+        timestep="minute",
+        quote=quote,
+        start_date=idx[0].to_pydatetime(),
+        end_date=idx[-1].to_pydatetime(),
+    )
+    expected_ask = float(getattr(broker.get_quote(base, quote=quote), "ask"))
+
+    order = strategy.create_order(
+        base,
+        Decimal("0.5"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.MARKET,
+        quote=quote,
+    )
+    strategy.submit_order(order)
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert order.is_filled()
+    assert strategy.filled_events == [
+        {
+            "symbol": "BTC",
+            "side": Order.OrderSide.BUY,
+            "price": pytest.approx(expected_ask),
+            "quantity": pytest.approx(0.5),
+            "multiplier": 1,
+        }
+    ]
 
 
 def test_ibkr_rest_backtesting_crypto_limit_orders_fill_against_quotes(monkeypatch):

--- a/tests/test_ibkr_futures_backtesting_smoke_stubbed.py
+++ b/tests/test_ibkr_futures_backtesting_smoke_stubbed.py
@@ -22,6 +22,27 @@ class _DummyIbkrFuturesStrategy(Strategy):
         return
 
 
+class _CallbackIbkrFuturesStrategy(_DummyIbkrFuturesStrategy):
+    def initialize(self, parameters=None):
+        super().initialize(parameters=parameters)
+        self.filled_events = []
+
+    def on_filled_order(self, position, order, price, quantity, multiplier):
+        filled_events = getattr(self, "filled_events", None)
+        if filled_events is None:
+            filled_events = []
+            self.filled_events = filled_events
+        filled_events.append(
+            {
+                "symbol": order.asset.symbol,
+                "side": order.side,
+                "price": price,
+                "quantity": quantity,
+                "multiplier": multiplier,
+            }
+        )
+
+
 def _make_df(*, bid0: float, ask0: float, bid1: float, ask1: float) -> pd.DataFrame:
     idx = pd.date_range("2025-12-08 09:31", periods=2, freq="1min", tz="America/New_York")
     df = pd.DataFrame(
@@ -129,6 +150,64 @@ def test_ibkr_rest_backtesting_futures_market_roundtrip_uses_bid_ask_and_multipl
     expected_pnl = (100.75 - 100.25) * 1.0 * 5.0
     expected_cash = 10_000.0 + expected_pnl
     assert strategy.cash == pytest.approx(expected_cash, rel=1e-9)
+
+
+def test_ibkr_rest_backtesting_futures_market_fill_preserves_custom_callback(monkeypatch):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    df = _make_quote_only_df(bids=[100.00, 100.75], asks=[100.25, 101.00])
+
+    def fake_get_price_data(*, asset, quote, timestep, start_dt, end_dt, exchange=None, include_after_hours=True, source=None):
+        return df
+
+    monkeypatch.setattr(ibkr_helper, "get_price_data", fake_get_price_data)
+
+    data_source = InteractiveBrokersRESTBacktesting(
+        datetime_start=df.index[0].to_pydatetime(),
+        datetime_end=(df.index[-1] + pd.Timedelta(minutes=1)).to_pydatetime(),
+        market="24/7",
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    data_source.load_data()
+
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    strategy = _CallbackIbkrFuturesStrategy(
+        broker=broker,
+        budget=10_000.0,
+        analyze_backtest=False,
+        parameters={},
+    )
+    strategy._first_iteration = False
+
+    fut = Asset("MES", asset_type=Asset.AssetType.FUTURE, expiration=date(2025, 12, 19), multiplier=5)
+
+    data_source.get_historical_prices_between_dates(
+        (fut, Asset("USD", asset_type=Asset.AssetType.FOREX)),
+        timestep="minute",
+        quote=None,
+        start_date=df.index[0].to_pydatetime(),
+        end_date=df.index[-1].to_pydatetime(),
+    )
+
+    order = strategy.create_order(fut, Decimal("1"), Order.OrderSide.BUY, order_type=Order.OrderType.MARKET)
+    strategy.submit_order(order)
+    broker.process_pending_orders(strategy)
+    strategy._executor.process_queue()
+
+    assert order.is_filled()
+    assert strategy.filled_events == [
+        {
+            "symbol": "MES",
+            "side": Order.OrderSide.BUY,
+            "price": pytest.approx(100.25),
+            "quantity": pytest.approx(1.0),
+            "multiplier": 5,
+        }
+    ]
 
 
 def test_ibkr_rest_backtesting_futures_smart_limit_uses_asset_min_tick(monkeypatch):

--- a/tests/test_ibkr_speed_burner_stubbed.py
+++ b/tests/test_ibkr_speed_burner_stubbed.py
@@ -183,6 +183,24 @@ def test_ibkr_speed_burner_prefetches_once_and_slices_forever(monkeypatch):
     assert len(bars_15m.df) == 10
     assert (bars_15m.df.index[1] - bars_15m.df.index[0]) == pd.Timedelta(minutes=15)
 
+    # Prime the strategy-native cache, then prove repeated reads do not need the data-source
+    # fallback path after the Data object is cached on the strategy.
+    assert futures.get_last_price(fut_mes) == pytest.approx(6400.0 + 199 * 0.01)
+    bars_1m_first = futures.get_historical_prices(fut_mes, length=100, timestep="minute")
+    bars_1m_second = futures.get_historical_prices(fut_mes, length=100, timestep="minute")
+    assert len(bars_1m_first.df) == 100
+    assert len(bars_1m_second.df) == 100
+
+    original_get_historical_prices = futures_broker.data_source.get_historical_prices
+
+    def fail_get_historical_prices(*args, **kwargs):
+        raise AssertionError("strategy-native IBKR historical cache was bypassed")
+
+    monkeypatch.setattr(futures_broker.data_source, "get_historical_prices", fail_get_historical_prices)
+    bars_1m_cached = futures.get_historical_prices(fut_mes, length=100, timestep="minute")
+    assert len(bars_1m_cached.df) == 100
+    monkeypatch.setattr(futures_broker.data_source, "get_historical_prices", original_get_historical_prices)
+
     # Run a few hundred iterations of each loop. This is a correctness/speed-structure test:
     # it should not refetch the same series per iteration.
     iterations = 200
@@ -299,6 +317,12 @@ def test_ibkr_speed_burner_prefetches_once_and_slices_forever(monkeypatch):
     crypto_fills = trade_events_crypto[trade_events_crypto["status"] == "fill"].reset_index(drop=True)
     assert len(crypto_fills) == orders_total_crypto
     assert list(crypto_fills.iloc[:3]["symbol"]) == ["BTC", "ETH", "SOL"]
+    assert len(getattr(crypto_broker, "_filled_order_identifiers", ())) == 0
+    for order in crypto_broker._filled_orders.get_list()[:6]:
+        assert not hasattr(order, "_fast_trade_event_pair_row")
+        assert not hasattr(order, "_fast_trade_event_pair_row_index")
+        assert not hasattr(order, "_fast_trade_event_static")
+    assert isinstance(crypto_broker._trade_event_log_rows[0], tuple)
 
     # Crypto: first iteration (dt=minute_index[200]).
     _assert_fill(

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -273,6 +273,14 @@ class TestOrderBasics:
         assert position.available == 0
         assert position.avg_fill_price == order.avg_fill_price
 
+    def test_add_transaction_fast_matches_transaction_field_order(self):
+        order = Order(strategy='abc', asset=Asset("SPY"), side="buy", quantity=100)
+
+        order.add_transaction_fast(price=101.25, quantity=2)
+
+        assert order.transactions[-1].price == 101.25
+        assert order.transactions[-1].quantity == 2
+
 
 class TestOrderAdvanced:
     def test_oco_type_reassigned(self):


### PR DESCRIPTION
Stacked on #1016. Split from #1013.

Scope:
- Optimize backtesting broker order buckets, trade-event logging, and fill hot paths.
- Add simple backtest market-order fast paths while preserving standard futures lifecycle behavior.
- Keep IBKR futures multiplier/order-path fixes with the execution layer that caused the acceptance drift.

Validation:
- `uv run ruff check --select F,I lumibot/tools/data_downloader_queue_client.py lumibot/tools/thetadata_helper.py lumibot/backtesting/interactive_brokers_rest_backtesting.py lumibot/strategies/_strategy.py`
- `uv run pytest -q tests/test_ibkr_speed_burner_stubbed.py tests/test_backtesting_futures_flips.py tests/test_ibkr_futures_backtesting_smoke_stubbed.py tests/test_order.py tests/test_backtesting_broker.py tests/test_strategy_methods.py`
- This branch has the same tree as green CI run 25522967025 from #1013.