### PR TITLE
Deploy LumiBot 4.5.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.20 - Unreleased
+
 ## 4.5.19 - 2026-05-14
 
 Deploy marker: 4.5.19 release commit (`deploy 4.5.19`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## 4.5.20 - Unreleased
+## 4.5.20 - 2026-05-15
+
+Deploy marker: 4.5.20 release commit (`deploy 4.5.20`)
+
+### Fixed
+- **Crypto futures and perpetual backtests can use spot crypto price history through routed backtesting.** `Asset.AssetType.CRYPTO_FUTURE` requests now route through explicit `crypto_future` provider settings, falling back to `crypto` when omitted, and USDT contracts such as `BTCUSDT`, `ETHUSDT`, and `SOLUSDT` can price from the matching USD spot proxy while preserving the original futures asset for strategy-facing orders and positions.
+- **Routed backtesting now preserves day-level stock/index data in mixed option workflows.** Stock/index lookups that support option strategies avoid stale minute-frame fallbacks when daily bars are requested.
+
+### Changed
+- **Release docs now require prompt review for platform capability changes.** Deployment review includes a token-efficient BotSpot agent prompt/shared-example check alongside the existing documentation and visual asset gates.
 
 ## 4.5.19 - 2026-05-14
 

--- a/README.md
+++ b/README.md
@@ -254,8 +254,10 @@ export BACKTESTING_DATA_SOURCE=thetadata   # or yahoo, ibkr, polygon
 Multi-provider routing by asset type:
 
 ```bash
-export BACKTESTING_DATA_SOURCE='{"default":"thetadata","crypto":"coinbase"}'
+export BACKTESTING_DATA_SOURCE='{"default":"thetadata","option":"thetadata","crypto":"ibkr","crypto_future":"ibkr","future":"ibkr","cont_future":"ibkr"}'
 ```
+
+Crypto futures/perpetual backtests can route `Asset.AssetType.CRYPTO_FUTURE` through spot crypto history. USDT symbols such as `BTCUSDT`, `ETHUSDT`, and `SOLUSDT` use the matching USD spot proxy for prices.
 
 ### Data source comparison
 

--- a/docs/BACKTESTING_ARCHITECTURE.md
+++ b/docs/BACKTESTING_ARCHITECTURE.md
@@ -706,11 +706,13 @@ IBKR backtesting uses the shared Data Downloader and is cached locally (and opti
 - Single-provider: `BACKTESTING_DATA_SOURCE=ibkr`
 - Multi-provider routing (Theta for stock/option/index; IBKR for futures/crypto):
   ```bash
-  export BACKTESTING_DATA_SOURCE='{"default":"thetadata","stock":"thetadata","option":"thetadata","index":"thetadata","future":"ibkr","crypto":"ibkr"}'
+  export BACKTESTING_DATA_SOURCE='{"default":"thetadata","stock":"thetadata","option":"thetadata","index":"thetadata","future":"ibkr","cont_future":"ibkr","crypto":"ibkr","crypto_future":"ibkr"}'
   ```
   - You can also route crypto to documented CCXT backtesting paths by using either:
     - `{"crypto":"ccxt"}` (auto-select exchange from existing env/credentials), or
     - a supported CCXT backtesting exchange id directly, e.g. `{"crypto":"kraken"}` or `{"crypto":"binance"}`.
+
+For `Asset.AssetType.CRYPTO_FUTURE`, routed backtesting fetches spot crypto history as the price source while storing bars against the original futures asset. USDT contracts such as `BTCUSDT`, `ETHUSDT`, and `SOLUSDT` use the USD spot proxy (`BTC/USD`, `ETH/USD`, `SOL/USD`) and log the proxy mapping.
 
 #### Crypto daily bars (important semantics)
 

--- a/docs/BACKTESTING_SPEED_PLAYBOOK.md
+++ b/docs/BACKTESTING_SPEED_PLAYBOOK.md
@@ -41,11 +41,11 @@ Production uses router-mode, so performance work must use router-mode too.
 **Canonical production routing JSON:**
 
 ```json
-{"default":"thetadata","crypto":"ibkr","future":"ibkr","cont_future":"ibkr"}
+{"default":"thetadata","crypto":"ibkr","crypto_future":"ibkr","future":"ibkr","cont_future":"ibkr"}
 ```
 
 This is set via:
-- `BACKTESTING_DATA_SOURCE='{"default":"thetadata","crypto":"ibkr","future":"ibkr","cont_future":"ibkr"}'`
+- `BACKTESTING_DATA_SOURCE='{"default":"thetadata","crypto":"ibkr","crypto_future":"ibkr","future":"ibkr","cont_future":"ibkr"}'`
 
 ### 0.3 Repo + process safety (multi-agent rules)
 
@@ -174,11 +174,12 @@ Implementation references:
 Use this for all benchmarks unless explicitly investigating a single-provider path:
 
 ```bash
-export BACKTESTING_DATA_SOURCE='{"default":"thetadata","crypto":"ibkr","future":"ibkr","cont_future":"ibkr"}'
+export BACKTESTING_DATA_SOURCE='{"default":"thetadata","crypto":"ibkr","crypto_future":"ibkr","future":"ibkr","cont_future":"ibkr"}'
 ```
 
 Notes:
 - Router aliases `"futures"` → `"future"` for user convenience, but **does not imply** `"cont_future"`.
+- `crypto_future` is explicit for crypto perps/futures; if omitted, the router falls back to `crypto`.
 - When routing is wrong, speed “fixes” can be fake (you may be measuring a different provider than production).
 
 ---

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -10,14 +10,15 @@
 
 ## TL;DR (do this in order)
 
-1) Get the `version/X.Y.Z` PR **green** (and ensure everyone has pushed their commits).
-2) Merge latest `dev` into `version/X.Y.Z` and re-check CI (prevents drift / missing commits from other engineers).
-3) Merge the PR into `dev` (no direct pushes to `dev`).
-4) Tag the **merge commit on `dev`** as `vX.Y.Z` (this triggers GitHub Actions to publish to PyPI + create a GitHub Release).
-5) Verify `pip install lumibot==X.Y.Z` works.
-6) **Switch your LOCAL checkout to `version/X.Y.(Z+1)`** (the release workflow auto-creates the remote branch; you must pull it and switch locally, carrying every local commit and dirty file forward via commit + cherry-pick). Verify with `git branch --show-current`, `grep version= setup.py`, and `git status --porcelain=v1` before doing anything else. This is NOT optional. There are zero exceptions. Skipping it means every subsequent commit lands on a frozen, released branch. See step 6 for the full checklist.
-7) Trigger BotManager deploys (dev then prod) only after step 6 is complete — this takes ~30 minutes and should be the last step.
-8) Post-deploy: run an MCP backtest against prod and assert `settings.json.lumibot_version == "X.Y.Z"`. See step 8.
+1) **First, make the release branch contain everything safe to ship.** Dirty files, untracked files, and local-only commits are not excuses to skip work. Review them, commit them, test them, push them, and include them in the `version/X.Y.Z` PR unless they are unsafe, secret-bearing, broken, generated junk, or explicitly out of scope.
+2) Get the `version/X.Y.Z` PR **green** after that full inclusion sweep.
+3) Merge latest `dev` into `version/X.Y.Z` and re-check CI (prevents drift / missing commits from other engineers).
+4) Merge the PR into `dev` (no direct pushes to `dev`).
+5) Tag the **merge commit on `dev`** as `vX.Y.Z` (this triggers GitHub Actions to publish to PyPI + create a GitHub Release).
+6) Verify `pip install lumibot==X.Y.Z` works.
+7) **Switch your LOCAL checkout to `version/X.Y.(Z+1)`** after the release. Carry-over is only for work that appeared after the release was tagged/published, or work intentionally excluded because it was unsafe or out of scope. Verify with `git branch --show-current`, `grep version= setup.py`, and `git status --porcelain=v1` before doing anything else. This is NOT optional. There are zero exceptions.
+8) Trigger BotManager deploys (dev then prod) only after step 7 is complete — this takes ~30 minutes and should be the last step.
+9) Post-deploy: run an MCP backtest against prod and assert `settings.json.lumibot_version == "X.Y.Z"`. See step 8.
 
 ## The `dev` Branch Is Sacred (CRITICAL)
 
