### PR TITLE
Improve Polars provider data flow

### DIFF
--- a/lumibot/backtesting/databento_backtesting_polars.py
+++ b/lumibot/backtesting/databento_backtesting_polars.py
@@ -1,9 +1,10 @@
 import traceback
 from datetime import datetime, timedelta
 
+import numpy as np
 import pandas as pd
 import polars as pl
-import numpy as np
+from termcolor import colored
 
 from lumibot import LUMIBOT_DEFAULT_PYTZ
 from lumibot.data_sources import PolarsData
@@ -12,9 +13,8 @@ from lumibot.entities.data_polars import DataPolars
 from lumibot.tools import databento_helper_polars as databento_helper
 from lumibot.tools.databento_helper_polars import DataBentoAuthenticationError
 from lumibot.tools.helpers import to_datetime_aware
-from termcolor import colored
-
 from lumibot.tools.lumibot_logger import get_logger
+
 logger = get_logger(__name__)
 
 # Conversion tracking for optimization analysis
@@ -221,7 +221,8 @@ class DataBentoDataBacktestingPolars(PolarsData):
                     end=end_datetime,
                     timestep=timestep,
                     venue=None,
-                    force_cache_update=False
+                    force_cache_update=False,
+                    return_polars=True,
                 )
 
                 is_empty = False
@@ -250,17 +251,25 @@ class DataBentoDataBacktestingPolars(PolarsData):
                     self.pandas_data[search_asset] = data_obj
                     self._cache_datetime_series(search_asset, data_obj)
                 else:
-                    pandas_df = df.to_pandas() if hasattr(df, "to_pandas") else df
-                    # Create Data object and store
-                    data_obj = Data(
-                        asset,
-                        df=pandas_df,
-                        timestep=timestep,
-                        quote=quote_asset,
-                    )
+                    if isinstance(df, pl.DataFrame):
+                        _log_conversion("STORE", "polars", "DataPolars", "prefetch_data")
+                        data_obj = DataPolars(
+                            asset,
+                            df=df,
+                            timestep=timestep,
+                            quote=quote_asset,
+                        )
+                        cached_len = df.height
+                    else:
+                        data_obj = Data(
+                            asset,
+                            df=df,
+                            timestep=timestep,
+                            quote=quote_asset,
+                        )
+                        cached_len = len(df) if hasattr(df, "__len__") else 0
                     self.pandas_data[search_asset] = data_obj
                     self._cache_datetime_series(search_asset, data_obj)
-                    cached_len = len(pandas_df) if hasattr(pandas_df, "__len__") else 0
                     logger.debug(f"Cached {cached_len} rows for {asset.symbol}")
                 
                 # Mark as prefetched
@@ -818,6 +827,7 @@ class DataBentoDataBacktestingPolars(PolarsData):
         quote=None,
         exchange=None,
         include_after_hours=True,
+        return_polars=False,
     ):
         """
         Override parent method to fetch data from DataBento instead of pre-loaded data store
@@ -836,10 +846,9 @@ class DataBentoDataBacktestingPolars(PolarsData):
         quote_asset = quote if quote is not None else Asset("USD", "forex")
 
         if isinstance(search_asset, tuple):
-            asset_separated, quote_asset = search_asset
+            _, quote_asset = search_asset
         else:
             search_asset = (search_asset, quote_asset)
-            asset_separated = asset
 
         # OPTIMIZATION: Build cache key and check cache
         # Convert timeshift to consistent format for caching
@@ -894,17 +903,6 @@ class DataBentoDataBacktestingPolars(PolarsData):
                         bar_delta = timedelta(days=1)
 
                     cutoff_dt = current_dt_aware - bar_delta
-
-                    # Convert to UTC for polars comparison (polars DataFrame datetime is in UTC)
-                    # Get the timezone from polars DataFrame
-                    polars_tz = polars_df["datetime"].dtype.time_zone
-                    if polars_tz:
-                        # Convert current_dt_aware to match polars timezone
-                        cutoff_dt_compat = pd.Timestamp(cutoff_dt).tz_convert(polars_tz)
-                        current_dt_compat = pd.Timestamp(current_dt_aware).tz_convert(polars_tz)
-                    else:
-                        cutoff_dt_compat = cutoff_dt
-                        current_dt_compat = current_dt_aware
 
                     datetime_key = (search_asset, asset_data.timestep)
                     datetime_ns = self._datetime_ns_cache.get(datetime_key)

--- a/lumibot/data_sources/databento_data_polars.py
+++ b/lumibot/data_sources/databento_data_polars.py
@@ -7,31 +7,36 @@ This implementation uses:
 - Correct price conversion from fixed-point format
 """
 
-from datetime import datetime, timedelta, timezone
-from decimal import Decimal
-from typing import Dict, Optional, Union
-import time
-import threading
 import queue
+import threading
+import time
 from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Optional
 
 import polars as pl
+
 try:
     import databento as db
 except ImportError:  # pragma: no cover - optional dependency
     db = None
 
-from .data_source import DataSource
-from .polars_mixin import PolarsMixin
 from lumibot.entities import Asset, Bars, Quote
 from lumibot.tools import databento_helper_polars, futures_roll
 from lumibot.tools.databento_helper_polars import (
-    _ensure_polars_datetime_timezone as _ensure_polars_tz,
     _ensure_polars_datetime_precision as _ensure_polars_precision,
+)
+from lumibot.tools.databento_helper_polars import (
+    _ensure_polars_datetime_timezone as _ensure_polars_tz,
+)
+from lumibot.tools.databento_helper_polars import (
     _format_futures_symbol_for_databento,
     _generate_databento_symbol_alternatives,
 )
 from lumibot.tools.lumibot_logger import get_logger
+
+from .data_source import DataSource
+from .polars_mixin import PolarsMixin
 
 logger = get_logger(__name__)
 
@@ -200,7 +205,7 @@ class DataBentoDataPolars(PolarsMixin, DataSource):
                         err_msg = getattr(record, 'err', 'Unknown error')
                         logger.error(f"[DATABENTO][PRODUCER] Error from server: {err_msg}")
                         if error_count > 3:
-                            logger.error(f"[DATABENTO][PRODUCER] Too many errors, will reconnect")
+                            logger.error("[DATABENTO][PRODUCER] Too many errors, will reconnect")
                             break
                         continue
                     
@@ -220,7 +225,7 @@ class DataBentoDataPolars(PolarsMixin, DataSource):
                             logger.debug(f"[DATABENTO][PRODUCER] {symbol} record #{record_count}: {record.__class__.__name__}")
                     
                     except queue.Full:
-                        logger.warning(f"[DATABENTO][PRODUCER] Queue full, dropping record")
+                        logger.warning("[DATABENTO][PRODUCER] Queue full, dropping record")
                 
                 # Clean exit
                 logger.debug(f"[DATABENTO][PRODUCER] {symbol} stopped after {record_count} records")
@@ -709,8 +714,11 @@ class DataBentoDataPolars(PolarsMixin, DataSource):
                 self._warn_stale(symbol, "stale trade cache")
 
         # Fallback to historical
-        bars = self.get_historical_prices(asset, 1, "minute", exchange=exchange)
+        bars = self.get_historical_prices(asset, 1, "minute", exchange=exchange, return_polars=True)
         if bars and len(bars) > 0:
+            bars_df = bars.polars_df
+            if isinstance(bars_df, pl.DataFrame):
+                return float(bars_df["close"][-1])
             return float(bars.df['close'].tail(1).item())
 
         return None

--- a/lumibot/data_sources/polars_data.py
+++ b/lumibot/data_sources/polars_data.py
@@ -5,9 +5,9 @@ from typing import Union
 
 import pandas as pd
 
+from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.data_sources import DataSourceBacktesting
 from lumibot.entities import Asset, Bars, Quote
-from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.tools.lumibot_logger import get_logger
 
 logger = get_logger(__name__)
@@ -690,6 +690,7 @@ class PolarsData(DataSourceBacktesting):
         quote=None,
         exchange=None,
         include_after_hours=True,
+        return_polars=False,
     ):
         timestep = timestep if timestep else self.MIN_TIMESTEP
         if exchange is not None:
@@ -751,7 +752,6 @@ class PolarsData(DataSourceBacktesting):
                 # CRITICAL: Integer timeshift represents BAR offsets, not minute deltas!
                 # Must calculate adjustment based on the actual timestep being requested.
                 if timeshift:
-                    from datetime import timedelta
                     if isinstance(timeshift, int):
                         # Calculate timedelta for one bar of this timestep
                         timestep_delta, _ = self.convert_timestep_str_to_timedelta(timestep)
