### PR TITLE
v4.5.19 - Alpaca native multi-timeframe backtesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.5.19 - Unreleased
 
+### Fixed
+- **Alpaca backtests now support multi-timeframe history requests such as `15min`.** `AlpacaBacktesting.get_historical_prices()` now fetches the underlying minute/day source bars and resamples them before slicing, so strategy calls like `get_historical_prices(asset, 100, "15min")` match the public strategy API contract instead of failing validation.
+
 ## 4.5.18 - 2026-05-14
 
 Deploy marker: 4.5.18 release commit (`deploy 4.5.18`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.19 - Unreleased
+
 ## 4.5.18 - 2026-05-14
 
 Deploy marker: 4.5.18 release commit (`deploy 4.5.18`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 4.5.19 - Unreleased
 
 ### Fixed
-- **Alpaca backtests now support multi-timeframe history requests such as `15min`.** `AlpacaBacktesting.get_historical_prices()` now fetches the underlying minute/day source bars and resamples them before slicing, so strategy calls like `get_historical_prices(asset, 100, "15min")` match the public strategy API contract instead of failing validation.
+- **Alpaca backtests now support multi-timeframe history requests such as `15min`.** `AlpacaBacktesting.get_historical_prices()` now requests native Alpaca minute/hour multiples where supported and only falls back to local aggregation for unsupported aliases such as multi-day bars, so strategy calls like `get_historical_prices(asset, 100, "15min")` match the public strategy API contract instead of failing validation.
 
 ## 4.5.18 - 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-## 4.5.19 - Unreleased
+## 4.5.19 - 2026-05-14
+
+Deploy marker: 4.5.19 release commit (`deploy 4.5.19`)
 
 ### Fixed
 - **Alpaca backtests now support multi-timeframe history requests such as `15min`.** `AlpacaBacktesting.get_historical_prices()` now requests native Alpaca minute/hour multiples where supported and only falls back to local aggregation for unsupported aliases such as multi-day bars, so strategy calls like `get_historical_prices(asset, 100, "15min")` match the public strategy API contract instead of failing validation.
+
+### Changed
+- **LumiBot release docs now include a Codex-safe remote-first release path for shared checkouts.** AI agents can avoid switching the canonical local checkout when unrelated dirty files are present while preserving the same version-branch, PR, tag, PyPI, and BotManager deployment invariants.
 
 ## 4.5.18 - 2026-05-14
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 > Release/deployment workflow for LumiBot (version branches, changelog, tags, and GitHub releases).
 
-**Last Updated:** 2026-05-10
+**Last Updated:** 2026-05-14
 **Status:** Active
 **Audience:** Developers + AI Agents
 
@@ -65,6 +65,35 @@ Release order for tearsheet metric changes:
   - When you start a new version branch, bump immediately and commit: `chore: start X.Y.Z`.
   - **Never downgrade** versions. If a bump was wrong, bump forward (and document why).
 - After a version branch is merged to `dev`, **immediately start the next version branch** (see Step 7).
+
+---
+
+## Codex-Safe Release Path For Shared Checkouts
+
+Use this path when an AI agent is deploying from the shared canonical checkout and
+local branch switching would risk another agent's work.
+
+The release invariants are the same:
+- the version branch must contain every commit that will ship,
+- the version branch must include latest `dev`,
+- the release must merge to `dev` via PR,
+- the `vX.Y.Z` tag must point at the resulting `dev` merge commit,
+- BotManager deploys happen only after the PyPI release is verified.
+
+Safe remote-first checklist:
+1. Confirm the local checkout is on `version/X.Y.Z`; do not switch to `dev`.
+2. Confirm no local-only commits exist: `git log --oneline origin/version/X.Y.Z..HEAD`.
+3. Confirm any local dirty files are unrelated to the release. If they are related, commit and push them first. If they are unrelated, do not stage them and call the dirty state out in the release notes.
+4. Fetch `origin/dev` and `origin/version/X.Y.Z`, then compare both directions:
+   - `git log --oneline origin/dev..origin/version/X.Y.Z`
+   - `git log --oneline origin/version/X.Y.Z..origin/dev`
+5. If `origin/dev` is ahead, merge/update the version branch through the release PR or a clean disposable release clone. Do not switch the canonical checkout just to do this.
+6. Create or update the release PR from `version/X.Y.Z` to `dev`, wait for CI, then merge the PR.
+7. Fetch the updated `origin/dev`, tag the `dev` merge commit, and push the tag.
+
+This does not relax the clean-tree requirement for normal human release work. It
+exists to prevent AI agents from switching branches in the shared LumiBot checkout
+when unrelated local work is present.
 
 ---
 

--- a/lumibot/backtesting/alpaca_backtesting.py
+++ b/lumibot/backtesting/alpaca_backtesting.py
@@ -354,17 +354,17 @@ class AlpacaBacktesting(DataSourceBacktesting):
             # For daily bars
             search_date = search_datetime.date()
             dates = df.index.date
-            current_index = dates.searchsorted(search_date)
+            current_index = dates.searchsorted(search_date, side="right") - 1
 
             # Adjust for incomplete current bar
-            if remove_incomplete_current_bar and current_index > 0 and dates[current_index] == search_date:
+            if remove_incomplete_current_bar and current_index >= 0 and dates[current_index] == search_date:
                 current_index -= 1
         else:
-            # For minute bars
-            current_index = df.index.searchsorted(search_datetime)
+            # For intraday bars, use the most recent bar at or before the search datetime.
+            current_index = df.index.searchsorted(search_datetime, side="right") - 1
 
             # Adjust for incomplete current bar
-            if remove_incomplete_current_bar and current_index > 0 and df.index[current_index] == search_datetime:
+            if remove_incomplete_current_bar and current_index >= 0 and df.index[current_index] == search_datetime:
                 current_index -= 1
 
         # Handle data retrieval and slicing
@@ -649,14 +649,19 @@ class AlpacaBacktesting(DataSourceBacktesting):
 
         df = df[['timestamp', 'open', 'high', 'low', 'close', 'volume']]
 
-        trading_times = self._get_trading_times_for_timestep(
-            pcal=self._trading_days,
-            timestep=timestep,
-        )
+        if timestep in ("day", "minute"):
+            trading_times = self._get_trading_times_for_timestep(
+                pcal=self._trading_days,
+                timestep=timestep,
+            )
 
-        # Reindex the dataframe with a row for each bar we should have a trading iteration for.
-        # Fill any empty bars with previous data.
-        df = self._reindex_and_fill(df=df, trading_times=trading_times, timestep=timestep)
+            # Reindex the dataframe with a row for each bar we should have a trading iteration for.
+            # Fill any empty bars with previous data.
+            df = self._reindex_and_fill(df=df, trading_times=trading_times, timestep=timestep)
+        else:
+            # Alpaca aligns native intraday multiples on provider-specific boundaries
+            # such as 09:40 for 20Min NYSE bars. Preserve those native timestamps.
+            df.sort_values("timestamp", inplace=True)
 
         # Filter data to include only rows between data_datetime_start and data_datetime_end
         df = df[(df['timestamp'] >= data_datetime_start) & (df['timestamp'] <= data_datetime_end)]

--- a/lumibot/backtesting/alpaca_backtesting.py
+++ b/lumibot/backtesting/alpaca_backtesting.py
@@ -289,7 +289,8 @@ class AlpacaBacktesting(DataSourceBacktesting):
         length : int
             The number of bars to get.
         timestep : str
-            The timestep to get the bars at. Accepts "day" or "minute".
+            The timestep to get the bars at. Accepts "day", "minute", and
+            multi-timeframe aliases such as "15min", "1h", or "2d".
         timeshift : datetime.timedelta
             The amount of time to shift the reference point (self._datetime).
             If you want 10 daily bars from 1 week ago (not including the last week),
@@ -315,6 +316,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
 
         if timestep is None:
             timestep = self._timestep
+        source_timestep, resample_rule = self._normalize_timestep_for_source(timestep)
 
         if quote is None:
             quote = self.LUMIBOT_DEFAULT_QUOTE_ASSET
@@ -329,7 +331,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             df = self.get_historical_prices_between_dates(
                 base_asset=asset,
                 quote_asset=quote,
-                timestep=timestep,
+                timestep=source_timestep,
                 data_datetime_start=self._data_datetime_start,
                 data_datetime_end=self._data_datetime_end,
                 auto_adjust=self._auto_adjust
@@ -338,6 +340,9 @@ class AlpacaBacktesting(DataSourceBacktesting):
             # Handle errors if fetching data fails
             raise RuntimeError(f"Unable to fetch historical prices during backtest: {e}")
 
+        if resample_rule is not None:
+            df = self._resample_ohlcv_dataframe(df, resample_rule)
+
         # Ensure sufficient bars are available
         if length > len(df):
             raise ValueError(
@@ -345,7 +350,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             )
 
         # Adjust the search based on timestep
-        if timestep == 'day':
+        if source_timestep == 'day':
             # For daily bars
             search_date = search_datetime.date()
             dates = df.index.date
@@ -382,6 +387,46 @@ class AlpacaBacktesting(DataSourceBacktesting):
             return_polars=return_polars,
             tzinfo=self.tzinfo,
         )
+
+    @staticmethod
+    def _normalize_timestep_for_source(timestep: str) -> tuple[str, str | None]:
+        """Return the Alpaca source timestep and optional pandas resample rule."""
+        if timestep in ("day", "minute"):
+            return timestep, None
+
+        delta, unit = DataSourceBacktesting.convert_timestep_str_to_timedelta(timestep)
+
+        if unit == "day":
+            days = max(int(delta.total_seconds() // 86400), 1)
+            return "day", None if days == 1 else f"{days}D"
+
+        minutes = max(int(delta.total_seconds() // 60), 1)
+        return "minute", None if minutes == 1 else f"{minutes}min"
+
+    @staticmethod
+    def _resample_ohlcv_dataframe(df: pd.DataFrame, resample_rule: str) -> pd.DataFrame:
+        """Aggregate source OHLCV bars into a requested multi-timeframe."""
+        if df.empty:
+            return df
+
+        aggregation = {
+            "open": "first",
+            "high": "max",
+            "low": "min",
+            "close": "last",
+            "volume": "sum",
+        }
+        available_aggregation = {column: method for column, method in aggregation.items() if column in df.columns}
+
+        resampled = (
+            df.sort_index()
+            .resample(resample_rule, label="left", closed="left")
+            .agg(available_aggregation)
+        )
+        required_columns = [column for column in ("open", "high", "low", "close") if column in resampled.columns]
+        if required_columns:
+            resampled = resampled.dropna(subset=required_columns, how="any")
+        return resampled
 
     def get_chains(self, asset, quote=None):
         """Mock implementation for getting option chains"""

--- a/lumibot/backtesting/alpaca_backtesting.py
+++ b/lumibot/backtesting/alpaca_backtesting.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytz
 from alpaca.data.historical import CryptoHistoricalDataClient, StockHistoricalDataClient
 from alpaca.data.requests import CryptoBarsRequest, StockBarsRequest
-from alpaca.data.timeframe import TimeFrame
+from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
 
 from lumibot.constants import LUMIBOT_CACHE_FOLDER
 from lumibot.data_sources import AlpacaData, DataSourceBacktesting
@@ -401,7 +401,56 @@ class AlpacaBacktesting(DataSourceBacktesting):
             return "day", None if days == 1 else f"{days}D"
 
         minutes = max(int(delta.total_seconds() // 60), 1)
-        return "minute", None if minutes == 1 else f"{minutes}min"
+        if minutes % 60 == 0:
+            hours = minutes // 60
+            if 1 <= hours <= 23:
+                return ("hour" if hours == 1 else f"{hours}hour"), None
+        if 1 <= minutes <= 59:
+            return ("minute" if minutes == 1 else f"{minutes}minute"), None
+
+        return "minute", f"{minutes}min"
+
+    @staticmethod
+    def _get_alpaca_timeframe(timestep: str) -> TimeFrame:
+        """Convert a normalized Lumibot timestep to an Alpaca SDK TimeFrame."""
+        delta, unit = DataSourceBacktesting.convert_timestep_str_to_timedelta(timestep)
+
+        if unit == "day":
+            days = max(int(delta.total_seconds() // 86400), 1)
+            if days != 1:
+                raise ValueError("Alpaca only supports native 1Day bars; multi-day bars must be resampled.")
+            return TimeFrame.Day
+
+        if unit == "hour":
+            hours = max(int(delta.total_seconds() // 3600), 1)
+            return TimeFrame(hours, TimeFrameUnit.Hour)
+
+        minutes = max(int(delta.total_seconds() // 60), 1)
+        if minutes % 60 == 0:
+            hours = minutes // 60
+            return TimeFrame(hours, TimeFrameUnit.Hour)
+        return TimeFrame(minutes, TimeFrameUnit.Minute)
+
+    @staticmethod
+    def _get_trading_times_for_timestep(pcal: pd.DataFrame, timestep: str) -> pd.DatetimeIndex:
+        if timestep in ("day", "minute"):
+            return get_trading_times(pcal=pcal, timestep=timestep)
+
+        delta, unit = DataSourceBacktesting.convert_timestep_str_to_timedelta(timestep)
+        if unit == "day":
+            return get_trading_times(pcal=pcal, timestep="day")
+
+        interval = pd.Timedelta(seconds=max(int(delta.total_seconds()), 60))
+        trading_times = []
+        for _, row in pcal.iterrows():
+            start = row["market_open"]
+            end = row["market_close"]
+            is_24_7 = end.hour == 23 and end.minute == 59
+            times = pd.date_range(start=start, end=end, freq=interval)
+            times = times[times <= end] if is_24_7 else times[times < end]
+            trading_times.extend(times)
+
+        return pd.DatetimeIndex(trading_times)
 
     @staticmethod
     def _resample_ohlcv_dataframe(df: pd.DataFrame, resample_rule: str) -> pd.DataFrame:
@@ -487,8 +536,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
         if timestep is None:
             timestep = self._timestep
 
-        if timestep not in ['day', 'minute']:
-            raise ValueError(f"Invalid timestep {timestep}. Must be 'day' or 'minute'.")
+        timestep, _ = self._normalize_timestep_for_source(timestep)
 
         base_quote = f"{base_asset.symbol}-{base_asset.asset_type}_{quote_asset.symbol}-{quote_asset.asset_type}"
         market = market
@@ -563,7 +611,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             # noinspection PyArgumentList
             request_params = CryptoBarsRequest(
                 symbol_or_symbols=symbol,
-                timeframe=self._parse_source_timestep(timestep, reverse=True),
+                timeframe=self._get_alpaca_timeframe(timestep),
                 start=data_datetime_start,
                 end=data_datetime_end + timedelta(days=1),  # alpaca end dates are exclusive
             )
@@ -574,7 +622,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
             # noinspection PyArgumentList
             request_params = StockBarsRequest(
                 symbol_or_symbols=base_asset.symbol,
-                timeframe=self._parse_source_timestep(timestep, reverse=True),
+                timeframe=self._get_alpaca_timeframe(timestep),
                 start=data_datetime_start,
                 end=data_datetime_end + timedelta(days=1),  # alpaca end dates are exclusive,
                 adjustment=adjustment,
@@ -601,7 +649,7 @@ class AlpacaBacktesting(DataSourceBacktesting):
 
         df = df[['timestamp', 'open', 'high', 'low', 'close', 'volume']]
 
-        trading_times = get_trading_times(
+        trading_times = self._get_trading_times_for_timestep(
             pcal=self._trading_days,
             timestep=timestep,
         )
@@ -751,11 +799,10 @@ class AlpacaBacktesting(DataSourceBacktesting):
         if missing_columns:
             raise ValueError(f"The dataframe is missing the following required columns: {', '.join(missing_columns)}")
 
-        if timestep not in ['day', 'minute']:
-            raise ValueError(f"The timestep must be 'day' or 'minute'.")
+        source_timestep, _ = self._normalize_timestep_for_source(timestep)
 
         # For daily bars, we want to preserve original timestamps but add missing days
-        if timestep == 'day':
+        if source_timestep == 'day':
             # Get just the dates from trading_times
             trading_dates = trading_times.date
             # Get dates from df timestamps

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.18",
+    version="4.5.19",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_alpaca_backtesting_multitimeframe_unit.py
+++ b/tests/test_alpaca_backtesting_multitimeframe_unit.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+
+import pandas as pd
+import pytz
+
+from lumibot.backtesting import AlpacaBacktesting
+from lumibot.entities import Asset
+
+
+def test_alpaca_backtesting_normalizes_common_multi_timeframe_aliases():
+    assert AlpacaBacktesting._normalize_timestep_for_source("15min") == ("minute", "15min")
+    assert AlpacaBacktesting._normalize_timestep_for_source("1h") == ("minute", "60min")
+    assert AlpacaBacktesting._normalize_timestep_for_source("4 hours") == ("minute", "240min")
+    assert AlpacaBacktesting._normalize_timestep_for_source("2d") == ("day", "2D")
+
+
+def test_alpaca_backtesting_resamples_15min_request_from_minute_data():
+    tzinfo = pytz.timezone("America/New_York")
+    data_source = AlpacaBacktesting.__new__(AlpacaBacktesting)
+    data_source._remove_incomplete_current_bar = False
+    data_source._timestep = "minute"
+    data_source._datetime = tzinfo.localize(datetime(2026, 1, 2, 10, 45))
+    data_source._data_datetime_start = tzinfo.localize(datetime(2026, 1, 2, 0, 0))
+    data_source._data_datetime_end = tzinfo.localize(datetime(2026, 1, 2, 23, 59))
+    data_source._auto_adjust = True
+    data_source.tzinfo = tzinfo
+
+    index = pd.date_range(
+        tzinfo.localize(datetime(2026, 1, 2, 9, 30)),
+        periods=76,
+        freq="min",
+    )
+    minute_df = pd.DataFrame(
+        {
+            "open": range(len(index)),
+            "high": [value + 0.5 for value in range(len(index))],
+            "low": [value - 0.5 for value in range(len(index))],
+            "close": [value + 0.25 for value in range(len(index))],
+            "volume": [1] * len(index),
+        },
+        index=index,
+    )
+
+    requested_timesteps = []
+
+    def fake_get_historical_prices_between_dates(**kwargs):
+        requested_timesteps.append(kwargs["timestep"])
+        return minute_df
+
+    data_source.get_historical_prices_between_dates = fake_get_historical_prices_between_dates
+
+    bars = data_source.get_historical_prices(Asset("TSLA"), length=3, timestep="15min")
+    df = bars.pandas_df
+
+    assert requested_timesteps == ["minute"]
+    assert list(df.index) == list(pd.date_range(index[-31], periods=3, freq="15min"))
+    assert list(df["open"]) == [45, 60, 75]
+    assert list(df["close"]) == [59.25, 74.25, 75.25]
+    assert list(df["volume"]) == [15, 15, 1]

--- a/tests/test_alpaca_backtesting_multitimeframe_unit.py
+++ b/tests/test_alpaca_backtesting_multitimeframe_unit.py
@@ -9,6 +9,8 @@ from lumibot.entities import Asset
 
 def test_alpaca_backtesting_normalizes_common_multi_timeframe_aliases():
     assert AlpacaBacktesting._normalize_timestep_for_source("15min") == ("15minute", None)
+    assert AlpacaBacktesting._normalize_timestep_for_source("13 minutes") == ("13minute", None)
+    assert AlpacaBacktesting._normalize_timestep_for_source("20min") == ("20minute", None)
     assert AlpacaBacktesting._normalize_timestep_for_source("1h") == ("hour", None)
     assert AlpacaBacktesting._normalize_timestep_for_source("4 hours") == ("4hour", None)
     assert AlpacaBacktesting._normalize_timestep_for_source("2d") == ("day", "2D")
@@ -59,7 +61,55 @@ def test_alpaca_backtesting_uses_native_15min_request():
     assert list(df["volume"]) == [1, 1, 1]
 
 
+def test_alpaca_backtesting_uses_latest_completed_native_intraday_bar():
+    tzinfo = pytz.timezone("America/New_York")
+    data_source = AlpacaBacktesting.__new__(AlpacaBacktesting)
+    data_source._remove_incomplete_current_bar = False
+    data_source._timestep = "minute"
+    data_source._datetime = tzinfo.localize(datetime(2026, 1, 2, 10, 50))
+    data_source._data_datetime_start = tzinfo.localize(datetime(2026, 1, 2, 0, 0))
+    data_source._data_datetime_end = tzinfo.localize(datetime(2026, 1, 2, 23, 59))
+    data_source._auto_adjust = True
+    data_source.tzinfo = tzinfo
+
+    index = pd.DatetimeIndex(
+        [
+            tzinfo.localize(datetime(2026, 1, 2, 10, 0)),
+            tzinfo.localize(datetime(2026, 1, 2, 10, 20)),
+            tzinfo.localize(datetime(2026, 1, 2, 10, 40)),
+            tzinfo.localize(datetime(2026, 1, 2, 11, 0)),
+        ]
+    )
+    native_20min_df = pd.DataFrame(
+        {
+            "open": range(len(index)),
+            "high": [value + 0.5 for value in range(len(index))],
+            "low": [value - 0.5 for value in range(len(index))],
+            "close": [value + 0.25 for value in range(len(index))],
+            "volume": [1] * len(index),
+        },
+        index=index,
+    )
+
+    requested_timesteps = []
+
+    def fake_get_historical_prices_between_dates(**kwargs):
+        requested_timesteps.append(kwargs["timestep"])
+        return native_20min_df
+
+    data_source.get_historical_prices_between_dates = fake_get_historical_prices_between_dates
+
+    bars = data_source.get_historical_prices(Asset("TSLA"), length=2, timestep="20min")
+    df = bars.pandas_df
+
+    assert requested_timesteps == ["20minute"]
+    assert list(df.index) == list(index[1:3])
+    assert list(df["open"]) == [1, 2]
+
+
 def test_alpaca_backtesting_uses_alpaca_sdk_timeframes_for_intraday_multiples():
+    assert str(AlpacaBacktesting._get_alpaca_timeframe("13minute")) == "13Min"
     assert str(AlpacaBacktesting._get_alpaca_timeframe("15minute")) == "15Min"
+    assert str(AlpacaBacktesting._get_alpaca_timeframe("20minute")) == "20Min"
     assert str(AlpacaBacktesting._get_alpaca_timeframe("hour")) == "1Hour"
     assert str(AlpacaBacktesting._get_alpaca_timeframe("4hour")) == "4Hour"

--- a/tests/test_alpaca_backtesting_multitimeframe_unit.py
+++ b/tests/test_alpaca_backtesting_multitimeframe_unit.py
@@ -8,13 +8,13 @@ from lumibot.entities import Asset
 
 
 def test_alpaca_backtesting_normalizes_common_multi_timeframe_aliases():
-    assert AlpacaBacktesting._normalize_timestep_for_source("15min") == ("minute", "15min")
-    assert AlpacaBacktesting._normalize_timestep_for_source("1h") == ("minute", "60min")
-    assert AlpacaBacktesting._normalize_timestep_for_source("4 hours") == ("minute", "240min")
+    assert AlpacaBacktesting._normalize_timestep_for_source("15min") == ("15minute", None)
+    assert AlpacaBacktesting._normalize_timestep_for_source("1h") == ("hour", None)
+    assert AlpacaBacktesting._normalize_timestep_for_source("4 hours") == ("4hour", None)
     assert AlpacaBacktesting._normalize_timestep_for_source("2d") == ("day", "2D")
 
 
-def test_alpaca_backtesting_resamples_15min_request_from_minute_data():
+def test_alpaca_backtesting_uses_native_15min_request():
     tzinfo = pytz.timezone("America/New_York")
     data_source = AlpacaBacktesting.__new__(AlpacaBacktesting)
     data_source._remove_incomplete_current_bar = False
@@ -27,10 +27,10 @@ def test_alpaca_backtesting_resamples_15min_request_from_minute_data():
 
     index = pd.date_range(
         tzinfo.localize(datetime(2026, 1, 2, 9, 30)),
-        periods=76,
-        freq="min",
+        periods=6,
+        freq="15min",
     )
-    minute_df = pd.DataFrame(
+    native_15min_df = pd.DataFrame(
         {
             "open": range(len(index)),
             "high": [value + 0.5 for value in range(len(index))],
@@ -45,15 +45,21 @@ def test_alpaca_backtesting_resamples_15min_request_from_minute_data():
 
     def fake_get_historical_prices_between_dates(**kwargs):
         requested_timesteps.append(kwargs["timestep"])
-        return minute_df
+        return native_15min_df
 
     data_source.get_historical_prices_between_dates = fake_get_historical_prices_between_dates
 
     bars = data_source.get_historical_prices(Asset("TSLA"), length=3, timestep="15min")
     df = bars.pandas_df
 
-    assert requested_timesteps == ["minute"]
-    assert list(df.index) == list(pd.date_range(index[-31], periods=3, freq="15min"))
-    assert list(df["open"]) == [45, 60, 75]
-    assert list(df["close"]) == [59.25, 74.25, 75.25]
-    assert list(df["volume"]) == [15, 15, 1]
+    assert requested_timesteps == ["15minute"]
+    assert list(df.index) == list(index[-3:])
+    assert list(df["open"]) == [3, 4, 5]
+    assert list(df["close"]) == [3.25, 4.25, 5.25]
+    assert list(df["volume"]) == [1, 1, 1]
+
+
+def test_alpaca_backtesting_uses_alpaca_sdk_timeframes_for_intraday_multiples():
+    assert str(AlpacaBacktesting._get_alpaca_timeframe("15minute")) == "15Min"
+    assert str(AlpacaBacktesting._get_alpaca_timeframe("hour")) == "1Hour"
+    assert str(AlpacaBacktesting._get_alpaca_timeframe("4hour")) == "4Hour"


### PR DESCRIPTION
## What
Release 4.5.19 fixes AlpacaBacktesting multi-timeframe historical price requests.

## Why
Users calling `get_historical_prices(asset, length, "15min")` during Alpaca backtests hit `Invalid timestep 15min. Must be 'day' or 'minute'` even though Alpaca supports native custom minute/hour timeframes.

## Changes
- Normalize Lumibot aliases like `15min`, `13min`, `20min`, `1h`, and `4h` into native Alpaca SDK `TimeFrame` requests where supported.
- Preserve Alpaca's provider-native intraday bar alignment instead of forcing a market-open reindex grid for native multi-minute/hour bars.
- Use the latest bar at or before the strategy clock when the clock falls between native bar timestamps.
- Add regression coverage for native Alpaca timeframe conversion and edge cases.
- Update deployment docs with a Codex-safe remote-first release path for shared checkouts.

## Risk
Low-to-moderate. This touches AlpacaBacktesting historical price fetching and bar selection. Main risk is behavior change for intraday multi-timeframe requests, but those previously failed or could be misaligned. Day/minute behavior is intentionally preserved.

## Tests run
- `.venv/bin/python -m pytest tests/test_alpaca_backtesting_multitimeframe_unit.py tests/test_get_historical_prices.py::TestTimestepParsing::test_parse_timestep_multi_minute_formats -q`
- `.venv/bin/python -m pytest tests/test_get_historical_prices.py tests/test_alpaca_backtesting_multitimeframe_unit.py -q`
- Real read-only Alpaca historical data checks for TSLA with `15min`, `13min`, and `20min`; confirmed native source timesteps with no local aggregation for those supported intervals.

## Docs
- `CHANGELOG.md`
- `docs/DEPLOYMENT.md`

## Notes
Local canonical checkout still has an unrelated pre-existing dirty file: `docsrc/_templates/layout.html`. It was not staged or included in this release PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Alpaca backtests now support multi-timeframe history requests (e.g., `15min`, `20min`, `2d`) using native Alpaca data when available and local aggregation as fallback.

* **Documentation**
  * Updated deployment documentation with a new remote-first release procedure for shared checkouts.

* **Tests**
  * Added unit tests for multi-timeframe backtesting functionality.

* **Chores**
  * Bumped version to 4.5.19.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1038)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->