@@ -68,13 +69,38 @@ Release order for tearsheet metric changes:
 
 ---
 
-## Shared Checkout Release Rule (NO EXCEPTIONS)
+## Release Inclusion Rule (NO EXCEPTIONS)
+
+When you deploy LumiBot, deploy everything in the checkout that is safe and
+intended to ship. Do not treat dirty, untracked, or local-only files as a reason
+to omit work from the current release.
+
+Before merging/tagging `version/X.Y.Z`:
+
+1. Run `git status --porcelain=v1` and `git log --oneline origin/version/X.Y.Z..HEAD`.
+2. Review every dirty file, untracked file, and local-only commit.
+3. If it is safe and relevant, commit it to `version/X.Y.Z`, test it, push it,
+   and make sure it is included in the release PR.
+4. If it is not safe to ship, manually remove or fix it before release. Examples:
+   secrets, `.env` files, logs, generated junk, accidental binaries, broken code,
+   or work the release captain explicitly decides must not ship.
+5. If another agent has local work on the release branch, coordinate and get it
+   pushed before release. A release should not knowingly strand another agent's
+   safe work on the old branch.
+
+The normal default is inclusion, not carry-over. Carry-over exists only for
+changes that appear after the release is already tagged/published, or for work
+that was intentionally excluded from the release after review.
+
+## Post-Release Branch Switch Rule (NO EXCEPTIONS)
 
 The canonical LumiBot checkout must never remain on the just-released branch after
 a release. This applies to humans and AI agents.
 
-There is no valid "dirty checkout" exception. If `git status --porcelain=v1` is
-not empty after the release, do one of these immediately:
+After the release is tagged/published, switch to `version/X.Y.(Z+1)` immediately.
+If `git status --porcelain=v1` is not empty at that point, it means work changed
+after the release or something was intentionally excluded. Do one of these
+immediately:
 
 1. Commit the dirty files on the old `version/X.Y.Z` branch as a carry-over commit,
    switch to `version/X.Y.(Z+1)`, cherry-pick the carry-over commit, then push
@@ -84,7 +110,9 @@ not empty after the release, do one of these immediately:
 
 Do not leave files dirty. Do not leave local-only commits on the released branch.
 Do not trigger BotManager deploys while the canonical checkout is still on
-`version/X.Y.Z`. Do not rely on another agent to fix this later.
+`version/X.Y.Z`. Do not use post-release carry-over as a substitute for shipping
+safe work in the release that should have included it. Do not rely on another
+agent to fix this later.
 
 Mandatory verification after every release:
 
@@ -138,13 +166,14 @@ Publishing is **tag-driven** via `.github/workflows/release.yml`.
   - If it’s missing, the “Publish to PyPI” step will fail.
 - Optional: configure the GitHub environment `pypi` to require approvals (human gate).
 
-0) **Preflight: “no-loss” + security/hygiene sweep**
-   - Ensure there is **no local-only work** (multi-agent safety):
-     - `git status --porcelain=v1` (must be empty)
-     - `git log --oneline origin/version/X.Y.Z..HEAD` (must be empty)
-     - If you see unexpected local changes/commits (even if you didn’t make them), **do not proceed** until you either:
-       - review the diff, commit, and push, or
-       - intentionally discard/revert them (manually; avoid destructive git commands).
+0) **Preflight: “ship everything safe” + security/hygiene sweep**
+   - The release branch must contain every safe change in the checkout before tagging:
+     - `git status --porcelain=v1`
+     - `git log --oneline origin/version/X.Y.Z..HEAD`
+     - If you see dirty files, untracked files, or local-only commits (even if you didn’t make them), **do not proceed** until you review them.
+     - If they are safe and relevant, commit them to `version/X.Y.Z`, test them, push them, and include them in the release PR.
+     - If they are unsafe, secret-bearing, broken, generated junk, or explicitly out of scope, manually remove/fix only those files and document why they were excluded.
+     - The expected state before merge/tag is clean local checkout plus no unpushed commits, because the release PR already contains everything that should ship.
    - Review what will ship (and look for “bullshit files”):
      - `git diff --name-status origin/dev..HEAD`
      - `git diff --stat origin/dev..HEAD`
@@ -182,11 +211,16 @@ Publishing is **tag-driven** via `.github/workflows/release.yml`.
    - If a change genuinely does not need docs or visuals, state that explicitly in the PR description under **Docs** with the reason.
    - If docs are changed, run the relevant docs build or at minimum inspect the changed RST/Markdown for broken references and missing images before release.
 
+0) **Agent prompt gate**
+   - For every platform capability, behavior change, broker/data-provider change, or new failure mode that strategy generation/refinement should understand, inspect the BotSpot agent prompts and shared examples.
+   - Prefer token-efficient edits: update an existing note, reminder, or example before adding a new block. Remove or compress stale wording when adding new guidance.
+   - Record prompt changes, or the reason no prompt change was needed, in the release PR under **Docs/Prompts**.
+
 0) **Sync your local repo**
    - `git switch dev && git pull --ff-only`
    - `git switch version/X.Y.Z && git pull --ff-only`
-   - Confirm clean tree: `git status --porcelain=v1` (must be empty)
-   - **IMPORTANT (multi-agent safety):** ensure *everyone* working on `version/X.Y.Z` has pushed their commits. Avoid releasing with local-only work in someone else’s clone.
+   - Confirm clean tree: `git status --porcelain=v1` (must be empty because all safe local work has already been committed and pushed)
+   - **IMPORTANT (multi-agent safety):** ensure *everyone* working on `version/X.Y.Z` has pushed their commits. Do not release while known safe work is stranded in someone else’s clone.
 
 0.5) **Bring `dev` into the version branch (avoid drift)**
    - Merge `dev` into `version/X.Y.Z` and push the merge commit.
