### PR TITLE
v4.5.12 - Backtest data cache fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.12 - Unreleased
+## 4.5.12 - 2026-05-13
+
+Deploy marker: 4.5.12 release commit (`deploy 4.5.12`)
 
 ### Fixed
 - **IBKR REST backtesting no longer treats underfilled minute history as full-window coverage.** If a full backtest-window prefetch returns only a later tail slice, `get_last_price()` / `get_quote()` now leave the series unmarked as fully loaded, fetch a bounded slice around the current simulation datetime, and retry. This fixes BotSpot option backtests where an Apr-09 Alpha Picks lookup was incorrectly attempted against a May-only minute cache and logged “outside data range.” Disjoint recovery slices are normalized before merging so timezone object differences cannot leave the stale slice in place.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - **IBKR REST backtesting no longer treats underfilled minute history as full-window coverage.** If a full backtest-window prefetch returns only a later tail slice, `get_last_price()` / `get_quote()` now leave the series unmarked as fully loaded, fetch a bounded slice around the current simulation datetime, and retry. This fixes BotSpot option backtests where an Apr-09 Alpha Picks lookup was incorrectly attempted against a May-only minute cache and logged “outside data range.” Disjoint recovery slices are normalized before merging so timezone object differences cannot leave the stale slice in place.
+- **ThetaData option quote caches now recover from stale provider-expiry placeholders.** Placeholder-only option quote caches now record the Theta provider expiration used for Friday/Saturday expiry mapping, and LumiBot refetches once when a legacy placeholder was written before the correct provider mapping was learned. This prevents a no-data placeholder from blocking later valid option quotes for symbols whose Theta history endpoint expects the exact Friday expiry.
 
 ## 4.5.11 - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.5.12 - Unreleased
 
+### Fixed
+- **IBKR REST backtesting no longer treats underfilled minute history as full-window coverage.** If a full backtest-window prefetch returns only a later tail slice, `get_last_price()` / `get_quote()` now leave the series unmarked as fully loaded, fetch a bounded slice around the current simulation datetime, and retry. This fixes BotSpot option backtests where an Apr-09 Alpha Picks lookup was incorrectly attempted against a May-only minute cache and logged “outside data range.” Disjoint recovery slices are normalized before merging so timezone object differences cannot leave the stale slice in place.
+
 ## 4.5.11 - 2026-05-12
 
 Deploy marker: 4.5.11 release commit (`deploy 4.5.11`)

--- a/lumibot/backtesting/interactive_brokers_rest_backtesting.py
+++ b/lumibot/backtesting/interactive_brokers_rest_backtesting.py
@@ -109,6 +109,63 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         return f"{qty}{unit}"
 
     @staticmethod
