### PR TITLE
v4.5.18 - Option backtest runtime guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.18 - Unreleased
+## 4.5.18 - 2026-05-14
+
+Deploy marker: 4.5.18 release commit (`deploy 4.5.18`)
 
 ### Fixed
 - **IBKR-routed stock/index lookups in option backtests now stay on native daily bars.** Implicit stock/index `get_last_price()` and `get_quote()` calls no longer fall through to IBKR minute history after an option backtest has observed intraday cadence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.5.18 - Unreleased
 
+### Fixed
+- **IBKR-routed stock/index lookups in option backtests now stay on native daily bars.** Implicit stock/index `get_last_price()` and `get_quote()` calls no longer fall through to IBKR minute history after an option backtest has observed intraday cadence.
+- **ThetaData option OHLC downloader waits are now bounded separately.** One stuck sparse option contract/day no longer inherits the broad OHLC history timeout used for larger history downloads.
+
 ## 4.5.17 - 2026-05-14
 
 Deploy marker: 4.5.17 release commit (`deploy 4.5.17`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.18 - Unreleased
+
 ## 4.5.17 - 2026-05-14
 
 Deploy marker: 4.5.17 release commit (`deploy 4.5.17`)

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -184,6 +184,12 @@ Selection rule (ThetaData):
 - Default: `300`.
 - Notes: this is intentionally shorter than `THETADATA_QUEUE_HISTORY_TIMEOUT` so one stuck option quote fails visibly instead of making a backtest appear frozen for a full OHLC-history timeout window.
 
+### `THETADATA_QUEUE_OPTION_OHLC_TIMEOUT`
+- Purpose: Data Downloader wait timeout for `/option/history/ohlc` requests used by sparse option contract probes.
+- Values: seconds (float); set to `0` only if you intentionally want unbounded waits.
+- Default: `300`.
+- Notes: stock/index history continues to use `THETADATA_QUEUE_HISTORY_TIMEOUT`; this only bounds option OHLC requests that can otherwise stall a backtest on one illiquid contract/day.
+
 ## ThetaData option chain building (performance)
 
 These env vars are used by the ThetaData chain cache/builder in `lumibot/tools/thetadata_helper.py`.

--- a/lumibot/backtesting/interactive_brokers_rest_backtesting.py
+++ b/lumibot/backtesting/interactive_brokers_rest_backtesting.py
@@ -282,6 +282,19 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         if asset_type in {"stock", "index"}:
             day_key = (base_asset, quote_asset, "day", self._normalize_exchange_key(effective_exchange))
             day_data = self._data_store.get(day_key)
+            if day_data is None:
+                try:
+                    self._refresh_window_around_datetime(
+                        asset=base_asset,
+                        quote=quote_asset,
+                        dataset_key="day",
+                        dt=now,
+                        exchange=effective_exchange,
+                        include_after_hours=False,
+                    )
+                    day_data = self._data_store.get(day_key)
+                except Exception:
+                    return None
             if day_data is not None:
                 try:
                     return day_data.get_last_price(now)
@@ -300,6 +313,7 @@ class InteractiveBrokersRESTBacktesting(PandasData):
                             return day_data.get_last_price(now)
                     except Exception:
                         return None
+            return None
 
         minute_key = (base_asset, quote_asset, "minute", self._normalize_exchange_key(effective_exchange))
         data = self._data_store.get(minute_key)
@@ -391,6 +405,19 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         if asset_type in {"stock", "index"}:
             day_key = (base_asset, quote_asset, "day", self._normalize_exchange_key(effective_exchange))
             day_data = self._data_store.get(day_key)
+            if day_data is None:
+                try:
+                    self._refresh_window_around_datetime(
+                        asset=base_asset,
+                        quote=quote_asset,
+                        dataset_key="day",
+                        dt=now,
+                        exchange=effective_exchange,
+                        include_after_hours=False,
+                    )
+                    day_data = self._data_store.get(day_key)
+                except Exception:
+                    return Quote(asset=base_asset)
             if day_data is not None:
                 try:
                     ohlcv_bid_ask_dict = day_data.get_quote(now)
@@ -431,6 +458,7 @@ class InteractiveBrokersRESTBacktesting(PandasData):
                             )
                     except Exception:
                         return Quote(asset=base_asset)
