### PR TITLE
Release 4.5.24 wheel-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Build package
         run: |
           set -euo pipefail
-          python -m build
+          python -m build --wheel
 
       - name: Upload dist
         uses: actions/upload-artifact@v4
@@ -156,7 +156,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Create the branch from dev
-          git checkout -b "${BRANCH}"
+          git switch -c "${BRANCH}"
 
           # Bump setup.py
           sed -i "s/version=\"${VERSION}\"/version=\"${NEXT_VERSION}\"/" setup.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## 4.5.23 - 2026-05-15
+## 4.5.24 - 2026-05-15
 
-Deploy marker: 4.5.23 release commit (`deploy 4.5.23`)
+Deploy marker: 4.5.24 release commit (`deploy 4.5.24`)
 
 ### Fixed
 - **IBKR REST backtests now negative-cache unresolvable stock/index conid lookups.** Symbols that IBKR cannot resolve, such as defunct AlphaPicks holdings, are treated as terminal no-data and persisted in the conid negative cache so long BotSpot backtests skip them deterministically instead of hammering secdef/history endpoints until the task times out.
+- **PyPI releases now build wheel-only artifacts.** This avoids source-distribution uploads hitting PyPI project storage limits while preserving the artifact BotManager installs for backtest workers.
 
 ## 4.5.22 - Unreleased
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.23",
+    version="4.5.24",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",


### PR DESCRIPTION
## Summary
- Move the IBKR negative-conid backtest fix forward to 4.5.24 after the 4.5.23 release failed before PyPI propagation.
- Build Lumibot releases as wheel-only artifacts so PyPI does not reject oversized source distribution uploads.
- Replace the release workflow branch creation command with `git switch`.

## Tests
- `pytest -q tests/test_ibkr_helper_unit.py tests/test_ibkr_helper_futures_unit.py`
- `python3 -m build --wheel`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IBKR REST backtests now implement negative caching for unresolvable conid lookups, treating them as terminal no-data responses.
  * PyPI releases now distribute wheel-only artifacts, removing source distributions from the release package.

* **Chores**
  * Package version updated to 4.5.24.
  * Release workflow enhanced with optimized build processes and improved branch creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1044)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->