+    def _series_covers_requested_window(
+        data: Optional[Data],
+        *,
+        asset: Asset,
+        timestep: str,
+        start_dt: datetime,
+        end_dt: datetime,
+    ) -> bool:
+        df = getattr(data, "df", None) if data is not None else None
+        try:
+            return ibkr_helper.frame_covers_requested_window(
+                df,
+                asset=asset,
+                timestep=timestep,
+                start_dt=start_dt,
+                end_dt=end_dt,
+            )
+        except Exception:
+            return False
+
+    def _refresh_window_around_datetime(
+        self,
+        *,
+        asset: Asset,
+        quote: Optional[Asset],
+        dataset_key: str,
+        dt: datetime,
+        exchange: Optional[str],
+        include_after_hours: bool,
+    ) -> None:
+        """Fetch a bounded slice around the current sim time after a full-window underfill.
+
+        IBKR history is capped to roughly 1000 bars per request and can return only the tail of a
+        larger requested minute window. If a full-window prefetch is underfilled, do not keep asking
+        Apr-09 lookups to use a May-only cache; fetch the local simulation-day slice and retry.
+        """
+        try:
+            start_dt = max(self.datetime_start, dt - timedelta(days=7))
+        except Exception:
+            start_dt = dt - timedelta(days=7)
+        try:
+            end_dt = min(self.datetime_end, dt + timedelta(days=1))
+        except Exception:
+            end_dt = dt + timedelta(days=1)
+        if start_dt >= end_dt:
+            end_dt = dt
+        self._update_pandas_data(
+            asset,
+            quote,
+            dataset_key,
+            start_dt=start_dt,
+            end_dt=end_dt,
+            exchange=exchange,
+            include_after_hours=include_after_hours,
+        )
+
+    @staticmethod
     def _previous_us_futures_session_open(dt_value: datetime) -> Optional[datetime]:
         """Return the most recent `us_futures` session open at or before `dt_value`.
 
@@ -223,13 +280,35 @@ class InteractiveBrokersRESTBacktesting(PandasData):
                 )
             except Exception:
                 pass
-            self._fully_loaded_series.add(minute_key)
+            minute_data = self._data_store.get(minute_key)
+            if self._series_covers_requested_window(
+                minute_data,
+                asset=base_asset,
+                timestep="minute",
+                start_dt=self.datetime_start,
+                end_dt=self.datetime_end,
+            ):
+                self._fully_loaded_series.add(minute_key)
         data = self._data_store.get(minute_key)
         if data is not None:
             try:
                 return data.get_last_price(now)
             except Exception:
-                pass
+                if minute_key not in self._fully_loaded_series:
+                    try:
+                        self._refresh_window_around_datetime(
+                            asset=base_asset,
+                            quote=quote_asset,
+                            dataset_key="minute",
+                            dt=now,
+                            exchange=effective_exchange,
+                            include_after_hours=True,
+                        )
+                        refreshed = self._data_store.get(minute_key)
+                        if refreshed is not None:
+                            return refreshed.get_last_price(now)
+                    except Exception:
+                        pass
         return None
 
     def get_quote(self, asset, quote=None, exchange=None, **kwargs):
@@ -323,7 +402,15 @@ class InteractiveBrokersRESTBacktesting(PandasData):
                 )
             except Exception:
                 pass
-            self._fully_loaded_series.add(minute_key)
+            minute_data = self._data_store.get(minute_key)
+            if self._series_covers_requested_window(
+                minute_data,
+                asset=base_asset,
+                timestep="minute",
+                start_dt=self.datetime_start,
+                end_dt=self.datetime_end,
+            ):
+                self._fully_loaded_series.add(minute_key)
 
         minute_data = self._data_store.get(minute_key)
         if minute_data is None:
@@ -331,7 +418,25 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         try:
             ohlcv_bid_ask_dict = minute_data.get_quote(now)
         except Exception:
-            return Quote(asset=base_asset)
+            if minute_key not in self._fully_loaded_series:
+                try:
+                    self._refresh_window_around_datetime(
+                        asset=base_asset,
+                        quote=quote_asset,
+                        dataset_key="minute",
+                        dt=now,
+                        exchange=effective_exchange,
+                        include_after_hours=True,
+                    )
+                    minute_data = self._data_store.get(minute_key)
+                    if minute_data is not None:
+                        ohlcv_bid_ask_dict = minute_data.get_quote(now)
+                    else:
+                        return Quote(asset=base_asset)
+                except Exception:
+                    return Quote(asset=base_asset)
+            else:
+                return Quote(asset=base_asset)
         return Quote(
             asset=base_asset,
             price=ohlcv_bid_ask_dict.get("close"),
@@ -386,6 +491,16 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             merged = merged[~merged.index.duplicated(keep="last")]
         else:
             merged = df
+        if len(merged.index) > 0:
+            # Merging disjoint IBKR slices can mix pandas/pytz/zoneinfo-aware timestamp objects.
+            # Normalize before constructing Data so a recovery fetch for Apr bars can merge with
+            # an existing May-only cache instead of failing and leaving the stale slice in place.
+            try:
+                merged = merged.copy()
+                merged.index = pd.to_datetime(merged.index, utc=True)
+                merged = merged.sort_index()
+            except Exception:
+                pass
 
         # `Data` supports only base units ("minute"/"day"). Store multi-minute datasets under a
         # separate key (e.g., "15minute") and annotate the instance so it can fast-path slices

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -2264,6 +2264,9 @@ def get_price_data(
     cache_invalid = False
     cache_file = build_cache_filename(asset, timespan, datastyle)
     remote_payload = build_remote_cache_payload(asset, timespan, datastyle)
+    provider_expiration = _option_provider_expiration_for_asset(asset)
+    if provider_expiration is not None:
+        remote_payload["provider_expiration"] = provider_expiration
     cache_manager = get_backtest_cache()
 
     if cache_manager.enabled:
@@ -2363,6 +2366,22 @@ def get_price_data(
     )
 
     sidecar_data = _load_cache_sidecar(cache_file)
+
+    if (
+        df_all is not None
+        and not df_all.empty
+        and cached_rows > 0
+        and placeholder_rows == cached_rows
+        and _placeholder_option_cache_needs_provider_expiry_refresh(asset, sidecar_data, remote_payload)
+    ):
+        cache_invalid = True
+        logger.info(
+            "[THETA][CACHE][PLACEHOLDER_PROVIDER_EXPIRY_REFRESH] asset=%s span=%s datastyle=%s; "
+            "placeholder-only cache was written without the current provider expiration mapping",
+            asset,
+            timespan,
+            datastyle,
+        )
 
     def _validate_cache_frame(
         frame: Optional[pd.DataFrame],
@@ -4412,6 +4431,7 @@ def _load_cache_sidecar(cache_file: Path) -> Optional[Dict[str, Any]]:
 def _build_sidecar_payload(
     df_working: pd.DataFrame,
     checksum: Optional[str],
+    remote_payload: Optional[Dict[str, object]] = None,
 ) -> Dict[str, Any]:
     min_ts = df_working.index.min() if len(df_working) > 0 else None
     max_ts = df_working.index.max() if len(df_working) > 0 else None
@@ -4427,6 +4447,11 @@ def _build_sidecar_payload(
         "checksum": checksum,
         "updated": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     }
+    if remote_payload:
+        payload["cache_payload"] = {
+            str(key): _isoformat_cache_payload_value(value)
+            for key, value in remote_payload.items()
+        }
     return payload
 
 
@@ -4434,10 +4459,11 @@ def _write_cache_sidecar(
     cache_file: Path,
     df_working: pd.DataFrame,
     checksum: Optional[str],
+    remote_payload: Optional[Dict[str, object]] = None,
 ) -> None:
     sidecar = _cache_sidecar_path(cache_file)
     try:
-        payload = _build_sidecar_payload(df_working, checksum)
+        payload = _build_sidecar_payload(df_working, checksum, remote_payload=remote_payload)
         sidecar.write_text(json.dumps(payload, indent=2))
         logger.debug(
             "[THETA][DEBUG][CACHE][SIDECAR_WRITE] %s rows=%d real_rows=%d placeholders=%d",
@@ -4570,7 +4596,7 @@ def update_cache(cache_file, df_all, df_cached, missing_dates=None, remote_paylo
     checksum = _hash_file(cache_file)
     sidecar_path = None
     try:
-        _write_cache_sidecar(cache_file, df_working, checksum)
+        _write_cache_sidecar(cache_file, df_working, checksum, remote_payload=remote_payload)
         sidecar_path = _cache_sidecar_path(cache_file)
     except Exception:
         # Sidecar is best-effort; failures shouldn't block cache writes.
@@ -6238,6 +6264,73 @@ def _thetadata_option_query_expiration(expiration: date, *, symbol: Optional[str
             return mapped
 
     return _thetadata_option_query_expiration_heuristic(expiration)
+
+
+def _isoformat_cache_payload_value(value: object) -> object:
+    """Return a JSON-friendly representation for cache sidecar metadata."""
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _option_provider_expiration_for_asset(asset: Asset) -> Optional[date]:
+    """Return the ThetaData provider expiration for an option asset, if known."""
+    if getattr(asset, "asset_type", None) != "option" or getattr(asset, "expiration", None) is None:
+        return None
+    try:
+        return _thetadata_option_query_expiration(
+            asset.expiration,
+            symbol=_thetadata_option_root_symbol(asset),
+        )
+    except Exception:
+        return None
+
+
+def _placeholder_option_cache_needs_provider_expiry_refresh(
+    asset: Asset,
+    sidecar_data: Optional[Dict[str, Any]],
+    remote_payload: Optional[Dict[str, object]],
+) -> bool:
+    """Detect placeholder-only option caches written with a stale provider expiry convention."""
+    if getattr(asset, "asset_type", None) != "option" or getattr(asset, "expiration", None) is None:
+        return False
+
+    current_provider_expiration = None
+    if remote_payload:
+        current_provider_expiration = remote_payload.get("provider_expiration")
+    if isinstance(current_provider_expiration, date):
+        current_provider_expiration = current_provider_expiration.isoformat()
+    elif current_provider_expiration is not None:
+        current_provider_expiration = str(current_provider_expiration)
+
+    if not current_provider_expiration:
+        provider_expiration = _option_provider_expiration_for_asset(asset)
+        if provider_expiration is None:
+            return False
+        current_provider_expiration = provider_expiration.isoformat()
+
+    stored_provider_expiration = None
+    if isinstance(sidecar_data, dict):
+        cache_payload = sidecar_data.get("cache_payload")
+        if isinstance(cache_payload, dict):
+            stored_provider_expiration = cache_payload.get("provider_expiration")
+    if isinstance(stored_provider_expiration, date):
+        stored_provider_expiration = stored_provider_expiration.isoformat()
+    elif stored_provider_expiration is not None:
+        stored_provider_expiration = str(stored_provider_expiration)
+
+    if stored_provider_expiration:
+        return stored_provider_expiration != current_provider_expiration
+
+    # Legacy placeholder-only sidecars did not record which provider expiry was queried. If a
+    # chain-derived mapping now overrides the old Saturday heuristic, refetch once under the
+    # learned provider convention and write the provider expiry into the sidecar.
+    heuristic_expiration = _thetadata_option_query_expiration_heuristic(asset.expiration)
+    return heuristic_expiration.isoformat() != current_provider_expiration
 
 
 def _normalize_strike_value(raw_value: object) -> Optional[float]:

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -2372,7 +2372,12 @@ def get_price_data(
         and not df_all.empty
         and cached_rows > 0
         and placeholder_rows == cached_rows
-        and _placeholder_option_cache_needs_provider_expiry_refresh(asset, sidecar_data, remote_payload)
+        and _placeholder_option_cache_needs_provider_expiry_refresh(
+            asset,
+            sidecar_data,
+            remote_payload,
+            allow_legacy_without_payload=(timespan != "day" and str(datastyle).lower() == "quote"),
+        )
     ):
         cache_invalid = True
         logger.info(
@@ -6294,6 +6299,8 @@ def _placeholder_option_cache_needs_provider_expiry_refresh(
     asset: Asset,
     sidecar_data: Optional[Dict[str, Any]],
     remote_payload: Optional[Dict[str, object]],
+    *,
+    allow_legacy_without_payload: bool = False,
 ) -> bool:
     """Detect placeholder-only option caches written with a stale provider expiry convention."""
     if getattr(asset, "asset_type", None) != "option" or getattr(asset, "expiration", None) is None:
@@ -6328,7 +6335,12 @@ def _placeholder_option_cache_needs_provider_expiry_refresh(
 
     # Legacy placeholder-only sidecars did not record which provider expiry was queried. If a
     # chain-derived mapping now overrides the old Saturday heuristic, refetch once under the
-    # learned provider convention and write the provider expiry into the sidecar.
+    # learned provider convention and write the provider expiry into the sidecar. Keep this
+    # opt-in because option day/EOD placeholder caches are deliberate stable negative caches in
+    # acceptance runs; refreshing all legacy EOD placeholders breaks warm-cache determinism.
+    if not allow_legacy_without_payload:
+        return False
+
     heuristic_expiration = _thetadata_option_query_expiration_heuristic(asset.expiration)
     return heuristic_expiration.isoformat() != current_provider_expiration
 

--- a/tests/test_interactive_brokers_rest_backtesting_unit.py
+++ b/tests/test_interactive_brokers_rest_backtesting_unit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 
@@ -196,4 +197,60 @@ def test_ibkr_rest_futures_minute_prefetch_stays_unloaded_when_coverage_fails(mo
         include_after_hours=True,
     )
 
+    assert (asset, quote, "minute", "AUTO") not in ds._fully_loaded_series
+
+
+def test_ibkr_rest_get_last_price_refetches_current_slice_after_underfilled_minute_prefetch(monkeypatch):
+    """Do not answer an Apr sim-time lookup from a May-only minute cache.
+
+    Regression for the Alpha Picks option backtests: the full-window minute prefetch returned only
+    the tail of the requested window, then `get_last_price()` marked that May-only frame as fully
+    loaded. The next Apr-09 lookup failed as "outside data range" instead of fetching Apr-09 data.
+    """
+
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    ny = ZoneInfo("America/New_York")
+    calls = []
+
+    def fake_get_price_data(*, asset, quote, timestep, start_dt, end_dt, exchange=None, include_after_hours=True, source=None):
+        calls.append((start_dt, end_dt))
+        if pd.Timestamp(end_dt).date() >= datetime(2026, 5, 1).date():
+            idx = pd.DatetimeIndex(
+                [
+                    datetime(2026, 5, 4, 9, 30, tzinfo=ny),
+                    datetime(2026, 5, 7, 16, 0, tzinfo=ny),
+                ]
+            )
+            closes = [100.0, 101.0]
+        else:
+            idx = pd.DatetimeIndex(
+                [
+                    datetime(2026, 4, 9, 9, 30, tzinfo=ny),
+                    datetime(2026, 4, 9, 9, 31, tzinfo=ny),
+                ]
+            )
+            closes = [42.0, 43.0]
+        return pd.DataFrame(
+            {"open": closes, "high": closes, "low": closes, "close": closes, "volume": [10, 11]},
+            index=idx,
+        )
+
+    monkeypatch.setattr(ibkr_helper, "get_price_data", fake_get_price_data)
+
+    ds = InteractiveBrokersRESTBacktesting(
+        datetime_start=datetime(2026, 4, 9, tzinfo=ny),
+        datetime_end=datetime(2026, 5, 8, 23, 59, tzinfo=ny),
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    ds._update_datetime(datetime(2026, 4, 9, 9, 30, tzinfo=ny))
+
+    asset = Asset(symbol="MU", asset_type=Asset.AssetType.STOCK)
+    quote = Asset(symbol="USD", asset_type=Asset.AssetType.FOREX)
+
+    assert ds.get_last_price(asset) == 42.0
+    assert len(calls) == 2
+    assert calls[0][1].date().isoformat() == "2026-05-08"
+    assert calls[1][1].date().isoformat() == "2026-04-10"
     assert (asset, quote, "minute", "AUTO") not in ds._fully_loaded_series

--- a/tests/test_thetadata_option_expiration_mapping.py
+++ b/tests/test_thetadata_option_expiration_mapping.py
@@ -105,6 +105,13 @@ def test_placeholder_option_cache_refetches_when_provider_expiry_mapping_changes
         option,
         {"version": 2, "rows": 1, "real_rows": 0, "placeholders": 1},
         remote_payload,
+        allow_legacy_without_payload=True,
+    )
+    assert not _placeholder_option_cache_needs_provider_expiry_refresh(
+        option,
+        {"version": 2, "rows": 1, "real_rows": 0, "placeholders": 1},
+        remote_payload,
+        allow_legacy_without_payload=False,
     )
     assert _placeholder_option_cache_needs_provider_expiry_refresh(
         option,

--- a/tests/test_thetadata_option_expiration_mapping.py
+++ b/tests/test_thetadata_option_expiration_mapping.py
@@ -1,8 +1,10 @@
 from datetime import date
 
+from lumibot.entities import Asset
 from lumibot.tools.thetadata_helper import (
     _THETADATA_EXPIRY_MAP,
     _THETADATA_EXPIRY_MAP_LOCK,
+    _placeholder_option_cache_needs_provider_expiry_refresh,
     _register_thetadata_expiry_map_from_chain,
     _thetadata_option_query_expiration,
 )
@@ -80,6 +82,40 @@ def test_thetadata_expiration_mapping_prefers_exact_friday_when_both_exist() -> 
     }
     _register_thetadata_expiry_map_from_chain("CVNA", chain)
     assert _thetadata_option_query_expiration(date(2018, 2, 16), symbol="CVNA") == date(2018, 2, 16)
+
+    with _THETADATA_EXPIRY_MAP_LOCK:
+        _THETADATA_EXPIRY_MAP.clear()
+
+
+def test_placeholder_option_cache_refetches_when_provider_expiry_mapping_changes() -> None:
+    """Legacy no-data placeholders must not block a later correctly mapped Theta quote request."""
+    with _THETADATA_EXPIRY_MAP_LOCK:
+        _THETADATA_EXPIRY_MAP.clear()
+
+    chain = {
+        "UnderlyingSymbol": "LITE",
+        "Chains": {"CALL": {"2027-01-15": [920.0]}, "PUT": {}},
+    }
+    _register_thetadata_expiry_map_from_chain("LITE", chain)
+
+    option = Asset("LITE", "option", expiration=date(2027, 1, 15), strike=920.0, right="CALL")
+    remote_payload = {"provider_expiration": date(2027, 1, 15)}
+
+    assert _placeholder_option_cache_needs_provider_expiry_refresh(
+        option,
+        {"version": 2, "rows": 1, "real_rows": 0, "placeholders": 1},
+        remote_payload,
+    )
+    assert _placeholder_option_cache_needs_provider_expiry_refresh(
+        option,
+        {"cache_payload": {"provider_expiration": "2027-01-16"}},
+        remote_payload,
+    )
+    assert not _placeholder_option_cache_needs_provider_expiry_refresh(
+        option,
+        {"cache_payload": {"provider_expiration": "2027-01-15"}},
+        remote_payload,
+    )
 
     with _THETADATA_EXPIRY_MAP_LOCK:
         _THETADATA_EXPIRY_MAP.clear()


### PR DESCRIPTION
What / Why:
Release 4.5.12 fixes two BotSpot backtesting data issues found while enabling AlphaPicks option backtests. IBKR REST backtesting no longer marks underfilled minute history as complete coverage, and ThetaData option quote caches now recover from stale provider-expiry placeholders without disturbing stable day/EOD negative caches.

Risk:
Data cache behavior changes can affect backtest hydration paths. Main risks are unexpected downloader submissions, stale placeholder reuse, or altered option quote availability. Detect via acceptance backtest queue telemetry, BotSpot backtest settings.json, and option quote logs.

Tests run:
- python3 -m pytest tests/test_ibkr_helper_unit.py tests/test_interactive_brokers_rest_backtesting_unit.py tests/test_thetadata_option_expiration_mapping.py -q -> 22 passed
- python3 -m pytest tests/test_thetadata_option_expiration_mapping.py tests/test_thetadata_quote_only_fetch.py tests/test_options_helper_thetadata_actionable_strikes.py -q -> 13 passed
- python3 -m pytest tests/backtest/test_acceptance_backtests_ci.py::test_acceptance_meli_deep_drawdown --tb=short -vv -> 1 passed
- python3 -m pytest -m "not apitest and not downloader" --tb=short -q --durations=30 -> timed out at 20 minutes after entering slow acceptance tests; isolated failing MELI cache invariant was fixed and rerun green.

Perf evidence:
No performance claim. The MELI acceptance rerun took about 363s after the cache-refresh scope fix.

Docs:
CHANGELOG.md updated for 4.5.12. No docs visuals needed; this is internal backtesting/cache correctness behavior with no user-facing UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Interactive Brokers REST backtesting now properly handles incomplete minute-level historical data by intelligently retrying with adjusted time windows around the simulation timestamp
  * ThetaData option quote caching now recovers from stale expiration mappings by detecting and automatically refetching outdated cached data

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1025)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->