@@ -278,7 +312,7 @@ Publishing is **tag-driven** via `.github/workflows/release.yml`.
 
    6a) **The release workflow auto-creates the remote branch** `version/X.Y.(Z+1)` from `dev` (see `.github/workflows/release.yml` → "Start next version branch" job). You do NOT need to create it. You DO need to pull it and switch your local checkout to it.
 
-   6b) **Capture every local change first.** If you have uncommitted changes, untracked files, or local-only commits on `version/X.Y.Z`, they did not ship in the release (the release tag points at the `dev` merge commit that existed at tag time). There is no "unrelated dirty file" exception during deployment. Either commit the change as carry-over or manually remove the exact unwanted generated artifact before switching. Move all remaining work to `version/X.Y.(Z+1)`:
+   6b) **Handle only post-release or intentionally excluded work here.** This step is not a loophole for skipping safe work during release. If uncommitted changes, untracked files, or local-only commits existed before the PR merge/tag, they should already have been reviewed, committed, tested, pushed, and deployed in `X.Y.Z` unless unsafe. Carry-over is only for changes that appeared after the release was tagged/published, or changes the release captain intentionally excluded because they were unsafe or out of scope. Move those remaining changes to `version/X.Y.(Z+1)`:
 
      ```bash
      # Snapshot anything uncommitted as a throwaway commit on the OLD branch

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -15,8 +15,8 @@
 3) Merge the PR into `dev` (no direct pushes to `dev`).
 4) Tag the **merge commit on `dev`** as `vX.Y.Z` (this triggers GitHub Actions to publish to PyPI + create a GitHub Release).
 5) Verify `pip install lumibot==X.Y.Z` works.
-6) **Switch your LOCAL checkout to `version/X.Y.(Z+1)`** (the release workflow auto-creates the remote branch; you must pull it and switch locally, carrying any uncommitted work via cherry-pick). Verify with `git branch --show-current` and `grep version= setup.py` before doing anything else. This is NOT optional — skipping it means every subsequent commit lands on a frozen, released branch. See step 6 for the full checklist.
-7) Trigger BotManager deploys (dev then prod) — this takes ~30 minutes and should be the last step.
+6) **Switch your LOCAL checkout to `version/X.Y.(Z+1)`** (the release workflow auto-creates the remote branch; you must pull it and switch locally, carrying every local commit and dirty file forward via commit + cherry-pick). Verify with `git branch --show-current`, `grep version= setup.py`, and `git status --porcelain=v1` before doing anything else. This is NOT optional. There are zero exceptions. Skipping it means every subsequent commit lands on a frozen, released branch. See step 6 for the full checklist.
+7) Trigger BotManager deploys (dev then prod) only after step 6 is complete — this takes ~30 minutes and should be the last step.
 8) Post-deploy: run an MCP backtest against prod and assert `settings.json.lumibot_version == "X.Y.Z"`. See step 8.
 
 ## The `dev` Branch Is Sacred (CRITICAL)
@@ -68,32 +68,38 @@ Release order for tearsheet metric changes:
 
 ---
 
-## Codex-Safe Release Path For Shared Checkouts
+## Shared Checkout Release Rule (NO EXCEPTIONS)
 
-Use this path when an AI agent is deploying from the shared canonical checkout and
-local branch switching would risk another agent's work.
+The canonical LumiBot checkout must never remain on the just-released branch after
+a release. This applies to humans and AI agents.
 
-The release invariants are the same:
-- the version branch must contain every commit that will ship,
-- the version branch must include latest `dev`,
-- the release must merge to `dev` via PR,
-- the `vX.Y.Z` tag must point at the resulting `dev` merge commit,
-- BotManager deploys happen only after the PyPI release is verified.
+There is no valid "dirty checkout" exception. If `git status --porcelain=v1` is
+not empty after the release, do one of these immediately:
 
-Safe remote-first checklist:
-1. Confirm the local checkout is on `version/X.Y.Z`; do not switch to `dev`.
-2. Confirm no local-only commits exist: `git log --oneline origin/version/X.Y.Z..HEAD`.
-3. Confirm any local dirty files are unrelated to the release. If they are related, commit and push them first. If they are unrelated, do not stage them and call the dirty state out in the release notes.
-4. Fetch `origin/dev` and `origin/version/X.Y.Z`, then compare both directions:
-   - `git log --oneline origin/dev..origin/version/X.Y.Z`
-   - `git log --oneline origin/version/X.Y.Z..origin/dev`
-5. If `origin/dev` is ahead, merge/update the version branch through the release PR or a clean disposable release clone. Do not switch the canonical checkout just to do this.
-6. Create or update the release PR from `version/X.Y.Z` to `dev`, wait for CI, then merge the PR.
-7. Fetch the updated `origin/dev`, tag the `dev` merge commit, and push the tag.
+1. Commit the dirty files on the old `version/X.Y.Z` branch as a carry-over commit,
+   switch to `version/X.Y.(Z+1)`, cherry-pick the carry-over commit, then push
+   `version/X.Y.(Z+1)`.
+2. If a dirty file is truly wrong and must not survive, manually edit it back or
+   remove only that specific generated artifact, then prove the tree is clean.
 
-This does not relax the clean-tree requirement for normal human release work. It
-exists to prevent AI agents from switching branches in the shared LumiBot checkout
-when unrelated local work is present.
+Do not leave files dirty. Do not leave local-only commits on the released branch.
+Do not trigger BotManager deploys while the canonical checkout is still on
+`version/X.Y.Z`. Do not rely on another agent to fix this later.
+
+Mandatory verification after every release:
+
+```bash
+git branch --show-current            # MUST print version/X.Y.(Z+1)
+grep 'version=' setup.py | head -1   # MUST print version="X.Y.(Z+1)",
+git status --porcelain=v1            # MUST be empty
+git log --oneline origin/version/X.Y.(Z+1)..HEAD
+```
+
+If the final command prints commits, push them:
+
+```bash
+git push origin version/X.Y.(Z+1)
+```
 
 ---
 
@@ -272,12 +278,12 @@ Publishing is **tag-driven** via `.github/workflows/release.yml`.
 
    6a) **The release workflow auto-creates the remote branch** `version/X.Y.(Z+1)` from `dev` (see `.github/workflows/release.yml` → "Start next version branch" job). You do NOT need to create it. You DO need to pull it and switch your local checkout to it.
 
-   6b) **Capture any local work first.** If you have uncommitted changes or local-only commits on `version/X.Y.Z`, they did not ship in the release (the release tag points at the `dev` merge commit that existed at tag time). Move them to `version/X.Y.(Z+1)`:
+   6b) **Capture every local change first.** If you have uncommitted changes, untracked files, or local-only commits on `version/X.Y.Z`, they did not ship in the release (the release tag points at the `dev` merge commit that existed at tag time). There is no "unrelated dirty file" exception during deployment. Either commit the change as carry-over or manually remove the exact unwanted generated artifact before switching. Move all remaining work to `version/X.Y.(Z+1)`:
 
      ```bash
      # Snapshot anything uncommitted as a throwaway commit on the OLD branch
      git status --porcelain=v1           # if non-empty, commit before switching