@@ -806,7 +806,19 @@ class PolarsData(DataSourceBacktesting):
         now = self.get_datetime()
 
         try:
-            res = data.get_bars(now, length=length, timestep=timestep, timeshift=timeshift)
+            if return_polars:
+                try:
+                    res = data.get_bars(
+                        now,
+                        length=length,
+                        timestep=timestep,
+                        timeshift=timeshift,
+                        return_polars=True,
+                    )
+                except TypeError:
+                    res = data.get_bars(now, length=length, timestep=timestep, timeshift=timeshift)
+            else:
+                res = data.get_bars(now, length=length, timestep=timestep, timeshift=timeshift)
         # Return None if data.get_bars returns a ValueError
         except ValueError as e:
             logger.debug(f"Error getting bars for {asset}: {e}")
@@ -1011,6 +1023,7 @@ class PolarsData(DataSourceBacktesting):
             quote=quote,
             exchange=exchange,
             include_after_hours=include_after_hours,
+            return_polars=return_polars,
         )
         if isinstance(response, float):
             return response

--- a/lumibot/data_sources/polars_data.py
+++ b/lumibot/data_sources/polars_data.py
@@ -815,7 +815,9 @@ class PolarsData(DataSourceBacktesting):
                         timeshift=timeshift,
                         return_polars=True,
                     )
-                except TypeError:
+                except TypeError as exc:
+                    if "return_polars" not in str(exc):
+                        raise
                     res = data.get_bars(now, length=length, timestep=timestep, timeshift=timeshift)
             else:
                 res = data.get_bars(now, length=length, timestep=timestep, timeshift=timeshift)

--- a/lumibot/entities/bars.py
+++ b/lumibot/entities/bars.py
@@ -211,7 +211,11 @@ class Bars:
                 if target_tz:
                     current_dtype = df.schema.get("datetime")
                     current_tz = getattr(current_dtype, "time_zone", None)
-                    if current_tz != target_tz:
+                    if current_dtype == pl.Date:
+                        df = df.with_columns(
+                            pl.col("datetime").cast(pl.Datetime).dt.replace_time_zone(target_tz)
+                        )
+                    elif current_tz != target_tz:
                         df = df.with_columns(
                             pl.col("datetime").dt.convert_time_zone(target_tz)
                         )

--- a/lumibot/entities/bars.py
+++ b/lumibot/entities/bars.py
@@ -1,7 +1,7 @@
 import atexit
 import re
 import weakref
-from datetime import datetime
+from datetime import date as date_type, datetime
 from decimal import Decimal
 from typing import Set, Union
 
@@ -539,7 +539,12 @@ class Bars:
         stock_splits = values.get("stock_splits", default_zero)
 
         for idx, dt_val in enumerate(datetimes):
