### PR TITLE
4.5.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 4.5.15 - Unreleased
+## 4.5.15 - 2026-05-13
+
+Deploy marker: 4.5.15 release commit (`deploy 4.5.15`)
+
+### Fixed
+- **IBKR REST daily stock/index price lookups now treat raw ticker strings as stock assets.** Strategies that call `get_last_price("MU")` or `get_quote("MU")` now use the same daily stock/index refresh path as `Asset("MU", "stock")`, preventing AlphaPicks option backtests from falling back to end-anchored IBKR `1min` data when the strategy passes string symbols.
 
 ## 4.5.14 - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.15 - Unreleased
+
 ## 4.5.14 - 2026-05-13
 
 Deploy marker: 4.5.14 release commit (`deploy 4.5.14`)

--- a/lumibot/backtesting/interactive_brokers_rest_backtesting.py
+++ b/lumibot/backtesting/interactive_brokers_rest_backtesting.py
@@ -72,6 +72,13 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         return raw
 
     @staticmethod
+    def _normalize_lookup_asset(asset):
+        """Treat raw ticker strings as stock assets for IBKR backtest price lookups."""
+        if isinstance(asset, str):
+            return Asset(symbol=asset, asset_type=Asset.AssetType.STOCK)
+        return asset
+
+    @staticmethod
     def _ibkr_include_after_hours(asset_type: str, timestep_unit: str) -> bool:
         """Return IBKR outsideRth policy for backtests.
 
@@ -228,6 +235,7 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         quote_asset = quote
         if isinstance(base_asset, tuple):
             base_asset, quote_asset = base_asset
+        base_asset = self._normalize_lookup_asset(base_asset)
         quote_asset = quote_asset if quote_asset is not None else Asset("USD", "forex")
 
         effective_exchange = exchange if exchange is not None else self.exchange
@@ -338,6 +346,7 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         quote_asset = quote
         if isinstance(base_asset, tuple):
             base_asset, quote_asset = base_asset
+        base_asset = self._normalize_lookup_asset(base_asset)
         quote_asset = quote_asset if quote_asset is not None else Asset("USD", "forex")
 
         effective_exchange = exchange if exchange is not None else self.exchange

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.14",
+    version="4.5.15",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_ibkr_index_daily_last_price_unit.py
+++ b/tests/test_ibkr_index_daily_last_price_unit.py
@@ -82,6 +82,27 @@ def test_ibkr_stock_get_last_price_refreshes_loaded_day_series_without_minute_fe
     assert len(refresh_calls) == 1
 
 
+def test_ibkr_string_stock_get_last_price_uses_loaded_day_series_without_minute_fetch(monkeypatch):
+    data_source = _make_data_source()
+    asset = Asset("MU", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    day_key = (asset, quote, "day", "AUTO")
+    data_source._data_store[day_key] = _FailingDayData()
+    refresh_calls = []
+
+    def _refresh_window_around_datetime(**kwargs):
+        refresh_calls.append(kwargs)
+        assert kwargs["asset"] == asset
+        assert kwargs["dataset_key"] == "day"
+        assert kwargs["include_after_hours"] is False
+        data_source._data_store[day_key] = _FakeDayData(92.75)
+
+    monkeypatch.setattr(data_source, "_refresh_window_around_datetime", _refresh_window_around_datetime)
+
+    assert data_source.get_last_price("MU") == 92.75
+    assert len(refresh_calls) == 1
+
+
 def test_ibkr_stock_get_last_price_does_not_fall_back_to_minute_after_day_refresh_failure(monkeypatch):
     data_source = _make_data_source()
     asset = Asset("CSTM", asset_type=Asset.AssetType.STOCK)
@@ -134,6 +155,31 @@ def test_ibkr_stock_get_quote_refreshes_loaded_day_series_without_minute_fetch(m
     monkeypatch.setattr(data_source, "_refresh_window_around_datetime", _refresh_window_around_datetime)
 
     snapshot = data_source.get_quote(asset)
+    assert snapshot is not None
+    assert snapshot.price == 93.25
+    assert snapshot.bid == 93.15
+    assert snapshot.ask == 93.35
+    assert len(refresh_calls) == 1
+
+
+def test_ibkr_string_stock_get_quote_uses_loaded_day_series_without_minute_fetch(monkeypatch):
+    data_source = _make_data_source()
+    asset = Asset("MU", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    day_key = (asset, quote, "day", "AUTO")
+    data_source._data_store[day_key] = _FailingDayData()
+    refresh_calls = []
+
+    def _refresh_window_around_datetime(**kwargs):
+        refresh_calls.append(kwargs)
+        assert kwargs["asset"] == asset
+        assert kwargs["dataset_key"] == "day"
+        assert kwargs["include_after_hours"] is False
+        data_source._data_store[day_key] = _FakeDayData(93.25)
+
+    monkeypatch.setattr(data_source, "_refresh_window_around_datetime", _refresh_window_around_datetime)
+
+    snapshot = data_source.get_quote("MU")
     assert snapshot is not None
     assert snapshot.price == 93.25
     assert snapshot.bid == 93.15


### PR DESCRIPTION
## Summary
- Normalize raw ticker-string price/quote lookups to stock Assets inside IBKR REST backtesting.
- Keeps string-symbol daily AlphaPicks option backtests on daily stock/index data instead of falling back to end-anchored 1-minute IBKR history.
- Adds regression coverage for get_last_price("MU") and get_quote("MU").

## Tests
- gtimeout 180 .venv/bin/python -m pytest tests/test_ibkr_index_daily_last_price_unit.py tests/test_ibkr_crypto_backtesting_smoke_stubbed.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Interactive Brokers REST daily price and quote lookups for raw ticker strings to treat them as stock assets, ensuring consistent daily data refresh behavior and preventing unnecessary fallback to minute-level data during backtests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1033)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->