### PR TITLE
v4.5.10 - Add scheduled live run once mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Scheduled live execution now has a true one-shot LumiBot path.** When BotManager sets `LUMIBOT_SCHEDULED_EXECUTION`, `Strategy.run_live()` runs one live trading iteration and exits instead of starting the normal always-on scheduler loop. Scheduled runs also restore and persist `self.vars` through the BotManager-provided scheduled state file.
+
 ## 4.5.10 - 2026-04-30
 
 Deploy marker: 9e73736f (`deploy 4.5.10`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Added
-- **Scheduled live execution now has a true one-shot LumiBot path.** When BotManager sets `LUMIBOT_SCHEDULED_EXECUTION`, `Strategy.run_live()` runs one live trading iteration and exits instead of starting the normal always-on scheduler loop. Scheduled runs also restore and persist `self.vars` through the BotManager-provided scheduled state file.
+- Scheduled live execution can now run one live iteration and exit when BotManager sets `LUMIBOT_SCHEDULED_EXECUTION`. Scheduled runs restore and persist `self.vars` through the BotManager state file.
 
 ## 4.5.10 - 2026-04-30
 

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -66,25 +66,9 @@ This page documents environment variables used by LumiBot, with an emphasis on *
 
 ## Live scheduled execution (BotSpot/BotManager)
 
-### `LUMIBOT_SCHEDULED_EXECUTION`
-- Purpose: Internal BotSpot/BotManager flag for externally scheduled live strategy runs.
-- Values: truthy enables (`1`, `true`, `yes`, `y`, `on`); unset/`0` disables.
-- Behavior:
-  - `Strategy.run_live()` runs exactly one live trading iteration and exits instead of starting the normal always-on scheduler loop.
-  - `self.vars` is loaded from and saved to `LUMIBOT_SCHEDULED_STATE_FILE` when that state file is configured.
-- Where: `lumibot/strategies/strategy.py`, `lumibot/traders/trader.py`, `lumibot/strategies/strategy_executor.py`, `lumibot/strategies/_strategy.py`
-
-### `LUMIBOT_SCHEDULED_STATE_BACKEND`
-- Purpose: Identifies the external scheduled-state backend prepared by BotManager.
-- Values: `s3`, `dynamodb`, or `none`.
-- Notes:
-  - LumiBot itself reads/writes the local `LUMIBOT_SCHEDULED_STATE_FILE`; BotManager is responsible for hydrating/persisting that file to the external backend.
-  - `none` disables scheduled `self.vars` file load/save.
-
-### `LUMIBOT_SCHEDULED_STATE_FILE`
-- Purpose: Local JSON file used to restore and persist `self.vars` for one scheduled live run.
-- Example: `/app/.botspot/scheduled_state.json`
-- Notes: This file should be managed by BotManager/bootstrap code, not by user strategies.
+- `LUMIBOT_SCHEDULED_EXECUTION`: internal BotManager flag. Truthy values (`1`, `true`, `yes`, `y`, `on`) make `Strategy.run_live()` run one live iteration and exit.
+- `LUMIBOT_SCHEDULED_STATE_BACKEND`: external state backend prepared by BotManager: `s3`, `dynamodb`, or `none`. `none` disables scheduled `self.vars` file load/save.
+- `LUMIBOT_SCHEDULED_STATE_FILE`: local JSON file managed by BotManager/bootstrap code to restore and persist `self.vars` for one scheduled live run. State is restored before scheduled lifecycle hooks.
 
 ## Backtest output + UX flags
 

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -64,6 +64,28 @@ This page documents environment variables used by LumiBot, with an emphasis on *
   - CI uses this to enforce the “warm S3 cache invariant” for canonical acceptance windows.
   - Exit behavior: tripwire prints `[ACCEPTANCE][TRIPWIRE] …` and hard-exits the subprocess with code `86`.
 
+## Live scheduled execution (BotSpot/BotManager)
+
+### `LUMIBOT_SCHEDULED_EXECUTION`
+- Purpose: Internal BotSpot/BotManager flag for externally scheduled live strategy runs.
+- Values: truthy enables (`1`, `true`, `yes`, `y`, `on`); unset/`0` disables.
+- Behavior:
+  - `Strategy.run_live()` runs exactly one live trading iteration and exits instead of starting the normal always-on scheduler loop.
+  - `self.vars` is loaded from and saved to `LUMIBOT_SCHEDULED_STATE_FILE` when that state file is configured.
+- Where: `lumibot/strategies/strategy.py`, `lumibot/traders/trader.py`, `lumibot/strategies/strategy_executor.py`, `lumibot/strategies/_strategy.py`
+
+### `LUMIBOT_SCHEDULED_STATE_BACKEND`
+- Purpose: Identifies the external scheduled-state backend prepared by BotManager.
+- Values: `s3`, `dynamodb`, or `none`.
+- Notes:
+  - LumiBot itself reads/writes the local `LUMIBOT_SCHEDULED_STATE_FILE`; BotManager is responsible for hydrating/persisting that file to the external backend.
+  - `none` disables scheduled `self.vars` file load/save.
+
+### `LUMIBOT_SCHEDULED_STATE_FILE`
+- Purpose: Local JSON file used to restore and persist `self.vars` for one scheduled live run.
+- Example: `/app/.botspot/scheduled_state.json`
+- Notes: This file should be managed by BotManager/bootstrap code, not by user strategies.
+
 ## Backtest output + UX flags
 
 ### `SHOW_PLOT`, `SHOW_INDICATORS`, `SHOW_TEARSHEET`

--- a/docsrc/environment_variables.rst
+++ b/docsrc/environment_variables.rst
@@ -86,30 +86,9 @@ LUMIBOT_ACCEPTANCE_TRIPWIRE
 Live scheduled execution (BotSpot/BotManager)
 ---------------------------------------------
 
-LUMIBOT_SCHEDULED_EXECUTION
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- Purpose: Internal BotSpot/BotManager flag for externally scheduled live strategy runs.
-- Values: truthy enables (``1``, ``true``, ``yes``, ``y``, ``on``); unset/``0`` disables.
-- Behavior:
-  - ``Strategy.run_live()`` runs exactly one live trading iteration and exits instead of starting the normal always-on scheduler loop.
-  - ``self.vars`` is loaded from and saved to ``LUMIBOT_SCHEDULED_STATE_FILE`` when that state file is configured.
-
-LUMIBOT_SCHEDULED_STATE_BACKEND
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- Purpose: Identifies the external scheduled-state backend prepared by BotManager.
-- Values: ``s3``, ``dynamodb``, or ``none``.
-- Notes:
-  - LumiBot reads/writes the local ``LUMIBOT_SCHEDULED_STATE_FILE``; BotManager is responsible for hydrating/persisting that file to the external backend.
-  - ``none`` disables scheduled ``self.vars`` file load/save.
-
-LUMIBOT_SCHEDULED_STATE_FILE
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- Purpose: Local JSON file used to restore and persist ``self.vars`` for one scheduled live run.
-- Example: ``/app/.botspot/scheduled_state.json``
-- Notes: This file should be managed by BotManager/bootstrap code, not by user strategies.
+- ``LUMIBOT_SCHEDULED_EXECUTION``: internal BotManager flag. Truthy values (``1``, ``true``, ``yes``, ``y``, ``on``) make ``Strategy.run_live()`` run one live iteration and exit.
+- ``LUMIBOT_SCHEDULED_STATE_BACKEND``: external state backend prepared by BotManager: ``s3``, ``dynamodb``, or ``none``. ``none`` disables scheduled ``self.vars`` file load/save.
+- ``LUMIBOT_SCHEDULED_STATE_FILE``: local JSON file managed by BotManager/bootstrap code to restore and persist ``self.vars`` for one scheduled live run. State is restored before scheduled lifecycle hooks.
 
 Backtest artifacts + UX flags
 -----------------------------

--- a/docsrc/environment_variables.rst
+++ b/docsrc/environment_variables.rst
@@ -83,6 +83,34 @@ LUMIBOT_ACCEPTANCE_TRIPWIRE
   - This is an engineering/CI guardrail to enforce “warm-cache” acceptance backtests. It should not be used for normal production backtests.
   - When triggered, it prints a marker and exits the subprocess with a non-zero code so the test fails reliably.
 
+Live scheduled execution (BotSpot/BotManager)
+---------------------------------------------
+
+LUMIBOT_SCHEDULED_EXECUTION
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Internal BotSpot/BotManager flag for externally scheduled live strategy runs.
+- Values: truthy enables (``1``, ``true``, ``yes``, ``y``, ``on``); unset/``0`` disables.
+- Behavior:
+  - ``Strategy.run_live()`` runs exactly one live trading iteration and exits instead of starting the normal always-on scheduler loop.
+  - ``self.vars`` is loaded from and saved to ``LUMIBOT_SCHEDULED_STATE_FILE`` when that state file is configured.
+
+LUMIBOT_SCHEDULED_STATE_BACKEND
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Identifies the external scheduled-state backend prepared by BotManager.
+- Values: ``s3``, ``dynamodb``, or ``none``.
+- Notes:
+  - LumiBot reads/writes the local ``LUMIBOT_SCHEDULED_STATE_FILE``; BotManager is responsible for hydrating/persisting that file to the external backend.
+  - ``none`` disables scheduled ``self.vars`` file load/save.
+
+LUMIBOT_SCHEDULED_STATE_FILE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Local JSON file used to restore and persist ``self.vars`` for one scheduled live run.
+- Example: ``/app/.botspot/scheduled_state.json``
+- Notes: This file should be managed by BotManager/bootstrap code, not by user strategies.
+
 Backtest artifacts + UX flags
 -----------------------------
 

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -4,6 +4,7 @@ import json
 import math
 import os
 import random
+import re
 import string
 import time
 import traceback
@@ -3757,8 +3758,102 @@ class _Strategy:
                     self.logger.error("Max retries reached for to_sql. Failing operation.")
                     raise
 
+    def _scheduled_state_enabled(self):
+        if self.is_backtesting:
+            return False
+        scheduled = str(os.environ.get("LUMIBOT_SCHEDULED_EXECUTION", "")).strip().lower()
+        if scheduled not in {"1", "true", "yes", "y", "on"}:
+            return False
+        if str(os.environ.get("LUMIBOT_SCHEDULED_STATE_BACKEND", "")).strip().lower() == "none":
+            return False
+        return bool(os.environ.get("LUMIBOT_SCHEDULED_STATE_FILE"))
+
+    @staticmethod
+    def _coerce_loaded_variable_value(value):
+        if not isinstance(value, str):
+            return value
+
+        iso_dt_re = re.compile(r"^\d{4}-\d{2}-\d{2}T")
+        iso_date_re = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+        if iso_dt_re.match(value):
+            try:
+                parsed = value.replace("Z", "+00:00") if value.endswith("Z") else value
+                return datetime.datetime.fromisoformat(parsed)
+            except Exception:
+                return value
+
+        if iso_date_re.match(value):
+            try:
+                return datetime.datetime.strptime(value, "%Y-%m-%d").date()
+            except Exception:
+                return value
+
+        return value
+
+    def _load_variables_from_scheduled_state_file(self):
+        state_file = os.environ.get("LUMIBOT_SCHEDULED_STATE_FILE")
+        if not state_file:
+            return
+
+        try:
+            with open(state_file, "r", encoding="utf-8") as f:
+                data = json.load(
+                    f,
+                    object_hook=lambda d: {
+                        key: self._coerce_loaded_variable_value(value) for key, value in d.items()
+                    },
+                )
+        except FileNotFoundError:
+            self.logger.info("Scheduled state file does not exist yet. Not restoring variables.")
+            return
+
+        if not isinstance(data, dict):
+            raise ValueError("Scheduled state file must contain a JSON object")
+
+        for key, value in data.items():
+            self.vars.set(key, value)
+
+        self._last_backup_state = json.dumps(self.vars.all(), sort_keys=True, cls=SafeJSONEncoder)
+        self.logger.info("Variables loaded successfully from scheduled state file")
+
+    def _backup_variables_to_scheduled_state_file(self):
+        state_file = os.environ.get("LUMIBOT_SCHEDULED_STATE_FILE")
+        if not state_file:
+            return
+
+        data_to_save = self.vars.all()
+        state_json = json.dumps(data_to_save, sort_keys=True, cls=SafeJSONEncoder)
+        if state_json == self._last_backup_state:
+            self.logger.info("No variables changed. Not backing up scheduled state.")
+            return
+
+        state_dir = os.path.dirname(state_file)
+        if state_dir:
+            os.makedirs(state_dir, exist_ok=True)
+        tmp_path = f"{state_file}.tmp"
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(state_json)
+            os.replace(tmp_path, state_file)
+            os.chmod(state_file, 0o600)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise
+
+        self._last_backup_state = state_json
+        self.logger.info("Variables backed up successfully to scheduled state file")
+
     def backup_variables_to_db(self):
         if self.is_backtesting:
+            return
+
+        if self._scheduled_state_enabled():
+            self._backup_variables_to_scheduled_state_file()
             return
 
         if not hasattr(self, "db_connection_str") or self.db_connection_str is None or self.db_connection_str == "" or not self.should_backup_variables_to_database:
@@ -3845,6 +3940,10 @@ class _Strategy:
     def load_variables_from_db(self):
         if self.is_backtesting:
             return
+
+        if self._scheduled_state_enabled():
+            self._load_variables_from_scheduled_state_file()
+            return
     
         if not hasattr(self, "db_connection_str") or self.db_connection_str is None or not self.should_backup_variables_to_database:
             return
@@ -3873,35 +3972,14 @@ class _Strategy:
     
             json_data = df['variables'].iloc[0]
     
-            import re
-    
-            iso_dt_re = re.compile(r"^\d{4}-\d{2}-\d{2}T")      # datetime prefix
-            iso_date_re = re.compile(r"^\d{4}-\d{2}-\d{2}$")    # date only
-    
-            def _coerce_value(v):
-                if not isinstance(v, str):
-                    return v
-    
-                # ISO datetime (support trailing Z)
-                if iso_dt_re.match(v):
-                    try:
-                        v2 = v.replace("Z", "+00:00") if v.endswith("Z") else v
-                        return datetime.datetime.fromisoformat(v2)
-                    except Exception:
-                        return v
-    
-                # ISO date (YYYY-MM-DD)
-                if iso_date_re.match(v):
-                    try:
-                        return datetime.datetime.strptime(v, "%Y-%m-%d").date()
-                    except Exception:
-                        return v
-    
-                return v
-    
             # Decode any special types we stored using our SafeJSONEncoder,
             # but only parse strings that actually look like ISO dates/datetimes.
-            data = json.loads(json_data, object_hook=lambda d: {k: _coerce_value(v) for k, v in d.items()})
+            data = json.loads(
+                json_data,
+                object_hook=lambda d: {
+                    k: self._coerce_loaded_variable_value(v) for k, v in d.items()
+                },
+            )
     
             # Update self.vars dictionary
             for key, value in data.items():

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -4,7 +4,6 @@ import json
 import math
 import os
 import random
-import re
 import string
 import time
 import traceback
@@ -3769,27 +3768,51 @@ class _Strategy:
         return bool(os.environ.get("LUMIBOT_SCHEDULED_STATE_FILE"))
 
     @staticmethod
-    def _coerce_loaded_variable_value(value):
-        if not isinstance(value, str):
-            return value
-
-        iso_dt_re = re.compile(r"^\d{4}-\d{2}-\d{2}T")
-        iso_date_re = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-
-        if iso_dt_re.match(value):
-            try:
-                parsed = value.replace("Z", "+00:00") if value.endswith("Z") else value
-                return datetime.datetime.fromisoformat(parsed)
-            except Exception:
-                return value
-
-        if iso_date_re.match(value):
-            try:
-                return datetime.datetime.strptime(value, "%Y-%m-%d").date()
-            except Exception:
-                return value
-
+    def _encode_variable_for_backup(value):
+        if isinstance(value, datetime.datetime):
+            return {"__lumibot_type__": "datetime", "value": value.isoformat()}
+        if isinstance(value, datetime.date):
+            return {"__lumibot_type__": "date", "value": value.isoformat()}
+        if isinstance(value, dict):
+            return {key: _Strategy._encode_variable_for_backup(nested) for key, nested in value.items()}
+        if isinstance(value, tuple):
+            return {
+                "__lumibot_type__": "tuple",
+                "value": [_Strategy._encode_variable_for_backup(nested) for nested in value],
+            }
+        if isinstance(value, list):
+            return [_Strategy._encode_variable_for_backup(nested) for nested in value]
         return value
+
+    @staticmethod
+    def _decode_variable_from_backup(value):
+        if isinstance(value, dict):
+            if set(value.keys()) == {"__lumibot_type__", "value"}:
+                if value["__lumibot_type__"] == "datetime":
+                    return datetime.datetime.fromisoformat(value["value"])
+                if value["__lumibot_type__"] == "date":
+                    return datetime.datetime.strptime(value["value"], "%Y-%m-%d").date()
+                if value["__lumibot_type__"] == "tuple":
+                    return tuple(_Strategy._decode_variable_from_backup(nested) for nested in value["value"])
+            return {key: _Strategy._decode_variable_from_backup(nested) for key, nested in value.items()}
+        if isinstance(value, list):
+            return [_Strategy._decode_variable_from_backup(nested) for nested in value]
+        return value
+
+    @classmethod
+    def _serialize_variables_for_backup(cls, variables):
+        return json.dumps(
+            cls._encode_variable_for_backup(variables),
+            sort_keys=True,
+            cls=SafeJSONEncoder,
+        )
+
+    @classmethod
+    def _deserialize_variables_from_backup(cls, json_data):
+        data = json.loads(json_data)
+        if not isinstance(data, dict):
+            raise ValueError("Variables backup must contain a JSON object")
+        return {key: cls._decode_variable_from_backup(value) for key, value in data.items()}
 
     def _load_variables_from_scheduled_state_file(self):
         state_file = os.environ.get("LUMIBOT_SCHEDULED_STATE_FILE")
@@ -3798,23 +3821,15 @@ class _Strategy:
 
         try:
             with open(state_file, "r", encoding="utf-8") as f:
-                data = json.load(
-                    f,
-                    object_hook=lambda d: {
-                        key: self._coerce_loaded_variable_value(value) for key, value in d.items()
-                    },
-                )
+                data = self._deserialize_variables_from_backup(f.read())
         except FileNotFoundError:
             self.logger.info("Scheduled state file does not exist yet. Not restoring variables.")
             return
 
-        if not isinstance(data, dict):
-            raise ValueError("Scheduled state file must contain a JSON object")
-
         for key, value in data.items():
             self.vars.set(key, value)
 
-        self._last_backup_state = json.dumps(self.vars.all(), sort_keys=True, cls=SafeJSONEncoder)
+        self._last_backup_state = self._serialize_variables_for_backup(self.vars.all())
         self.logger.info("Variables loaded successfully from scheduled state file")
 
     def _backup_variables_to_scheduled_state_file(self):
@@ -3822,8 +3837,7 @@ class _Strategy:
         if not state_file:
             return
 
-        data_to_save = self.vars.all()
-        state_json = json.dumps(data_to_save, sort_keys=True, cls=SafeJSONEncoder)
+        state_json = self._serialize_variables_for_backup(self.vars.all())
         if state_json == self._last_backup_state:
             self.logger.info("No variables changed. Not backing up scheduled state.")
             return
@@ -3831,7 +3845,7 @@ class _Strategy:
         state_dir = os.path.dirname(state_file)
         if state_dir:
             os.makedirs(state_dir, exist_ok=True)
-        tmp_path = f"{state_file}.tmp"
+        tmp_path = f"{state_file}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
         fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
@@ -3853,7 +3867,10 @@ class _Strategy:
             return
 
         if self._scheduled_state_enabled():
-            self._backup_variables_to_scheduled_state_file()
+            try:
+                self._backup_variables_to_scheduled_state_file()
+            except Exception as e:
+                self.logger.error(f"Error backing up variables to scheduled state file: {e}", exc_info=True)
             return
 
         if not hasattr(self, "db_connection_str") or self.db_connection_str is None or self.db_connection_str == "" or not self.should_backup_variables_to_database:
@@ -3942,7 +3959,10 @@ class _Strategy:
             return
 
         if self._scheduled_state_enabled():
-            self._load_variables_from_scheduled_state_file()
+            try:
+                self._load_variables_from_scheduled_state_file()
+            except Exception as e:
+                self.logger.error(f"Error loading variables from scheduled state file: {e}", exc_info=True)
             return
     
         if not hasattr(self, "db_connection_str") or self.db_connection_str is None or not self.should_backup_variables_to_database:
@@ -3971,15 +3991,36 @@ class _Strategy:
                 return
     
             json_data = df['variables'].iloc[0]
-    
+
+            import re
+
+            iso_dt_re = re.compile(r"^\d{4}-\d{2}-\d{2}T")      # datetime prefix
+            iso_date_re = re.compile(r"^\d{4}-\d{2}-\d{2}$")    # date only
+
+            def _coerce_value(v):
+                if not isinstance(v, str):
+                    return v
+
+                # ISO datetime (support trailing Z)
+                if iso_dt_re.match(v):
+                    try:
+                        v2 = v.replace("Z", "+00:00") if v.endswith("Z") else v
+                        return datetime.datetime.fromisoformat(v2)
+                    except Exception:
+                        return v
+
+                # ISO date (YYYY-MM-DD)
+                if iso_date_re.match(v):
+                    try:
+                        return datetime.datetime.strptime(v, "%Y-%m-%d").date()
+                    except Exception:
+                        return v
+
+                return v
+
             # Decode any special types we stored using our SafeJSONEncoder,
             # but only parse strings that actually look like ISO dates/datetimes.
-            data = json.loads(
-                json_data,
-                object_hook=lambda d: {
-                    k: self._coerce_loaded_variable_value(v) for k, v in d.items()
-                },
-            )
+            data = json.loads(json_data, object_hook=lambda d: {k: _coerce_value(v) for k, v in d.items()})
     
             # Update self.vars dictionary
             for key, value in data.items():

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -5421,17 +5421,32 @@ class Strategy(_Strategy):
         """
         pass
 
-    def run_live(self):
+    def run_live(self, run_once: bool | None = None):
         """
         Executes the trading strategy in Live mode
+
+        Parameters
+        ----------
+        run_once : bool, optional
+            Run one trading iteration and exit instead of starting the normal always-on scheduler loop.
+            If omitted, this is enabled automatically when ``LUMIBOT_SCHEDULED_EXECUTION`` is truthy.
 
         Returns:
             None
         """
+        if run_once is None:
+            run_once = str(os.environ.get("LUMIBOT_SCHEDULED_EXECUTION", "")).strip().lower() in {
+                "1",
+                "true",
+                "yes",
+                "y",
+                "on",
+            }
+
         trader = Trader()
 
         trader.add_strategy(self)
-        trader.run_all()
+        trader.run_all(run_once=run_once)
 
     @classmethod
     def backtest(

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -1074,7 +1074,8 @@ class StrategyExecutor(Thread):
         # Time-consuming
         try:
             # Variable Restore
-            self.strategy.load_variables_from_db()
+            if not self._run_once_requested:
+                self.strategy.load_variables_from_db()
             on_trading_iteration()
 
             self.strategy._first_iteration = False
@@ -1131,7 +1132,7 @@ class StrategyExecutor(Thread):
 
             if self._run_once_requested:
                 self.exception = e
-                raise e
+                raise
 
             self._on_bot_crash(e)
 
@@ -1996,74 +1997,17 @@ class StrategyExecutor(Thread):
 
         return next_run_time
 
-    def _initialize_market_calendars_for_run(self):
-        """Initialize broker calendars for the current execution mode."""
-        market = self.broker.market
-
-        # For *pure* PandasData backtests, derive the calendar from the data itself so the
-        # StrategyExecutor can run on timestamps that exist in the supplied DataFrames
-        # (including daily bars where market_open == market_close).
-        #
-        # IMPORTANT: do NOT apply this to PolygonDataBacktesting (or other providers that
-        # inherit from PandasData) because their _date_index is typically empty at startup.
-        # In that case, get_trading_days_pandas() returns a "full-day open" dummy calendar
-        # (00:00–23:59:59), which can skip lifecycle hooks like before_market_opens() and
-        # breaks legacy backtests (e.g. tests/backtest/test_polygon.py).
-        data_source = getattr(self.broker, "data_source", None)
-        is_pure_pandas_data_source = (
-            self.strategy.is_backtesting
-            and data_source is not None
-            and type(data_source).__name__ in ("PandasData", "PandasDataBacktesting")
-            and hasattr(data_source, "get_trading_days_pandas")
-        )
-        if is_pure_pandas_data_source:
-            self.broker.initialize_market_calendars(data_source.get_trading_days_pandas())
-            return
-
-        # PERFORMANCE: default `get_trading_days()` spans 1950->today, which can be very expensive.
-        # In backtesting we know the simulation window; bound the calendar query to that range
-        # (+/- a small buffer) so schedule generation is O(window) instead of O(decades).
-        if self.strategy.is_backtesting:
-            try:
-                datetime_start = (
-                    getattr(self.broker, "datetime_start", None)
-                    or getattr(data_source, "datetime_start", None)
-                    or getattr(self.strategy, "_backtesting_start", None)
-                    or getattr(self.strategy, "backtesting_start", None)
-                )
-                datetime_end = (
-                    getattr(self.broker, "datetime_end", None)
-                    or getattr(data_source, "datetime_end", None)
-                    or getattr(self.strategy, "_backtesting_end", None)
-                    or getattr(self.strategy, "backtesting_end", None)
-                )
-                tzinfo = getattr(data_source, "tzinfo", None) or LUMIBOT_DEFAULT_PYTZ
-
-                if datetime_start is not None and datetime_end is not None:
-                    buffer = timedelta(days=14)
-                    # `get_trading_days` treats end_date as exclusive; include the final day.
-                    self.broker.initialize_market_calendars(
-                        get_trading_days(
-                            market=market,
-                            start_date=datetime_start - buffer,
-                            end_date=datetime_end + buffer + timedelta(days=1),
-                            tzinfo=tzinfo,
-                        )
-                    )
-                else:
-                    self.broker.initialize_market_calendars(get_trading_days(market))
-            except Exception:
-                self.broker.initialize_market_calendars(get_trading_days(market))
-        else:
-            self.broker.initialize_market_calendars(get_trading_days(market))
-
     def _run_live_once(self):
         """Run exactly one live trading iteration without starting APScheduler."""
         if self.strategy.is_backtesting:
             raise RuntimeError("run_once is only supported for live trading strategies")
 
+        # Scheduled one-shot runs must restore state before any lifecycle hook can read or mutate self.vars.
+        self.strategy.load_variables_from_db()
         self.strategy.log_message("Running one live trading iteration", color="blue")
-        if self.broker.is_market_open():
+        market_open = self.broker.is_market_open()
+        if market_open:
+            # Each scheduled run is a fresh live session, so the per-session hook runs every tick.
             self._before_starting_trading()
             self.lifecycle_last_date["before_starting_trading"] = self.strategy.get_datetime().date()
 
@@ -2082,7 +2026,7 @@ class StrategyExecutor(Thread):
             self.broker.set_strategy_name(self.strategy._name)
 
             self._initialize()
-            self._initialize_market_calendars_for_run()
+            self.broker.initialize_market_calendars(get_trading_days(self.broker.market))
             self._run_live_once()
             self._on_strategy_end()
 
@@ -2116,7 +2060,66 @@ class StrategyExecutor(Thread):
 
             self._initialize()
 
-            self._initialize_market_calendars_for_run()
+            # Get the trading days based on the market that the strategy is trading on
+            market = self.broker.market
+
+            # Initialize broker calendar and caches using trading days.
+            #
+            # For *pure* PandasData backtests, derive the calendar from the data itself so the
+            # StrategyExecutor can run on timestamps that exist in the supplied DataFrames
+            # (including daily bars where market_open == market_close).
+            #
+            # IMPORTANT: do NOT apply this to PolygonDataBacktesting (or other providers that
+            # inherit from PandasData) because their _date_index is typically empty at startup.
+            # In that case, get_trading_days_pandas() returns a "full-day open" dummy calendar
+            # (00:00–23:59:59), which can skip lifecycle hooks like before_market_opens() and
+            # breaks legacy backtests (e.g. tests/backtest/test_polygon.py).
+            data_source = getattr(self.broker, "data_source", None)
+            is_pure_pandas_data_source = (
+                self.strategy.is_backtesting
+                and data_source is not None
+                and type(data_source).__name__ in ("PandasData", "PandasDataBacktesting")
+                and hasattr(data_source, "get_trading_days_pandas")
+            )
+            if is_pure_pandas_data_source:
+                self.broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+            else:
+                # PERFORMANCE: default `get_trading_days()` spans 1950->today, which can be very expensive.
+                # In backtesting we know the simulation window; bound the calendar query to that range
+                # (+/- a small buffer) so schedule generation is O(window) instead of O(decades).
+                if self.strategy.is_backtesting:
+                    try:
+                        datetime_start = (
+                            getattr(self.broker, "datetime_start", None)
+                            or getattr(data_source, "datetime_start", None)
+                            or getattr(self.strategy, "_backtesting_start", None)
+                            or getattr(self.strategy, "backtesting_start", None)
+                        )
+                        datetime_end = (
+                            getattr(self.broker, "datetime_end", None)
+                            or getattr(data_source, "datetime_end", None)
+                            or getattr(self.strategy, "_backtesting_end", None)
+                            or getattr(self.strategy, "backtesting_end", None)
+                        )
+                        tzinfo = getattr(data_source, "tzinfo", None) or LUMIBOT_DEFAULT_PYTZ
+
+                        if datetime_start is not None and datetime_end is not None:
+                            buffer = timedelta(days=14)
+                            # `get_trading_days` treats end_date as exclusive; include the final day.
+                            self.broker.initialize_market_calendars(
+                                get_trading_days(
+                                    market=market,
+                                    start_date=datetime_start - buffer,
+                                    end_date=datetime_end + buffer + timedelta(days=1),
+                                    tzinfo=tzinfo,
+                                )
+                            )
+                        else:
+                            self.broker.initialize_market_calendars(get_trading_days(market))
+                    except Exception:
+                        self.broker.initialize_market_calendars(get_trading_days(market))
+                else:
+                    self.broker.initialize_market_calendars(get_trading_days(market))
 
             #####
             # Main strategy execution loop

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -56,6 +56,7 @@ class StrategyExecutor(Thread):
 
         # Store any exception that occurs during execution
         self.exception = None
+        self._run_once_requested = False
 
         # Create a dictionary of job stores. A job store is where the scheduler persists its jobs. In this case,
         # we create an in-memory job store for "default" and "On_Trading_Iteration" which is the job store we will
@@ -1128,6 +1129,10 @@ class StrategyExecutor(Thread):
             # Log the traceback
             self.strategy.log_message(traceback.format_exc(), color="red")
 
+            if self._run_once_requested:
+                self.exception = e
+                raise e
+
             self._on_bot_crash(e)
 
     @lifecycle_method
@@ -1991,6 +1996,115 @@ class StrategyExecutor(Thread):
 
         return next_run_time
 
+    def _initialize_market_calendars_for_run(self):
+        """Initialize broker calendars for the current execution mode."""
+        market = self.broker.market
+
+        # For *pure* PandasData backtests, derive the calendar from the data itself so the
+        # StrategyExecutor can run on timestamps that exist in the supplied DataFrames
+        # (including daily bars where market_open == market_close).
+        #
+        # IMPORTANT: do NOT apply this to PolygonDataBacktesting (or other providers that
+        # inherit from PandasData) because their _date_index is typically empty at startup.
+        # In that case, get_trading_days_pandas() returns a "full-day open" dummy calendar
+        # (00:00–23:59:59), which can skip lifecycle hooks like before_market_opens() and
+        # breaks legacy backtests (e.g. tests/backtest/test_polygon.py).
+        data_source = getattr(self.broker, "data_source", None)
+        is_pure_pandas_data_source = (
+            self.strategy.is_backtesting
+            and data_source is not None
+            and type(data_source).__name__ in ("PandasData", "PandasDataBacktesting")
+            and hasattr(data_source, "get_trading_days_pandas")
+        )
+        if is_pure_pandas_data_source:
+            self.broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+            return
+
+        # PERFORMANCE: default `get_trading_days()` spans 1950->today, which can be very expensive.
+        # In backtesting we know the simulation window; bound the calendar query to that range
+        # (+/- a small buffer) so schedule generation is O(window) instead of O(decades).
+        if self.strategy.is_backtesting:
+            try:
+                datetime_start = (
+                    getattr(self.broker, "datetime_start", None)
+                    or getattr(data_source, "datetime_start", None)
+                    or getattr(self.strategy, "_backtesting_start", None)
+                    or getattr(self.strategy, "backtesting_start", None)
+                )
+                datetime_end = (
+                    getattr(self.broker, "datetime_end", None)
+                    or getattr(data_source, "datetime_end", None)
+                    or getattr(self.strategy, "_backtesting_end", None)
+                    or getattr(self.strategy, "backtesting_end", None)
+                )
+                tzinfo = getattr(data_source, "tzinfo", None) or LUMIBOT_DEFAULT_PYTZ
+
+                if datetime_start is not None and datetime_end is not None:
+                    buffer = timedelta(days=14)
+                    # `get_trading_days` treats end_date as exclusive; include the final day.
+                    self.broker.initialize_market_calendars(
+                        get_trading_days(
+                            market=market,
+                            start_date=datetime_start - buffer,
+                            end_date=datetime_end + buffer + timedelta(days=1),
+                            tzinfo=tzinfo,
+                        )
+                    )
+                else:
+                    self.broker.initialize_market_calendars(get_trading_days(market))
+            except Exception:
+                self.broker.initialize_market_calendars(get_trading_days(market))
+        else:
+            self.broker.initialize_market_calendars(get_trading_days(market))
+
+    def _run_live_once(self):
+        """Run exactly one live trading iteration without starting APScheduler."""
+        if self.strategy.is_backtesting:
+            raise RuntimeError("run_once is only supported for live trading strategies")
+
+        self.strategy.log_message("Running one live trading iteration", color="blue")
+        if self.broker.is_market_open():
+            self._before_starting_trading()
+            self.lifecycle_last_date["before_starting_trading"] = self.strategy.get_datetime().date()
+
+        self.cron_count_target = 1
+        self.cron_count = 0
+        try:
+            self._on_trading_iteration()
+            self.process_queue()
+        finally:
+            self._in_trading_iteration = False
+
+    def run_once(self):
+        self._run_once_requested = True
+        try:
+            # Set the strategy name at the broker
+            self.broker.set_strategy_name(self.strategy._name)
+
+            self._initialize()
+            self._initialize_market_calendars_for_run()
+            self._run_live_once()
+            self._on_strategy_end()
+
+            self.result = self.strategy._analysis
+            self.gracefully_exit()
+            return True
+        except Exception as e:
+            try:
+                self.strategy.logger.error(e)
+                self.strategy.logger.error(traceback.format_exc())
+                try:
+                    self._on_bot_crash(e)
+                except Exception as e1:
+                    self.strategy.logger.error(e1)
+                    self.strategy.logger.error(traceback.format_exc())
+            finally:
+                self.exception = e
+                self.result = self.strategy._analysis if hasattr(self.strategy, '_analysis') else {}
+            return False
+        finally:
+            self._run_once_requested = False
+
     def run(self):
         try:
             # Only overload the broker sleep method when backtesting
@@ -2002,66 +2116,7 @@ class StrategyExecutor(Thread):
 
             self._initialize()
 
-            # Get the trading days based on the market that the strategy is trading on
-            market = self.broker.market
-
-            # Initialize broker calendar and caches using trading days.
-            #
-            # For *pure* PandasData backtests, derive the calendar from the data itself so the
-            # StrategyExecutor can run on timestamps that exist in the supplied DataFrames
-            # (including daily bars where market_open == market_close).
-            #
-            # IMPORTANT: do NOT apply this to PolygonDataBacktesting (or other providers that
-            # inherit from PandasData) because their _date_index is typically empty at startup.
-            # In that case, get_trading_days_pandas() returns a "full-day open" dummy calendar
-            # (00:00–23:59:59), which can skip lifecycle hooks like before_market_opens() and
-            # breaks legacy backtests (e.g. tests/backtest/test_polygon.py).
-            data_source = getattr(self.broker, "data_source", None)
-            is_pure_pandas_data_source = (
-                self.strategy.is_backtesting
-                and data_source is not None
-                and type(data_source).__name__ in ("PandasData", "PandasDataBacktesting")
-                and hasattr(data_source, "get_trading_days_pandas")
-            )
-            if is_pure_pandas_data_source:
-                self.broker.initialize_market_calendars(data_source.get_trading_days_pandas())
-            else:
-                # PERFORMANCE: default `get_trading_days()` spans 1950->today, which can be very expensive.
-                # In backtesting we know the simulation window; bound the calendar query to that range
-                # (+/- a small buffer) so schedule generation is O(window) instead of O(decades).
-                if self.strategy.is_backtesting:
-                    try:
-                        datetime_start = (
-                            getattr(self.broker, "datetime_start", None)
-                            or getattr(data_source, "datetime_start", None)
-                            or getattr(self.strategy, "_backtesting_start", None)
-                            or getattr(self.strategy, "backtesting_start", None)
-                        )
-                        datetime_end = (
-                            getattr(self.broker, "datetime_end", None)
-                            or getattr(data_source, "datetime_end", None)
-                            or getattr(self.strategy, "_backtesting_end", None)
-                            or getattr(self.strategy, "backtesting_end", None)
-                        )
-                        tzinfo = getattr(data_source, "tzinfo", None) or LUMIBOT_DEFAULT_PYTZ
-
-                        if datetime_start is not None and datetime_end is not None:
-                            buffer = timedelta(days=14)
-                            # `get_trading_days` treats end_date as exclusive; include the final day.
-                            self.broker.initialize_market_calendars(
-                                get_trading_days(
-                                    market=market,
-                                    start_date=datetime_start - buffer,
-                                    end_date=datetime_end + buffer + timedelta(days=1),
-                                    tzinfo=tzinfo,
-                                )
-                            )
-                        else:
-                            self.broker.initialize_market_calendars(get_trading_days(market))
-                    except Exception:
-                        self.broker.initialize_market_calendars(get_trading_days(market))
-                else:
-                    self.broker.initialize_market_calendars(get_trading_days(market))
+            self._initialize_market_calendars_for_run()
 
             #####
             # Main strategy execution loop

--- a/lumibot/traders/trader.py
+++ b/lumibot/traders/trader.py
@@ -90,6 +90,7 @@ class Trader:
             tearsheet_file=None,
             tearsheet_metrics_file=None,
             base_filename=None,
+            run_once=False,
             ):
         """
         run all strategies
@@ -138,6 +139,10 @@ class Trader:
         base_filename: str
             The base filename to save the tearsheet, plot, indicators, etc. This is only used for backtesting.
 
+        run_once: bool
+            For live strategies, run one trading iteration synchronously and exit instead of starting the normal
+            always-on scheduler loop. This is intended for externally scheduled deployments.
+
         Returns
         -------
         dict
@@ -166,6 +171,12 @@ class Trader:
                     f"Running multiple live strategies is not implemented yet. You passed "
                     f"in {len(self._strategies)} strategies."
                 )