-            timestamp = int(dt_val.timestamp()) if hasattr(dt_val, 'timestamp') else int(dt_val)
+            if hasattr(dt_val, "timestamp"):
+                timestamp = int(dt_val.timestamp())
+            elif isinstance(dt_val, date_type):
+                timestamp = int(datetime.combine(dt_val, datetime.min.time()).timestamp())
+            else:
+                timestamp = int(dt_val)
 
             item = {
                 "timestamp": timestamp,

--- a/lumibot/entities/bars.py
+++ b/lumibot/entities/bars.py
@@ -1,10 +1,9 @@
-from datetime import datetime, timedelta
+import atexit
 import re
 import weakref
+from datetime import datetime
 from decimal import Decimal
-from typing import Union, Set
-import warnings
-import atexit
+from typing import Set, Union
 
 import numpy as np
 import pandas as pd
@@ -506,33 +505,51 @@ class Bars:
             underlying_df = self._df
         else:
             underlying_df = pl.from_pandas(self._df.reset_index() if hasattr(self._df, 'index') else self._df)
-        # Polars implementation
-        for row in underlying_df.iter_rows(named=True):
-            # Find datetime column
-            dt_val = None
-            for col in underlying_df.columns:
-                if underlying_df[col].dtype in [pl.Datetime, pl.Date]:
-                    dt_val = row[col]
+
+        dt_col = None
+        for col, dtype in underlying_df.schema.items():
+            if dtype in (pl.Datetime, pl.Date):
+                dt_col = col
+                break
+
+        if dt_col is None:
+            for col in ['datetime', 'date', 'timestamp']:
+                if col in underlying_df.columns:
+                    dt_col = col
                     break
 
-            if dt_val is None:
-                # Try to find a column with date/time in the name
-                for col in ['datetime', 'date', 'timestamp']:
-                    if col in row:
-                        dt_val = row[col]
-                        break
+        if dt_col is None:
+            return result
 
-            timestamp = int(dt_val.timestamp()) if hasattr(dt_val, 'timestamp') else int(dt_val.timestamp())
+        values = {
+            col: underlying_df[col].to_list()
+            for col in ("open", "high", "low", "close", "volume", "dividend", "stock_splits")
+            if col in underlying_df.columns
+        }
+        datetimes = underlying_df[dt_col].to_list()
+        row_count = len(datetimes)
+        default_none = [None] * row_count
+        default_zero = [0] * row_count
+        opens = values.get("open", default_none)
+        highs = values.get("high", default_none)
+        lows = values.get("low", default_none)
+        closes = values.get("close", default_none)
+        volumes = values.get("volume", default_none)
+        dividends = values.get("dividend", default_zero)
+        stock_splits = values.get("stock_splits", default_zero)
+
+        for idx, dt_val in enumerate(datetimes):
+            timestamp = int(dt_val.timestamp()) if hasattr(dt_val, 'timestamp') else int(dt_val)
 
             item = {
                 "timestamp": timestamp,
-                "open": row.get("open"),
-                "high": row.get("high"),
-                "low": row.get("low"),
-                "close": row.get("close"),
-                "volume": row.get("volume"),
-                "dividend": row.get("dividend", 0),
-                "stock_splits": row.get("stock_splits", 0),
+                "open": opens[idx],
+                "high": highs[idx],
+                "low": lows[idx],
+                "close": closes[idx],
+                "volume": volumes[idx],
+                "dividend": dividends[idx],
+                "stock_splits": stock_splits[idx],
             }
             bar = Bar(item)
             result.append(bar)

--- a/lumibot/entities/data_polars.py
+++ b/lumibot/entities/data_polars.py
@@ -4,9 +4,9 @@ from typing import Optional, Union
 
 import pandas as pd
 import polars as pl
+import pytz
 
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ as DEFAULT_PYTZ
-import pytz
 from lumibot.tools.helpers import parse_timestep_qty_and_unit, to_datetime_aware
 from lumibot.tools.lumibot_logger import get_logger
 
@@ -134,7 +134,7 @@ class DataPolars:
             raise ValueError("Polars DataFrame must have a 'datetime' column")
 
         # Convert datetime column to proper type if needed
-        # CRITICAL: Preserve timezone if it already exists (e.g., UTC from DataBento)
+        # CRITICAL: Preserve timezone if it already exists in provider data.
         dtype = self.polars_df.schema["datetime"]
         if isinstance(dtype, pl.datatypes.Datetime) and dtype.time_zone:
             # Column already has timezone, preserve it during cast
@@ -331,6 +331,7 @@ class DataPolars:
 
         # Check if we have a volume column, if not then add it and fill with 0 or NaN.
         if "volume" in df.columns:
+            df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
             df.loc[df["volume"].isna(), "volume"] = 0
         else:
             df["volume"] = None
@@ -360,6 +361,7 @@ class DataPolars:
 
         # Update the cached pandas DataFrame
         self._pandas_df = df
+        self._repaired_polars_df = None
 
         # Set up iter_index and iter_index_dict for later use.
         iter_index = pd.Series(df.index)
@@ -587,8 +589,161 @@ class DataPolars:
 
         return dict
 
-    def get_bars(self, dt, length=1, timestep=MIN_TIMESTEP, timeshift=0):
+    def _ensure_repaired_polars_df(self) -> pl.DataFrame:
+        """Return the repaired/forward-filled data as Polars for hot bar slicing."""
+        repaired_polars = getattr(self, "_repaired_polars_df", None)
+        if repaired_polars is not None:
+            return repaired_polars
+
+        if getattr(self, "iter_index_dict", None) is None:
+            self.repair_times_and_fill(self.df.index)
+
+        pandas_df = self._pandas_df
+        reset_df = pandas_df.reset_index()
+        if "datetime" not in reset_df.columns:
+            reset_df = reset_df.rename(columns={reset_df.columns[0]: "datetime"})
+        repaired_polars = pl.from_pandas(reset_df)
+        self._repaired_polars_df = repaired_polars
+        return repaired_polars
+
+    def _get_bars_polars_frame(self, dt, length=1, timestep=None, timeshift=0) -> pl.DataFrame:
+        """Slice repaired bar data directly from the cached Polars frame."""
+        if dt < self.datetime_start:
+            raise ValueError(
+                f"The date you are looking for ({dt}) for ({self.asset}) is outside of the data's date range ({self.datetime_start} to {self.datetime_end}). This could be because the data for this asset does not exist for the date you are looking for, or something else."
+            )
+
+        if isinstance(timeshift, datetime.timedelta):
+            ts = timestep if timestep is not None else self.timestep
+            if ts == "day":
+                timeshift = int(timeshift.total_seconds() / (24 * 3600))
+            elif ts == "hour":
+                timeshift = int(timeshift.total_seconds() / 3600)
+            else:
+                timeshift = int(timeshift.total_seconds() / 60)
+
+        end_row = self.get_iter_count(dt) - timeshift
+        if pd.isna(end_row):
+            end_row = 0
+        else:
+            data_index = end_row + 1 - int(length)
+            if data_index < 0:
+                logger.warning(
+                    f"The date you are looking for ({dt}) is outside of the data's date range ({self.datetime_start} to {self.datetime_end}) after accounting for a length of {length} and a timeshift of {timeshift}. Keep in mind that the length you are requesting must also be available in your data, in this case we are {data_index} rows away from the data you need."
+                )
+
+        df = self._ensure_repaired_polars_df()
+        end_row = max(0, min(int(end_row), df.height))
+        start_row = max(0, end_row - int(length))
+        if start_row > end_row:
+            start_row = end_row
+
+        return df.slice(start_row, end_row - start_row)
+
+    def _get_bars_between_dates_polars_frame(self, start_date=None, end_date=None) -> pl.DataFrame:
+        """Slice a date range directly from the cached repaired Polars frame."""
+        end_row = self.get_iter_count(end_date)
+        start_row = self.get_iter_count(start_date)
+
+        if pd.isna(end_row):
+            end_row = 0
+        if pd.isna(start_row) or start_row < 0:
+            start_row = 0
+
+        df = self._ensure_repaired_polars_df()
+        start_row = max(0, min(int(start_row), df.height))
+        end_row = max(start_row, min(int(end_row), df.height))
+        return df.slice(start_row, end_row - start_row)
+
+    @staticmethod
+    def _drop_null_or_nan(df: pl.DataFrame, columns: list[str]) -> pl.DataFrame:
+        """Match pandas dropna() for the resampled OHLCV/dividend output."""
+        filters = []
+        for column in columns:
+            if column not in df.columns:
+                continue
+
+            expr = pl.col(column).is_not_null()
+            if df.schema.get(column) in (pl.Float32, pl.Float64):
+                expr &= pl.col(column).is_not_nan()
+            filters.append(expr)
+
+        if not filters:
+            return df
+
+        condition = filters[0]
+        for expr in filters[1:]:
+            condition &= expr
+        return df.filter(condition)
+
+    @staticmethod
+    def _align_datetime_for_polars(df: pl.DataFrame, dt, column: str = "datetime"):
+        """Align a Python/pandas datetime literal to a Polars datetime column timezone."""
+        dtype = df.schema.get(column)
+        time_zone = dtype.time_zone if isinstance(dtype, pl.Datetime) else None
+        ts = pd.Timestamp(dt)
+
+        if time_zone is None:
+            return ts.tz_localize(None) if ts.tz is not None else ts
+
+        if ts.tz is None:
+            return ts.tz_localize(time_zone)
+        return ts.tz_convert(time_zone)
+
+    @classmethod
+    def _resample_polars_bars(cls, df: pl.DataFrame, quantity: int, unit: str) -> pl.DataFrame:
+        """Resample OHLCV data with Polars while preserving Data.get_bars() output columns."""
+        if df.is_empty():
+            return df
+
+        unit_suffix = {"min": "m", "h": "h", "D": "d"}[unit]
+        every = f"{int(quantity)}{unit_suffix}"
+
+        agg_exprs = []
+        output_columns = []
+        if "open" in df.columns:
+            agg_exprs.append(pl.col("open").first().alias("open"))
+            output_columns.append("open")
+        if "high" in df.columns:
+            agg_exprs.append(pl.col("high").max().alias("high"))
+            output_columns.append("high")
+        if "low" in df.columns:
+            agg_exprs.append(pl.col("low").min().alias("low"))
+            output_columns.append("low")
+        if "close" in df.columns:
+            agg_exprs.append(pl.col("close").last().alias("close"))
+            output_columns.append("close")
+        if "volume" in df.columns:
+            agg_exprs.append(pl.col("volume").fill_nan(0).fill_null(0).sum().alias("volume"))
+            output_columns.append("volume")
+        if "dividend" in df.columns:
+            agg_exprs.append(pl.col("dividend").fill_nan(0).fill_null(0).sum().alias("dividend"))
+            output_columns.append("dividend")
+
+        if not agg_exprs:
+            return df.select("datetime")
+
+        result = (
+            df.sort("datetime")
+            .group_by_dynamic("datetime", every=every, period=every, closed="left", label="left")
+            .agg(agg_exprs)
+            .sort("datetime")
+        )
+        return cls._drop_null_or_nan(result, output_columns)
+
+    @staticmethod
+    def _polars_to_pandas_datetime_index(df: pl.DataFrame) -> pd.DataFrame:
+        """Convert a Polars bars frame to the existing pandas-indexed return shape."""
+        pandas_df = df.to_pandas()
+        if "datetime" in pandas_df.columns:
+            pandas_df = pandas_df.set_index("datetime")
+        return pandas_df
+
+    def get_bars(self, dt, length=1, timestep=MIN_TIMESTEP, timeshift=0, return_polars: bool = False):
         """Returns a dataframe of the data."""
+        if type(length) not in [int, float]:
+            raise TypeError(f"Length must be an integer. {type(length)} was provided.")
+
         # Parse the timestep
         quantity, timestep = parse_timestep_qty_and_unit(timestep)
         num_periods = length
@@ -604,63 +759,59 @@ class DataPolars:
         if timestep not in {"minute", "hour", "day"}:
             raise ValueError(f"Only minute, hour, and day are supported for timestep. You provided: {timestep}")
 
-        agg_column_map = {
-            "open": "first",
-            "high": "max",
-            "low": "min",
-            "close": "last",
-            "volume": "sum",
-        }
         if timestep == "day" and self.timestep == "minute":
             length = length * 1440
             unit = "D"
-            data = self._get_bars_dict(dt, length=length, timestep="minute", timeshift=timeshift)
+            source_timestep = "minute"
 
         elif timestep == "day" and self.timestep == "hour":
             length = length * 24
             unit = "D"
-            data = self._get_bars_dict(dt, length=length, timestep="hour", timeshift=timeshift)
+            source_timestep = "hour"
 
         elif timestep == 'day' and self.timestep == 'day':
             unit = "D"
-            data = self._get_bars_dict(dt, length=length, timestep=timestep, timeshift=timeshift)
+            source_timestep = timestep
 
         elif timestep == "hour" and self.timestep == "minute":
             length = length * 60 * quantity
             unit = "h"
-            data = self._get_bars_dict(dt, length=length, timestep="minute", timeshift=timeshift)
+            source_timestep = "minute"
 
         elif timestep == "hour" and self.timestep == "hour":
             unit = "h"
             length = length * quantity
-            data = self._get_bars_dict(dt, length=length, timestep="hour", timeshift=timeshift)
+            source_timestep = "hour"
 
         else:
             unit = "min"
             length = length * quantity
-            data = self._get_bars_dict(dt, length=length, timestep=timestep, timeshift=timeshift)
+            source_timestep = timestep
 
-        if data is None:
-            return None
-
-        df = pd.DataFrame(data).assign(datetime=lambda df: pd.to_datetime(df['datetime'])).set_index('datetime')
-        if "dividend" in df.columns:
-            agg_column_map["dividend"] = "sum"
-        df_result = df.resample(f"{quantity}{unit}").agg(agg_column_map)
-
-        # Drop any rows that have NaN values
-        df_result = df_result.dropna()
+        df = self._get_bars_polars_frame(dt, length=length, timestep=source_timestep, timeshift=timeshift)
+        df_result = self._resample_polars_bars(df, int(quantity), unit)
 
         # Remove partial day data from the current day
         if timestep == "day" and self.timestep in {"minute", "hour"}:
-            df_result = df_result[df_result.index < dt.replace(hour=0, minute=0, second=0, microsecond=0)]
+            cutoff = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+            cutoff = self._align_datetime_for_polars(df_result, cutoff)
+            df_result = df_result.filter(pl.col("datetime") < cutoff)
 
         # Only return the last n rows
         df_result = df_result.tail(n=int(num_periods))
 
-        return df_result
+        if return_polars:
+            return df_result
+        return self._polars_to_pandas_datetime_index(df_result)
 
-    def get_bars_between_dates(self, timestep=MIN_TIMESTEP, exchange=None, start_date=None, end_date=None):
+    def get_bars_between_dates(
+        self,
+        timestep=MIN_TIMESTEP,
+        exchange=None,
+        start_date=None,
+        end_date=None,
+        return_polars: bool = False,
+    ):
         """Returns a dataframe of all the data available between the start and end dates."""
         quantity, timestep = parse_timestep_qty_and_unit(timestep)
 
@@ -675,26 +826,19 @@ class DataPolars:
         if timestep not in {"minute", "hour", "day"}:
             raise ValueError(f"Only minute, hour, and day are supported for timestep. You provided: {timestep}")
 
-        data = self._get_bars_between_dates_dict(timestep=timestep, start_date=start_date, end_date=end_date)
-        if data is None:
-            return None
-
-        df = pd.DataFrame(data).set_index("datetime")
-        if df is None or df.empty:
-            return df
+        df = self._get_bars_between_dates_polars_frame(start_date=start_date, end_date=end_date)
+        if df is None or df.is_empty():
+            if return_polars:
+                return df
+            return self._polars_to_pandas_datetime_index(df)
 
         if timestep == "minute" and int(quantity) == 1:
-            return df
-
-        agg = {
-            "open": "first",
-            "high": "max",
-            "low": "min",
-            "close": "last",
-            "volume": "sum",
-        }
-        if "dividend" in df.columns:
-            agg["dividend"] = "sum"
+            if return_polars:
+                return df
+            return self._polars_to_pandas_datetime_index(df)
 
         unit_code = "min" if timestep == "minute" else "h" if timestep == "hour" else "D"
-        return df.resample(f"{int(quantity)}{unit_code}").agg(agg).dropna()
+        df_result = self._resample_polars_bars(df, int(quantity), unit_code)
+        if return_polars:
+            return df_result
+        return self._polars_to_pandas_datetime_index(df_result)

--- a/lumibot/tools/databento_helper_polars.py
+++ b/lumibot/tools/databento_helper_polars.py
@@ -5,19 +5,21 @@
 import os
 import re
 from datetime import date, datetime, timedelta, timezone
-from pathlib import Path
-from typing import Optional, List, Dict, Tuple, Union
 from decimal import Decimal
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 import polars as pl
+from termcolor import colored
+
 from lumibot import LUMIBOT_CACHE_FOLDER
 from lumibot.entities import Asset
 from lumibot.tools import futures_roll
-from termcolor import colored
 
 # Set up module-specific logger
 from lumibot.tools.lumibot_logger import get_logger
+
 logger = get_logger(__name__)
 
 
@@ -27,8 +29,8 @@ class DataBentoAuthenticationError(RuntimeError):
 
 # DataBento imports (will be installed as dependency)
 try:
-    import databento as db
     from databento import Historical
+
     DATABENTO_AVAILABLE = True
 except ImportError:
     DATABENTO_AVAILABLE = False
@@ -226,7 +228,6 @@ class DataBentoClient:
 
             # Fetch instrument definition using 'definition' schema
             # DataBento requires end > start, so add 1 day to end
-            from datetime import timedelta
             if isinstance(reference_date, datetime):
                 end_date = (reference_date + timedelta(days=1)).strftime("%Y-%m-%d")
             elif isinstance(reference_date, date):
@@ -287,7 +288,6 @@ def _convert_to_databento_format(symbol: str, asset_symbol: str = None) -> str:
     str
         DataBento-formatted symbol (e.g., MESU5)
     """
-    import re
 
     # Handle mock values used in tests
     if asset_symbol and symbol in ['MOCKED_CONTRACT', 'CENTRALIZED_RESULT']:
@@ -346,7 +346,6 @@ def _format_futures_symbol_for_databento(asset: Asset, reference_date: datetime 
     ValueError
         If symbol resolution fails with actionable error message
     """
-    import re
 
     symbol = asset.symbol.upper()
 
@@ -570,6 +569,22 @@ def _load_cache(cache_file: Path) -> Optional[pd.DataFrame]:
     return None
 
 
+def _load_cache_polars(cache_file: Path) -> Optional[pl.DataFrame]:
+    """Load data from cache as a Polars DataFrame."""
+    try:
+        if cache_file.exists():
+            df = pl.read_parquet(cache_file)
+            return _normalize_databento_dataframe_polars(df)
+    except Exception as e:
+        logger.warning(f"Error loading cache file {cache_file}: {e}")
+        try:
+            cache_file.unlink()
+        except Exception:
+            pass
+
+    return None
+
+
 def _ensure_datetime_index_utc(df: pd.DataFrame) -> pd.DataFrame:
     """Ensure the DataFrame index is a UTC-aware DatetimeIndex with standard name 'datetime'."""
     if isinstance(df.index, pd.DatetimeIndex):
@@ -601,16 +616,88 @@ def _save_cache(df: pd.DataFrame, cache_file: Path) -> None:
         logger.warning(f"Error saving cache file {cache_file}: {e}")
 
 
+def _save_cache_polars(df: Union[pd.DataFrame, pl.DataFrame], cache_file: Path) -> None:
+    """Save data to cache using Polars parquet IO."""
+    try:
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        df_to_save = _normalize_databento_dataframe_polars(df)
+        df_to_save.write_parquet(cache_file, compression="snappy", statistics=True)
+        logger.debug(f"Cached data saved to {cache_file}")
+    except Exception as e:
+        logger.warning(f"Error saving cache file {cache_file}: {e}")
+
+
+def _find_polars_datetime_column(df: pl.DataFrame) -> Optional[str]:
+    """Find the timestamp column used by a DataBento/Polars frame."""
+    for col in ("datetime", "ts_event", "timestamp", "time"):
+        if col in df.columns:
+            return col
+
+    for col, dtype in df.schema.items():
+        if isinstance(dtype, pl.Datetime) or dtype == pl.Date:
+            return col
+
+    return None
+
+
+def _align_timestamp_to_timezone(ts: datetime | pd.Timestamp | None, time_zone: Optional[str]) -> pd.Timestamp | None:
+    """Align a timestamp to the timezone semantics of a datetime column."""
+    if ts is None:
+        return None
+
+    ts_pd = pd.Timestamp(ts)
+    if time_zone is None:
+        return ts_pd.tz_localize(None) if ts_pd.tz is not None else ts_pd
+
+    if ts_pd.tz is None:
+        return ts_pd.tz_localize(time_zone)
+    return ts_pd.tz_convert(time_zone)
+
+
 def _filter_front_month_rows_polars(
-    df: pd.DataFrame,
+    df: Union[pd.DataFrame, pl.DataFrame],
     schedule: List[Tuple[str, datetime, datetime]],
-) -> pd.DataFrame:
+) -> Union[pd.DataFrame, pl.DataFrame]:
     """
     Filter combined contract data so each timestamp uses the scheduled symbol.
 
     POLARS OPTIMIZED VERSION: Uses polars for fast datetime filtering.
     This targets the DatetimeArray iteration bottleneck identified in profiling.
     """
