### PR TITLE
v4.5.17 - Quote timeout guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.17 - Unreleased
+## 4.5.17 - 2026-05-14
+
+Deploy marker: 4.5.17 release commit (`deploy 4.5.17`)
 
 ### Fixed
 - **ThetaData quote-history requests now use a bounded quote-specific timeout.** Point-in-time option quote lookups no longer inherit the larger OHLC history timeout, so one stuck quote request fails visibly instead of making BotSpot option backtests appear frozen early in the run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.17 - Unreleased
+
 ## 4.5.16 - 2026-05-14
 
 Deploy marker: 4.5.16 release commit (`deploy 4.5.16`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.5.17 - Unreleased
 
+### Fixed
+- **ThetaData quote-history requests now use a bounded quote-specific timeout.** Point-in-time option quote lookups no longer inherit the larger OHLC history timeout, so one stuck quote request fails visibly instead of making BotSpot option backtests appear frozen early in the run.
+
 ## 4.5.16 - 2026-05-14
 
 Deploy marker: 4.5.16 release commit (`deploy 4.5.16`)

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -178,6 +178,12 @@ Selection rule (ThetaData):
 ### `DATADOWNLOADER_SKIP_LOCAL_START`
 - Purpose: Prevents any local downloader/ThetaTerminal bootstrap logic from running (backtests must use the remote downloader in production workflows).
 
+### `THETADATA_QUEUE_QUOTE_TIMEOUT`
+- Purpose: Data Downloader wait timeout for `/history/quote` requests used in point-in-time option pricing.
+- Values: seconds (float); set to `0` only if you intentionally want unbounded waits.
+- Default: `300`.
+- Notes: this is intentionally shorter than `THETADATA_QUEUE_HISTORY_TIMEOUT` so one stuck option quote fails visibly instead of making a backtest appear frozen for a full OHLC-history timeout window.
+
 ## ThetaData option chain building (performance)
 
 These env vars are used by the ThetaData chain cache/builder in `lumibot/tools/thetadata_helper.py`.

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -5111,10 +5111,12 @@ def get_request(
         if effective_timeout is None:
             try:
                 list_timeout = float(os.environ.get("THETADATA_QUEUE_LIST_TIMEOUT", "600"))
+                quote_timeout = float(os.environ.get("THETADATA_QUEUE_QUOTE_TIMEOUT", "300"))
                 history_timeout = float(os.environ.get("THETADATA_QUEUE_HISTORY_TIMEOUT", "1800"))
                 default_timeout = float(os.environ.get("THETADATA_QUEUE_DEFAULT_TIMEOUT", "900"))
             except Exception:
                 list_timeout = 600.0
+                quote_timeout = 300.0
                 history_timeout = 1800.0
                 default_timeout = 900.0
 
@@ -5123,6 +5125,11 @@ def get_request(
             request_path = (urlparse(url).path or "").lower()
             if "/option/list/" in request_path:
                 effective_timeout = list_timeout if list_timeout > 0 else None
+            elif "/history/quote" in request_path:
+                # Quote history requests are used for point-in-time option pricing. They should
+                # return quickly or fail visibly; using the broader OHLC history timeout can make
+                # a backtest appear frozen on one stale quote request for 30 minutes.
+                effective_timeout = quote_timeout if quote_timeout > 0 else None
             elif "/history/" in request_path:
                 effective_timeout = history_timeout if history_timeout > 0 else None
             else:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.16",
+    version="4.5.17",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_thetadata_transport_selection.py
+++ b/tests/test_thetadata_transport_selection.py
@@ -42,6 +42,40 @@ def test_get_request_uses_downloader_when_base_url_set(monkeypatch):
     assert result["response"] == [[1]]
 
 
+def test_get_request_uses_shorter_timeout_for_quote_history(monkeypatch):
+    import lumibot.tools.thetadata_helper as thetadata_helper
+    import lumibot.tools.data_downloader_queue_client as queue_client
+
+    monkeypatch.setenv("DATADOWNLOADER_BASE_URL", "http://example:8080")
+    monkeypatch.setenv("DATADOWNLOADER_API_KEY", "test-key")
+    monkeypatch.setenv("THETADATA_QUEUE_QUOTE_TIMEOUT", "123")
+    monkeypatch.setenv("THETADATA_QUEUE_HISTORY_TIMEOUT", "1800")
+
+    seen = {}
+
+    def fake_queue_request(url: str, querystring, headers=None, timeout=None):
+        seen["timeout"] = timeout
+        return {"header": {"format": []}, "response": [[1]]}
+
+    monkeypatch.setattr(queue_client, "queue_request", fake_queue_request)
+
+    result = thetadata_helper.get_request(
+        url="http://example:8080/v3/option/history/quote",
+        headers={},
+        querystring={
+            "symbol": "SPY",
+            "expiration": "2026-06-18",
+            "strike": "500",
+            "right": "call",
+            "date": "2026-04-09",
+            "format": "json",
+        },
+    )
+
+    assert isinstance(result, dict)
+    assert seen["timeout"] == 123.0
+
+
 def test_get_request_raises_when_downloader_base_url_set_but_api_key_missing(monkeypatch):
     import lumibot.tools.thetadata_helper as thetadata_helper
 


### PR DESCRIPTION
## Summary
- add a quote-history-specific downloader timeout for point-in-time option pricing
- document THETADATA_QUEUE_QUOTE_TIMEOUT
- add regression coverage that quote history does not inherit the larger OHLC history timeout

## Tests
- gtimeout 180 .venv/bin/python -m pytest tests/test_thetadata_transport_selection.py tests/test_thetadata_download_progress.py tests/test_thetadata_helper.py::test_get_request_error_in_json tests/test_thetadata_helper.py::test_get_request_exception_handling -q
- gtimeout 240 .venv/bin/python -m pytest tests/test_routed_backtesting_unit.py tests/test_routed_backtesting_registry_unit.py tests/test_ibkr_index_daily_last_price_unit.py tests/test_thetadata_transport_selection.py tests/test_thetadata_download_progress.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ThetaData quote-history requests now use a bounded, quote-specific timeout instead of inheriting the larger history timeout, preventing option backtests from appearing frozen early.

* **Documentation**
  * Added docs for the new THETADATA_QUEUE_QUOTE_TIMEOUT environment variable to control quote request timeouts (default: 300s).

* **Tests**
  * Added a test to verify quote requests apply the correct timeout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1035)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->