### PR TITLE
v4.5.16 - Routed daily stock lookup fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 4.5.16 - Unreleased
+## 4.5.16 - 2026-05-14
+
+Deploy marker: 4.5.16 release commit (`deploy 4.5.16`)
+
+### Fixed
+- **Routed daily stock/index backtests no longer satisfy day lookups from stale minute frames.** `RoutedBacktestingPandas` now pins stock/index day requests to native daily bars, and `ThetaDataBacktestingPandas.get_last_price()` / `get_quote()` preserve daily cadence instead of falling back through base `PandasData` lookups that can resolve May-only minute caches during April AlphaPicks option backtests.
 
 ## 4.5.15 - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.16 - Unreleased
+
 ## 4.5.15 - 2026-05-13
 
 Deploy marker: 4.5.15 release commit (`deploy 4.5.15`)

--- a/lumibot/backtesting/routed_backtesting.py
+++ b/lumibot/backtesting/routed_backtesting.py
@@ -952,6 +952,9 @@ class RoutedBacktestingPandas(ThetaDataBacktestingPandas):
     """
 
     _CONFIG_KEY = "backtesting_data_routing"
+    # Routed stock/index day requests can be backed by IBKR. Keep those requests pinned to
+    # native daily bars so a warmed minute frame cannot satisfy a daily lookup at the wrong date.
+    PREFER_NATIVE_DAY_BARS_FOR_STOCK_INDEX = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -27,6 +27,16 @@ def _parity_log(message: str, *args) -> None:
 START_BUFFER = timedelta(days=5)
 
 
+def _asset_type_token(asset) -> str:
+    asset_for_type = asset[0] if isinstance(asset, tuple) else asset
+    raw = getattr(asset_for_type, "asset_type", "")
+    raw = getattr(raw, "value", raw)
+    raw = str(raw or "").strip().lower()
+    if "." in raw:
+        raw = raw.split(".")[-1]
+    return raw
+
+
 class ThetaDataBacktestingPandas(PandasData):
     """
     Backtesting implementation of ThetaData
@@ -2775,8 +2785,20 @@ class ThetaDataBacktestingPandas(PandasData):
         # NOTE: Do not infer day-mode from "any day data exists" because intraday strategies may
         # still request daily history for indicators.
         current_mode = getattr(self, "_timestep", None)
+        asset_type_token = _asset_type_token(asset)
+        effective_day_mode = bool(getattr(self, "_effective_day_mode", False))
 