+    if isinstance(df, pl.DataFrame):
+        if df.is_empty() or "symbol" not in df.columns or schedule is None:
+            return df
+
+        datetime_col = _find_polars_datetime_column(df)
+        if datetime_col is None:
+            return df
+
+        datetime_dtype = df.schema.get(datetime_col)
+        time_zone = datetime_dtype.time_zone if isinstance(datetime_dtype, pl.Datetime) else None
+        filter_expr = pl.lit(False)
+
+        for symbol, start_dt, end_dt in schedule:
+            cond = pl.col("symbol") == symbol
+
+            start_aligned = _align_timestamp_to_timezone(start_dt, time_zone)
+            if start_aligned is not None:
+                start_lit = pl.lit(start_aligned)
+                if isinstance(datetime_dtype, pl.Datetime):
+                    start_lit = start_lit.cast(datetime_dtype)
+                cond &= pl.col(datetime_col) >= start_lit
+
+            end_aligned = _align_timestamp_to_timezone(end_dt, time_zone)
+            if end_aligned is not None:
+                end_lit = pl.lit(end_aligned)
+                if isinstance(datetime_dtype, pl.Datetime):
+                    end_lit = end_lit.cast(datetime_dtype)
+                cond &= pl.col(datetime_col) < end_lit
+
+            filter_expr |= cond
+
+        filtered = df.filter(filter_expr)
+        return filtered if not filtered.is_empty() else df
+
     if df.empty or "symbol" not in df.columns or schedule is None:
         return df
 
