### PR TITLE
Lazy-load import startup paths

### DIFF
--- a/lumibot/__init__.py
+++ b/lumibot/__init__.py
@@ -1,8 +1,12 @@
+import importlib.util
 import os
+import re
 import sys
-import warnings
 import types
+import warnings
 from importlib.machinery import ModuleSpec
+
+_SETUP_VERSION_RE = re.compile(r"^\s*version\s*=\s*(['\"])(?P<version>.+?)\1\s*,?\s*$")
 
 
 def _read_version_from_setup_py() -> str | None:
@@ -19,12 +23,9 @@ def _read_version_from_setup_py() -> str | None:
             if os.path.isfile(setup_py):
                 with open(setup_py, encoding="utf-8", errors="ignore") as file:
                     for line in file:
-                        if "version" not in line:
-                            continue
-                        _, _, value = line.partition("=")
-                        value = value.strip().strip(",")
-                        if len(value) >= 2 and value[0] in "'\"" and value[-1] == value[0]:
-                            return value[1:-1].strip()
+                        match = _SETUP_VERSION_RE.match(line)
+                        if match:
+                            return match.group("version").strip()
             parent = os.path.dirname(current)
             if parent == current:
                 break
@@ -132,6 +133,7 @@ class _EntitiesAliasFinder:
 
 
 class _EntitiesAlias(types.ModuleType):
+    _lumibot_entities_alias = True
     __path__ = [os.path.join(os.path.dirname(os.path.abspath(__file__)), "entities")]
     __file__ = os.path.join(os.path.dirname(os.path.abspath(__file__)), "entities", "__init__.py")
     __package__ = "entities"
@@ -203,15 +205,34 @@ _ENTITY_SUBMODULES = (
     "smart_limit",
 )
 _ENTITY_SUBMODULE_ALIAS_NAMES = {f"entities.{_submodule}" for _submodule in _ENTITY_SUBMODULES}
-if not any(getattr(_finder, "_lumibot_entities_alias_finder", False) for _finder in sys.meta_path):
-    sys.meta_path.insert(0, _EntitiesAliasFinder())
 
-sys.modules.setdefault("entities", _EntitiesAlias("entities"))
-for _submodule in _ENTITY_SUBMODULES:
-    sys.modules.setdefault(
-        f"entities.{_submodule}",
-        _EntitiesSubmoduleAlias(f"entities.{_submodule}", f"lumibot.entities.{_submodule}"),
-    )
+
+def _has_entities_alias_finder() -> bool:
+    return any(getattr(_finder, "_lumibot_entities_alias_finder", False) for _finder in sys.meta_path)
+
+
+def _entities_package_exists() -> bool:
+    existing = sys.modules.get("entities")
+    if existing is not None and not getattr(existing, "_lumibot_entities_alias", False):
+        return True
+    if _has_entities_alias_finder():
+        return False
+    try:
+        return importlib.util.find_spec("entities") is not None
+    except (ImportError, AttributeError, ValueError):
+        return False
+
+
+if not _entities_package_exists():
+    if not _has_entities_alias_finder():
+        sys.meta_path.insert(0, _EntitiesAliasFinder())
+
+    sys.modules.setdefault("entities", _EntitiesAlias("entities"))
+    for _submodule in _ENTITY_SUBMODULES:
+        sys.modules.setdefault(
+            f"entities.{_submodule}",
+            _EntitiesSubmoduleAlias(f"entities.{_submodule}", f"lumibot.entities.{_submodule}"),
+        )
 
 
 def __getattr__(name):

--- a/lumibot/__init__.py
+++ b/lumibot/__init__.py
@@ -1,13 +1,8 @@
 import os
 import sys
 import warnings
-import importlib
-import re
-from pathlib import Path
-
-from lumibot.tools.lumibot_logger import get_logger
-
-logger = get_logger(__name__)
+import types
+from importlib.machinery import ModuleSpec
 
 
 def _read_version_from_setup_py() -> str | None:
@@ -18,15 +13,22 @@ def _read_version_from_setup_py() -> str | None:
     """
 
     try:
-        module_path = Path(__file__).resolve()
-        for parent in module_path.parents:
-            setup_py = parent / "setup.py"
-            if not setup_py.is_file():
-                continue
-            text = setup_py.read_text(encoding="utf-8", errors="ignore")
-            match = re.search(r"version\s*=\s*['\"]([^'\"]+)['\"]", text)
-            if match:
-                return match.group(1).strip()
+        current = os.path.dirname(os.path.abspath(__file__))
+        while True:
+            setup_py = os.path.join(current, "setup.py")
+            if os.path.isfile(setup_py):
+                with open(setup_py, encoding="utf-8", errors="ignore") as file:
+                    for line in file:
+                        if "version" not in line:
+                            continue
+                        _, _, value = line.partition("=")
+                        value = value.strip().strip(",")
+                        if len(value) >= 2 and value[0] in "'\"" and value[-1] == value[0]:
+                            return value[1:-1].strip()
+            parent = os.path.dirname(current)
+            if parent == current:
+                break
+            current = parent
     except Exception:
         pass
     return None
@@ -49,8 +51,6 @@ except ImportError:
 except:
     __version__ = "unknown"
 
-logger.info(f"LumiBot v{__version__} starting")
-
 # Get the major and minor Python version
 major, minor = sys.version_info[:2]
 
@@ -59,66 +59,187 @@ if (major, minor) < (3, 10):
     warnings.warn("Lumibot requires Python 3.10 or higher.", RuntimeWarning)
 
 # SOURCE PATH
-# Import constants from constants module (before importing submodules to avoid circular imports)
-from .constants import (
-    LUMIBOT_CACHE_FOLDER,
-    LUMIBOT_DEFAULT_PYTZ,
-    LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL,
-    LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE,
-    LUMIBOT_DEFAULT_TIMEZONE,
-    LUMIBOT_SOURCE_PATH,
-)
+LUMIBOT_SOURCE_PATH = os.path.dirname(os.path.abspath(__file__))
+LUMIBOT_DEFAULT_TIMEZONE = "America/New_York"
+LUMIBOT_DEFAULT_QUOTE_ASSET_SYMBOL = "USD"
+LUMIBOT_DEFAULT_QUOTE_ASSET_TYPE = "forex"
 
-# Import main submodules (after constants to avoid circular imports)
-from . import backtesting, brokers, data_sources, entities, strategies, traders
+
+def _default_cache_folder() -> str:
+    env_value = os.environ.get("LUMIBOT_CACHE_FOLDER")
+    if env_value:
+        return env_value
+    if sys.platform == "darwin":
+        return os.path.expanduser("~/Library/Caches/lumibot/1.0")
+    if os.name == "nt":
+        root = os.environ.get("LOCALAPPDATA") or os.path.expanduser("~\\AppData\\Local")
+        return os.path.join(root, "LumiWealth", "lumibot", "Cache", "1.0")
+    root = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return os.path.join(root, "lumibot", "1.0")
+
+
+LUMIBOT_CACHE_FOLDER = _default_cache_folder()
 
 # Ensure cache folder exists
 if not os.path.exists(LUMIBOT_CACHE_FOLDER):
     try:
         os.makedirs(LUMIBOT_CACHE_FOLDER)
     except Exception as e:
-        logger.critical(
+        warnings.warn(
             f"""Could not create cache folder because of the following error:
             {e}. Please fix the issue to use data caching."""
         )
 
-# === Backward Compatibility Aliases ===
-# Some older code and documentation may still refer to the top-level
-# package name `entities` (e.g. `entities.asset`) that existed in
-# earlier Lumibot versions.  To avoid breaking those references we
-# expose `lumibot.entities` and its sub-modules under the legacy name
-# when the library is imported.
+_SUBMODULE_EXPORTS = {
+    "strategies",
+    "brokers",
+    "backtesting",
+    "entities",
+    "data_sources",
+    "traders",
+    "tools",
+    "components",
+    "constants",
+    "credentials",
+    "trading_builtins",
+}
 
-# Map the root package alias.
-import lumibot.entities as _lb_entities
-sys.modules.setdefault("entities", _lb_entities)
 
-# Expose common sub-modules (asset, bars, data, order, position, trading_fee)
-# so that e.g. `import entities.asset` keeps working.
-for _sub in ("asset", "bars", "data", "order", "position", "trading_fee"):
-    _full = f"lumibot.entities.{_sub}"
-    _alias = f"entities.{_sub}"
-    try:
-        _mod = importlib.import_module(_full)
-        sys.modules[_alias] = _mod
-    except ModuleNotFoundError as e:
-        # If a particular sub-module was removed or fails to import (e.g., due to deeper issues like 'fp')
-        # log a warning and skip. Sphinx will simply not find this specific alias.
-        logger.warning(f"[lumibot/__init__.py] Could not create alias '{_alias}' for '{_full}': {e}")
-        # Ensure the problematic alias isn't lingering if it was partially set or if it's a mock
-        if _alias in sys.modules and isinstance(sys.modules[_alias], importlib.util.LazyLoader):
-            pass # Don't remove if it's a lazy loader that might resolve later or differently
-        elif _alias in sys.modules:
-            # If it's a real module or a simple mock that failed, best to remove its alias attempt
-            # to avoid Sphinx confusion with a potentially broken module object.
-            # However, if Sphinx/autodoc is running, it might be safer to leave mocks as they are.
-            # For now, we'll log and continue, letting Sphinx handle missing modules.
-            # Reconsidering removal: could interfere with Sphinx's own mock handling.
-            pass # Reconsidering removal: could interfere with Sphinx's own mock handling
-    except ImportError as e: # Catch other import-related errors
-        logger.warning(f"[lumibot/__init__.py] ImportError while creating alias '{_alias}' for '{_full}': {e}")
-    except Exception as e: # Catch any other unexpected errors during aliasing
-        logger.warning(f"[lumibot/__init__.py] Unexpected error creating alias '{_alias}' for '{_full}': {e}")
+class _EntitiesAliasLoader:
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        load = module.__dict__.get("_load")
+        if load is not None:
+            load()
+
+
+_ENTITIES_ALIAS_LOADER = _EntitiesAliasLoader()
+
+
+class _EntitiesAliasFinder:
+    _lumibot_entities_alias_finder = True
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname in _ENTITY_SUBMODULE_ALIAS_NAMES:
+            return ModuleSpec(fullname, _ENTITIES_ALIAS_LOADER, is_package=False)
+        if fullname == "entities":
+            spec = ModuleSpec(fullname, _ENTITIES_ALIAS_LOADER, is_package=True)
+            spec.submodule_search_locations = _EntitiesAlias.__path__
+            return spec
+        return None
+
+
+class _EntitiesAlias(types.ModuleType):
+    __path__ = [os.path.join(os.path.dirname(os.path.abspath(__file__)), "entities")]
+    __file__ = os.path.join(os.path.dirname(os.path.abspath(__file__)), "entities", "__init__.py")
+    __package__ = "entities"
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.__spec__ = ModuleSpec(name, _ENTITIES_ALIAS_LOADER, is_package=True)
+        self.__spec__.submodule_search_locations = self.__path__
+
+    def __getattr__(self, name):
+        import importlib
+
+        entities_module = importlib.import_module("lumibot.entities")
+        if name in getattr(entities_module, "__all__", ()):
+            value = getattr(entities_module, name)
+            setattr(self, name, value)
+            return value
+
+        alias = sys.modules.get(f"entities.{name}")
+        if alias is not None:
+            return alias
+
+        try:
+            module = importlib.import_module(f"lumibot.entities.{name}")
+            sys.modules[f"entities.{name}"] = module
+        except ModuleNotFoundError:
+            module = importlib.import_module(f"entities.{name}")
+        return module
+
+
+class _EntitiesSubmoduleAlias(types.ModuleType):
+    def __init__(self, alias_name: str, target_name: str):
+        super().__init__(alias_name)
+        self.__package__ = "entities"
+        self.__spec__ = ModuleSpec(alias_name, _ENTITIES_ALIAS_LOADER, is_package=False)
+        self._target_name = target_name
+        self._target_module = None
+
+    def _load(self):
+        import importlib
+
+        module = self._target_module
+        if module is None:
+            module = importlib.import_module(self._target_name)
+            self._target_module = module
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __dir__(self):
+        return dir(self._load())
+
+
+_ENTITY_SUBMODULES = (
+    "asset",
+    "bar",
+    "bars",
+    "cash_event",
+    "chains",
+    "data",
+    "data_polars",
+    "dataline",
+    "order",
+    "position",
+    "quote",
+    "trading_fee",
+    "trading_slippage",
+    "smart_limit",
+)
+_ENTITY_SUBMODULE_ALIAS_NAMES = {f"entities.{_submodule}" for _submodule in _ENTITY_SUBMODULES}
+if not any(getattr(_finder, "_lumibot_entities_alias_finder", False) for _finder in sys.meta_path):
+    sys.meta_path.insert(0, _EntitiesAliasFinder())
+
+sys.modules.setdefault("entities", _EntitiesAlias("entities"))
+for _submodule in _ENTITY_SUBMODULES:
+    sys.modules.setdefault(
+        f"entities.{_submodule}",
+        _EntitiesSubmoduleAlias(f"entities.{_submodule}", f"lumibot.entities.{_submodule}"),
+    )
+
+
+def __getattr__(name):
+    if name == "LUMIBOT_DEFAULT_PYTZ":
+        from .constants import LUMIBOT_DEFAULT_PYTZ
+
+        globals()[name] = LUMIBOT_DEFAULT_PYTZ
+        return LUMIBOT_DEFAULT_PYTZ
+    if name in _SUBMODULE_EXPORTS:
+        import importlib
+
+        module = importlib.import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    if name == "get_logger":
+        from lumibot.tools.lumibot_logger import get_logger
+
+        globals()[name] = get_logger
+        return get_logger
+    if name == "logger":
+        logger = __getattr__("get_logger")(__name__)
+        globals()[name] = logger
+        return logger
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))
 
 # Export the default timezone constants so they can be imported by other modules
 __all__ = [
@@ -134,5 +255,12 @@ __all__ = [
     'backtesting',
     'entities',
     'data_sources',
-    'traders'
+    'traders',
+    'tools',
+    'components',
+    'constants',
+    'credentials',
+    'trading_builtins',
+    'get_logger',
+    'logger',
 ]

--- a/lumibot/backtesting/__init__.py
+++ b/lumibot/backtesting/__init__.py
@@ -1,32 +1,37 @@
-from .alpaca_backtesting import AlpacaBacktesting
-from .alpha_vantage_backtesting import AlphaVantageBacktesting
-from .backtesting_broker import BacktestingBroker
-from .ccxt_backtesting import CcxtBacktesting
-from .interactive_brokers_rest_backtesting import InteractiveBrokersRESTBacktesting
-from .pandas_backtesting import PandasDataBacktesting
-from .polygon_backtesting import PolygonDataBacktesting
-from .routed_backtesting import RoutedBacktestingPandas
-from .thetadata_backtesting import ThetaDataBacktesting
-from .thetadata_backtesting_pandas import ThetaDataBacktestingPandas
-from .yahoo_backtesting import YahooDataBacktesting
+"""Backtesting package exports without importing every backend."""
 
-from .databento_backtesting import DataBentoDataBacktesting
-from .databento_backtesting_pandas import DataBentoDataBacktestingPandas
-from .databento_backtesting_polars import DataBentoDataBacktestingPolars
+from importlib import import_module as _import_module
 
-__all__ = [
-    "AlpacaBacktesting",
-    "AlphaVantageBacktesting",
-    "BacktestingBroker",
-    "CcxtBacktesting",
-    "InteractiveBrokersRESTBacktesting",
-    "PandasDataBacktesting",
-    "PolygonDataBacktesting",
-    "RoutedBacktestingPandas",
-    "ThetaDataBacktesting",
-    "ThetaDataBacktestingPandas",
-    "YahooDataBacktesting",
-    "DataBentoDataBacktesting",
-    "DataBentoDataBacktestingPandas",
-    "DataBentoDataBacktestingPolars",
-]
+_NAME_TO_MODULE = {
+    "AlpacaBacktesting": "alpaca_backtesting",
+    "AlphaVantageBacktesting": "alpha_vantage_backtesting",
+    "BacktestingBroker": "backtesting_broker",
+    "CcxtBacktesting": "ccxt_backtesting",
+    "DataBentoDataBacktesting": "databento_backtesting",
+    "DataBentoDataBacktestingPandas": "databento_backtesting_pandas",
+    "DataBentoDataBacktestingPolars": "databento_backtesting_polars",
+    "InteractiveBrokersRESTBacktesting": "interactive_brokers_rest_backtesting",
+    "PandasDataBacktesting": "pandas_backtesting",
+    "PolygonDataBacktesting": "polygon_backtesting",
+    "RoutedBacktestingPandas": "routed_backtesting",
+    "ThetaDataBacktesting": "thetadata_backtesting",
+    "ThetaDataBacktestingPandas": "thetadata_backtesting_pandas",
+    "YahooDataBacktesting": "yahoo_backtesting",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/brokers/__init__.py
+++ b/lumibot/brokers/__init__.py
@@ -1,11 +1,35 @@
-from .alpaca import Alpaca
-from .bitunix import Bitunix
-from .broker import Broker, LumibotBrokerAPIError
-from .ccxt import Ccxt
-from .example_broker import ExampleBroker
-from .interactive_brokers import InteractiveBrokers
-from .interactive_brokers_rest import InteractiveBrokersREST
-from .projectx import ProjectX
-from .schwab import Schwab
-from .tradier import Tradier
-from .tradovate import Tradovate
+"""Broker package exports without importing every broker backend."""
+
+from importlib import import_module as _import_module
+
+_NAME_TO_MODULE = {
+    "Alpaca": "alpaca",
+    "Bitunix": "bitunix",
+    "Broker": "broker",
+    "LumibotBrokerAPIError": "broker",
+    "Ccxt": "ccxt",
+    "ExampleBroker": "example_broker",
+    "InteractiveBrokers": "interactive_brokers",
+    "InteractiveBrokersREST": "interactive_brokers_rest",
+    "ProjectX": "projectx",
+    "Schwab": "schwab",
+    "Tradier": "tradier",
+    "Tradovate": "tradovate",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/components/__init__.py
+++ b/lumibot/components/__init__.py
@@ -1,9 +1,32 @@
-from .agents import AgentManager, AgentRunResult, BuiltinTools, MCPServer, agent_tool
+"""Lazy exports for optional component packages."""
 
-__all__ = [
+from importlib import import_module as _import_module
+
+_AGENT_EXPORTS = {
     "AgentManager",
     "AgentRunResult",
     "BuiltinTools",
     "MCPServer",
     "agent_tool",
-]
+}
+_SUBMODULES = {"agents"}
+
+__all__ = sorted(_AGENT_EXPORTS)
+
+
+def __getattr__(name):
+    if name in _SUBMODULES:
+        module = _import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+
+    if name in _AGENT_EXPORTS:
+        agents = _import_module(f"{__name__}.agents")
+        value = getattr(agents, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__) | _SUBMODULES)

--- a/lumibot/components/agents/__init__.py
+++ b/lumibot/components/agents/__init__.py
@@ -1,17 +1,47 @@
-from .builtins import BuiltinTools
-from .manager import AgentHandle, AgentManager
-from .runtime import GoogleADKRuntime, StubAgentRuntime
-from .schemas import AgentRunResult, AgentTraceEvent, MCPServer
-from .tools import agent_tool
+"""Lazy exports for agent runtime components."""
 
-__all__ = [
-    "AgentHandle",
-    "AgentManager",
-    "AgentRunResult",
-    "AgentTraceEvent",
-    "BuiltinTools",
-    "GoogleADKRuntime",
-    "MCPServer",
-    "StubAgentRuntime",
-    "agent_tool",
-]
+from importlib import import_module as _import_module
+
+_NAME_TO_MODULE = {
+    "AgentHandle": "manager",
+    "AgentManager": "manager",
+    "AgentRunResult": "schemas",
+    "AgentTraceEvent": "schemas",
+    "BuiltinTools": "builtins",
+    "GoogleADKRuntime": "runtime",
+    "MCPServer": "schemas",
+    "StubAgentRuntime": "runtime",
+    "agent_tool": "tools",
+}
+_SUBMODULES = {
+    "asset_resolution",
+    "builtins",
+    "docs_tools",
+    "duckdb_tools",
+    "manager",
+    "replay_cache",
+    "runtime",
+    "schemas",
+    "tools",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    if name in _SUBMODULES:
+        module = _import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__) | _SUBMODULES)

--- a/lumibot/components/agents/builtins.py
+++ b/lumibot/components/agents/builtins.py
@@ -2,11 +2,8 @@ import json
 import math
 import os
 from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
 from typing import Any, Literal
-
-import requests
-
-from lumibot.entities import Asset, Order
 
 from .docs_tools import search_lumibot_docs
 from .asset_resolution import resolve_asset_and_quote
@@ -31,6 +28,55 @@ COMMON_INDICATORS = [
     "roc",
     "stoch",
 ]
+
+
+class _LazyModule:
+    """Read-only proxy that imports the target module on first attribute access.
+
+    object.__setattr__ touches the internal slots directly; callers should only
+    read attributes through this proxy so module mutation is not hidden here.
+    """
+
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        if name in {"_module_name", "_module"}:
+            object.__setattr__(self, name, value)
+            return
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+            return
+        delattr(self._load(), name)
+
+
+requests = _LazyModule("requests")
+
+
+def _requests():
+    return requests
+
+
+def _asset_class():
+    from lumibot.entities import Asset
+
+    return Asset
 
 
 def _parse_datetime_value(value: Any) -> datetime | None:
@@ -476,7 +522,7 @@ def _bind_alpaca_news(strategy: Any, manager: Any) -> BoundTool:
         if page_token:
             params["page_token"] = page_token
 
-        response = requests.get(
+        response = _requests().get(
             "https://data.alpaca.markets/v1beta1/news",
             headers=auth_headers,
             params=params,
@@ -656,7 +702,7 @@ def _bind_get_indicator(strategy: Any, manager: Any) -> BoundTool:
         asset_type: AssetTypeArg = "stock",
         parameters_json: str | None = None,
     ) -> dict[str, Any]:
-        asset = Asset(symbol, asset_type=asset_type)
+        asset = _asset_class()(symbol, asset_type=asset_type)
         indicator_name = _require_non_empty_text("indicator", indicator)
         indicator_kwargs: dict[str, Any] = {}
         if parameters_json:

--- a/lumibot/components/agents/duckdb_tools.py
+++ b/lumibot/components/agents/duckdb_tools.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 import hashlib
 import re
 import time
 from collections import defaultdict
+from importlib import import_module
 from typing import Any
-
-import duckdb
-import pandas as pd
 
 from lumibot.tools.helpers import parse_timestep_qty_and_unit
 
@@ -13,6 +13,34 @@ from .asset_resolution import resolve_asset_and_quote
 
 
 _READ_ONLY_SQL_RE = re.compile(r"^\s*(select|with|show|describe|pragma|explain)\b", re.IGNORECASE)
+
+
+class _LazyModule:
+    """Proxy that imports a module on first attribute read.
+
+    object.__setattr__ and object.__getattribute__ bypass __getattr__ while the
+    internal slots are empty, avoiding recursion before the real module loads.
+    """
+
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+duckdb = _LazyModule("duckdb")
+pd = _LazyModule("pandas")
 
 
 class DuckDBQueryLayer:

--- a/lumibot/components/agents/manager.py
+++ b/lumibot/components/agents/manager.py
@@ -8,19 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-import pandas as pd
+from lumibot import LUMIBOT_CACHE_FOLDER
 
-from lumibot.constants import LUMIBOT_CACHE_FOLDER
-from lumibot.tools.parquet_utils import (
-    coerce_object_columns_to_json_strings,
-    is_parquet_required,
-    write_parquet_with_logging,
-)
-
-from .builtins import _order_to_dict, _position_to_dict
-from .duckdb_tools import DuckDBQueryLayer
-from .replay_cache import AgentReplayCache, _normalize_json
-from .runtime import GoogleADKRuntime, RuntimeRequest, StubAgentRuntime, call_mcp_tool
 from .schemas import AgentRunResult, AgentTraceEvent, BoundTool, MCPServer, ToolDefinition
 from .tools import bind_callable_tool
 
@@ -34,6 +23,80 @@ _DEFAULT_MEMORY_NOTE_MAX_CHARS = 2000
 
 class AgentModelCallLimitExceeded(RuntimeError):
     """Raised before a model call when the configured agent-call budget is exhausted."""
+
+
+_PANDAS_MODULE = None
+_REPLAY_IMPORTS = None
+_DUCKDB_QUERY_LAYER = None
+_RUNTIME_IMPORTS = None
+_PARQUET_UTILS = None
+_BUILTIN_SERIALIZERS = None
+
+
+def _get_pandas():
+    global _PANDAS_MODULE
+    if _PANDAS_MODULE is None:
+        import pandas as pd
+
+        _PANDAS_MODULE = pd
+    return _PANDAS_MODULE
+
+
+def _get_replay_imports():
+    global _REPLAY_IMPORTS
+    if _REPLAY_IMPORTS is None:
+        from .replay_cache import AgentReplayCache, _normalize_json as normalize_json
+
+        _REPLAY_IMPORTS = (AgentReplayCache, normalize_json)
+    return _REPLAY_IMPORTS
+
+
+def _normalize_json(value: Any) -> Any:
+    return _get_replay_imports()[1](value)
+
+
+def _get_duckdb_query_layer_class():
+    global _DUCKDB_QUERY_LAYER
+    if _DUCKDB_QUERY_LAYER is None:
+        from .duckdb_tools import DuckDBQueryLayer
+
+        _DUCKDB_QUERY_LAYER = DuckDBQueryLayer
+    return _DUCKDB_QUERY_LAYER
+
+
+def _get_runtime_imports():
+    global _RUNTIME_IMPORTS
+    if _RUNTIME_IMPORTS is None:
+        from .runtime import GoogleADKRuntime, RuntimeRequest, StubAgentRuntime, call_mcp_tool
+
+        _RUNTIME_IMPORTS = (GoogleADKRuntime, RuntimeRequest, StubAgentRuntime, call_mcp_tool)
+    return _RUNTIME_IMPORTS
+
+
+def _get_parquet_utils():
+    global _PARQUET_UTILS
+    if _PARQUET_UTILS is None:
+        from lumibot.tools.parquet_utils import (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+
+        _PARQUET_UTILS = (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        )
+    return _PARQUET_UTILS
+
+
+def _get_builtin_serializers():
+    global _BUILTIN_SERIALIZERS
+    if _BUILTIN_SERIALIZERS is None:
+        from .builtins import _order_to_dict, _position_to_dict
+
+        _BUILTIN_SERIALIZERS = (_order_to_dict, _position_to_dict)
+    return _BUILTIN_SERIALIZERS
 
 
 def _safe_call(func, default=None):
@@ -79,8 +142,15 @@ def _strategy_timezone_name(strategy: Any, current_dt: Any) -> str | None:
 
 
 def _serialize_recent_trade_events(strategy: Any, limit: int = 10) -> list[dict[str, Any]]:
+    """Serialize broker trade events; optional expand_trade_event_rows maps rows -> rows."""
+
     broker = getattr(strategy, "broker", None)
     rows = list(getattr(broker, "_trade_event_log_rows", []) or [])
+    expand_rows = getattr(broker, "expand_trade_event_rows", None)
+    if expand_rows is None:
+        expand_rows = getattr(broker, "_expand_trade_event_rows", None)
+    if callable(expand_rows):
+        rows = expand_rows(rows)
     columns = list(getattr(broker, "_trade_event_log_columns", []) or [])
     serialized: list[dict[str, Any]] = []
     for row in rows[-limit:]:
@@ -534,7 +604,8 @@ class AgentHandle:
             # Always include built-in tools, plus any custom tools the user added
             self._tool_inputs = builtin_tools + self._filter_tools_for_trading_permission(list(tools))
         self._mcp_servers = mcp_servers or []
-        self._runtime = runtime or GoogleADKRuntime(mcp_servers=self._mcp_servers)
+        google_runtime, _RuntimeRequest, _StubAgentRuntime, _call_mcp_tool = _get_runtime_imports()
+        self._runtime = runtime or google_runtime(mcp_servers=self._mcp_servers)
         self._bound_tools: list[BoundTool] | None = None
 
     def _filter_tools_for_trading_permission(self, tools: list[Any]) -> list[Any]:
@@ -587,6 +658,7 @@ class AgentHandle:
         if not hasattr(self.manager.strategy, "get_positions"):
             return []
         positions = _safe_call(lambda: self.manager.strategy.get_positions(include_cash_positions=True), default=[]) or []
+        _order_to_dict, _position_to_dict = _get_builtin_serializers()
         return [_position_to_dict(position) for position in positions]
 
     def _serialize_account_state(self) -> dict[str, Any]:
@@ -601,6 +673,7 @@ class AgentHandle:
         if not hasattr(self.manager.strategy, "get_orders"):
             return []
         orders = _safe_call(self.manager.strategy.get_orders, default=[]) or []
+        _order_to_dict, _position_to_dict = _get_builtin_serializers()
         return [_order_to_dict(order) for order in orders[-limit:]]
 
     def _runtime_mode(self) -> str:
@@ -768,6 +841,7 @@ class AgentHandle:
                                     color="yellow",
                                 )
                             self.manager._warned_backtest_mcp_tools.add(warning_key)
+                        _GoogleADKRuntime, _RuntimeRequest, _StubAgentRuntime, call_mcp_tool = _get_runtime_imports()
                         return call_mcp_tool(_server, _tool_name, payload)
 
                     return remote_tool
@@ -1194,7 +1268,8 @@ class AgentHandle:
                 self._log_run_summary(result, runtime_context)
                 return result
 
-        request = RuntimeRequest(
+        _GoogleADKRuntime, runtime_request_class, _StubAgentRuntime, _call_mcp_tool = _get_runtime_imports()
+        request = runtime_request_class(
             agent_name=self.name,
             model=model_name,
             system_prompt=effective_system_prompt,
@@ -1401,8 +1476,9 @@ class AgentManager:
         self._agents: dict[str, AgentHandle] = {}
         self._warned_backtest_mcp_tools: set[tuple[str, str]] = set()
         self._model_call_count = 0
-        self.replay_cache = AgentReplayCache()
-        self.duckdb = DuckDBQueryLayer(strategy)
+        agent_replay_cache_class, _ = _get_replay_imports()
+        self.replay_cache = agent_replay_cache_class()
+        self.duckdb = _get_duckdb_query_layer_class()(strategy)
         self._observability_totals: dict[str, dict[str, int]] = {}
         self._observability_call_index: dict[str, int] = {}
         self._observability_rows: dict[str, list[dict[str, Any]]] = {}
@@ -1563,7 +1639,12 @@ class AgentManager:
             )
         agent_rows = self._observability_rows.setdefault(handle.name, [])
         agent_rows.extend(rows)
-        detail_df = pd.DataFrame(agent_rows, columns=_AGENT_DETAIL_COLUMNS)
+        detail_df = _get_pandas().DataFrame(agent_rows, columns=_AGENT_DETAIL_COLUMNS)
+        (
+            coerce_object_columns_to_json_strings,
+            is_parquet_required,
+            write_parquet_with_logging,
+        ) = _get_parquet_utils()
         write_parquet_with_logging(
             df=detail_df,
             path=str(detail_path),

--- a/lumibot/components/agents/replay_cache.py
+++ b/lumibot/components/agents/replay_cache.py
@@ -11,7 +11,17 @@ from pathlib import Path
 from typing import Any
 
 from lumibot.constants import LUMIBOT_CACHE_FOLDER
-from lumibot.tools.backtest_cache import get_backtest_cache
+
+_BACKTEST_CACHE_GETTER = None
+
+
+def get_backtest_cache():
+    global _BACKTEST_CACHE_GETTER
+    if _BACKTEST_CACHE_GETTER is None:
+        from lumibot.tools.backtest_cache import get_backtest_cache as _get_backtest_cache
+
+        _BACKTEST_CACHE_GETTER = _get_backtest_cache
+    return _BACKTEST_CACHE_GETTER()
 
 
 def _normalize_json(value: Any) -> Any:

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -1,4 +1,5 @@
-import asyncio
+from __future__ import annotations
+
 import contextlib
 import hashlib
 import importlib
@@ -17,17 +18,31 @@ from datetime import date, datetime, timezone
 from typing import Any
 from uuid import uuid4
 
-import httpx
-from anyio import run as anyio_run
-from anyio.from_thread import start_blocking_portal
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
-
 from .schemas import AgentRunResult, AgentTraceEvent, BoundTool, MCPServer
 
 
 _GOOGLE_SDK_NOISE_FILTERS_CONFIGURED = False
+ClientSession = None
+StdioServerParameters = None
+stdio_client = None
+streamablehttp_client = None
+
+
+def _ensure_mcp_client_imports():
+    global ClientSession, StdioServerParameters, stdio_client, streamablehttp_client
+    if ClientSession is None or StdioServerParameters is None:
+        from mcp import ClientSession as _ClientSession, StdioServerParameters as _StdioServerParameters
+
+        ClientSession = _ClientSession
+        StdioServerParameters = _StdioServerParameters
+    if stdio_client is None:
+        from mcp.client.stdio import stdio_client as _stdio_client
+
+        stdio_client = _stdio_client
+    if streamablehttp_client is None:
+        from mcp.client.streamable_http import streamablehttp_client as _streamablehttp_client
+
+        streamablehttp_client = _streamablehttp_client
 
 
 class _GoogleGenAITypesNoiseFilter(logging.Filter):
@@ -835,6 +850,7 @@ class GoogleADKRuntime:
         return _classify_agent_error(exc) not in ("transient", "unknown")
 
     def run(self, request: RuntimeRequest) -> AgentRunResult:
+        import asyncio
         import time as _time
 
         last_exc: BaseException | None = None
@@ -959,6 +975,7 @@ def _jsonable(value: Any) -> Any:
 
 
 async def _with_mcp_session(server: MCPServer, callback):
+    _ensure_mcp_client_imports()
     transport = (server.transport or "http").lower().replace("-", "_")
     if transport == "stdio":
         parameters = StdioServerParameters(
@@ -989,10 +1006,16 @@ async def _with_mcp_session(server: MCPServer, callback):
 
 
 def _run_mcp_sync(async_fn, *args):
+    import asyncio
+
     try:
         asyncio.get_running_loop()
     except RuntimeError:
+        from anyio import run as anyio_run
+
         return anyio_run(async_fn, *args)
+    from anyio.from_thread import start_blocking_portal
+
     with start_blocking_portal() as portal:
         return portal.call(async_fn, *args)
 
@@ -1031,6 +1054,8 @@ async def _call_mcp_tool_async(server: MCPServer, name: str, arguments: dict[str
 
 
 async def _legacy_http_list_tools(server: MCPServer) -> list[dict[str, Any]]:
+    import httpx
+
     payload = {
         "jsonrpc": "2.0",
         "id": "tools-list",
@@ -1047,6 +1072,8 @@ async def _legacy_http_list_tools(server: MCPServer) -> list[dict[str, Any]]:
 
 
 async def _legacy_http_call_tool(server: MCPServer, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    import httpx
+
     payload = {
         "jsonrpc": "2.0",
         "id": f"{name}-call",

--- a/lumibot/components/drift_rebalancer_logic.py
+++ b/lumibot/components/drift_rebalancer_logic.py
@@ -1,13 +1,55 @@
+from __future__ import annotations
+
 import time
 from decimal import ROUND_DOWN, ROUND_UP, Decimal
-from typing import Any, Dict, List
-
-import pandas as pd
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from lumibot.entities import Asset, TradingFee
 from lumibot.entities.order import Order
-from lumibot.strategies.strategy import Strategy
-from lumibot.tools.pandas import prettify_dataframe_with_decimals
+
+if TYPE_CHECKING:
+    from lumibot.strategies.strategy import Strategy
+
+
+class _LazyModule:
+    """Defer module import until first attribute access.
+
+    Invariant: this proxy is for attribute reads such as pd.DataFrame; assignment
+    should not be routed through the underlying module.
+    """
+
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+# pandas stays behind a proxy so importing component logic does not import pandas.
+pd = _LazyModule("pandas")
+# Cache the prettifier on first use so importing drift logic stays lightweight.
+_PRETTIFY_DATAFRAME_WITH_DECIMALS = None
+
+
+def _prettify_dataframe_with_decimals(*args, **kwargs):
+    # First call imports the helper; later calls reuse the same function object.
+    global _PRETTIFY_DATAFRAME_WITH_DECIMALS
+    if _PRETTIFY_DATAFRAME_WITH_DECIMALS is None:
+        from lumibot.tools.pandas import prettify_dataframe_with_decimals
+
+        _PRETTIFY_DATAFRAME_WITH_DECIMALS = prettify_dataframe_with_decimals
+    return _PRETTIFY_DATAFRAME_WITH_DECIMALS(*args, **kwargs)
 
 
 class DriftType:
@@ -364,7 +406,7 @@ class DriftOrderLogic:
 
         # Just print the drift_df to the log but sort it by symbol column
         drift_df = drift_df.sort_values(by='symbol')
-        self.strategy.logger.info(f"drift_df:\n{prettify_dataframe_with_decimals(df=drift_df)}")
+        self.strategy.logger.info(f"drift_df:\n{_prettify_dataframe_with_decimals(df=drift_df)}")
 
         rebalance_needed = self._check_if_rebalance_needed(drift_df)
         if rebalance_needed:

--- a/lumibot/components/grok_helper.py
+++ b/lumibot/components/grok_helper.py
@@ -2,11 +2,15 @@ import json
 import re
 import time
 
-from openai import OpenAI
-
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _openai_client_class():
+    from openai import OpenAI
+
+    return OpenAI
 
 class GrokHelper:
     """