-        if current_mode == "day" and timestep == "minute":
+        if (
+            timestep == "minute"
+            and (
+                current_mode == "day"
+                or (
+                    asset_type_token in {"stock", "equity", "index"}
+                    and effective_day_mode
+                    and not bool(getattr(self, "_observed_intraday_cadence", False))
+                )
+            )
+        ):
             timestep = "day"
             logger.debug(
                 "[THETA][DEBUG][TIMESTEP_ALIGN] get_last_price aligned from minute to day for asset=%s",
@@ -2907,9 +2929,10 @@ class ThetaDataBacktestingPandas(PandasData):
                         meta["last_trade_lookback_days"] = lookback_days
                         break
 
-        # As a fallback (e.g., empty dataframe), defer to the base implementation which is
-        # still trade-based (no quote/mid contamination).
-        if value is None:
+        # As a fallback (e.g., empty dataframe), defer to the base implementation which is still
+        # trade-based (no quote/mid contamination). Do not do this for stock/index daily lookups:
+        # PandasData has no timestep argument and may resolve a stale warmed minute frame instead.
+        if value is None and not (timestep == "day" and asset_type_token in {"stock", "equity", "index"}):
             value = super().get_last_price(asset=asset, quote=quote, exchange=exchange)
 
         logger.debug(
@@ -3363,9 +3386,22 @@ class ThetaDataBacktestingPandas(PandasData):
         # (see `BacktestingBroker._try_fill_with_quote`) without forcing all quote consumers onto
         # minute-level data.
         current_mode = getattr(self, "_timestep", None)
-        self._effective_day_mode = current_mode == "day"
+        asset_type_token = _asset_type_token(asset)
+        effective_day_mode = current_mode == "day" or bool(getattr(self, "_effective_day_mode", False))
+        self._effective_day_mode = effective_day_mode
 
-        if current_mode == "day" and timestep == "minute" and not snapshot_only:
+        if (
+            timestep == "minute"
+            and not snapshot_only
+            and (
+                current_mode == "day"
+                or (
+                    asset_type_token in {"stock", "equity", "index"}
+                    and effective_day_mode
+                    and not bool(getattr(self, "_observed_intraday_cadence", False))
+                )
+            )
+        ):
             timestep = "day"
             logger.debug(
                 "[THETA][DEBUG][TIMESTEP_ALIGN] get_quote aligned from minute to day for asset=%s",
@@ -3777,15 +3813,34 @@ class ThetaDataBacktestingPandas(PandasData):
                 quote_obj = None
 
         if quote_obj is None:
-            try:
-                quote_obj = super().get_quote(asset=asset, quote=quote, exchange=exchange)
-            except Exception:
-                # Missing data (placeholders / no trades / sparse NBBO) is expected for many option
-                # contracts at many timestamps. Avoid raising and triggering high-volume error logs
-                # from Strategy.get_quote(); return an "empty" Quote instead.
-                from lumibot.entities import Quote
+            from lumibot.entities import Quote
 
-                quote_obj = Quote(asset=asset, timestamp=dt)
+            if timestep == "day" and asset_type_token in {"stock", "equity", "index"}:
+                try:
+                    day_key = self.find_asset_in_data_store(asset, quote, "day")
+                    day_data = self.pandas_data.get(day_key) if day_key is not None else None
+                    ohlcv_bid_ask_dict = day_data.get_quote(dt) if day_data is not None else {}
+                    quote_obj = Quote(
+                        asset=asset,
+                        price=ohlcv_bid_ask_dict.get("close"),
+                        bid=ohlcv_bid_ask_dict.get("bid"),
+                        ask=ohlcv_bid_ask_dict.get("ask"),
+                        volume=ohlcv_bid_ask_dict.get("volume"),
+                        timestamp=dt,
+                        bid_size=ohlcv_bid_ask_dict.get("bid_size"),
+                        ask_size=ohlcv_bid_ask_dict.get("ask_size"),
+                        raw_data=ohlcv_bid_ask_dict,
+                    )
+                except Exception:
+                    quote_obj = Quote(asset=asset, timestamp=dt)
+            else:
+                try:
+                    quote_obj = super().get_quote(asset=asset, quote=quote, exchange=exchange)
+                except Exception:
+                    # Missing data (placeholders / no trades / sparse NBBO) is expected for many option
+                    # contracts at many timestamps. Avoid raising and triggering high-volume error logs
+                    # from Strategy.get_quote(); return an "empty" Quote instead.
+                    quote_obj = Quote(asset=asset, timestamp=dt)
 
         # ThetaData quote history for options can omit actionable NBBO while still surfacing a trade-derived
         # "close" field.

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.15",
+    version="4.5.16",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_routed_backtesting_unit.py
+++ b/tests/test_routed_backtesting_unit.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from lumibot.backtesting.routed_backtesting import RoutedBacktestingPandas, _ProviderRegistry
 from lumibot.backtesting.thetadata_backtesting_pandas import ThetaDataBacktestingPandas
-from lumibot.entities import Asset
+from lumibot.entities import Asset, Data
 
 
 def test_router_routes_crypto_to_ibkr(monkeypatch):
@@ -190,6 +190,91 @@ def test_router_get_quote_aligns_snapshot_only_for_non_theta_daily_mode(monkeypa
 
     assert captured["timestep"] == "day"
     assert captured["snapshot_only"] is True
+
+
+def test_routed_daily_stock_last_price_uses_day_frame_over_stale_minute(monkeypatch):
+    import lumibot.tools.thetadata_helper as thetadata_helper
+
+    monkeypatch.setattr(ThetaDataBacktestingPandas, "kill_processes_by_name", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(thetadata_helper, "reset_theta_terminal_tracking", lambda *_args, **_kwargs: None)
+
+    ds = RoutedBacktestingPandas(
+        datetime_start=datetime(2026, 4, 9, tzinfo=timezone.utc),
+        datetime_end=datetime(2026, 5, 9, tzinfo=timezone.utc),
+        config={"backtesting_data_routing": {"stock": "ibkr", "default": "thetadata"}},
+        username="dev",
+        password="dev",
+        use_quote_data=False,
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    ds._datetime = datetime(2026, 4, 9, 9, 30, tzinfo=timezone.utc)
+    ds._effective_day_mode = True
+    ds._observed_intraday_cadence = False
+
+    asset = Asset("MU", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    day_df = pd.DataFrame(
+        {"open": [10.0, 19.0], "high": [11.0, 21.0], "low": [9.0, 18.0], "close": [10.5, 20.0], "volume": [1, 2]},
+        index=pd.DatetimeIndex(
+            [datetime(2026, 4, 8, tzinfo=timezone.utc), datetime(2026, 4, 9, tzinfo=timezone.utc)]
+        ),
+    )
+    stale_minute_df = pd.DataFrame(
+        {"open": [100.0], "high": [101.0], "low": [99.0], "close": [100.5], "volume": [1]},
+        index=pd.DatetimeIndex([datetime(2026, 5, 4, 14, 0, tzinfo=timezone.utc)]),
+    )
+    ds._data_store[(asset, quote, "day")] = Data(asset, day_df, quote=quote, timestep="day")
+    ds._data_store[(asset, quote, "minute")] = Data(asset, stale_minute_df, quote=quote, timestep="minute")
+
+    requested_timesteps = []
+
+    def fake_update(_asset, _quote, _length, timestep, *_args, **_kwargs):
+        requested_timesteps.append(timestep)
+
+    monkeypatch.setattr(ds, "_update_pandas_data", fake_update)
+
+    assert ds.get_last_price(asset) == 20.0
+    assert requested_timesteps == ["day"]
+
+
+def test_routed_daily_stock_last_price_does_not_fall_back_to_stale_minute(monkeypatch):
+    import lumibot.tools.thetadata_helper as thetadata_helper
+
+    monkeypatch.setattr(ThetaDataBacktestingPandas, "kill_processes_by_name", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(thetadata_helper, "reset_theta_terminal_tracking", lambda *_args, **_kwargs: None)
+
+    ds = RoutedBacktestingPandas(
+        datetime_start=datetime(2026, 4, 9, tzinfo=timezone.utc),
+        datetime_end=datetime(2026, 5, 9, tzinfo=timezone.utc),
+        config={"backtesting_data_routing": {"stock": "ibkr", "default": "thetadata"}},
+        username="dev",
+        password="dev",
+        use_quote_data=False,
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    ds._datetime = datetime(2026, 4, 9, 9, 30, tzinfo=timezone.utc)
+    ds._effective_day_mode = True
+    ds._observed_intraday_cadence = False
+
+    asset = Asset("CSTM", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    stale_minute_df = pd.DataFrame(
+        {"open": [100.0], "high": [101.0], "low": [99.0], "close": [100.5], "volume": [1]},
+        index=pd.DatetimeIndex([datetime(2026, 5, 4, 14, 0, tzinfo=timezone.utc)]),
+    )
+    ds._data_store[(asset, quote, "minute")] = Data(asset, stale_minute_df, quote=quote, timestep="minute")
+
+    requested_timesteps = []
+
+    def fake_update(_asset, _quote, _length, timestep, *_args, **_kwargs):
+        requested_timesteps.append(timestep)
+
+    monkeypatch.setattr(ds, "_update_pandas_data", fake_update)
+
+    assert ds.get_last_price(asset) is None
+    assert requested_timesteps == ["day"]
 
 
 def test_update_cadence_daily_mode_does_not_mark_intraday():


### PR DESCRIPTION
What / Why:
Fixes the remaining AlphaPicks option backtest data bug where routed daily stock/index lookups could still resolve against stale May-only minute frames during an April simulation. Routed stock/index day requests now require native day bars, and daily get_last_price/get_quote paths no longer fall back through base PandasData lookups that can pick minute caches.

Risk:
Low-to-medium. This affects routed backtesting price/quote lookup behavior for stock/index daily cadence. Intraday cadence remains guarded by the observed intraday cadence flag. Detect quickly by watching for IBKR 1min downloader requests and outside-data-range logs in routed daily backtests.

Tests run:
- gtimeout 180 .venv/bin/python -m pytest tests/test_routed_backtesting_unit.py tests/test_routed_backtesting_registry_unit.py tests/test_ibkr_index_daily_last_price_unit.py tests/test_ibkr_crypto_backtesting_smoke_stubbed.py -q

Perf evidence:
No perf claim; this prevents redundant/incorrect minute fetches in daily routed backtests.

Docs:
CHANGELOG.md updated for 4.5.16. No user-facing docs/visuals needed; this is a backtesting data-source correctness fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backtesting cadence issue where routed daily stock/index backtests now correctly pin requests to native daily bars, preventing fallback to stale intraday cache data during backtests.

* **Tests**
  * Added unit tests validating daily-mode backtesting behavior with stock assets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1034)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->