+            return Quote(asset=base_asset)
 
         minute_key = (base_asset, quote_asset, "minute", self._normalize_exchange_key(effective_exchange))
         minute_data = self._data_store.get(minute_key)

--- a/lumibot/backtesting/routed_backtesting.py
+++ b/lumibot/backtesting/routed_backtesting.py
@@ -1062,8 +1062,13 @@ class RoutedBacktestingPandas(ThetaDataBacktestingPandas):
             spec = ProviderSpec(provider="thetadata")
 
         if spec.provider != "thetadata" and timestep == "minute":
+            asset_obj = asset if not isinstance(asset, tuple) else asset[0]
+            asset_type = str(getattr(asset_obj, "asset_type", "") or "").strip().lower()
+            prefer_native_day = bool(getattr(self, "PREFER_NATIVE_DAY_BARS_FOR_STOCK_INDEX", False))
             source_timestep = str(getattr(self, "_timestep", "") or "").strip().lower()
-            if _is_day_like_timestep(source_timestep):
+            if prefer_native_day and asset_type in {"stock", "equity", "index"}:
+                timestep = "day"
+            elif _is_day_like_timestep(source_timestep):
                 timestep = "day"
             elif not bool(getattr(self, "_observed_intraday_cadence", False)) and bool(
                 getattr(self, "_effective_day_mode", False)
@@ -1091,8 +1096,13 @@ class RoutedBacktestingPandas(ThetaDataBacktestingPandas):
             spec = ProviderSpec(provider="thetadata")
 
         if spec.provider != "thetadata" and timestep == "minute":
+            asset_obj = asset if not isinstance(asset, tuple) else asset[0]
+            asset_type = str(getattr(asset_obj, "asset_type", "") or "").strip().lower()
+            prefer_native_day = bool(getattr(self, "PREFER_NATIVE_DAY_BARS_FOR_STOCK_INDEX", False))
             source_timestep = str(getattr(self, "_timestep", "") or "").strip().lower()
-            if _is_day_like_timestep(source_timestep):
+            if prefer_native_day and asset_type in {"stock", "equity", "index"}:
+                timestep = "day"
+            elif _is_day_like_timestep(source_timestep):
                 timestep = "day"
             elif not bool(getattr(self, "_observed_intraday_cadence", False)) and bool(
                 getattr(self, "_effective_day_mode", False)

--- a/lumibot/tools/thetadata_helper.py
+++ b/lumibot/tools/thetadata_helper.py
@@ -5112,11 +5112,13 @@ def get_request(
             try:
                 list_timeout = float(os.environ.get("THETADATA_QUEUE_LIST_TIMEOUT", "600"))
                 quote_timeout = float(os.environ.get("THETADATA_QUEUE_QUOTE_TIMEOUT", "300"))
+                option_ohlc_timeout = float(os.environ.get("THETADATA_QUEUE_OPTION_OHLC_TIMEOUT", "300"))
                 history_timeout = float(os.environ.get("THETADATA_QUEUE_HISTORY_TIMEOUT", "1800"))
                 default_timeout = float(os.environ.get("THETADATA_QUEUE_DEFAULT_TIMEOUT", "900"))
             except Exception:
                 list_timeout = 600.0
                 quote_timeout = 300.0
+                option_ohlc_timeout = 300.0
                 history_timeout = 1800.0
                 default_timeout = 900.0
 
@@ -5130,6 +5132,11 @@ def get_request(
                 # return quickly or fail visibly; using the broader OHLC history timeout can make
                 # a backtest appear frozen on one stale quote request for 30 minutes.
                 effective_timeout = quote_timeout if quote_timeout > 0 else None
+            elif "/option/history/ohlc" in request_path:
+                # Option OHLC requests during point-in-time backtests are often one-contract,
+                # one-day probes. Bound them separately from broad stock/index history fetches so
+                # a stuck sparse option contract does not park the whole simulation for 30 minutes.
+                effective_timeout = option_ohlc_timeout if option_ohlc_timeout > 0 else None
             elif "/history/" in request_path:
                 effective_timeout = history_timeout if history_timeout > 0 else None
             else:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.17",
+    version="4.5.18",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_ibkr_index_daily_last_price_unit.py
+++ b/tests/test_ibkr_index_daily_last_price_unit.py
@@ -82,6 +82,25 @@ def test_ibkr_stock_get_last_price_refreshes_loaded_day_series_without_minute_fe
     assert len(refresh_calls) == 1
 
 
+def test_ibkr_stock_get_last_price_loads_day_series_without_minute_fallback(monkeypatch):
+    data_source = _make_data_source()
+    asset = Asset("PARR", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    day_key = (asset, quote, "day", "AUTO")
+    refresh_calls = []
+
+    def _refresh_window_around_datetime(**kwargs):
+        refresh_calls.append(kwargs)
+        assert kwargs["dataset_key"] == "day"
+        assert kwargs["include_after_hours"] is False
+        data_source._data_store[day_key] = _FakeDayData(61.25)
+
+    monkeypatch.setattr(data_source, "_refresh_window_around_datetime", _refresh_window_around_datetime)
+
+    assert data_source.get_last_price(asset) == 61.25
+    assert len(refresh_calls) == 1
+
+
 def test_ibkr_string_stock_get_last_price_uses_loaded_day_series_without_minute_fetch(monkeypatch):
     data_source = _make_data_source()
     asset = Asset("MU", asset_type=Asset.AssetType.STOCK)
@@ -159,6 +178,29 @@ def test_ibkr_stock_get_quote_refreshes_loaded_day_series_without_minute_fetch(m
     assert snapshot.price == 93.25
     assert snapshot.bid == 93.15
     assert snapshot.ask == 93.35
+    assert len(refresh_calls) == 1
+
+
+def test_ibkr_stock_get_quote_loads_day_series_without_minute_fallback(monkeypatch):
+    data_source = _make_data_source()
+    asset = Asset("PARR", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    day_key = (asset, quote, "day", "AUTO")
+    refresh_calls = []
+
+    def _refresh_window_around_datetime(**kwargs):
+        refresh_calls.append(kwargs)
+        assert kwargs["dataset_key"] == "day"
+        assert kwargs["include_after_hours"] is False
+        data_source._data_store[day_key] = _FakeDayData(61.25)
+
+    monkeypatch.setattr(data_source, "_refresh_window_around_datetime", _refresh_window_around_datetime)
+
+    snapshot = data_source.get_quote(asset)
+    assert snapshot is not None
+    assert snapshot.price == 61.25
+    assert snapshot.bid == 61.15
+    assert snapshot.ask == 61.35
     assert len(refresh_calls) == 1
 
 

--- a/tests/test_routed_backtesting_registry_unit.py
+++ b/tests/test_routed_backtesting_registry_unit.py
@@ -116,6 +116,25 @@ def test_routed_get_last_price_aligns_1d_source_timestep_to_day_for_non_theta(mo
     assert seen == ["day"]
 
 
+def test_routed_get_last_price_keeps_ibkr_stock_on_day_even_after_intraday_cadence(monkeypatch):
+    ds = _make_ds(routing={"stock": "ibkr", "default": "thetadata"}, monkeypatch=monkeypatch)
+    ds._timestep = "minute"
+    ds._observed_intraday_cadence = True
+    ds._effective_day_mode = False
+
+    seen: list[str] = []
+
+    def _fake_super_get_last_price(self, asset, timestep="minute", quote=None, exchange=None, **kwargs):
+        seen.append(str(timestep))
+        return 123.45
+
+    monkeypatch.setattr(ThetaDataBacktestingPandas, "get_last_price", _fake_super_get_last_price)
+
+    price = ds.get_last_price(Asset("PARR", asset_type="stock"))
+    assert price == 123.45
+    assert seen == ["day"]
+
+
 def test_routed_get_quote_aligns_1d_source_timestep_to_day_for_non_theta(monkeypatch):
     ds = _make_ds(routing={"stock": "ibkr", "default": "thetadata"}, monkeypatch=monkeypatch)
     ds._timestep = "1D"
@@ -129,4 +148,22 @@ def test_routed_get_quote_aligns_1d_source_timestep_to_day_for_non_theta(monkeyp
     monkeypatch.setattr(ThetaDataBacktestingPandas, "get_quote", _fake_super_get_quote)
 
     _ = ds.get_quote(Asset("AAPL", asset_type="stock"))
+    assert seen == ["day"]
+
+
+def test_routed_get_quote_keeps_ibkr_stock_on_day_even_after_intraday_cadence(monkeypatch):
+    ds = _make_ds(routing={"stock": "ibkr", "default": "thetadata"}, monkeypatch=monkeypatch)
+    ds._timestep = "minute"
+    ds._observed_intraday_cadence = True
+    ds._effective_day_mode = False
+
+    seen: list[str] = []
+
+    def _fake_super_get_quote(self, asset, quote=None, exchange=None, timestep="minute", **kwargs):
+        seen.append(str(timestep))
+        return None
+
+    monkeypatch.setattr(ThetaDataBacktestingPandas, "get_quote", _fake_super_get_quote)
+
+    _ = ds.get_quote(Asset("PARR", asset_type="stock"))
     assert seen == ["day"]

--- a/tests/test_thetadata_transport_selection.py
+++ b/tests/test_thetadata_transport_selection.py
@@ -76,6 +76,40 @@ def test_get_request_uses_shorter_timeout_for_quote_history(monkeypatch):
     assert seen["timeout"] == 123.0
 
 
+def test_get_request_uses_shorter_timeout_for_option_ohlc_history(monkeypatch):
+    import lumibot.tools.thetadata_helper as thetadata_helper
+    import lumibot.tools.data_downloader_queue_client as queue_client
+
+    monkeypatch.setenv("DATADOWNLOADER_BASE_URL", "http://example:8080")
+    monkeypatch.setenv("DATADOWNLOADER_API_KEY", "test-key")
+    monkeypatch.setenv("THETADATA_QUEUE_OPTION_OHLC_TIMEOUT", "234")
+    monkeypatch.setenv("THETADATA_QUEUE_HISTORY_TIMEOUT", "1800")
+
+    seen = {}
+
+    def fake_queue_request(url: str, querystring, headers=None, timeout=None):
+        seen["timeout"] = timeout
+        return {"header": {"format": []}, "response": [[1]]}
+
+    monkeypatch.setattr(queue_client, "queue_request", fake_queue_request)
+
+    result = thetadata_helper.get_request(
+        url="http://example:8080/v3/option/history/ohlc",
+        headers={},
+        querystring={
+            "symbol": "SPY",
+            "expiration": "2026-06-18",
+            "strike": "500",
+            "right": "call",
+            "date": "2026-04-09",
+            "format": "json",
+        },
+    )
+
+    assert isinstance(result, dict)
+    assert seen["timeout"] == 234.0
+
+
 def test_get_request_raises_when_downloader_base_url_set_but_api_key_missing(monkeypatch):
     import lumibot.tools.thetadata_helper as thetadata_helper
 


### PR DESCRIPTION
## Summary
- keep IBKR-routed stock/index lookups on native day bars during option backtests
- add a bounded timeout for ThetaData option OHLC queue waits
- add regression coverage for both paths

## Tests
- gtimeout 240 .venv/bin/python -m pytest tests/test_thetadata_transport_selection.py tests/test_ibkr_index_daily_last_price_unit.py tests/test_routed_backtesting_registry_unit.py tests/test_routed_backtesting_unit.py tests/test_thetadata_download_progress.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 4.5.18

* **New Features**
  * Added `THETADATA_QUEUE_OPTION_OHLC_TIMEOUT` environment variable for independent control of option OHLC download timeouts.

* **Bug Fixes**
  * Fixed IBKR stock/index lookups during option backtests to remain on native daily bars instead of falling back to minute-level data.
  * Improved ThetaData option OHLC timeout handling to prevent one stuck contract from blocking others.
  * Enhanced daily data retrieval when initial data is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1036)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->