### PR TITLE
v4.5.13 - IBKR point-in-time backtest lookup fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 4.5.13 - Unreleased
+## 4.5.13 - 2026-05-13
+
+Deploy marker: 4.5.13 release commit (`deploy 4.5.13`)
+
+### Fixed
+- **IBKR REST backtesting point-in-time option price lookups now fetch bounded minute slices around the simulation time.** `get_last_price()` and `get_quote()` no longer prefetch the full backtest window for point lookups, which avoids IBKR returning only a later tail segment and then mispricing earlier AlphaPicks option entries.
 
 ## 4.5.12 - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.13 - Unreleased
+
 ## 4.5.12 - 2026-05-13
 
 Deploy marker: 4.5.12 release commit (`deploy 4.5.12`)

--- a/lumibot/backtesting/interactive_brokers_rest_backtesting.py
+++ b/lumibot/backtesting/interactive_brokers_rest_backtesting.py
@@ -164,6 +164,17 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             exchange=exchange,
             include_after_hours=include_after_hours,
         )
+        canonical_key, _ = self._build_dataset_keys(asset, quote, dataset_key, exchange)
+        data = self._data_store.get(canonical_key)
+        df = getattr(data, "df", None) if data is not None else None
+        if ibkr_helper.frame_covers_requested_window(
+            df,
+            asset=asset,
+            timestep=dataset_key,
+            start_dt=self.datetime_start,
+            end_dt=self.datetime_end,
+        ):
+            self._fully_loaded_series.add(canonical_key)
 
     @staticmethod
     def _previous_us_futures_session_open(dt_value: datetime) -> Optional[datetime]:

--- a/lumibot/backtesting/interactive_brokers_rest_backtesting.py
+++ b/lumibot/backtesting/interactive_brokers_rest_backtesting.py
@@ -208,7 +208,10 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         window is prohibitively slow (and unnecessary). Prefer the daily series for crypto when
         available, which is derived from intraday history and aligned to LumiBot's day cadence.
 