+
+        if run_once and async_:
+            raise RuntimeError("run_once cannot be combined with async_=True")
+
+        if run_once and self.is_backtest_broker:
+            raise RuntimeError("run_once is only supported for live trading strategies")
 
         strat = self._strategies[0]
         # NOTE: Market auto-detection now happens inside Broker.__init__.
@@ -209,9 +220,12 @@ class Trader:
                 logger.warning("Failed to enable yappi profiling: %s", exc)
 
         try:
-            self._start_pool()
-            if not async_:
-                self._join_pool()
+            if run_once:
+                self._run_pool_once()
+            else:
+                self._start_pool()
+                if not async_:
+                    self._join_pool()
             result = self._collect_analysis()
 
             if self.is_backtest_broker:
@@ -409,6 +423,14 @@ class Trader:
                 # Check if the thread stored an exception
                 if hasattr(strategy_thread, 'exception') and strategy_thread.exception is not None:
                     raise strategy_thread.exception
+
+    def _run_pool_once(self):
+        for strategy_thread in self._pool:
+            strategy_thread.run_once()
+
+        for strategy_thread in self._pool:
+            if hasattr(strategy_thread, 'exception') and strategy_thread.exception is not None:
+                raise strategy_thread.exception
 
     def _stop_pool(self, sig=None, frame=None):
         """Run all strategies on_abrupt_closing

--- a/tests/test_scheduled_run_once.py
+++ b/tests/test_scheduled_run_once.py
@@ -1,0 +1,207 @@
+import datetime
+import json
+import logging
+from types import SimpleNamespace
+
+from lumibot.strategies import strategy as strategy_module
+from lumibot.strategies._strategy import Vars, _Strategy
+from lumibot.strategies.strategy_executor import StrategyExecutor
+from lumibot.traders.trader import Trader
+
+
+class _DummyBroker:
+    IS_BACKTESTING_BROKER = False
+    market = "NYSE"
+
+    def __init__(self):
+        self._first_iteration = True
+        self._orders_queue = SimpleNamespace(queue=[])
+        self.closed = False
+        self.strategy_name = None
+        self.trading_days = None
+
+    def is_backtesting_broker(self):
+        return False
+
+    def set_strategy_name(self, name):
+        self.strategy_name = name
+
+    def initialize_market_calendars(self, trading_days):
+        self.trading_days = trading_days
+
+    def is_market_open(self):
+        return True
+
+    def _close_connection(self):
+        self.closed = True
+
+
+class _DummyStrategy:
+    def __init__(self):
+        self.broker = _DummyBroker()
+        self._name = "dummy"
+        self.parameters = {}
+        self.is_backtesting = False
+        self.logger = logging.getLogger("test_scheduled_run_once")
+        self.sleeptime = "1D"
+        self._analysis = {}
+        self._first_iteration = True
+        self._last_on_trading_iteration_datetime = None
+        self.portfolio_value = 100
+        self.cash = 100
+        self.vars = Vars()
+        self.rows = []
+        self.initialized = 0
+        self.before_starting = 0
+        self.iterations = 0
+        self.ended = 0
+        self.backups = 0
+
+    @property
+    def name(self):
+        return self._name
+
+    def log_message(self, *args, **kwargs):
+        return None
+
+    def initialize(self):
+        self.initialized += 1
+
+    def before_starting_trading(self):
+        self.before_starting += 1
+
+    def on_trading_iteration(self):
+        self.iterations += 1
+        self.vars.set("ran", self.iterations)
+
+    def on_strategy_end(self):
+        self.ended += 1
+
+    def _dump_stats(self):
+        self._analysis = {"iterations": self.iterations}
+
+    def _update_portfolio_value(self):
+        return None
+
+    def _apply_daily_cash_financing_if_needed(self):
+        return None
+
+    def _copy_dict(self):
+        return {}
+
+    def trace_stats(self, context, snapshot_before):
+        return {}
+
+    def get_datetime(self):
+        return datetime.datetime(2026, 5, 11, 9, 30)
+
+    def get_positions(self):
+        return []
+
+    def _append_row(self, row):
+        self.rows.append(row)
+
+    def send_account_summary_to_discord(self):
+        return None
+
+    def load_variables_from_db(self):
+        return None
+
+    def backup_variables_to_db(self):
+        self.backups += 1
+
+    def on_bot_crash(self, error):
+        return None
+
+
+def test_strategy_executor_run_once_runs_one_live_iteration(monkeypatch):
+    monkeypatch.setattr(
+        "lumibot.strategies.strategy_executor.get_trading_days",
+        lambda market: [{"date": datetime.date(2026, 5, 11)}],
+    )
+    strategy = _DummyStrategy()
+    executor = StrategyExecutor(strategy)
+    executor.sync_broker = lambda: None
+
+    assert executor.run_once() is True
+
+    assert strategy.initialized == 1
+    assert strategy.before_starting == 1
+    assert strategy.iterations == 1
+    assert strategy.ended == 1
+    assert strategy.backups >= 1
+    assert strategy.broker.closed is True
+    assert executor.result == {"iterations": 1}
+
+
+def test_trader_run_all_run_once_uses_executor_run_once():
+    class Executor:
+        name = "dummy"
+        result = {"ok": True}
+        exception = None
+
+        def __init__(self):
+            self.called = False
+
+        def run_once(self):
+            self.called = True
+
+    class Strategy:
+        broker = _DummyBroker()
+
+        def __init__(self):
+            self._executor = Executor()
+
+    strategy = Strategy()
+    trader = Trader(strategies=[strategy])
+
+    result = trader.run_all(run_once=True)
+
+    assert strategy._executor.called is True
+    assert result == {"dummy": {"ok": True}}
+
+
+def test_run_live_enables_run_once_for_scheduled_execution(monkeypatch):
+    captured = {}
+
+    class DummyTrader:
+        def add_strategy(self, strategy):
+            captured["strategy"] = strategy
+
+        def run_all(self, **kwargs):
+            captured.update(kwargs)
+
+    strategy = object.__new__(strategy_module.Strategy)
+    monkeypatch.setattr(strategy_module, "Trader", DummyTrader)
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_EXECUTION", "true")
+
+    strategy_module.Strategy.run_live(strategy)
+
+    assert captured["strategy"] is strategy
+    assert captured["run_once"] is True
+
+
+def test_scheduled_state_file_loads_and_persists_self_vars(tmp_path, monkeypatch):
+    state_file = tmp_path / "scheduled_state.json"
+    state_file.write_text('{"count": 2, "trade_date": "2026-05-11"}', encoding="utf-8")
+    strategy = object.__new__(_Strategy)
+    strategy.is_backtesting = False
+    strategy.vars = Vars()
+    strategy.logger = logging.getLogger("test_scheduled_state")
+    strategy._last_backup_state = None
+
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_EXECUTION", "true")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_STATE_BACKEND", "s3")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_STATE_FILE", str(state_file))
+
+    _Strategy.load_variables_from_db(strategy)
+
+    assert strategy.vars.get("count") == 2
+    assert strategy.vars.get("trade_date") == datetime.date(2026, 5, 11)
+
+    strategy.vars.set("count", 3)
+    _Strategy.backup_variables_to_db(strategy)
+
+    persisted = json.loads(state_file.read_text(encoding="utf-8"))
+    assert persisted["count"] == 3
+    assert persisted["trade_date"] == "2026-05-11"

--- a/tests/test_scheduled_run_once.py
+++ b/tests/test_scheduled_run_once.py
@@ -13,12 +13,13 @@ class _DummyBroker:
     IS_BACKTESTING_BROKER = False
     market = "NYSE"
 
-    def __init__(self):
+    def __init__(self, market_open=True):
         self._first_iteration = True
         self._orders_queue = SimpleNamespace(queue=[])
         self.closed = False
         self.strategy_name = None
         self.trading_days = None
+        self.market_open = market_open
 
     def is_backtesting_broker(self):
         return False
@@ -30,7 +31,7 @@ class _DummyBroker:
         self.trading_days = trading_days
 
     def is_market_open(self):
-        return True
+        return self.market_open
 
     def _close_connection(self):
         self.closed = True
@@ -114,6 +115,19 @@ class _DummyStrategy:
         return None
 
 
+class _ScheduledStateDummyStrategy(_DummyStrategy, _Strategy):
+    load_variables_from_db = _Strategy.load_variables_from_db
+    backup_variables_to_db = _Strategy.backup_variables_to_db
+
+    @property
+    def cash(self):
+        return self._cash
+
+    @cash.setter
+    def cash(self, value):
+        self._cash = value
+
+
 def test_strategy_executor_run_once_runs_one_live_iteration(monkeypatch):
     monkeypatch.setattr(
         "lumibot.strategies.strategy_executor.get_trading_days",
@@ -181,9 +195,40 @@ def test_run_live_enables_run_once_for_scheduled_execution(monkeypatch):
     assert captured["run_once"] is True
 
 
+def test_run_live_explicit_run_once_false_overrides_env(monkeypatch):
+    captured = {}
+
+    class DummyTrader:
+        def add_strategy(self, strategy):
+            captured["strategy"] = strategy
+
+        def run_all(self, **kwargs):
+            captured.update(kwargs)
+
+    strategy = object.__new__(strategy_module.Strategy)
+    monkeypatch.setattr(strategy_module, "Trader", DummyTrader)
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_EXECUTION", "true")
+
+    strategy_module.Strategy.run_live(strategy, run_once=False)
+
+    assert captured["strategy"] is strategy
+    assert captured["run_once"] is False
+
+
 def test_scheduled_state_file_loads_and_persists_self_vars(tmp_path, monkeypatch):
     state_file = tmp_path / "scheduled_state.json"
-    state_file.write_text('{"count": 2, "trade_date": "2026-05-11"}', encoding="utf-8")
+    state_file.write_text(
+        json.dumps(
+            {
+                "count": 2,
+                "trade_date": "2026-05-11",
+                "run_date": {"__lumibot_type__": "date", "value": "2026-05-10"},
+                "run_at": {"__lumibot_type__": "datetime", "value": "2026-05-11T09:30:00"},
+                "bands": {"__lumibot_type__": "tuple", "value": ["low", "high"]},
+            }
+        ),
+        encoding="utf-8",
+    )
     strategy = object.__new__(_Strategy)
     strategy.is_backtesting = False
     strategy.vars = Vars()
@@ -197,11 +242,71 @@ def test_scheduled_state_file_loads_and_persists_self_vars(tmp_path, monkeypatch
     _Strategy.load_variables_from_db(strategy)
 
     assert strategy.vars.get("count") == 2
-    assert strategy.vars.get("trade_date") == datetime.date(2026, 5, 11)
+    assert strategy.vars.get("trade_date") == "2026-05-11"
+    assert strategy.vars.get("run_date") == datetime.date(2026, 5, 10)
+    assert strategy.vars.get("run_at") == datetime.datetime(2026, 5, 11, 9, 30)
+    assert strategy.vars.get("bands") == ("low", "high")
 
     strategy.vars.set("count", 3)
+    strategy.vars.set("next_date", datetime.date(2026, 5, 12))
+    strategy.vars.set("limits", (1, datetime.date(2026, 5, 13)))
     _Strategy.backup_variables_to_db(strategy)
 
     persisted = json.loads(state_file.read_text(encoding="utf-8"))
     assert persisted["count"] == 3
     assert persisted["trade_date"] == "2026-05-11"
+    assert persisted["next_date"] == {"__lumibot_type__": "date", "value": "2026-05-12"}
+    assert persisted["limits"] == {
+        "__lumibot_type__": "tuple",
+        "value": [1, {"__lumibot_type__": "date", "value": "2026-05-13"}],
+    }
+
+
+def test_run_once_restores_state_before_closed_market_exit(tmp_path, monkeypatch):
+    state_file = tmp_path / "scheduled_state.json"
+    state_file.write_text('{"count": 2}', encoding="utf-8")
+    monkeypatch.setattr(
+        "lumibot.strategies.strategy_executor.get_trading_days",
+        lambda market: [{"date": datetime.date(2026, 5, 11)}],
+    )
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_EXECUTION", "true")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_STATE_BACKEND", "s3")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_STATE_FILE", str(state_file))
+
+    strategy = _ScheduledStateDummyStrategy()
+    strategy.broker = _DummyBroker(market_open=False)
+    executor = StrategyExecutor(strategy)
+    executor.sync_broker = lambda: None
+
+    assert executor.run_once() is True
+
+    persisted = json.loads(state_file.read_text(encoding="utf-8"))
+    assert persisted == {"count": 2}
+    assert strategy.iterations == 0
+
+
+def test_run_once_restores_state_before_lifecycle_hooks(tmp_path, monkeypatch):
+    state_file = tmp_path / "scheduled_state.json"
+    state_file.write_text('{"count": 2}', encoding="utf-8")
+    monkeypatch.setattr(
+        "lumibot.strategies.strategy_executor.get_trading_days",
+        lambda market: [{"date": datetime.date(2026, 5, 11)}],
+    )
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_EXECUTION", "true")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_STATE_BACKEND", "s3")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_STATE_FILE", str(state_file))
+
+    class Strategy(_ScheduledStateDummyStrategy):
+        def before_starting_trading(self):
+            super().before_starting_trading()
+            self.vars.set("count", self.vars.get("count") + 1)
+
+    strategy = Strategy()
+    executor = StrategyExecutor(strategy)
+    executor.sync_broker = lambda: None
+
+    assert executor.run_once() is True
+
+    persisted = json.loads(state_file.read_text(encoding="utf-8"))
+    assert persisted["count"] == 3
+    assert strategy.iterations == 1


### PR DESCRIPTION
## Summary
- add live one-shot execution for externally scheduled LumiBot runs
- persist scheduled self.vars through a Bot Manager-provided state file
- document the scheduled execution environment variables

## Tests
- .venv/bin/python -m pytest tests/test_scheduled_run_once.py -q
- .venv/bin/python -m compileall -q lumibot/strategies/_strategy.py lumibot/strategies/strategy.py lumibot/strategies/strategy_executor.py lumibot/traders/trader.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-shot scheduled live execution: run a single live iteration and exit (env var or explicit parameter).
  * Optional persistence/restoration of strategy variables for scheduled runs via a configurable state backend/file.

* **Documentation**
  * Added docs describing one-shot scheduled execution and three environment variables controlling mode and state backend/file.

* **Tests**
  * New tests covering one-shot runs, state restore/persist, lifecycle ordering, and closed-market behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1022)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->