@@ -789,6 +876,67 @@ def _normalize_databento_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     return df_norm
 
 
+def _normalize_databento_dataframe_polars(df: Union[pd.DataFrame, pl.DataFrame]) -> pl.DataFrame:
+    """
+    Normalize DataBento data to a Polars DataFrame with Lumibot OHLCV columns.
+    """
+    if isinstance(df, pl.DataFrame):
+        if df.is_empty():
+            return df
+        df_norm = df.clone()
+    elif isinstance(df, pd.DataFrame):
+        if df.empty:
+            return pl.DataFrame()
+
+        df_pd = df.copy()
+        if isinstance(df_pd.index, pd.DatetimeIndex):
+            df_pd = _ensure_datetime_index_utc(df_pd)
+            if df_pd.index.name in df_pd.columns:
+                df_pd = df_pd.drop(columns=[df_pd.index.name])
+            df_pd.reset_index(inplace=True)
+
+        df_norm = pl.from_pandas(df_pd)
+    else:
+        raise TypeError(f"Unexpected DataBento frame type: {type(df)}")
+
+    timestamp_col = _find_polars_datetime_column(df_norm)
+    if timestamp_col and timestamp_col != "datetime" and "datetime" not in df_norm.columns:
+        df_norm = df_norm.rename({timestamp_col: "datetime"})
+
+    if "datetime" in df_norm.columns:
+        datetime_dtype = df_norm.schema.get("datetime")
+        if not isinstance(datetime_dtype, pl.Datetime):
+            df_norm = df_norm.with_columns(
+                pl.col("datetime").cast(pl.Datetime(time_unit="ns"), strict=False)
+            )
+        df_norm = _ensure_polars_datetime_timezone(df_norm)
+        df_norm = _ensure_polars_datetime_precision(df_norm)
+
+    required_cols = ["open", "high", "low", "close", "volume"]
+    missing_cols = [col for col in required_cols if col not in df_norm.columns]
+    if missing_cols:
+        logger.warning(f"Missing required columns in DataBento data: {missing_cols}")
+        for col in missing_cols:
+            fill_value = 0 if col == "volume" else None
+            df_norm = df_norm.with_columns(pl.lit(fill_value).alias(col))
+
+    numeric_cols = ["open", "high", "low", "close"]
+    numeric_exprs = [
+        pl.col(col).cast(pl.Float64, strict=False).alias(col)
+        for col in numeric_cols
+        if col in df_norm.columns
+    ]
+    if "volume" in df_norm.columns:
+        numeric_exprs.append(pl.col("volume").cast(pl.Int64, strict=False).alias("volume"))
+    if numeric_exprs:
+        df_norm = df_norm.with_columns(numeric_exprs)
+
+    if "datetime" in df_norm.columns:
+        df_norm = df_norm.sort("datetime")
+
+    return df_norm
+
+
 # Instrument definition cache: stores multipliers and contract specs (shared with polars)
 _INSTRUMENT_DEFINITION_CACHE = {}  # {(symbol, dataset): definition_dict}
 
@@ -839,7 +987,7 @@ def _fetch_and_update_futures_multiplier(
             logger.debug(f"[MULTIPLIER] ✓ Using cached multiplier for {resolved_symbol}: {asset.multiplier}")
             return
         else:
-            logger.warning(f"[MULTIPLIER] Cache entry exists but missing unit_of_measure_qty field")
+            logger.warning("[MULTIPLIER] Cache entry exists but missing unit_of_measure_qty field")
 
     # Fetch from DataBento using the RESOLVED symbol
     logger.debug(f"[MULTIPLIER] Fetching from DataBento for {resolved_symbol}, dataset={dataset}, ref_date={reference_date}")
@@ -950,6 +1098,109 @@ def get_price_data_from_databento(
         )
     except Exception as exc:
         logger.warning(f"Unable to update futures multiplier for {asset.symbol}: {exc}")
+
+    if return_polars:
+        frames_polars: List[pl.DataFrame] = []
+        symbols_missing: List[str] = []
+
+        if not force_cache_update:
+            for symbol in symbols:
+                cache_path = _build_cache_filename(asset, start, end, timestep, symbol_override=symbol)
+                cached_df = _load_cache_polars(cache_path)
+                if cached_df is None or cached_df.is_empty():
+                    symbols_missing.append(symbol)
+                    continue
+                cached_df = cached_df.with_columns(pl.lit(symbol).alias("symbol"))
+                frames_polars.append(cached_df)
+        else:
+            symbols_missing = list(symbols)
+
+        data_client: Optional[DataBentoClient] = None
+        if symbols_missing:
+            try:
+                data_client = DataBentoClient(api_key=api_key)
+            except Exception as exc:
+                logger.error(f"DataBento data fetch error: {exc}")
+                return None
+
+            min_step = timedelta(minutes=1)
+            if schema == "ohlcv-1h":
+                min_step = timedelta(hours=1)
+            elif schema == "ohlcv-1d":
+                min_step = timedelta(days=1)
+            if end_naive <= start_naive:
+                end_naive = start_naive + min_step
+
+            for symbol in symbols_missing:
+                try:
+                    logger.debug(
+                        "Requesting DataBento data for %s (%s) between %s and %s",
+                        symbol,
+                        schema,
+                        start_naive,
+                        end_naive,
+                    )
+                    df_raw = data_client.get_historical_data(
+                        dataset=dataset,
+                        symbols=symbol,
+                        schema=schema,
+                        start=start_naive,
+                        end=end_naive,
+                        **kwargs,
+                    )
+                except DataBentoAuthenticationError as exc:
+                    auth_msg = colored(
+                        f"❌ DataBento authentication failed while requesting {symbol}: {exc}",
+                        "red"
+                    )
+                    logger.error(auth_msg)
+                    raise
+                except Exception as exc:
+                    logger.warning(f"Error fetching {symbol} from DataBento: {exc}")
+                    continue
+
+                is_empty = False
+                if df_raw is None:
+                    is_empty = True
+                elif isinstance(df_raw, pl.DataFrame):
+                    is_empty = df_raw.is_empty()
+                elif hasattr(df_raw, "empty"):
+                    is_empty = df_raw.empty
+
+                if is_empty:
+                    logger.warning(f"No data returned from DataBento for symbol {symbol}")
+                    continue
+
+                df_normalized = _normalize_databento_dataframe_polars(df_raw)
+                df_normalized = df_normalized.with_columns(pl.lit(symbol).alias("symbol"))
+                cache_path = _build_cache_filename(asset, start, end, timestep, symbol_override=symbol)
+                _save_cache_polars(df_normalized, cache_path)
+                frames_polars.append(df_normalized)
+
+        if not frames_polars:
+            logger.warning(f"No DataBento data available for {asset.symbol} between {start} and {end}")
+            return None
+
+        combined_polars = pl.concat(frames_polars, how="diagonal_relaxed")
+        if "datetime" in combined_polars.columns:
+            combined_polars = combined_polars.sort("datetime")
+
+        schedule = futures_roll.build_roll_schedule(
+            roll_asset,
+            schedule_start,
+            end,
+            year_digits=1,
+        )
+
+        if schedule:
+            combined_polars = _filter_front_month_rows_polars(combined_polars, schedule)
+
+        if "symbol" in combined_polars.columns:
+            combined_polars = combined_polars.drop("symbol")
+
+        combined_polars = _ensure_polars_datetime_timezone(combined_polars)
+        combined_polars = _ensure_polars_datetime_precision(combined_polars)
+        return combined_polars
 
     frames: List[pd.DataFrame] = []
     symbols_missing: List[str] = []

--- a/tests/test_bars_frequency_flex.py
+++ b/tests/test_bars_frequency_flex.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pandas as pd
 import polars as pl
@@ -121,3 +121,22 @@ def test_split_polars_bars_preserves_values():
     assert split[1].close == 11.25
     assert split[1].volume == 200
     assert split[1].dividend == 0.1
+
+
+def test_split_polars_date_column_converts_to_midnight_timestamp():
+    asset = Asset(symbol='DATE', asset_type='stock')
+    trade_date = date(2025, 1, 2)
+    df = pl.DataFrame({
+        'datetime': [trade_date],
+        'open': [10.0],
+        'high': [10.5],
+        'low': [9.5],
+        'close': [10.25],
+        'volume': [100],
+    }).with_columns(pl.col('datetime').cast(pl.Date))
+
+    bars = Bars(df, source='test', asset=asset, return_polars=True)
+    split = bars.split()
+
+    assert len(split) == 1
+    assert split[0].timestamp == int(datetime.combine(trade_date, datetime.min.time()).timestamp())

--- a/tests/test_bars_frequency_flex.py
+++ b/tests/test_bars_frequency_flex.py
@@ -1,11 +1,12 @@
-import polars as pl
-import pandas as pd
-import pytest
 from datetime import datetime, timedelta, timezone
 
-from lumibot.entities.bars import Bars
-from lumibot.entities.asset import Asset
+import pandas as pd
+import polars as pl
+import pytest
+
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
+from lumibot.entities.asset import Asset
+from lumibot.entities.bars import Bars
 
 
 def _make_minute_df(start_epoch: int, minutes: int = 12):
@@ -92,3 +93,31 @@ def test_bars_datetime_index_normalized_to_default_timezone():
     assert isinstance(index, pd.DatetimeIndex)
     assert index.tz is not None
     assert index.tz.zone == LUMIBOT_DEFAULT_PYTZ.zone
+
+
+def test_split_polars_bars_preserves_values():
+    asset = Asset(symbol='SPLT', asset_type='stock')
+    start = datetime(2025, 1, 1, 14, 30, tzinfo=timezone.utc)
+    datetimes = [start + timedelta(minutes=i) for i in range(3)]
+    df = pl.DataFrame({
+        'datetime': datetimes,
+        'open': [10.0, 11.0, 12.0],
+        'high': [10.5, 11.5, 12.5],
+        'low': [9.5, 10.5, 11.5],
+        'close': [10.25, 11.25, 12.25],
+        'volume': [100, 200, 300],
+        'dividend': [0.0, 0.1, 0.0],
+        'stock_splits': [0.0, 0.0, 0.0],
+    })
+
+    bars = Bars(df, source='test', asset=asset, return_polars=True)
+    split = bars.split()
+
+    assert len(split) == 3
+    assert split[0].timestamp == int(datetimes[0].timestamp())
+    assert split[1].open == 11.0
+    assert split[1].high == 11.5
+    assert split[1].low == 10.5
+    assert split[1].close == 11.25
+    assert split[1].volume == 200
+    assert split[1].dividend == 0.1

--- a/tests/test_bars_frequency_flex.py
+++ b/tests/test_bars_frequency_flex.py
@@ -139,4 +139,5 @@ def test_split_polars_date_column_converts_to_midnight_timestamp():
     split = bars.split()
 
     assert len(split) == 1
-    assert split[0].timestamp == int(datetime.combine(trade_date, datetime.min.time()).timestamp())
+    expected_dt = LUMIBOT_DEFAULT_PYTZ.localize(datetime.combine(trade_date, datetime.min.time()))
+    assert split[0].timestamp == int(expected_dt.timestamp())

--- a/tests/test_data_polars_parity.py
+++ b/tests/test_data_polars_parity.py
@@ -1,5 +1,6 @@
 """Regression coverage for Data, DataPolars, Bars, and provider-boundary Polars behavior."""
 
+from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
 from unittest.mock import PropertyMock, patch
 
@@ -97,6 +98,18 @@ class ProviderBoundaryPolarsData(PolarsData):
             }
         )
         return self.response
