### PR TITLE
v4.5.23 - IBKR backtest conid cache fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.5.23 - Unreleased
 
+### Fixed
+- **IBKR REST backtests now negative-cache unresolvable stock/index conid lookups.** Symbols that IBKR cannot resolve, such as defunct AlphaPicks holdings, are treated as terminal no-data and persisted in the conid negative cache so long BotSpot backtests skip them deterministically instead of hammering secdef/history endpoints until the task times out.
+
 ## 4.5.22 - Unreleased
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.23 - Unreleased
+
 ## 4.5.22 - Unreleased
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.23 - Unreleased
+## 4.5.23 - 2026-05-15
+
+Deploy marker: 4.5.23 release commit (`deploy 4.5.23`)
 
 ### Fixed
 - **IBKR REST backtests now negative-cache unresolvable stock/index conid lookups.** Symbols that IBKR cannot resolve, such as defunct AlphaPicks holdings, are treated as terminal no-data and persisted in the conid negative cache so long BotSpot backtests skip them deterministically instead of hammering secdef/history endpoints until the task times out.

--- a/docsrc/backtesting.ibkr.rst
+++ b/docsrc/backtesting.ibkr.rst
@@ -83,6 +83,15 @@ IBKR backtests cache historical bars as Parquet:
 - Local: ``LUMIBOT_CACHE_FOLDER/ibkr/...``
 - Optional S3 mirroring: configured via the standard ``LUMIBOT_CACHE_*`` variables (see :ref:`environment_variables`).
 
+Conid lookups also maintain cache files under ``LUMIBOT_CACHE_FOLDER/ibkr``:
+
+- ``conids.json`` stores successful conid resolutions.
+- ``conids_negative.json`` stores short-lived negative markers for symbols IBKR cannot resolve.
+
+Negative conid markers prevent long backtests from repeatedly retrying permanently unavailable symbols, such as
+defunct equities returned by an external universe API. These lookup failures are treated as terminal no-data
+conditions for the affected request window, not as synthetic price data.
+
 Multi-provider routing (Theta + IBKR)
 -------------------------------------
 

