### PR TITLE
4.5.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.14 - Unreleased
+
 ## 4.5.13 - 2026-05-13
 
 Deploy marker: 4.5.13 release commit (`deploy 4.5.13`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 4.5.14 - Unreleased
+## 4.5.14 - 2026-05-13
+
+Deploy marker: 4.5.14 release commit (`deploy 4.5.14`)
+
+### Fixed
+- **IBKR REST daily stock/index backtests no longer fall back to minute data after a stale daily slice.** When daily stock/index data is already loaded but missing the current simulation timestamp, `get_last_price()` and `get_quote()` now refresh a bounded daily slice around the simulation date and return empty/None if that still fails. This prevents daily AlphaPicks option backtests from making unnecessary IBKR `1min` requests anchored near the backtest end date and then trying to use May-only data for April entries.
 
 ## 4.5.13 - 2026-05-13
 

--- a/lumibot/backtesting/interactive_brokers_rest_backtesting.py
+++ b/lumibot/backtesting/interactive_brokers_rest_backtesting.py
@@ -278,7 +278,20 @@ class InteractiveBrokersRESTBacktesting(PandasData):
                 try:
                     return day_data.get_last_price(now)
                 except Exception:
-                    pass
+                    try:
+                        self._refresh_window_around_datetime(
+                            asset=base_asset,
+                            quote=quote_asset,
+                            dataset_key="day",
+                            dt=now,
+                            exchange=effective_exchange,
+                            include_after_hours=False,
+                        )
+                        day_data = self._data_store.get(day_key)
+                        if day_data is not None:
+                            return day_data.get_last_price(now)
+                    except Exception:
+                        return None
 
         minute_key = (base_asset, quote_asset, "minute", self._normalize_exchange_key(effective_exchange))
         data = self._data_store.get(minute_key)
@@ -384,7 +397,31 @@ class InteractiveBrokersRESTBacktesting(PandasData):
                         raw_data=ohlcv_bid_ask_dict,
                     )
                 except Exception:
-                    pass
+                    try:
+                        self._refresh_window_around_datetime(
+                            asset=base_asset,
+                            quote=quote_asset,
+                            dataset_key="day",
+                            dt=now,
+                            exchange=effective_exchange,
+                            include_after_hours=False,
+                        )
+                        day_data = self._data_store.get(day_key)
+                        if day_data is not None:
+                            ohlcv_bid_ask_dict = day_data.get_quote(now)
+                            return Quote(
+                                asset=base_asset,
+                                price=ohlcv_bid_ask_dict.get("close"),
+                                bid=ohlcv_bid_ask_dict.get("bid"),
+                                ask=ohlcv_bid_ask_dict.get("ask"),
+                                volume=ohlcv_bid_ask_dict.get("volume"),
+                                timestamp=now,
+                                bid_size=ohlcv_bid_ask_dict.get("bid_size"),
+                                ask_size=ohlcv_bid_ask_dict.get("ask_size"),
+                                raw_data=ohlcv_bid_ask_dict,
+                            )
+                    except Exception:
+                        return Quote(asset=base_asset)
 
         minute_key = (base_asset, quote_asset, "minute", self._normalize_exchange_key(effective_exchange))
         minute_data = self._data_store.get(minute_key)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.13",
+    version="4.5.14",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_ibkr_index_daily_last_price_unit.py
+++ b/tests/test_ibkr_index_daily_last_price_unit.py
@@ -24,6 +24,14 @@ class _FakeDayData:
         }
 
 
+class _FailingDayData:
+    def get_last_price(self, now):
+        raise ValueError("requested timestamp is outside of this daily slice")
+
+    def get_quote(self, now):
+        raise ValueError("requested timestamp is outside of this daily slice")
+
+
 def _make_data_source() -> InteractiveBrokersRESTBacktesting:
     start = datetime(2026, 4, 9, 20, 0, tzinfo=timezone.utc)
     end = datetime(2026, 4, 10, 20, 0, tzinfo=timezone.utc)