+
+
+class LegacyGetBarsData:
+    timestep = "minute"
+
+    def __init__(self, failure_message=None):
+        self.failure_message = failure_message
+
+    def get_bars(self, *args, **kwargs):
+        if "return_polars" in kwargs:
+            raise TypeError(self.failure_message or "got an unexpected keyword argument 'return_polars'")
+        return "fallback-bars"
 
 
 def test_data_polars_row_count_parity():
@@ -340,6 +353,26 @@ def test_provider_return_polars_keeps_internal_response_polars():
         return_polars=False,
     )
     _assert_frame_values_equal(bars.pandas_df, pandas_bars.pandas_df)
+
+
+def test_return_polars_fallback_only_swallows_unsupported_keyword_typeerror():
+    asset = Asset("LEGACY", asset_type=Asset.AssetType.STOCK)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    source = PolarsData(
+        datetime_start=datetime(2024, 7, 18, tzinfo=timezone.utc),
+        datetime_end=datetime(2024, 7, 19, tzinfo=timezone.utc),
+        pandas_data=[],
+    )
+    source._data_store = OrderedDict({(asset, quote, "minute"): LegacyGetBarsData()})
+
+    assert (
+        source.get_historical_prices(asset, length=1, timestep="minute", quote=quote, return_polars=True)
+        == "fallback-bars"
+    )
+
+    source._data_store = OrderedDict({(asset, quote, "minute"): LegacyGetBarsData("internal type bug")})
+    with pytest.raises(TypeError, match="internal type bug"):
+        source.get_historical_prices(asset, length=1, timestep="minute", quote=quote, return_polars=True)
 
 
 @pytest.mark.parametrize("provider_frame_type", ["polars", "pandas"])

--- a/tests/test_data_polars_parity.py
+++ b/tests/test_data_polars_parity.py
@@ -1,16 +1,14 @@
-"""
-Regression test for Data vs DataPolars parity bug.
-
-This test isolates the issue where DataPolars returns 234 rows when asked for 2 rows
-with timeshift=-2 parameter.
-"""
+"""Regression coverage for Data, DataPolars, Bars, and provider-boundary Polars behavior."""
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import PropertyMock, patch
+
 import pandas as pd
 import polars as pl
 import pytest
 
-from lumibot.entities import Data, DataPolars, Asset
+from lumibot.data_sources.polars_data import PolarsData
+from lumibot.entities import Asset, Bars, Data, DataPolars
 
 
 def _create_mock_ohlc_data(start: datetime, periods: int = 300) -> pd.DataFrame:
@@ -32,6 +30,73 @@ def _create_mock_ohlc_data(start: datetime, periods: int = 300) -> pd.DataFrame:
         "volume": [10000 + i * 100 for i in range(periods)],
     }
     return pd.DataFrame(data, index=index)
+
+
+def _create_data_pair(start: datetime, periods: int = 300, df_mutator=None):
+    mock_df = _create_mock_ohlc_data(start, periods=periods)
+    if df_mutator is not None:
+        df_mutator(mock_df)
+
+    asset = Asset("HIMS", asset_type=Asset.AssetType.STOCK)
+    data_pandas = Data(
+        asset=asset,
+        df=mock_df.copy(),
+        timestep="minute",
+        quote=asset,
+    )
+
+    mock_df_reset = mock_df.reset_index()
+    mock_df_reset.columns = ["datetime", *mock_df.columns]
+    mock_polars = pl.from_pandas(mock_df_reset)
+    data_polars = DataPolars(
+        asset=asset,
+        df=mock_polars,
+        timestep="minute",
+        quote=asset,
+    )
+    return data_pandas, data_polars
+
+
+def _assert_frame_values_equal(left: pd.DataFrame, right: pd.DataFrame):
+    pd.testing.assert_frame_equal(
+        left,
+        right,
+        check_dtype=False,
+        check_freq=False,
+    )
+
+
+class ProviderBoundaryPolarsData(PolarsData):
+    """Small provider-like source used to test PolarsData integration boundaries."""
+
+    SOURCE = "GENERIC_PROVIDER"
+
+    def __init__(self, response, *args, **kwargs):
+        super().__init__(*args, pandas_data=[], **kwargs)
+        self.response = response
+        self.calls = []
+
+    def _pull_source_symbol_bars(
+        self,
+        asset,
+        length,
+        timestep="",
+        timeshift=0,
+        quote=None,
+        exchange=None,
+        include_after_hours=True,
+        return_polars=False,
+    ):
+        self.calls.append(
+            {
+                "asset": asset,
+                "length": length,
+                "timestep": timestep,
+                "quote": quote,
+                "return_polars": return_polars,
+            }
+        )
+        return self.response
 
 
 def test_data_polars_row_count_parity():