@@ -39,7 +43,7 @@ class GrokHelper:
                 raise ValueError("API key is required for GrokHelper. Set it as GROK_API_KEY or XAI_API_KEY in your environment or pass it directly.")
 
         self.api_key = api_key
-        self.client = OpenAI(
+        self.client = _openai_client_class()(
             api_key=self.api_key,
             base_url="https://api.x.ai/v1",
         )

--- a/lumibot/components/perplexity_helper.py
+++ b/lumibot/components/perplexity_helper.py
@@ -2,11 +2,15 @@ import json
 import re
 import time
 
-from openai import OpenAI
-
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _openai_client_class():
+    from openai import OpenAI
+
+    return OpenAI
 
 # --- constants ---------------------------------------------------------------
 _MODEL_LIMITS = {
@@ -126,7 +130,7 @@ class PerplexityHelper:
                 raise ValueError("API key is required for PerplexityHelper. Set it as PERPLEXITY_API_KEY in your environment or your secrets")
 
         self.api_key = api_key
-        self.client = OpenAI(
+        self.client = _openai_client_class()(
             api_key=self.api_key,
             base_url="https://api.perplexity.ai",  # Correct base URL
         )

--- a/lumibot/components/vix_helper.py
+++ b/lumibot/components/vix_helper.py
@@ -1,23 +1,9 @@
+from __future__ import annotations
+
 import datetime
 import traceback
 from datetime import timedelta
-
-import pandas as pd
-import yfinance as yf
-from scipy import stats
-import traceback
-import datetime
-
-# Fix for NumPy 2.0+ compatibility with pandas_ta
-import numpy as np
-
-# pandas_ta 0.3.14b uses numpy.NaN which was removed in NumPy 2.0
-# Create alias for backward compatibility if needed
-if not hasattr(np, 'NaN'):
-    np.NaN = np.nan
-
-# Import pandas-ta-classic
-import pandas_ta_classic as ta
+from importlib import import_module
 
 """ 
     Description
@@ -26,6 +12,51 @@ import pandas_ta_classic as ta
     This is a general component for working with the VIX. It can be used to check the 
     VIX, VIX 1D, VIX RSI, VIX percentile values and more.
 """
+
+
+class _LazyModule:
+    __slots__ = ("_module_name", "_module")
+
+    def __init__(self, module_name: str):
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name):
+        if name in {"_module_name", "_module"}:
+            object.__delattr__(self, name)
+        else:
+            delattr(self._load(), name)
+
+
+pd = _LazyModule("pandas")
+yf = _LazyModule("yfinance")
+stats = _LazyModule("scipy.stats")
+_TA_MODULE = None
+
+
+def _get_ta_module():
+    # Lazy-load pandas_ta_classic on the first RSI call so importing VixHelper
+    # does not pull NumPy/pandas-ta into startup paths that never compute RSI.
+    global _TA_MODULE
+    if _TA_MODULE is None:
+        np = import_module("numpy")
+        if not hasattr(np, "NaN"):
+            np.NaN = np.nan
+        _TA_MODULE = import_module("pandas_ta_classic")
+    return _TA_MODULE
 
 class VixHelper:
     def __init__(self, strategy) -> None:
@@ -420,7 +451,7 @@ class VixHelper:
         vix_df = pd.DataFrame(vix_values, columns=['VIX'])
 
         # Calculate the RSI
-        vix_df['RSI'] = ta.rsi(vix_df['VIX'], length=window)
+        vix_df['RSI'] = _get_ta_module().rsi(vix_df['VIX'], length=window)
 
         # Get the last VIX RSI value
         vix_rsi = vix_df['RSI'].iloc[-1]
@@ -1103,7 +1134,7 @@ class VixHelper:
         gvz_df = pd.DataFrame(gvz_values, columns=['GVZ'])
 
         # Calculate the RSI
-        gvz_df['RSI'] = ta.rsi(gvz_df['GVZ'], length=window)
+        gvz_df['RSI'] = _get_ta_module().rsi(gvz_df['GVZ'], length=window)
 
         # Get the last GVZ RSI value
         gvz_rsi = gvz_df['RSI'].iloc[-1]
@@ -1482,7 +1513,7 @@ class VixHelper:
         vix_df = pd.DataFrame(vix_values, columns=['VIX'])
 
         # Calculate the RSI
-        vix_df['RSI'] = ta.rsi(vix_df['VIX'], length=window)
+        vix_df['RSI'] = _get_ta_module().rsi(vix_df['VIX'], length=window)
 
         # Get the last VIX RSI value
         vix_rsi = vix_df['RSI'].iloc[-1]

--- a/lumibot/data_sources/__init__.py
+++ b/lumibot/data_sources/__init__.py
@@ -1,22 +1,51 @@
-from .alpaca_data import AlpacaData
-from .alpha_vantage_data import AlphaVantageData
-from .ccxt_data import CcxtData
-from .data_source import DataSource
-from .data_source_backtesting import DataSourceBacktesting
-from .exceptions import NoDataFound, UnavailabeTimestep
-from .interactive_brokers_data import InteractiveBrokersData
-from .pandas_data import PandasData
-from .polars_data import PolarsData
-from .tradier_data import TradierData
-from .bitunix_data import BitunixData
-from .ccxt_backtesting_data import CcxtBacktestingData
-from .example_broker_data import ExampleBrokerData
-from .interactive_brokers_rest_data import InteractiveBrokersRESTData
-from .schwab_data import SchwabData
-from .tradovate_data import TradovateData
-from .yahoo_data import YahooData
+"""Data source package exports without importing every provider backend."""
 
-from .databento_data import DataBentoData, DataBentoDataPandas, DataBentoDataPolars
-from .projectx_data import ProjectXData
+from importlib import import_module as _import_module
 
-from ..backtesting.polygon_backtesting import PolygonDataBacktesting
+_NAME_TO_MODULE = {
+    "AlpacaData": "alpaca_data",
+    "AlphaVantageData": "alpha_vantage_data",
+    "BitunixData": "bitunix_data",
+    "CcxtBacktestingData": "ccxt_backtesting_data",
+    "CcxtData": "ccxt_data",
+    "DataBentoData": "databento_data",
+    "DataBentoDataPandas": "databento_data",
+    "DataBentoDataPolars": "databento_data",
+    "DataSource": "data_source",
+    "DataSourceBacktesting": "data_source_backtesting",
+    "ExampleBrokerData": "example_broker_data",
+    "InteractiveBrokersData": "interactive_brokers_data",
+    "InteractiveBrokersRESTData": "interactive_brokers_rest_data",
+    "NoDataFound": "exceptions",
+    "PandasData": "pandas_data",
+    "PolarsData": "polars_data",
+    "PolygonDataBacktesting": "polygon_backtesting",
+    "ProjectXData": "projectx_data",
+    "SchwabData": "schwab_data",
+    "TradierData": "tradier_data",
+    "TradovateData": "tradovate_data",
+    "UnavailabeTimestep": "exceptions",
+    "YahooData": "yahoo_data",
+}
+
+_EXTERNAL_MODULES = {
+    "polygon_backtesting": "lumibot.backtesting.polygon_backtesting",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import_name = _EXTERNAL_MODULES.get(module_name, f"{__name__}.{module_name}")
+    module = _import_module(import_name)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/entities/__init__.py
+++ b/lumibot/entities/__init__.py
@@ -1,38 +1,39 @@
-from .asset import Asset, AssetsMapping
-from .bar import Bar
+"""Compatibility exports for entity classes without importing every entity."""
 
-# Import base implementations
-from .bars import Bars as _BarsBase
-from .cash_event import CashEvent
-from .chains import Chains
-from .data import Data as _DataBase
-from .data_polars import DataPolars
-from .dataline import Dataline
-from .order import Order
-from .position import Position
-from .quote import Quote
-from .trading_fee import TradingFee
-from .trading_slippage import TradingSlippage
-from .smart_limit import SmartLimitConfig, SmartLimitPreset
+from importlib import import_module as _import_module
 
-# Use base implementations directly
-Bars = _BarsBase
-Data = _DataBase
-__all__ = [
-    "Asset",
-    "AssetsMapping",
-    "Bar",
-    "Bars",
-    "CashEvent",
-    "Chains",
-    "Data",
-    "DataPolars",
-    "Dataline",
-    "Order",
-    "Position",
-    "Quote",
-    "TradingFee",
-    "TradingSlippage",
-    "SmartLimitConfig",
-    "SmartLimitPreset",
-]
+_NAME_TO_MODULE = {
+    "Asset": "asset",
+    "AssetsMapping": "asset",
+    "Bar": "bar",
+    "Bars": "bars",
+    "CashEvent": "cash_event",
+    "Chains": "chains",
+    "Data": "data",
+    "DataPolars": "data_polars",
+    "Dataline": "dataline",
+    "Order": "order",
+    "Position": "position",
+    "Quote": "quote",
+    "TradingFee": "trading_fee",
+    "TradingSlippage": "trading_slippage",
+    "SmartLimitConfig": "smart_limit",
+    "SmartLimitPreset": "smart_limit",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/strategies/__init__.py
+++ b/lumibot/strategies/__init__.py
@@ -1,2 +1,25 @@
-from .strategy import Strategy
-from .strategy_executor import StrategyExecutor
+"""Strategy package exports without importing executor unless requested."""
+
+from importlib import import_module as _import_module
+
+_NAME_TO_MODULE = {
+    "Strategy": "strategy",
+    "StrategyExecutor": "strategy_executor",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/tools/__init__.py
+++ b/lumibot/tools/__init__.py
@@ -1,42 +1,165 @@
-# TODO: Using * is really bad and leads to random circular imports (especially in polygon_helper and indicators)
-# TODO: When using *, you have to ensure that the underlying module does not import ANYTHING from the lumibot package
-# TODO: This tools module is a bad place to auto import as a helper to the code because all of the modules and functions
-# TODO: are not related to each other. It's just a collection of random functions and classes and it is unclear what
-# TODO: is being loaded when simply trying to load anything from the tools module. It's better to import the specific
-# TODO: functions and classes that you need from the tools module. This has made everything from black_scholes to
-# TODO: yahoo_helper all interrelated and it's a mess.
-from .black_scholes import BS
-from .debugers import *
-from .decorators import append_locals, execute_after, snatch_locals, staticdecorator
-from .helpers import *
-from .indicators import (
-    cash_flow_adjusted_returns,
-    cagr,
-    calculate_returns,
-    create_tearsheet,
-    cumulative_to_period_flows,
-    get_risk_free_rate,
-    get_symbol_returns,
-    max_drawdown,
-    performance,
-    plot_indicators,
-    plot_returns,
-    romad,
-    sharpe,
-    stats_summary,
-    total_return,
-    volatility,
-)
-from .pandas import *
-from .types import *
-from .yahoo_helper import YahooHelper
-from .ccxt_data_store import CcxtCacheDB
-from .schwab_helper import SchwabHelper
+"""Compatibility exports for :mod:`lumibot.tools`.
 
-# Unified logging system
-from .lumibot_logger import (
-    get_logger,
-    get_strategy_logger, 
-    set_log_level,
-    add_file_handler
-)
+The old package initializer imported every helper module at once. That made
+basic imports pay for plotting, broker caches, Yahoo, CCXT, and analytics even
+when callers only needed one small helper.
+"""
+
+from importlib import import_module as _import_module
+
+_SUBMODULES = {
+    "backtest_cache",
+    "black_scholes",
+    "ccxt_data_store",
+    "data_downloader_queue_client",
+    "databento_helper",
+    "databento_helper_polars",
+    "debugers",
+    "decorators",
+    "futures_roll",
+    "helpers",
+    "ibkr_helper",
+    "ibkr_secdef",
+    "indicators",
+    "lumibot_logger",
+    "pandas",
+    "parquet_series_cache",
+    "parquet_utils",
+    "polars_utils",
+    "polygon_helper",
+    "polygon_helper_async",
+    "polygon_helper_polars_optimized",
+    "projectx_helpers",
+    "runtime_telemetry",
+    "schwab_helper",
+    "smart_limit_utils",
+    "symbol_parser",
+    "symbol_normalization",
+    "thetadata_helper",
+    "types",
+    "yahoo_helper",
+    "alpaca_helpers",
+    "bitunix_helpers",
+}
+
+_NAME_TO_MODULE = {
+    "BS": "black_scholes",
+    "CcxtCacheDB": "ccxt_data_store",
+    "SchwabHelper": "schwab_helper",
+    "YahooHelper": "yahoo_helper",
+    "append_locals": "decorators",
+    "execute_after": "decorators",
+    "snatch_locals": "decorators",
+    "staticdecorator": "decorators",
+    "add_file_handler": "lumibot_logger",
+    "get_logger": "lumibot_logger",
+    "get_strategy_logger": "lumibot_logger",
+    "set_log_level": "lumibot_logger",
+    "cagr": "indicators",
+    "calculate_returns": "indicators",
+    "cash_flow_adjusted_returns": "indicators",
+    "create_tearsheet": "indicators",
+    "cumulative_to_period_flows": "indicators",
+    "get_risk_free_rate": "indicators",
+    "get_symbol_returns": "indicators",
+    "max_drawdown": "indicators",
+    "performance": "indicators",
+    "plot_indicators": "indicators",
+    "plot_returns": "indicators",
+    "romad": "indicators",
+    "sharpe": "indicators",
+    "stats_summary": "indicators",
+    "total_return": "indicators",
+    "volatility": "indicators",
+    "Decimal": "types",
+    "check_numeric": "types",
+    "check_positive": "types",
+    "check_price": "types",
+    "check_quantity": "types",
+}
+
+_HELPER_EXPORTS = {
+    "LUMIBOT_DEFAULT_PYTZ",
+    "LUMIBOT_DEFAULT_TIMEZONE",
+    "MarketCalendar",
+    "TwentyFourSevenCalendar",
+    "ComparaisonMixin",
+    "colored",
+    "create_options_symbol",
+    "date_n_trading_days_from_date",
+    "day_deduplicate",
+    "deduplicate_sequence",
+    "dt",
+    "fill_void",
+    "get_chunks",
+    "get_decimals",
+    "get_lumibot_datetime",
+    "get_timezone_from_datetime",
+    "get_trading_days",
+    "get_trading_times",
+    "has_more_than_n_decimal_places",
+    "hashlib",
+    "is_daily_data",
+    "is_market_open",
+    "lru_cache",
+    "mcal",
+    "os",
+    "parse_symbol",
+    "parse_timestep_qty_and_unit",
+    "pd",
+    "prettify_dataframe_with_decimals",
+    "print_full_pandas_dataframes",
+    "print_progress_bar",
+    "pytz",
+    "quantize_to_num_decimals",
+    "re",
+    "set_pandas_float_display_precision",
+    "sys",
+    "time",
+    "to_datetime_aware",
+    "weakref",
+}
+
+for _name in _HELPER_EXPORTS:
+    _NAME_TO_MODULE[_name] = "helpers"
+
+_NAME_TO_MODULE["parse_symbol"] = "symbol_parser"
+
+for _name in (
+    "day_deduplicate",
+    "fill_void",
+    "is_daily_data",
+    "np",
+    "pd",
+    "prettify_dataframe_with_decimals",
+    "print_full_pandas_dataframes",
+    "set_pandas_float_display_precision",
+):
+    _NAME_TO_MODULE[_name] = "pandas"
+
+for _name in ("PerfCounters", "perf_counter", "perf_counters"):
+    _NAME_TO_MODULE[_name] = "debugers"
+
+_NAME_TO_MODULE["ROUND_HALF_EVEN"] = "helpers"
+
+__all__ = sorted(_SUBMODULES | set(_NAME_TO_MODULE))
+
+
+def __getattr__(name):
+    if name in _SUBMODULES:
+        module = _import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/lumibot/tools/symbol_parser.py
+++ b/lumibot/tools/symbol_parser.py
@@ -1,0 +1,34 @@
+import datetime as dt
+import re
+
+_OPTION_SYMBOL_PATTERN = re.compile(r"([A-Z]+)(\d{6})([CP])(\d+)")
+
+
+def parse_symbol(symbol):
+    """
+    Parse the given symbol and determine if it's an option or a stock.
+    For options, extract and return the stock symbol, expiration date (as a datetime.date object),
+    type (call or put), and strike price.
+    For stocks, simply return the stock symbol.
+    TODO: Crypto and Forex support
+    """
+    if not isinstance(symbol, str):
+        return {"type": None}
+
+    match = _OPTION_SYMBOL_PATTERN.fullmatch(symbol)
+    if match:
+        stock_symbol, expiration, option_type, strike_price = match.groups()
+        try:
+            expiration_date = dt.datetime.strptime(expiration, "%y%m%d").date()
+        except ValueError:
+            return {"type": None}
+        option_type = "CALL" if option_type == "C" else "PUT"
+        return {
+            "type": "option",
+            "stock_symbol": stock_symbol,
+            "expiration_date": expiration_date,
+            "option_type": option_type,
+            # OCC option symbols encode strikes in thousandths; keep 3 decimals after scaling.
+            "strike_price": round(float(strike_price) / 1000, 3),
+        }
+    return {"type": "stock", "stock_symbol": symbol}

--- a/lumibot/traders/__init__.py
+++ b/lumibot/traders/__init__.py
@@ -1,1 +1,24 @@
-from .trader import Trader
+"""Trader package exports without eager imports."""
+
+from importlib import import_module as _import_module
+
+_NAME_TO_MODULE = {
+    "Trader": "trader",
+}
+
+__all__ = sorted(_NAME_TO_MODULE)
+
+
+def __getattr__(name):
+    module_name = _NAME_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = _import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/tests/test_botspot_handler.py
+++ b/tests/test_botspot_handler.py
@@ -1,6 +1,7 @@
 import os
 import time
 import logging
+from types import SimpleNamespace
 
 from lumibot.tools.lumibot_logger import BotspotErrorHandler
 
@@ -28,10 +29,11 @@ def test_botspot_handler_dedup_and_aggregation(monkeypatch):
 
     # Patch the requests.post used inside the handler
     assert handler.requests is not None, "requests should be available when API key is set"
-    monkeypatch.setattr(handler.requests, "post", fake_post)
+    handler.requests = SimpleNamespace(post=fake_post)
 
     logger = logging.getLogger("lumibot.test.botspot")
     logger.setLevel(logging.ERROR)
+    monkeypatch.setattr(logger, "propagate", False)
     # Ensure no duplicate handlers from previous tests
     for h in list(logger.handlers):
         logger.removeHandler(h)
@@ -88,12 +90,13 @@ def test_botspot_handler_distinct_fingerprints(monkeypatch):
         return DummyResp()
 
     assert handler.requests is not None
-    monkeypatch.setattr(handler.requests, "post", fake_post)
+    handler.requests = SimpleNamespace(post=fake_post)
 
     logger_a = logging.getLogger("lumibot.test.botspot.a")
     logger_b = logging.getLogger("lumibot.test.botspot.b")
     for lg in (logger_a, logger_b):
         lg.setLevel(logging.ERROR)
+        monkeypatch.setattr(lg, "propagate", False)
         for h in list(lg.handlers):
             lg.removeHandler(h)
         lg.addHandler(handler)

--- a/tests/test_lazy_exports.py
+++ b/tests/test_lazy_exports.py
@@ -46,21 +46,23 @@ def test_lazy_package_exports_defer_heavy_submodule_imports():
 
 
 def test_legacy_star_import_exports_resolve():
-    namespace = {}
+    tools_ns = {}
+    exec("from lumibot.tools import *", tools_ns)
+    for name in ("Decimal", "np", "pd", "parse_symbol", "time", "get_logger", "YahooHelper"):
+        assert name in tools_ns
+    assert tools_ns["pd"].__name__ == "pandas"
+    assert tools_ns["np"].__name__ == "numpy"
+    assert tools_ns["time"].__name__ == "time"
 
-    exec("from lumibot.tools import *", namespace)
-    for name in ("np", "pd", "parse_symbol", "get_logger", "YahooHelper"):
-        assert name in namespace
-    assert namespace["pd"].__name__ == "pandas"
-    assert namespace["np"].__name__ == "numpy"
-
-    exec("from lumibot.entities import *", namespace)
+    entities_ns = {}
+    exec("from lumibot.entities import *", entities_ns)
     for name in ("Asset", "Order", "Position", "Data"):
-        assert name in namespace
+        assert name in entities_ns
 
-    exec("from lumibot.backtesting import *", namespace)
+    backtesting_ns = {}
+    exec("from lumibot.backtesting import *", backtesting_ns)
     for name in ("BacktestingBroker", "PandasDataBacktesting", "YahooDataBacktesting"):
-        assert name in namespace
+        assert name in backtesting_ns
 
 
 def test_lazy_module_proxies_preserve_module_identity():
@@ -122,13 +124,13 @@ def test_lazy_module_patch_teardown_restores_existing_attributes():
         assert proxy.get is original
 
 
-def test_lazy_agent_builtin_module_supports_string_patches():
+def test_lazy_agent_builtin_module_supports_string_patches(monkeypatch):
     import lumibot.components as components
     import lumibot.components.agents as agents
 
-    components.__dict__.pop("agents", None)
-    agents.__dict__.pop("builtins", None)
-    sys.modules.pop("lumibot.components.agents.builtins", None)
+    monkeypatch.delitem(components.__dict__, "agents", raising=False)
+    monkeypatch.delitem(agents.__dict__, "builtins", raising=False)
+    monkeypatch.delitem(sys.modules, "lumibot.components.agents.builtins", raising=False)
 
     with patch("lumibot.components.agents.builtins.requests.get") as mocked:
         from lumibot.components.agents import builtins

--- a/tests/test_lazy_exports.py
+++ b/tests/test_lazy_exports.py
@@ -24,7 +24,7 @@ def test_lazy_package_all_exports_resolve():
             getattr(module, export_name)
 
 
-def test_lazy_package_exports_defer_heavy_submodule_imports():
+def test_lazy_package_exports_defer_heavy_submodule_imports(monkeypatch):
     # Invariant: importing package namespaces must not import heavy optional
     # backends until their public export is first accessed.
     cases = [
@@ -36,9 +36,12 @@ def test_lazy_package_exports_defer_heavy_submodule_imports():
     ]
 
     for module_name, export_name, target_module in cases:
-        sys.modules.pop(target_module, None)
+        parent_name, child_name = target_module.rsplit(".", 1)
+        parent_module = importlib.import_module(parent_name)
+        monkeypatch.delitem(parent_module.__dict__, child_name, raising=False)
+        monkeypatch.delitem(sys.modules, target_module, raising=False)
         module = importlib.import_module(module_name)
-        module.__dict__.pop(export_name, None)
+        monkeypatch.delitem(module.__dict__, export_name, raising=False)
 
         assert target_module not in sys.modules
         getattr(module, export_name)

--- a/tests/test_lazy_exports.py
+++ b/tests/test_lazy_exports.py
@@ -1,0 +1,154 @@
+import importlib
+import inspect
+import sys
+from unittest.mock import patch
+
+
+def test_lazy_package_all_exports_resolve():
+    modules = [
+        "lumibot",
+        "lumibot.backtesting",
+        "lumibot.brokers",
+        "lumibot.components",
+        "lumibot.components.agents",
+        "lumibot.data_sources",
+        "lumibot.entities",
+        "lumibot.strategies",
+        "lumibot.tools",
+        "lumibot.traders",
+    ]
+
+    for module_name in modules:
+        module = importlib.import_module(module_name)
+        for export_name in getattr(module, "__all__", ()):
+            getattr(module, export_name)
+
+
+def test_lazy_package_exports_defer_heavy_submodule_imports():
+    # Invariant: importing package namespaces must not import heavy optional
+    # backends until their public export is first accessed.
+    cases = [
+        ("lumibot.backtesting", "BacktestingBroker", "lumibot.backtesting.backtesting_broker"),
+        ("lumibot.brokers", "Alpaca", "lumibot.brokers.alpaca"),
+        ("lumibot.components", "BuiltinTools", "lumibot.components.agents"),
+        ("lumibot.data_sources", "YahooData", "lumibot.data_sources.yahoo_data"),
+        ("lumibot.tools", "YahooHelper", "lumibot.tools.yahoo_helper"),
+    ]
+
+    for module_name, export_name, target_module in cases:
+        sys.modules.pop(target_module, None)
+        module = importlib.import_module(module_name)
+        module.__dict__.pop(export_name, None)
+
+        assert target_module not in sys.modules
+        getattr(module, export_name)
+        assert target_module in sys.modules
+
+
+def test_legacy_star_import_exports_resolve():
+    namespace = {}
+
+    exec("from lumibot.tools import *", namespace)
+    for name in ("np", "pd", "parse_symbol", "get_logger", "YahooHelper"):
+        assert name in namespace
+    assert namespace["pd"].__name__ == "pandas"
+    assert namespace["np"].__name__ == "numpy"
+
+    exec("from lumibot.entities import *", namespace)
+    for name in ("Asset", "Order", "Position", "Data"):
+        assert name in namespace
+
+    exec("from lumibot.backtesting import *", namespace)
+    for name in ("BacktestingBroker", "PandasDataBacktesting", "YahooDataBacktesting"):
+        assert name in namespace
+
+
+def test_lazy_module_proxies_preserve_module_identity():
+    from lumibot.backtesting import backtesting_broker
+    from lumibot.entities import bars, data
+    from lumibot.strategies import strategy, strategy_executor
+    from lumibot.tools import helpers
+    from lumibot.tools import ibkr_helper, thetadata_helper
+
+    for value in (
+        helpers.pd,
+        ibkr_helper.pd,
+        thetadata_helper.pd,
+        thetadata_helper.mcal,
+        thetadata_helper.requests,
+        data.pd,
+        data.np,
+        bars.pd,
+        bars.np,
+        backtesting_broker.pd,
+        backtesting_broker.np,
+        strategy.pd,
+        strategy.np,
+        strategy_executor.pd,
+    ):
+        assert inspect.ismodule(value)
+
+
+def test_lazy_module_patch_teardown_forwards_deletion():
+    targets = [
+        "lumibot.tools.thetadata_helper.requests._lumibot_patch_probe",
+        "lumibot.brokers.tradier.requests._lumibot_patch_probe",
+        "lumibot.tools.projectx_helpers.requests._lumibot_patch_probe",
+        "lumibot.backtesting.routed_backtesting.pd._lumibot_patch_probe",
+        "lumibot.backtesting.databento_backtesting_pandas.pd._lumibot_patch_probe",
+        "lumibot.data_sources.databento_data_pandas.pd._lumibot_patch_probe",
+        "lumibot.indicators.indicators.pd._lumibot_patch_probe",
+    ]
+
+    for target in targets:
+        with patch(target, object(), create=True):
+            pass
+
+
+def test_lazy_module_patch_teardown_restores_existing_attributes():
+    from lumibot.brokers import tradier
+    from lumibot.tools import projectx_helpers, thetadata_helper
+
+    target_pairs = [
+        (thetadata_helper.requests, "lumibot.tools.thetadata_helper.requests.get"),
+        (tradier.requests, "lumibot.brokers.tradier.requests.get"),
+        (projectx_helpers.requests, "lumibot.tools.projectx_helpers.requests.get"),
+    ]
+
+    for proxy, target in target_pairs:
+        original = proxy.get
+        with patch(target) as mocked:
+            assert proxy.get is mocked
+        assert proxy.get is original
+
+
+def test_lazy_agent_builtin_module_supports_string_patches():
+    import lumibot.components as components
+    import lumibot.components.agents as agents
+
+    components.__dict__.pop("agents", None)
+    agents.__dict__.pop("builtins", None)
+    sys.modules.pop("lumibot.components.agents.builtins", None)
+
+    with patch("lumibot.components.agents.builtins.requests.get") as mocked:
+        from lumibot.components.agents import builtins
+
+        assert components.agents is agents
+        assert builtins.requests.get is mocked
+
+
+def test_legacy_entities_package_alias_resolves_submodules():
+    import lumibot  # noqa: F401
+    import entities
+    from entities import asset as asset_module
+    from entities.asset import Asset
+    from entities.order import Order
+
+    assert importlib.util.find_spec("entities.asset") is not None
+    assert importlib.util.find_spec("entities.order") is not None
+    assert importlib.reload(entities) is entities
+    assert importlib.reload(asset_module).Asset is Asset
+    assert entities.Asset is Asset
+    assert entities.Order is Order
+    assert Asset("SPY").symbol == "SPY"
+    assert Order.OrderType.MARKET.value == "market"

--- a/tests/test_symbol_parser.py
+++ b/tests/test_symbol_parser.py
@@ -1,0 +1,19 @@
+import datetime as dt
+
+from lumibot.tools.symbol_parser import parse_symbol
+
+
+def test_parse_option_symbol_requires_full_match_and_valid_date():
+    parsed = parse_symbol("AAPL250621C00100000")
+
+    assert parsed["type"] == "option"
+    assert parsed["stock_symbol"] == "AAPL"
+    assert parsed["expiration_date"] == dt.date(2025, 6, 21)
+    assert parsed["option_type"] == "CALL"
+    assert parsed["strike_price"] == 100.0
+
+    assert parse_symbol("AAPL250621C00100000XYZ") == {
+        "type": "stock",
+        "stock_symbol": "AAPL250621C00100000XYZ",
+    }
+    assert parse_symbol("AAPL991332C00100000") == {"type": None}

--- a/tests/test_vix_helper.py
+++ b/tests/test_vix_helper.py
@@ -93,7 +93,10 @@ class TestVixHelper(unittest.TestCase):
     @patch('yfinance.Ticker')
     def test_get_vix_rsi_value(self, mock_ticker_class):
         """Test getting VIX RSI value"""
+        import lumibot.components.vix_helper as vix_helper_module
         from lumibot.components.vix_helper import VixHelper
+
+        vix_helper_module._TA_MODULE = None
         helper = VixHelper(self.mock_strategy)
         
         # Mock yfinance Ticker and history method
@@ -110,11 +113,13 @@ class TestVixHelper(unittest.TestCase):
         mock_ticker.history.return_value = mock_df
         
         # This should calculate RSI using pandas_ta
+        self.assertIsNone(vix_helper_module._TA_MODULE)
         result = helper.get_vix_rsi_value(datetime.now(), window=14)
         
         # Should return a float value between 0 and 100
         self.assertIsInstance(result, (float, np.floating))
         self.assertTrue(0 <= result <= 100)
+        self.assertIsNotNone(vix_helper_module._TA_MODULE)
     
     def test_check_max_vix_1d(self):
         """Test check_max_vix_1d functionality"""


### PR DESCRIPTION
Summary
- Lazy-load package exports and optional agent/component helpers.
- Add symbol parser module for Asset parsing without importing all tools.

Validation
- pytest -q tests/test_lazy_exports.py tests/test_symbol_parser.py tests/test_vix_helper.py
- pytest -q tests/test_botspot_logger.py tests/test_botspot_handler.py