-     git add -u && git commit -m "wip: carry-over to X.Y.(Z+1)"
+     git add -A && git commit -m "wip: carry-over to X.Y.(Z+1)"
      # Note SHAs of all commits that are on local version/X.Y.Z but not on origin/version/X.Y.Z
      git log --oneline origin/version/X.Y.Z..HEAD
      ```
@@ -297,7 +303,7 @@ Publishing is **tag-driven** via `.github/workflows/release.yml`.
      ```bash
      git branch --show-current            # MUST print version/X.Y.(Z+1)
      grep 'version=' setup.py | head -1   # MUST print version="X.Y.(Z+1)",
-     git status --porcelain=v1            # MUST be empty
+     git status --porcelain=v1            # MUST be empty after pushing carry-overs
      ```
 
      If any of those three checks is wrong, STOP and fix before proceeding. Do not trigger BotManager deploy on the wrong local branch state.

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -51,12 +51,13 @@ This page documents environment variables used by LumiBot, with an emphasis on *
   - `ibkr` / `interactivebrokersrest` / `interactive_brokers_rest` (IBKR Client Portal REST via Data Downloader)
   - `router` (multi-provider routing; defaults to Theta for stock/option/index and IBKR for futures/crypto)
   - JSON mapping (multi-provider routing by asset type), e.g.:
-    - `{"default":"thetadata","stock":"thetadata","option":"thetadata","index":"thetadata","future":"ibkr","crypto":"ibkr"}`
+    - `{"default":"thetadata","stock":"thetadata","option":"thetadata","index":"thetadata","future":"ibkr","cont_future":"ibkr","crypto":"ibkr","crypto_future":"ibkr"}`
     - Provider values are case/whitespace/_/- insensitive. Supported values include:
       - `thetadata`, `ibkr`, `polygon`, `alpaca`
       - `ccxt` (auto-select exchange from existing env/credentials)
       - supported CCXT backtesting exchange ids such as `kraken`, `binance`, `kucoin`, `bitmex`, `bybit`, and `okx`
   - `none` to disable env override and rely on code.
+- Crypto futures/perpetuals: `Asset.AssetType.CRYPTO_FUTURE` routes through `crypto_future` when present, otherwise `crypto`, then `default`. USDT contracts such as `BTCUSDT`, `ETHUSDT`, and `SOLUSDT` can use USD spot history as the backtest price proxy.
 - Where: `lumibot/strategies/_strategy.py` datasource selection logic.
 
 ## Testing / CI guardrails (engineering-only)

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -298,7 +298,7 @@ Notes:
 - Default: `~/.lumibot/cache/sec`.
 
 ### `FRED_API_KEY`
-- Purpose: Optional official FRED/ALFRED API key for macro data tools.
+- Purpose: Required official FRED/ALFRED API key for macro data tools.
 - Default: unset.
 - Notes: Required for FRED macro data tools. Lumibot requests vintage observations with `realtime_start` and `realtime_end` for point-in-time backtests. Built-in FRED agent tools are not exposed during backtests without this key because Lumibot does not use revised public CSV fallbacks for macro data.
 

--- a/docsrc/_templates/layout.html
+++ b/docsrc/_templates/layout.html
@@ -62,7 +62,7 @@
       "name": "What LLM providers does LumiBot support?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "LumiBot's agent runtime is built on Google ADK (Agent Development Kit). The default model is Gemini (gemini-3.1-flash-lite-preview). The architecture supports routing to other providers through Google ADK's LiteLLM bridge. You need a GEMINI_API_KEY environment variable for Gemini."
+        "text": "LumiBot's agent runtime is built on Google ADK (Agent Development Kit). The default model is Gemini (gemini-3.1-flash-lite). The architecture supports routing to other providers through Google ADK's LiteLLM bridge. You need a GEMINI_API_KEY environment variable for Gemini."
       }
     },
     {

--- a/docsrc/agents_quickstart.rst
+++ b/docsrc/agents_quickstart.rst
@@ -270,7 +270,7 @@ No. All built-in tools (positions, portfolio, prices, orders, DuckDB, docs) are 
 
 **What API keys do I need?**
 
-At minimum, one model provider key matching your ``default_model``. The default is Gemini, which needs ``GEMINI_API_KEY``. LumiBot also supports ``openai/...`` ids (needs ``OPENAI_API_KEY``), ``xai/...`` ids for Grok (needs ``XAI_API_KEY`` or ``GROK_API_KEY``), and ``anthropic/...`` ids for Claude (needs ``ANTHROPIC_API_KEY``). If your ``@agent_tool`` functions call external APIs, you also need those keys -- for example ``ALPACA_API_KEY`` and ``ALPACA_API_SECRET`` for Alpaca-based demos. The M2 Liquidity demo only needs one model-provider key because it uses FRED's public revised-data CSV endpoint; strict point-in-time macro backtests should use the built-in FRED tools with ``FRED_API_KEY``.
+At minimum, one model provider key matching your ``default_model``. The default is Gemini, which needs ``GEMINI_API_KEY``. LumiBot also supports ``openai/...`` ids (needs ``OPENAI_API_KEY``), ``xai/...`` ids for Grok (needs ``XAI_API_KEY`` or ``GROK_API_KEY``), and ``anthropic/...`` ids for Claude (needs ``ANTHROPIC_API_KEY``). If your ``@agent_tool`` functions call external APIs, you also need those keys -- for example ``ALPACA_API_KEY`` and ``ALPACA_API_SECRET`` for Alpaca-based demos. FRED macro tools require ``FRED_API_KEY`` so backtests can request official FRED/ALFRED observations with point-in-time vintage parameters instead of using revised CSV data.
 
 **How long should my system prompt be?**
 

--- a/docsrc/backtesting.ibkr.rst
+++ b/docsrc/backtesting.ibkr.rst
@@ -90,9 +90,14 @@ To use multiple providers in a single backtest (example: ThetaData for options/s
 
 .. code-block:: bash
 
-   export BACKTESTING_DATA_SOURCE='{"default":"thetadata","stock":"thetadata","option":"thetadata","index":"thetadata","future":"ibkr","crypto":"ibkr"}'
+   export BACKTESTING_DATA_SOURCE='{"default":"thetadata","stock":"thetadata","option":"thetadata","index":"thetadata","future":"ibkr","cont_future":"ibkr","crypto":"ibkr","crypto_future":"ibkr"}'
 
 Routing values are case/whitespace/_/- insensitive. For crypto, you may also route to documented CCXT backtesting paths by using either ``"ccxt"`` (auto-select exchange) or a supported CCXT backtesting exchange id directly (for example: ``"kraken"`` or ``"binance"``).
+
+Crypto futures and perpetuals
+-----------------------------
+
+For ``Asset.AssetType.CRYPTO_FUTURE`` backtests, LumiBot can load spot crypto history as a price proxy while preserving the strategy-facing futures asset for orders and positions. USDT contracts such as ``BTCUSDT``, ``ETHUSDT``, and ``SOLUSDT`` resolve to the corresponding USD spot proxy (``BTC/USD``, ``ETH/USD``, ``SOL/USD``) because common crypto perpetual venues keep the futures price close to spot. The log will state when a USD spot proxy is used.
 
 Market Data Subscriptions (IBKR)
 --------------------------------

--- a/docsrc/faq.rst
+++ b/docsrc/faq.rst
@@ -317,7 +317,7 @@ LumiBot ships four reference demo strategies in ``lumibot/example_strategies/``:
 3. **Momentum Allocator** (``agent_momentum_allocator.py``) -- momentum + sentiment using price bars and news
 4. **M2 Liquidity** (``agent_m2_liquidity.py``) -- liquidity-driven allocation using FRED money supply data
 
-Start with the M2 Liquidity demo if you want the fewest credentials. It only needs a model-provider key because the demo uses FRED's public revised-data CSV endpoint. For strict point-in-time macro backtests, use the built-in FRED tools with ``FRED_API_KEY``.
+Start with a demo that only uses built-in market data if you want the fewest credentials. FRED macro tools require ``FRED_API_KEY`` because LumiBot uses official FRED/ALFRED vintage parameters for point-in-time macro backtests instead of revised public CSV data.
 
 How much does it cost to run AI agent backtests?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lumibot/backtesting/routed_backtesting.py
+++ b/lumibot/backtesting/routed_backtesting.py
@@ -20,6 +20,7 @@ from lumibot.tools.helpers import parse_timestep_qty_and_unit
 logger = logging.getLogger(__name__)
 
 _DEFAULT_QUOTE_ASSET = Asset("USD", "forex")
+_USD_STABLECOIN_PROXY_QUOTES = {"USDT"}
 
 
 class RoutingProviderError(ValueError):
@@ -42,6 +43,43 @@ def _normalize_asset_type(value: Any) -> str:
     if "." in raw:
         raw = raw.split(".")[-1]
     return raw
+
+
+def _resolve_crypto_future_spot_proxy(asset: Asset, quote_asset: Asset) -> tuple[Asset, Asset, str | None]:
+    """Resolve crypto futures/perps to spot crypto history for backtesting."""
+    if _normalize_asset_type(getattr(asset, "asset_type", "")) != "crypto_future":
+        return asset, quote_asset, None
+
+    symbol = str(getattr(asset, "symbol", "") or "").strip().upper()
+    explicit_quote = str(getattr(quote_asset, "symbol", "") or "").strip().upper()
+    base_symbol = symbol
+    quote_symbol = explicit_quote or "USD"
+
+    pair_parts = [part for part in re.split(r"[/:\-]", symbol) if part]
+    if len(pair_parts) >= 2:
+        base_symbol = pair_parts[0]
+        quote_symbol = pair_parts[1]
+    else:
+        for suffix in ("USDT", "USD"):
+            if symbol.endswith(suffix) and len(symbol) > len(suffix):
+                base_symbol = symbol[: -len(suffix)]
+                quote_symbol = suffix
+                break
+
+    proxy_quote_symbol = "USD" if quote_symbol in _USD_STABLECOIN_PROXY_QUOTES else quote_symbol
+    proxy_quote_type = Asset.AssetType.FOREX if proxy_quote_symbol == "USD" else Asset.AssetType.CRYPTO
+    proxy_asset = Asset(base_symbol, asset_type=Asset.AssetType.CRYPTO)
+    proxy_quote = Asset(proxy_quote_symbol, asset_type=proxy_quote_type)
+
+    proxy_label = (
+        f"Using {proxy_asset.symbol}/{proxy_quote.symbol} spot proxy for "
+        f"{asset.symbol} crypto-futures backtest"
+    )
+    if quote_symbol in _USD_STABLECOIN_PROXY_QUOTES:
+        proxy_label += f" ({quote_symbol} mapped to USD spot)."
+    else:
+        proxy_label += "."
+    return proxy_asset, proxy_quote, proxy_label
 
 
 def _ibkr_include_after_hours(asset_type: str, timestep_unit: str) -> bool:
@@ -220,6 +258,12 @@ class _DataFrameRoutingAdapter(_RoutingAdapter):
         if snapshot_only:
             return None
 
+        original_asset = asset
+        original_quote_asset = quote_asset
+        fetch_asset, fetch_quote_asset, proxy_label = _resolve_crypto_future_spot_proxy(asset, quote_asset)
+        if proxy_label:
+            logger.info(proxy_label)
+
         end_dt = start_dt if isinstance(start_dt, datetime) else self._router.get_datetime()
         ts = timestep or self._router.get_timestep()
 
@@ -227,7 +271,7 @@ class _DataFrameRoutingAdapter(_RoutingAdapter):
             length,
             ts,
             start_dt=end_dt,
-            start_buffer=self._start_buffer(asset, provider_spec),
+            start_buffer=self._start_buffer(fetch_asset, provider_spec),
         )
 
         if ts_unit == "day":
@@ -236,7 +280,7 @@ class _DataFrameRoutingAdapter(_RoutingAdapter):
             except Exception:
                 pass
 
-        canonical_key, legacy_key = self._router._build_dataset_keys(asset, quote_asset, ts_unit)
+        canonical_key, legacy_key = self._router._build_dataset_keys(original_asset, original_quote_asset, ts_unit)
         existing = self._router._data_store.get(canonical_key)
         existing_df = getattr(existing, "df", None) if existing is not None else None
 
@@ -253,8 +297,8 @@ class _DataFrameRoutingAdapter(_RoutingAdapter):
                 pass
 
         df = self._fetch_df(
-            asset=asset,
-            quote_asset=quote_asset,
+            asset=fetch_asset,
+            quote_asset=fetch_quote_asset,
             ts_unit=ts_unit,
             start_datetime=start_datetime,
             end_dt=end_dt,
@@ -280,7 +324,7 @@ class _DataFrameRoutingAdapter(_RoutingAdapter):
         else:
             merged = df
 
-        data = Data(asset, merged, timestep=ts_unit, quote=quote_asset)
+        data = Data(original_asset, merged, timestep=ts_unit, quote=original_quote_asset)
         self._router._data_store[canonical_key] = data
         if legacy_key not in self._router._data_store:
             self._router._data_store[legacy_key] = data
@@ -329,6 +373,12 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
         if snapshot_only:
             return None
 
+        original_asset = asset
+        original_quote_asset = quote_asset
+        fetch_asset, fetch_quote_asset, proxy_label = _resolve_crypto_future_spot_proxy(asset, quote_asset)
+        if proxy_label:
+            logger.info(proxy_label)
+
         end_dt = start_dt if isinstance(start_dt, datetime) else self._router.get_datetime()
         ts = timestep or self._router.get_timestep()
 
@@ -336,7 +386,7 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
             length,
             ts,
             start_dt=end_dt,
-            start_buffer=self._start_buffer(asset, provider_spec),
+            start_buffer=self._start_buffer(fetch_asset, provider_spec),
         )
 
         if ts_unit == "day":
@@ -350,7 +400,7 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
         qty = int(qty)
         unit = str(unit)
 
-        canonical_key, legacy_key = self._router._build_dataset_keys(asset, quote_asset, dataset_key)
+        canonical_key, legacy_key = self._router._build_dataset_keys(original_asset, original_quote_asset, dataset_key)
         if canonical_key in self._fully_loaded_series and canonical_key in self._router._data_store:
             return None
         if canonical_key in self._empty_prefetch_series:
@@ -370,7 +420,7 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
             except Exception:
                 pass
 
-        asset_type = _normalize_asset_type(getattr(asset, "asset_type", ""))
+        asset_type = _normalize_asset_type(getattr(fetch_asset, "asset_type", ""))
         include_after_hours = _ibkr_include_after_hours(asset_type, unit)
         df = None
 
@@ -388,8 +438,8 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
                 prefetch_start = start_datetime
             prefetch_end = self._router.datetime_end or end_dt
             df = ibkr_helper.get_price_data(
-                asset=asset,
-                quote=quote_asset,
+                asset=fetch_asset,
+                quote=fetch_quote_asset,
                 timestep=dataset_key,
                 start_dt=prefetch_start,
                 end_dt=prefetch_end,
@@ -401,7 +451,7 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
                 return None
             if ibkr_helper.frame_covers_requested_window(
                 df,
-                asset=asset,
+                asset=fetch_asset,
                 timestep=dataset_key,
                 start_dt=prefetch_start,
                 end_dt=prefetch_end,
@@ -419,8 +469,8 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
                 has_coarser_loaded = any(
                     isinstance(key, tuple)
                     and len(key) >= 3
-                    and key[0] is asset
-                    and key[1] is quote_asset
+                    and key[0] is original_asset
+                    and key[1] is original_quote_asset
                     and isinstance(key[2], str)
                     and key[2] not in {"day", "minute"}
                     for key in self._fully_loaded_series
@@ -446,8 +496,8 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
 
             prefetch_end = self._router.datetime_end or end_dt
             df = ibkr_helper.get_price_data(
-                asset=asset,
-                quote=quote_asset,
+                asset=fetch_asset,
+                quote=fetch_quote_asset,
                 timestep=dataset_key,
                 start_dt=prefetch_start,
                 end_dt=prefetch_end,
@@ -459,7 +509,7 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
                 return None
             if ibkr_helper.frame_covers_requested_window(
                 df,
-                asset=asset,
+                asset=fetch_asset,
                 timestep=dataset_key,
                 start_dt=prefetch_start,
                 end_dt=prefetch_end,
@@ -472,8 +522,8 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
                 prefetch_start = start_datetime
             prefetch_end = self._router.datetime_end or end_dt
             df = ibkr_helper.get_price_data(
-                asset=asset,
-                quote=quote_asset,
+                asset=fetch_asset,
+                quote=fetch_quote_asset,
                 timestep=dataset_key,
                 start_dt=prefetch_start,
                 end_dt=prefetch_end,
@@ -485,7 +535,7 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
                 return None
             if ibkr_helper.frame_covers_requested_window(
                 df,
-                asset=asset,
+                asset=fetch_asset,
                 timestep=dataset_key,
                 start_dt=prefetch_start,
                 end_dt=prefetch_end,
@@ -499,8 +549,8 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
             prefetch_start = start_datetime
             prefetch_end = self._router.datetime_end or end_dt
             df = ibkr_helper.get_price_data(
-                asset=asset,
-                quote=quote_asset,
+                asset=fetch_asset,
+                quote=fetch_quote_asset,
                 timestep=dataset_key,
                 start_dt=prefetch_start,
                 end_dt=prefetch_end,
@@ -512,7 +562,7 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
                 return None
             if ibkr_helper.frame_covers_requested_window(
                 df,
-                asset=asset,
+                asset=fetch_asset,
                 timestep=dataset_key,
                 start_dt=prefetch_start,
                 end_dt=prefetch_end,
@@ -526,8 +576,8 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
             prefetch_start = min(start_datetime, self._router.datetime_start - timedelta(days=lookback_days))
             prefetch_end = self._router.datetime_end or end_dt
             df = ibkr_helper.get_price_data(
-                asset=asset,
-                quote=quote_asset,
+                asset=fetch_asset,
+                quote=fetch_quote_asset,
                 timestep=dataset_key,
                 start_dt=prefetch_start,
                 end_dt=prefetch_end,
@@ -539,7 +589,7 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
                 return None
             if ibkr_helper.frame_covers_requested_window(
                 df,
-                asset=asset,
+                asset=fetch_asset,
                 timestep=dataset_key,
                 start_dt=prefetch_start,
                 end_dt=prefetch_end,
@@ -547,8 +597,8 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
                 self._fully_loaded_series.add(canonical_key)
         else:
             df = ibkr_helper.get_price_data(
-                asset=asset,
-                quote=quote_asset,
+                asset=fetch_asset,
+                quote=fetch_quote_asset,
                 timestep=dataset_key,
                 start_dt=start_datetime,
                 end_dt=end_dt,
@@ -575,7 +625,7 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
         # a separate key (e.g., "60minute") and annotate the instance so `Data.get_bars()` can
         # slice directly without resampling each iteration.
         data_timestep = unit if unit in {"minute", "hour", "day"} else "minute"
-        data = Data(asset, merged, timestep=data_timestep, quote=quote_asset)
+        data = Data(original_asset, merged, timestep=data_timestep, quote=original_quote_asset)
         data._native_timestep_quantity = int(qty)  # type: ignore[attr-defined]
         data._native_timestep_unit = unit  # type: ignore[attr-defined]
         try:
@@ -980,6 +1030,7 @@ class RoutedBacktestingPandas(ThetaDataBacktestingPandas):
                 "future": "ibkr",
                 "cont_future": "ibkr",
                 "crypto": "ibkr",
+                "crypto_future": "ibkr",
             }
 
         normalized: Dict[str, str] = {}
@@ -1002,6 +1053,10 @@ class RoutedBacktestingPandas(ThetaDataBacktestingPandas):
         if future_provider and "cont_future" not in normalized:
             normalized["cont_future"] = future_provider
 
+        crypto_provider = normalized.get("crypto")
+        if crypto_provider and "crypto_future" not in normalized:
+            normalized["crypto_future"] = crypto_provider
+
         normalized.setdefault("default", "thetadata")
         return normalized
 
@@ -1010,7 +1065,10 @@ class RoutedBacktestingPandas(ThetaDataBacktestingPandas):
             # Defensive: some unit tests construct the router via __new__ without running __init__.
             self._registry = _ProviderRegistry(self)
         asset_type = _normalize_asset_type(getattr(asset, "asset_type", ""))
-        raw = self._routing.get(asset_type) or self._routing.get("default") or "thetadata"
+        if asset_type == "crypto_future":
+            raw = self._routing.get("crypto_future") or self._routing.get("crypto") or self._routing.get("default") or "thetadata"
+        else:
+            raw = self._routing.get(asset_type) or self._routing.get("default") or "thetadata"
         return self._registry.resolve_provider_spec(raw)
 
     def _update_pandas_data(

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -3244,8 +3244,17 @@ class _Strategy:
             self.logger.error(traceback.format_exc())
             return False
 
-        # Get the current positions
+        # Get the current positions. Cloud consumers treat an explicit
+        # positions=[] as "verified flat", so do not publish positions unless
+        # the broker/local position read actually succeeded.
+        positions = None
+        positions_snapshot_status = "verified"
+        positions_snapshot_source = "strategy_positions_cache"
         try:
+            sync_positions = getattr(self.broker, "sync_positions", None)
+            if callable(sync_positions):
+                sync_positions(self)
+                positions_snapshot_source = "broker_positions_refresh"
             positions = self.get_positions()
             self.logger.debug(f"Number of positions: {len(positions)}")
             # DEBUG: Log position details
@@ -3255,9 +3264,10 @@ class _Strategy:
                     attrs = {k: v for k, v in pos.__dict__.items() if not k.startswith('_')}
                     self.logger.debug(f"[DEBUG] Position attrs for {pos.symbol}: {list(attrs.keys())}")
         except Exception as e:
-            self.logger.error(f"Failed to get positions: {e}")
+            positions_snapshot_status = "unverified"
+            positions_snapshot_source = "positions_refresh_failed"
+            self.logger.error(f"Failed to refresh/get positions for cloud update; omitting positions snapshot: {e}")
             self.logger.error(traceback.format_exc())
-            return False
 
         # Get the current orders
         try:
@@ -3278,14 +3288,10 @@ class _Strategy:
             "Content-Type": "application/json",
         }
 
-        # Create the data to send to the cloud
-        positions_data = [position.to_dict() for position in positions]
-
         data = {
             "data_type": "portfolio_event",
             "portfolio_value": portfolio_value,
             "cash": cash,
-            "positions": positions_data,
             "orders": [order.to_dict() for order in orders],
             "cash_events": [event.to_dict() for event in cash_events],
             "strategy_name": self._name,
@@ -3293,11 +3299,16 @@ class _Strategy:
             "account_snapshot_status": "verified",
             "account_snapshot_source": "broker_balance_refresh",
             "account_snapshot_checked_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "positions_snapshot_status": positions_snapshot_status,
+            "positions_snapshot_source": positions_snapshot_source,
         }
+        if positions is not None:
+            data["positions"] = [position.to_dict() for position in positions]
 
         self.logger.debug(
             f"Preparing to send portfolio update: value={portfolio_value}, cash={cash}, "
-            f"positions={len(positions)}, orders={len(orders)}, cash_events={len(cash_events)}"
+            f"positions={len(positions) if positions is not None else 'omitted'}, "
+            f"orders={len(orders)}, cash_events={len(cash_events)}"
         )
 
         # Helper function to recursively replace NaN in dictionaries

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.19",
+    version="4.5.20",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_cloud_account_snapshot.py
+++ b/tests/test_cloud_account_snapshot.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 from lumibot.strategies._strategy import _Strategy
@@ -62,6 +63,50 @@ def test_cloud_update_marks_successful_broker_snapshot_verified(monkeypatch):
     assert payloads, "cloud update should be sent after broker balances are verified"
     assert '"account_snapshot_status": "verified"' in payloads[0]
     assert '"account_snapshot_source": "broker_balance_refresh"' in payloads[0]
+
+
+def test_cloud_update_refreshes_positions_before_publish(monkeypatch):
+    strategy = _fake_strategy(balances_updated=True)
+    sync_calls = []
+    strategy.broker.sync_positions = lambda strategy_arg: sync_calls.append(strategy_arg)
+    payloads = []
+
+    def fake_post(url, headers=None, data=None, **kwargs):
+        payloads.append(json.loads(data))
+        return _Response()
+
+    monkeypatch.setattr("lumibot.strategies._strategy.requests.post", fake_post)
+
+    result = _Strategy.send_update_to_cloud(strategy)
+
+    assert result is not False
+    assert sync_calls == [strategy]
+    assert payloads[0]["positions"] == []
+    assert payloads[0]["positions_snapshot_status"] == "verified"
+    assert payloads[0]["positions_snapshot_source"] == "broker_positions_refresh"
+
+
+def test_cloud_update_omits_positions_when_position_refresh_fails(monkeypatch):
+    strategy = _fake_strategy(balances_updated=True)
+
+    def raise_position_sync(_strategy):
+        raise RuntimeError("broker positions unavailable")
+
+    strategy.broker.sync_positions = raise_position_sync
+    payloads = []
+
+    def fake_post(url, headers=None, data=None, **kwargs):
+        payloads.append(json.loads(data))
+        return _Response()
+
+    monkeypatch.setattr("lumibot.strategies._strategy.requests.post", fake_post)
+
+    result = _Strategy.send_update_to_cloud(strategy)
+
+    assert result is not False
+    assert "positions" not in payloads[0]
+    assert payloads[0]["positions_snapshot_status"] == "unverified"
+    assert payloads[0]["positions_snapshot_source"] == "positions_refresh_failed"
 
 
 def test_cloud_update_skips_when_broker_balances_are_not_verified(monkeypatch):

--- a/tests/test_routed_backtesting_routing_validation.py
+++ b/tests/test_routed_backtesting_routing_validation.py
@@ -21,6 +21,21 @@ def test_routed_backtesting_accepts_polygon_provider_in_json_mapping():
     assert rb._provider_spec_for_asset(asset).provider == "polygon"
 
 
+def test_routed_backtesting_crypto_future_inherits_crypto_provider():
+    routing = RoutedBacktestingPandas._normalize_routing(
+        {
+            "default": "thetadata",
+            "crypto": "ibkr",
+        }
+    )
+    rb = RoutedBacktestingPandas.__new__(RoutedBacktestingPandas)
+    rb._routing = routing  # type: ignore[attr-defined]
+    rb._registry = _ProviderRegistry(rb)  # type: ignore[attr-defined]
+
+    asset = Asset("BTCUSDT", asset_type=Asset.AssetType.CRYPTO_FUTURE)
+    assert rb._provider_spec_for_asset(asset).provider == "ibkr"
+
+
 def test_routed_backtesting_rejects_unknown_provider():
     rb = RoutedBacktestingPandas.__new__(RoutedBacktestingPandas)
     rb._registry = _ProviderRegistry(rb)  # type: ignore[attr-defined]

--- a/tests/test_routed_backtesting_unit.py
+++ b/tests/test_routed_backtesting_unit.py
@@ -52,6 +52,56 @@ def test_router_routes_crypto_to_ibkr(monkeypatch):
     assert ds._data_store
 
 
+def test_router_routes_crypto_future_to_spot_usd_proxy(monkeypatch, caplog):
+    import lumibot.tools.thetadata_helper as thetadata_helper
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    monkeypatch.setattr(ThetaDataBacktestingPandas, "kill_processes_by_name", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(thetadata_helper, "reset_theta_terminal_tracking", lambda *_args, **_kwargs: None)
+
+    captured = {}
+
+    def fake_get_price_data(*, asset, quote, timestep, start_dt, end_dt, exchange=None, include_after_hours=True):
+        captured["asset"] = asset
+        captured["quote"] = quote
+        idx = pd.DatetimeIndex(
+            [
+                datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc),
+                datetime(2025, 1, 1, 0, 1, tzinfo=timezone.utc),
+            ]
+        ).tz_convert("America/New_York")
+        return pd.DataFrame(
+            {"open": [1.0, 2.0], "high": [1.1, 2.1], "low": [0.9, 1.9], "close": [1.0, 2.0], "volume": [10, 11]},
+            index=idx,
+        )
+
+    monkeypatch.setattr(ibkr_helper, "get_price_data", fake_get_price_data)
+
+    ds = RoutedBacktestingPandas(
+        datetime_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        datetime_end=datetime(2025, 1, 2, tzinfo=timezone.utc),
+        config={"backtesting_data_routing": {"crypto": "ibkr", "default": "thetadata"}},
+        username="dev",
+        password="dev",
+        use_quote_data=False,
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+
+    perp = Asset(symbol="BTCUSDT", asset_type=Asset.AssetType.CRYPTO_FUTURE)
+    quote = Asset(symbol="USDT", asset_type=Asset.AssetType.CRYPTO)
+    with caplog.at_level("INFO"):
+        ds._update_pandas_data(perp, quote, length=2, timestep="minute", start_dt=datetime(2025, 1, 2, tzinfo=timezone.utc))
+
+    assert captured["asset"] == Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+    assert captured["quote"] == Asset("USD", asset_type=Asset.AssetType.FOREX)
+    assert (perp, quote, "minute") in ds._data_store
+    stored = ds._data_store[(perp, quote, "minute")]
+    assert stored.asset == perp
+    assert stored.quote == quote
+    assert "USDT mapped to USD spot" in caplog.text
+
+
 def test_router_accepts_futures_key_alias(monkeypatch):
     import lumibot.tools.thetadata_helper as thetadata_helper
     import lumibot.tools.ibkr_helper as ibkr_helper

--- a/tests/test_routed_backtesting_unit.py
+++ b/tests/test_routed_backtesting_unit.py
@@ -52,14 +52,16 @@ def test_router_routes_crypto_to_ibkr(monkeypatch):
     assert ds._data_store
 
 
-def test_router_routes_crypto_future_to_spot_usd_proxy(monkeypatch, caplog):
+def test_router_routes_crypto_future_to_spot_usd_proxy(monkeypatch):
     import lumibot.tools.thetadata_helper as thetadata_helper
     import lumibot.tools.ibkr_helper as ibkr_helper
+    import lumibot.backtesting.routed_backtesting as routed_backtesting
 
     monkeypatch.setattr(ThetaDataBacktestingPandas, "kill_processes_by_name", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(thetadata_helper, "reset_theta_terminal_tracking", lambda *_args, **_kwargs: None)
 
     captured = {}
+    log_messages = []
 
     def fake_get_price_data(*, asset, quote, timestep, start_dt, end_dt, exchange=None, include_after_hours=True):
         captured["asset"] = asset
@@ -76,6 +78,7 @@ def test_router_routes_crypto_future_to_spot_usd_proxy(monkeypatch, caplog):
         )
 
     monkeypatch.setattr(ibkr_helper, "get_price_data", fake_get_price_data)
+    monkeypatch.setattr(routed_backtesting.logger, "info", log_messages.append)
 
     ds = RoutedBacktestingPandas(
         datetime_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
@@ -90,8 +93,7 @@ def test_router_routes_crypto_future_to_spot_usd_proxy(monkeypatch, caplog):
 
     perp = Asset(symbol="BTCUSDT", asset_type=Asset.AssetType.CRYPTO_FUTURE)
     quote = Asset(symbol="USDT", asset_type=Asset.AssetType.CRYPTO)
-    with caplog.at_level("INFO"):
-        ds._update_pandas_data(perp, quote, length=2, timestep="minute", start_dt=datetime(2025, 1, 2, tzinfo=timezone.utc))
+    ds._update_pandas_data(perp, quote, length=2, timestep="minute", start_dt=datetime(2025, 1, 2, tzinfo=timezone.utc))
 
     assert captured["asset"] == Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
     assert captured["quote"] == Asset("USD", asset_type=Asset.AssetType.FOREX)
@@ -99,7 +101,7 @@ def test_router_routes_crypto_future_to_spot_usd_proxy(monkeypatch, caplog):
     stored = ds._data_store[(perp, quote, "minute")]
     assert stored.asset == perp
     assert stored.quote == quote
-    assert "USDT mapped to USD spot" in caplog.text
+    assert any("USDT mapped to USD spot" in message for message in log_messages)
 
 
 def test_router_accepts_futures_key_alias(monkeypatch):


### PR DESCRIPTION
## Summary
- add crypto-futures/perpetual routed backtesting support with spot USD proxy for USDT contracts
- carry routed backtesting stock/index daily lookup fixes
- document crypto_future routing and add deployment prompt-review gate

## Tests
- python -m pytest tests/test_routed_backtesting_unit.py tests/test_routed_backtesting_routing_validation.py -q

## Docs/Prompts
- Docs updated in README.md, docs/BACKTESTING_ARCHITECTURE.md, docs/BACKTESTING_SPEED_PLAYBOOK.md, docs/ENV_VARS.md, and docsrc/backtesting.ibkr.rst.
- Visuals: no new generated image needed; this is a data-routing/runtime behavior change documented with config examples.
- Prompt review: BotSpot agent prompt update is in botspot_agent commit 9ad36ff.

Deploy marker: 3bf5dc67 deploy 4.5.20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v4.5.20

* **Bug Fixes**
  * Resolved crypto futures/perpetual backtesting routing.
  * Fixed day-level stock/index preservation in mixed option workflows.

* **Changed**
  * `FRED_API_KEY` now required for official macro tools.
  * Release docs now require prompt-review and an added prompt/shared-example check.

* **Documentation**
  * Expanded backtesting data-source routing examples and clarified crypto-future spot-proxy behavior.
  * Tightened deployment workflow and FAQ/provider guidance.

* **Improved**
  * Cloud position snapshots include verification status.

* **Tests**
  * Added tests for routing and cloud snapshot behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->