--- a/lumibot/tools/ibkr_helper.py
+++ b/lumibot/tools/ibkr_helper.py
@@ -2591,6 +2591,17 @@ def _resolve_conid(*, asset: Asset, quote: Optional[Asset], exchange: Optional[s
             _RUNTIME_CONID_CACHE[key] = int(cached)
             return cached
 
+    if asset_type not in {"future", "cont_future"}:
+        _load_negative_conid_cache()
+        for key in candidates:
+            neg_hit = _NEGATIVE_CONID_CACHE.get(key)
+            if isinstance(neg_hit, dict):
+                cached_msg = str(neg_hit.get("message") or "").strip() or (
+                    f"IBKR conid lookup is negatively cached for {asset.symbol} (type={asset_type})."
+                )
+                logger.error("IBKR negative conid cache hit: %s", cached_msg)
+                raise RuntimeError(cached_msg)
+
     if asset_type in {"future", "cont_future"} and primary.expiration:
         same_month_cached = _lookup_same_month_future_conid_from_mapping(mapping=mapping, key=primary)
         if same_month_cached is not None:
@@ -2632,6 +2643,9 @@ def _resolve_conid(*, asset: Asset, quote: Optional[Asset], exchange: Optional[s
         if prior_alt != conid_int:
             keys_added.add(alt_key)
 
+    for key in set(candidates + [primary_key]):
+        _clear_negative_conid(key=key)
+
     cache_file.parent.mkdir(parents=True, exist_ok=True)
     cache_file.write_text(json.dumps(mapping, indent=2, sort_keys=True), encoding="utf-8")
     try:
@@ -2661,6 +2675,9 @@ def _is_terminal_no_data_error(exc: Exception) -> bool:
             "no data available",
             "does not have data",
             "asset does not exist",
+            "unable to resolve ibkr conid",
+            "ibkr conid lookup is negatively cached",
+            "secdef/search returned no",
             # `_fetch_history_between_dates` raises this when IBKR pagination returns
             # empty before we covered the requested window. In practice this happens
             # for entitlement/stitching gaps (e.g. CONT_FUTURE 1-minute Trades) where
@@ -2843,7 +2860,9 @@ def _lookup_conid_remote(
         conid = payload[0].get("conid")
         if conid is not None:
             return int(conid)
-    raise RuntimeError(f"Unable to resolve IBKR conid for {asset.symbol} (type={asset_type})")
+    message = f"Unable to resolve IBKR conid for {asset.symbol} (type={asset_type})"
+    _record_negative_conid(key=_conid_key(asset=asset, quote=quote, exchange=exchange).to_key(), reason="no_conid", message=message)
+    raise RuntimeError(message)
 
 
 def _lookup_conid_crypto(*, asset: Asset, quote: Optional[Asset]) -> int:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.22",
+    version="4.5.23",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_ibkr_helper_unit.py
+++ b/tests/test_ibkr_helper_unit.py
@@ -391,3 +391,44 @@ def test_history_period_for_request_daily_stock_index_uses_cap():
             assert period == ibkr_helper.IBKR_STOCK_INDEX_DAILY_MAX_PERIOD, (
                 f"asset_type={asset_type} bar={bar} period={period}"
             )
+
+
+def test_unresolvable_stock_conid_is_terminal_no_data():
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    assert ibkr_helper._is_terminal_no_data_error(RuntimeError("Unable to resolve IBKR conid for ARCH-DEFUNCT-2838"))
+    assert ibkr_helper._is_terminal_no_data_error(RuntimeError("IBKR conid lookup is negatively cached for ARCH-DEFUNCT-2838"))
+
+
+def test_unresolvable_stock_conid_uses_negative_cache(monkeypatch, tmp_path):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    monkeypatch.setattr(ibkr_helper, "LUMIBOT_CACHE_FOLDER", tmp_path.as_posix())
+    ibkr_helper._RUNTIME_CONID_CACHE.clear()
+    ibkr_helper._NEGATIVE_CONID_CACHE.clear()
+    monkeypatch.setattr(ibkr_helper, "_NEGATIVE_CONID_CACHE_LOADED", False)
+
+    calls = {"secdef": 0}
+
+    def fake_queue_request(url: str, querystring, headers=None, timeout=None):
+        if url.endswith("/ibkr/iserver/secdef/search"):
+            calls["secdef"] += 1
+            return []
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr(ibkr_helper, "queue_request", fake_queue_request)
+
+    asset = Asset(symbol="ARCH-DEFUNCT-2838", asset_type=Asset.AssetType.STOCK)
+    quote = Asset(symbol="USD", asset_type=Asset.AssetType.FOREX)
+
+    with pytest.raises(RuntimeError, match="Unable to resolve IBKR conid"):
+        ibkr_helper._resolve_conid(asset=asset, quote=quote, exchange=None)
+
+    assert calls["secdef"] == 1
+    assert (tmp_path / "ibkr" / "conids_negative.json").exists()
+    assert "stock|ARCH-DEFUNCT-2838|USD||" in ibkr_helper._NEGATIVE_CONID_CACHE
+
+    with pytest.raises(RuntimeError, match="Unable to resolve IBKR conid"):
+        ibkr_helper._resolve_conid(asset=asset, quote=quote, exchange=None)
+
+    assert calls["secdef"] == 1


### PR DESCRIPTION
## What / Why
Fixes IBKR REST backtests that repeatedly retry unresolvable stock/index conids, such as defunct AlphaPicks symbols returned by historical universe APIs. These failures are now classified as terminal no-data and persisted in the existing conid negative cache so long BotSpot backtests can skip unavailable symbols instead of timing out.

## Risk
Low to moderate. This only changes handling for symbols IBKR cannot resolve through secdef/search. A stale negative cache marker is cleared automatically after a later successful conid resolution, and the marker TTL remains 24 hours.

## Tests run
- /Users/robertgrzesik/bin/safe-timeout 600s pytest -q tests/test_ibkr_helper_unit.py tests/test_ibkr_helper_futures_unit.py

## Docs
- CHANGELOG.md
- docsrc/backtesting.ibkr.rst

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backtests now persistently skip unresolvable IBKR symbols by negative-caching them, treating them as terminal no-data to avoid repeated lookup attempts.

* **Documentation**
  * Added guidance on IBKR symbol resolution and negative-caching behavior to clarify backtest behavior and performance impact.

* **Tests**
  * Added unit tests validating negative-cache behavior for unresolvable IBKR symbol lookups.

* **Chores**
  * Package version updated to 4.5.23.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1042)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->