-        For non-crypto, keep the existing minute-first behavior to preserve prior semantics.
+        For point-in-time intraday lookups, fetch a bounded slice around the current simulation
+        time instead of prefetching the full backtest window at minute granularity. IBKR can cap
+        large minute requests to the tail of the requested range, which is both slow and can leave
+        an April lookup backed only by May bars.
         """
         base_asset = asset
         quote_asset = quote
@@ -267,48 +270,32 @@ class InteractiveBrokersRESTBacktesting(PandasData):
                     pass
 
         minute_key = (base_asset, quote_asset, "minute", self._normalize_exchange_key(effective_exchange))
-        if minute_key not in self._fully_loaded_series:
-            try:
-                self._update_pandas_data(
-                    base_asset,
-                    quote_asset,
-                    "minute",
-                    start_dt=self.datetime_start,
-                    end_dt=self.datetime_end,
-                    exchange=effective_exchange,
-                    include_after_hours=True,
-                )
-            except Exception:
-                pass
-            minute_data = self._data_store.get(minute_key)
-            if self._series_covers_requested_window(
-                minute_data,
-                asset=base_asset,
-                timestep="minute",
-                start_dt=self.datetime_start,
-                end_dt=self.datetime_end,
-            ):
-                self._fully_loaded_series.add(minute_key)
         data = self._data_store.get(minute_key)
         if data is not None:
             try:
                 return data.get_last_price(now)
             except Exception:
-                if minute_key not in self._fully_loaded_series:
-                    try:
-                        self._refresh_window_around_datetime(
-                            asset=base_asset,
-                            quote=quote_asset,
-                            dataset_key="minute",
-                            dt=now,
-                            exchange=effective_exchange,
-                            include_after_hours=True,
-                        )
-                        refreshed = self._data_store.get(minute_key)
-                        if refreshed is not None:
-                            return refreshed.get_last_price(now)
-                    except Exception:
-                        pass
+                pass
+
+        if minute_key not in self._fully_loaded_series:
+            try:
+                self._refresh_window_around_datetime(
+                    asset=base_asset,
+                    quote=quote_asset,
+                    dataset_key="minute",
+                    dt=now,
+                    exchange=effective_exchange,
+                    include_after_hours=True,
+                )
+            except Exception:
+                pass
+
+        data = self._data_store.get(minute_key)
+        if data is not None:
+            try:
+                return data.get_last_price(now)
+            except Exception:
+                pass
         return None
 
     def get_quote(self, asset, quote=None, exchange=None, **kwargs):
@@ -389,32 +376,25 @@ class InteractiveBrokersRESTBacktesting(PandasData):
                     pass
 
         minute_key = (base_asset, quote_asset, "minute", self._normalize_exchange_key(effective_exchange))
-        if minute_key not in self._fully_loaded_series:
-            try:
-                self._update_pandas_data(
-                    base_asset,
-                    quote_asset,
-                    "minute",
-                    start_dt=self.datetime_start,
-                    end_dt=self.datetime_end,
-                    exchange=effective_exchange,
-                    include_after_hours=True,
-                )
-            except Exception:
-                pass
-            minute_data = self._data_store.get(minute_key)
-            if self._series_covers_requested_window(
-                minute_data,
-                asset=base_asset,
-                timestep="minute",
-                start_dt=self.datetime_start,
-                end_dt=self.datetime_end,
-            ):
-                self._fully_loaded_series.add(minute_key)
-
         minute_data = self._data_store.get(minute_key)
         if minute_data is None:
-            return Quote(asset=base_asset)
+            if minute_key not in self._fully_loaded_series:
+                try:
+                    self._refresh_window_around_datetime(
+                        asset=base_asset,
+                        quote=quote_asset,
+                        dataset_key="minute",
+                        dt=now,
+                        exchange=effective_exchange,
+                        include_after_hours=True,
+                    )
+                    minute_data = self._data_store.get(minute_key)
+                except Exception:
+                    return Quote(asset=base_asset)
+            minute_data = self._data_store.get(minute_key)
+            if minute_data is None:
+                return Quote(asset=base_asset)
+
         try:
             ohlcv_bid_ask_dict = minute_data.get_quote(now)
         except Exception:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.12",
+    version="4.5.13",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import atexit
 import threading
 import os
 import json
+from unittest import mock
 from pathlib import Path
 from dotenv import load_dotenv
 from collections import defaultdict
@@ -85,6 +86,47 @@ if os.getcwd() != str(project_root):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "ibkr: downloader-only IBKR tests that do not require Polygon or ThetaData credentials")
+
+
+class _PatchProxy:
+    def __init__(self, patches):
+        self._patches = patches
+
+    def __call__(self, *args, **kwargs):
+        patcher = mock.patch(*args, **kwargs)
+        patched = patcher.start()
+        self._patches.append(patcher)
+        return patched
+
+    def object(self, *args, **kwargs):
+        patcher = mock.patch.object(*args, **kwargs)
+        patched = patcher.start()
+        self._patches.append(patcher)
+        return patched
+
+
+class _SimpleMocker:
+    Mock = mock.Mock
+    MagicMock = mock.MagicMock
+    call = mock.call
+
+    def __init__(self):
+        self._patches = []
+        self.patch = _PatchProxy(self._patches)
+
+    def stopall(self):
+        while self._patches:
+            self._patches.pop().stop()
+
+
+@pytest.fixture
+def mocker():
+    """Small pytest-mock compatible fixture for tests that only need patch/Mock."""
+    fixture = _SimpleMocker()
+    try:
+        yield fixture
+    finally:
+        fixture.stopall()
 
 
 def cleanup_all_schedulers():

--- a/tests/test_interactive_brokers_rest_backtesting_unit.py
+++ b/tests/test_interactive_brokers_rest_backtesting_unit.py
@@ -200,12 +200,12 @@ def test_ibkr_rest_futures_minute_prefetch_stays_unloaded_when_coverage_fails(mo
     assert (asset, quote, "minute", "AUTO") not in ds._fully_loaded_series
 
 
-def test_ibkr_rest_get_last_price_refetches_current_slice_after_underfilled_minute_prefetch(monkeypatch):
+def test_ibkr_rest_get_last_price_fetches_current_slice_without_full_window_prefetch(monkeypatch):
     """Do not answer an Apr sim-time lookup from a May-only minute cache.
 