@@ -54,6 +62,42 @@ def test_ibkr_index_get_last_price_prefers_loaded_day_series(monkeypatch):
     assert data_source.get_last_price(asset) == 21.5
 
 
+def test_ibkr_stock_get_last_price_refreshes_loaded_day_series_without_minute_fetch(monkeypatch):
+    data_source = _make_data_source()
+    asset = Asset("MU", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    day_key = (asset, quote, "day", "AUTO")
+    data_source._data_store[day_key] = _FailingDayData()
+    refresh_calls = []
+
+    def _refresh_window_around_datetime(**kwargs):
+        refresh_calls.append(kwargs)
+        assert kwargs["dataset_key"] == "day"
+        assert kwargs["include_after_hours"] is False
+        data_source._data_store[day_key] = _FakeDayData(92.75)
+
+    monkeypatch.setattr(data_source, "_refresh_window_around_datetime", _refresh_window_around_datetime)
+
+    assert data_source.get_last_price(asset) == 92.75
+    assert len(refresh_calls) == 1
+
+
+def test_ibkr_stock_get_last_price_does_not_fall_back_to_minute_after_day_refresh_failure(monkeypatch):
+    data_source = _make_data_source()
+    asset = Asset("CSTM", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    day_key = (asset, quote, "day", "AUTO")
+    data_source._data_store[day_key] = _FailingDayData()
+
+    def _refresh_window_around_datetime(**kwargs):
+        assert kwargs["dataset_key"] == "day"
+        raise ValueError("daily refresh failed")
+
+    monkeypatch.setattr(data_source, "_refresh_window_around_datetime", _refresh_window_around_datetime)
+
+    assert data_source.get_last_price(asset) is None
+
+
 def test_ibkr_index_get_quote_prefers_loaded_day_series(monkeypatch):
     data_source = _make_data_source()
     asset = Asset("SPX", asset_type=Asset.AssetType.INDEX)
@@ -71,3 +115,27 @@ def test_ibkr_index_get_quote_prefers_loaded_day_series(monkeypatch):
     assert snapshot.price == 5100.25
     assert snapshot.bid == 5100.15
     assert snapshot.ask == 5100.35
+
+
+def test_ibkr_stock_get_quote_refreshes_loaded_day_series_without_minute_fetch(monkeypatch):
+    data_source = _make_data_source()
+    asset = Asset("MU", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    day_key = (asset, quote, "day", "AUTO")
+    data_source._data_store[day_key] = _FailingDayData()
+    refresh_calls = []
+
+    def _refresh_window_around_datetime(**kwargs):
+        refresh_calls.append(kwargs)
+        assert kwargs["dataset_key"] == "day"
+        assert kwargs["include_after_hours"] is False
+        data_source._data_store[day_key] = _FakeDayData(93.25)
+
+    monkeypatch.setattr(data_source, "_refresh_window_around_datetime", _refresh_window_around_datetime)
+
+    snapshot = data_source.get_quote(asset)
+    assert snapshot is not None
+    assert snapshot.price == 93.25
+    assert snapshot.bid == 93.15
+    assert snapshot.ask == 93.35
+    assert len(refresh_calls) == 1


### PR DESCRIPTION
## Summary
- Keep IBKR daily stock/index backtests on daily data after stale daily slices by refreshing a bounded daily window around the simulation date.
- Prevent daily AlphaPicks option backtests from falling back into end-anchored 1-minute IBKR requests for stock/index price and quote lookups.
- Add regression tests for daily refresh and no-minute-fallback behavior.

## Tests
- gtimeout 180 .venv/bin/python -m pytest tests/test_ibkr_index_daily_last_price_unit.py tests/test_ibkr_crypto_backtesting_smoke_stubbed.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IBKR REST daily stock/index backtesting issue where missing current simulation timestamps triggered unnecessary minute-level data requests. System now intelligently refreshes daily data around the simulation date, improving performance and resolving incorrect behavior in AlphaPicks option backtests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1032)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->