### PR TITLE
Fix CI Ruff downloader target

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -65,7 +65,7 @@ jobs:
           # tests this PR touches.
           ruff check --select F,I \
             lumibot/tools/thetadata_helper.py \
-            lumibot/tools/thetadata_queue_client.py \
+            lumibot/tools/data_downloader_queue_client.py \
             lumibot/backtesting/thetadata_backtesting_pandas.py \
             lumibot/components/options_helper.py \
             lumibot/strategies/_strategy.py \


### PR DESCRIPTION
Summary
- Point the CI Ruff check at data_downloader_queue_client.py.

Validation
- Parsed workflow YAML.