-    Regression for the Alpha Picks option backtests: the full-window minute prefetch returned only
-    the tail of the requested window, then `get_last_price()` marked that May-only frame as fully
-    loaded. The next Apr-09 lookup failed as "outside data range" instead of fetching Apr-09 data.
+    Regression for the Alpha Picks option backtests: a full-window minute prefetch can return only
+    the tail of the requested window. Spot lookups should fetch the local simulation slice directly
+    instead of downloading the whole backtest window at minute granularity.
     """
 
     import lumibot.tools.ibkr_helper as ibkr_helper
@@ -250,7 +250,7 @@ def test_ibkr_rest_get_last_price_refetches_current_slice_after_underfilled_minu
     quote = Asset(symbol="USD", asset_type=Asset.AssetType.FOREX)
 
     assert ds.get_last_price(asset) == 42.0
-    assert len(calls) == 2
-    assert calls[0][1].date().isoformat() == "2026-05-08"
-    assert calls[1][1].date().isoformat() == "2026-04-10"
+    assert len(calls) == 1
+    assert calls[0][0].date().isoformat() == "2026-04-09"
+    assert calls[0][1].date().isoformat() == "2026-04-10"
     assert (asset, quote, "minute", "AUTO") not in ds._fully_loaded_series

--- a/tests/test_thetadata_helper.py
+++ b/tests/test_thetadata_helper.py
@@ -1168,10 +1168,10 @@ def test_get_trading_dates():
         ('quote'),
     ],
 )
-def test_build_cache_filename(mocker, tmpdir, datastyle):
+def test_build_cache_filename(monkeypatch, tmpdir, datastyle):
     asset = Asset("SPY")
     timespan = "1D"
-    mocker.patch.object(thetadata_helper, "LUMIBOT_CACHE_FOLDER", str(tmpdir))
+    monkeypatch.setattr(thetadata_helper, "LUMIBOT_CACHE_FOLDER", str(tmpdir))
     expected = tmpdir / "thetadata" / "stock" / "1d" / datastyle / f"stock_SPY_1D_{datastyle}.parquet"
     assert thetadata_helper.build_cache_filename(asset, timespan, datastyle) == expected
 

--- a/tests/test_thetadata_helper.py
+++ b/tests/test_thetadata_helper.py
@@ -1273,8 +1273,8 @@ def test_missing_dates():
         'quote'),
     ],
 )
-def test_update_cache(mocker, tmpdir, df_all, df_cached, datastyle):
-    mocker.patch.object(thetadata_helper, "LUMIBOT_CACHE_FOLDER", str(tmpdir))
+def test_update_cache(monkeypatch, tmpdir, df_all, df_cached, datastyle):
+    monkeypatch.setattr(thetadata_helper, "LUMIBOT_CACHE_FOLDER", str(tmpdir))
     cache_file = thetadata_helper.build_cache_filename(Asset("SPY"), "1D", datastyle)
     
     # Empty DataFrame of df_all, don't write cache file
@@ -1577,9 +1577,9 @@ def test_get_price_data_invokes_remote_cache_manager(tmp_path, monkeypatch):
         'quote'),
     ],
 )
-def test_load_data_from_cache(mocker, tmpdir, df_cached, datastyle):
+def test_load_data_from_cache(monkeypatch, tmpdir, df_cached, datastyle):
     # Setup some basics
-    mocker.patch.object(thetadata_helper, "LUMIBOT_CACHE_FOLDER", str(tmpdir))
+    monkeypatch.setattr(thetadata_helper, "LUMIBOT_CACHE_FOLDER", str(tmpdir))
     asset = Asset("SPY")
     cache_file = thetadata_helper.build_cache_filename(asset, "1D", datastyle)
 


### PR DESCRIPTION
What / Why: Fixes IBKR REST backtesting point-in-time option quote lookups so AlphaPicks option backtests fetch bounded minute slices around the simulated datetime instead of prefetching the whole backtest window. This avoids IBKR returning only a later tail segment and causing bad earlier option prices.\n\nRisk: Low and localized to InteractiveBrokersRESTBacktesting get_last_price/get_quote fallback fetching. The main risk is extra small data requests on cache miss, but this replaces large full-window point lookup prefetches.\n\nTests run:\n- .venv/bin/python -m pytest tests/test_interactive_brokers_rest_backtesting_unit.py tests/test_get_last_price_sim_time_safety.py -q\n\nDocs: CHANGELOG.md updated. No diagrams needed for this patch-level backtesting data fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IBKR REST backtesting point-in-time option lookups now fetch bounded minute slices around the simulation time to avoid mispricing from incomplete prefetches.
* **Tests**
  * Unit tests updated to validate bounded-slice fetch behavior; test utilities/fixtures adjusted for more reliable mocking.
* **Chores**
  * Package version bumped to 4.5.13.
* **Documentation**
  * Added changelog entry for 4.5.13.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1026)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->