@@ -150,9 +215,174 @@ def test_data_polars_timeshift_timedelta():
         timeshift=timeshift_td
     )
 
-    assert len(df_pandas) == 2, f"Pandas should return 2 rows with timedelta timeshift"
-    assert len(df_polars) == 2, f"Polars should return 2 rows with timedelta timeshift"
+    assert len(df_pandas) == 2, "Pandas should return 2 rows with timedelta timeshift"
+    assert len(df_polars) == 2, "Polars should return 2 rows with timedelta timeshift"
     assert len(df_pandas) == len(df_polars), "Row count mismatch with timedelta timeshift"
+
+
+@pytest.mark.parametrize(
+    "requested_timestep,length,current_dt",
+    [
+        ("5minute", 4, datetime(2024, 7, 18, 12, 15, tzinfo=timezone.utc)),
+        ("hour", 3, datetime(2024, 7, 18, 14, 30, tzinfo=timezone.utc)),
+        ("day", 1, datetime(2024, 7, 19, 12, 30, tzinfo=timezone.utc)),
+    ],
+)
+def test_data_polars_resample_value_parity(requested_timestep, length, current_dt):
+    data_pandas, data_polars = _create_data_pair(
+        datetime(2024, 7, 18, 0, 0, tzinfo=timezone.utc),
+        periods=3_000,
+    )
+
+    df_pandas = data_pandas.get_bars(
+        dt=current_dt,
+        length=length,
+        timestep=requested_timestep,
+        timeshift=0,
+    )
+    df_polars = data_polars.get_bars(
+        dt=current_dt,
+        length=length,
+        timestep=requested_timestep,
+        timeshift=0,
+    )
+
+    _assert_frame_values_equal(df_polars, df_pandas)
+
+
+@pytest.mark.parametrize("requested_timestep", ["15minute", "hour"])
+def test_data_polars_between_dates_resample_value_parity(requested_timestep):
+    start = datetime(2024, 7, 18, 0, 0, tzinfo=timezone.utc)
+    data_pandas, data_polars = _create_data_pair(start, periods=1_000)
+
+    start_date = start + timedelta(hours=2)
+    end_date = start + timedelta(hours=9, minutes=30)
+
+    df_pandas = data_pandas.get_bars_between_dates(
+        timestep=requested_timestep,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    df_polars = data_polars.get_bars_between_dates(
+        timestep=requested_timestep,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    _assert_frame_values_equal(df_polars, df_pandas)
+
+
+def test_data_polars_resample_ignores_extra_nan_columns_like_data():
+    def mutate(df):
+        df["bid"] = None
+        df["volume"] = None
+
+    data_pandas, data_polars = _create_data_pair(
+        datetime(2024, 7, 18, 9, 30, tzinfo=timezone.utc),
+        periods=300,
+        df_mutator=mutate,
+    )
+    test_dt = datetime(2024, 7, 18, 10, 0, tzinfo=timezone.utc)
+
+    df_pandas = data_pandas.get_bars(
+        dt=test_dt,
+        length=2,
+        timestep="5minute",
+        timeshift=0,
+    )
+    df_polars = data_polars.get_bars(
+        dt=test_dt,
+        length=2,
+        timestep="5minute",
+        timeshift=0,
+    )
+
+    _assert_frame_values_equal(df_polars, df_pandas)
+    assert "bid" not in df_polars.columns
+    assert df_polars["volume"].isna().sum() == 0
+    assert all(float(v) == 0.0 for v in df_polars["volume"])
+
+
+def test_provider_return_polars_keeps_internal_response_polars():
+    start = datetime(2024, 7, 18, 0, 0, tzinfo=timezone.utc)
+    data_pandas, data_polars = _create_data_pair(start, periods=1_000)
+    asset = data_polars.asset
+    quote = data_polars.quote
+    current_dt = start + timedelta(hours=10)
+
+    polars_source = PolarsData(
+        datetime_start=start,
+        datetime_end=start + timedelta(days=1),
+        pandas_data=[data_polars],
+    )
+    polars_source._datetime = current_dt
+
+    with patch.object(Bars, "pandas_df", new_callable=PropertyMock) as mock_pandas_df:
+        mock_pandas_df.side_effect = AssertionError("return_polars=True should not force pandas conversion")
+        bars = polars_source.get_historical_prices(
+            asset,
+            length=4,
+            timestep="5minute",
+            quote=quote,
+            return_polars=True,
+        )
+
+    assert bars is not None
+    assert isinstance(bars.df, pl.DataFrame)
+    assert bars.polars_df.height == 4
+    mock_pandas_df.assert_not_called()
+
+    pandas_bars = polars_source.get_historical_prices(
+        asset,
+        length=4,
+        timestep="5minute",
+        quote=quote,
+        return_polars=False,
+    )
+    _assert_frame_values_equal(bars.pandas_df, pandas_bars.pandas_df)
+
+
+@pytest.mark.parametrize("provider_frame_type", ["polars", "pandas"])
+def test_provider_boundary_threads_return_polars_and_preserves_quote_pair(provider_frame_type):
+    start = datetime(2024, 7, 18, 9, 30, tzinfo=timezone.utc)
+    pandas_frame = _create_mock_ohlc_data(start, periods=5)
+    polars_frame = pl.from_pandas(
+        pandas_frame.reset_index().rename(columns={"index": "datetime"})
+    )
+    provider_response = polars_frame if provider_frame_type == "polars" else pandas_frame
+    base = Asset("ETH", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    source = ProviderBoundaryPolarsData(
+        provider_response,
+        datetime_start=start,
+        datetime_end=start + timedelta(hours=1),
+    )
+
+    bars = source.get_historical_prices(
+        (base, quote),
+        length=3,
+        timestep="minute",
+        return_polars=True,
+    )
+
+    assert source.calls[-1]["return_polars"] is True
+    assert source.calls[-1]["asset"] == (base, quote)
+    assert bars.asset == base
+    assert bars.quote == quote
+    assert bars.source == "GENERIC_PROVIDER"
+    assert isinstance(bars.df, pl.DataFrame)
+
+    pandas_bars = source.get_historical_prices(
+        (base, quote),
+        length=3,
+        timestep="minute",
+        return_polars=False,
+    )
+
+    assert source.calls[-1]["return_polars"] is False
+    assert isinstance(pandas_bars.df, pd.DataFrame)
+    assert pandas_bars.asset == base
+    assert pandas_bars.quote == quote
 
 
 def test_data_get_bars_fast_path_does_not_drop_on_nan_extra_columns():

--- a/tests/test_data_polars_parity.py
+++ b/tests/test_data_polars_parity.py
@@ -103,13 +103,14 @@ class ProviderBoundaryPolarsData(PolarsData):
 class LegacyGetBarsData:
     timestep = "minute"
 
-    def __init__(self, failure_message=None):
+    def __init__(self, response, failure_message=None):
+        self.response = response
         self.failure_message = failure_message
 
     def get_bars(self, *args, **kwargs):
         if "return_polars" in kwargs:
             raise TypeError(self.failure_message or "got an unexpected keyword argument 'return_polars'")
-        return "fallback-bars"
+        return self.response
 
 
 def test_data_polars_row_count_parity():
@@ -363,14 +364,16 @@ def test_return_polars_fallback_only_swallows_unsupported_keyword_typeerror():
         datetime_end=datetime(2024, 7, 19, tzinfo=timezone.utc),
         pandas_data=[],
     )
-    source._data_store = OrderedDict({(asset, quote, "minute"): LegacyGetBarsData()})
+    response = _create_mock_ohlc_data(datetime(2024, 7, 18, tzinfo=timezone.utc), periods=1)
+    source._data_store = OrderedDict({(asset, quote, "minute"): LegacyGetBarsData(response)})
 
-    assert (
-        source.get_historical_prices(asset, length=1, timestep="minute", quote=quote, return_polars=True)
-        == "fallback-bars"
-    )
+    bars = source.get_historical_prices(asset, length=1, timestep="minute", quote=quote, return_polars=True)
+    assert bars is not None
+    assert len(bars.df) == 1
 
-    source._data_store = OrderedDict({(asset, quote, "minute"): LegacyGetBarsData("internal type bug")})
+    source._data_store = OrderedDict({
+        (asset, quote, "minute"): LegacyGetBarsData(response, failure_message="internal type bug")
+    })
     with pytest.raises(TypeError, match="internal type bug"):
         source.get_historical_prices(asset, length=1, timestep="minute", quote=quote, return_polars=True)
 

--- a/tests/test_databento_backtesting_polars.py
+++ b/tests/test_databento_backtesting_polars.py
@@ -1,12 +1,15 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
 import pandas as pd
 import polars as pl
 import pytest
-from datetime import datetime, timezone, timedelta
-from unittest.mock import MagicMock, patch
 
-from lumibot.tools.databento_helper_polars import DataBentoAuthenticationError
 from lumibot.backtesting.databento_backtesting_polars import DataBentoDataBacktestingPolars
 from lumibot.entities import Asset
+from lumibot.entities.data_polars import DataPolars
+from lumibot.tools import databento_helper_polars as databento_helper
+from lumibot.tools.databento_helper_polars import DataBentoAuthenticationError
 
 API_KEY = "test_key"
 
@@ -80,8 +83,43 @@ def test_prefetch_data_populates_cache(mock_get_data):
         pytest.skip("prefetch_data not implemented for polars backtesting backend")
 
     backtester.prefetch_data([asset], timestep="minute")
-    assert (asset, Asset("USD", "forex")) in backtester._prefetched_assets
+    search_asset = (asset, Asset("USD", "forex"))
+    assert search_asset in backtester._prefetched_assets
+    stored = backtester.pandas_data[search_asset]
+    assert isinstance(stored, DataPolars)
+    assert stored.polars_df.height == 8
+    assert mock_get_data.call_args.kwargs["return_polars"] is True
     mock_get_data.assert_called_once()
+
+
+def test_polars_cache_roundtrip_stays_polars(tmp_path):
+    cache_file = tmp_path / "bars.parquet"
+    frame = _polars_frame(0, rows=4).with_columns(pl.lit("MESH5").alias("symbol"))
+
+    databento_helper._save_cache_polars(frame, cache_file)
+    loaded = databento_helper._load_cache_polars(cache_file)
+
+    assert isinstance(loaded, pl.DataFrame)
+    assert loaded.height == frame.height
+    assert loaded.schema["datetime"] == pl.Datetime(time_unit="ns", time_zone="UTC")
+    assert loaded["symbol"].to_list() == ["MESH5"] * 4
+
+
+def test_filter_front_month_rows_polars_preserves_polars_type():
+    base = datetime(2025, 1, 6, 14, 0, tzinfo=timezone.utc)
+    frame = _polars_frame(0, rows=6).with_columns(
+        pl.Series("symbol", ["MESH5", "MESH5", "MESM5", "MESM5", "MESM5", "MESH5"])
+    )
+    schedule = [
+        ("MESH5", base, base + timedelta(minutes=2)),
+        ("MESM5", base + timedelta(minutes=2), base + timedelta(minutes=5)),
+    ]
+
+    filtered = databento_helper._filter_front_month_rows_polars(frame, schedule)
+
+    assert isinstance(filtered, pl.DataFrame)
+    assert filtered.height == 5
+    assert filtered["symbol"].to_list() == ["MESH5", "MESH5", "MESM5", "MESM5", "MESM5"]
 
 
 @pytest.mark.usefixtures("mocked_polars_helper")

--- a/tests/test_databento_data.py
+++ b/tests/test_databento_data.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pandas as pd
 import polars as pl
@@ -19,10 +19,13 @@ class TestDataBentoData(unittest.TestCase):
             patch("lumibot.tools.databento_helper.DATABENTO_AVAILABLE", True),
             patch("lumibot.tools.databento_helper_polars.DATABENTO_AVAILABLE", True),
             patch("lumibot.tools.databento_helper_polars.DataBentoClient", MagicMock()),
-        patch("lumibot.tools.databento_helper_polars._fetch_and_update_futures_multiplier", lambda *args, **kwargs: None),
+            patch(
+                "lumibot.tools.databento_helper_polars._fetch_and_update_futures_multiplier",
+                lambda *args, **kwargs: None,
+            ),
         ]
         for patcher in patchers:
-            patched = patcher.start()
+            patcher.start()
             self.addCleanup(patcher.stop)
 
         import importlib
@@ -151,11 +154,13 @@ class TestDataBentoData(unittest.TestCase):
         with patch(
             "lumibot.data_sources.databento_data_polars.databento_helper_polars.get_price_data_from_databento_polars",
             return_value=frame,
-        ):
+        ), patch.object(Bars, "pandas_df", new_callable=PropertyMock) as mock_pandas_df:
+            mock_pandas_df.side_effect = AssertionError("get_last_price should not force pandas conversion")
             data_source = DataBentoData(**self.datasource_kwargs)
             price = data_source.get_last_price(asset=self.future_asset)
 
         self.assertEqual(price, last_close)
+        mock_pandas_df.assert_not_called()
 
     def test_get_last_price_returns_none_when_no_data(self):
         with patch(

--- a/tests/test_databento_timezone_fixes.py
+++ b/tests/test_databento_timezone_fixes.py
@@ -9,9 +9,10 @@ This module tests the critical fixes implemented to resolve:
 
 These tests ensure that the timezone handling and error logging fixes remain stable.
 """
-import pytest
 from datetime import datetime, timedelta
+
 import pandas as pd
+import pytest
 import pytz
 
 from lumibot.data_sources import DataBentoData
@@ -20,6 +21,7 @@ from lumibot.entities import Asset
 
 # Set up unified logging for tests
 from lumibot.tools.lumibot_logger import get_logger, set_log_level
+
 set_log_level('ERROR')  # Suppress unnecessary logging during tests
 
 
@@ -182,7 +184,7 @@ class TestDataBentoIntegration:
     def test_databento_data_source_initialization(self):
         """Test that DataBento data source can be initialized without errors"""
         # Test with dummy API key
-        data_source = DataBentoData(api_key="test_key")
+        data_source = DataBentoData(api_key="test_key", enable_live_stream=False)
         assert data_source is not None
         assert data_source._api_key == "test_key"
         assert data_source.name == "data_source"  # This is the default from DataSource base class
@@ -190,7 +192,7 @@ class TestDataBentoIntegration:
         
     def test_databento_futures_asset_validation(self):
         """Test that DataBento correctly validates asset types"""
-        data_source = DataBentoData(api_key="test_key")
+        data_source = DataBentoData(api_key="test_key", enable_live_stream=False)
         
         # DataBentoDataPolars logs an error but doesn't raise for non-futures
         # It just returns None
@@ -223,7 +225,7 @@ class TestDataBentoIntegration:
 
     def test_databento_live_trading_mode(self):
         """Test that DataBento works in live trading mode"""
-        data_source = DataBentoData(api_key="test_key")
+        data_source = DataBentoData(api_key="test_key", enable_live_stream=False)
         
         # Should be configured for live trading by default
         assert data_source.IS_BACKTESTING_DATA_SOURCE is False
@@ -272,7 +274,7 @@ class TestPolarsDSTHandling:
         assert cleaned[-1] == market_close
     def test_databento_supported_asset_types(self):
         """Test that DataBento supports the expected asset types"""
-        data_source = DataBentoData(api_key="test_key")
+        data_source = DataBentoData(api_key="test_key", enable_live_stream=False)
         
         # Test continuous futures
         cont_future_asset = Asset(symbol="ES", asset_type="cont_future")


### PR DESCRIPTION
## Summary
- Keep Polars-backed bar data in Polars through shared `DataPolars`, `PolarsData`, and `Bars` flows when requested.
- Add provider-boundary coverage for `return_polars`, quote-pair assets, and pandas/Polars provider responses.
- Use the DataBento integration as one provider path for the shared Polars behavior, including cache and front-month filtering improvements.

## Validation
- `.venv/bin/ruff check --select F,I ...`
- `git diff --check`
- `.venv/bin/python -m pytest -q tests/test_bars_frequency_flex.py tests/test_bars_aggregation_timeunits.py tests/test_bars_aggregate_frequency_normalization.py tests/test_data_polars_parity.py tests/test_polars_resample.py tests/backtest/test_polars_lru_eviction.py tests/test_databento_backtesting_polars.py tests/test_databento_data.py tests/test_databento_helper.py tests/test_databento_backtesting.py tests/test_databento_timezone_fixes.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional return_polars mode across historical APIs to request/return native Polars frames.

* **Refactor**
  * Polars-native caching, normalization and resampling for faster, memory‑efficient historical data processing.
  * Polars-aware datetime/timezone and timeshift handling and streamlined data paths.

* **Bug Fixes**
  * Improved fallback when providers don’t support Polars output; avoid unintended pandas conversions.

* **Tests**
  * Added parity, caching roundtrip, provider-boundary, and Polars split/resample correctness tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->