### PR TITLE
Release 4.5.25 IBKR stock conid filtering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Build package
         run: |
           set -euo pipefail
-          python -m build
+          python -m build --wheel
 
       - name: Upload dist
         uses: actions/upload-artifact@v4
@@ -156,7 +156,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Create the branch from dev
-          git checkout -b "${BRANCH}"
+          git switch -c "${BRANCH}"
 
           # Bump setup.py
           sed -i "s/version=\"${VERSION}\"/version=\"${NEXT_VERSION}\"/" setup.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.5.25 - 2026-05-15
+
+Deploy marker: 4.5.25 release commit (`deploy 4.5.25`)
+
+### Fixed
+- **IBKR REST stock/index conid lookup now filters secdef results by asset type.** Ambiguous tickers such as `MHO` no longer resolve to a futures contract when the strategy requested a stock, preventing false “Chart data unavailable” failures in AlphaPicks backtests.
+
 ## 4.5.24 - 2026-05-15
 
 Deploy marker: 4.5.24 release commit (`deploy 4.5.24`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## 4.5.23 - 2026-05-15
+## 4.5.24 - 2026-05-15
 
-Deploy marker: 4.5.23 release commit (`deploy 4.5.23`)
+Deploy marker: 4.5.24 release commit (`deploy 4.5.24`)
 
 ### Fixed
 - **IBKR REST backtests now negative-cache unresolvable stock/index conid lookups.** Symbols that IBKR cannot resolve, such as defunct AlphaPicks holdings, are treated as terminal no-data and persisted in the conid negative cache so long BotSpot backtests skip them deterministically instead of hammering secdef/history endpoints until the task times out.
+- **PyPI releases now build wheel-only artifacts.** This avoids source-distribution uploads hitting PyPI project storage limits while preserving the artifact BotManager installs for backtest workers.
 
 ## 4.5.22 - Unreleased
 

--- a/lumibot/tools/ibkr_helper.py
+++ b/lumibot/tools/ibkr_helper.py
@@ -2852,14 +2852,59 @@ def _lookup_conid_remote(
     if asset_type in {"crypto"}:
         return _lookup_conid_crypto(asset=asset, quote=quote)
 
-    # Default: fall back to secdef search and use the first conid.
+    preferred_sec_types: tuple[str, ...] = ()
+    if asset_type == "stock":
+        preferred_sec_types = ("STK",)
+    elif asset_type == "index":
+        preferred_sec_types = ("IND",)
+
+    def _payload_item_matches_sec_type(item: dict, allowed: tuple[str, ...]) -> bool:
+        if not allowed:
+            return True
+        direct = str(item.get("secType") or "").upper()
+        if direct in allowed:
+            return True
+        sections = item.get("sections")
+        if isinstance(sections, list):
+            for section in sections:
+                if isinstance(section, dict) and str(section.get("secType") or "").upper() in allowed:
+                    return True
+        return False
+
+    def _extract_conid(payload: Any, allowed: tuple[str, ...]) -> Optional[int]:
+        if not isinstance(payload, list):
+            return None
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            if not _payload_item_matches_sec_type(item, allowed):
+                continue
+            conid = item.get("conid")
+            if conid is not None:
+                return int(conid)
+        return None
+
     base_url = _downloader_base_url()
     url = f"{base_url}/ibkr/iserver/secdef/search"
+
+    if preferred_sec_types:
+        for sec_type in preferred_sec_types:
+            payload = queue_request(
+                url=url,
+                querystring={"symbol": asset.symbol, "secType": sec_type},
+                headers=None,
+                timeout=None,
+            )
+            conid = _extract_conid(payload, (sec_type,))
+            if conid is not None:
+                return int(conid)
+
+    # Default: fall back to secdef search, but still filter ambiguous symbols by asset type.
     payload = queue_request(url=url, querystring={"symbol": asset.symbol}, headers=None, timeout=None)
-    if isinstance(payload, list) and payload:
-        conid = payload[0].get("conid")
-        if conid is not None:
-            return int(conid)
+    conid = _extract_conid(payload, preferred_sec_types)
+    if conid is not None:
+        return int(conid)
+
     message = f"Unable to resolve IBKR conid for {asset.symbol} (type={asset_type})"
     _record_negative_conid(key=_conid_key(asset=asset, quote=quote, exchange=exchange).to_key(), reason="no_conid", message=message)
     raise RuntimeError(message)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.23",
+    version="4.5.24",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.24",
+    version="4.5.25",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_ibkr_helper_unit.py
+++ b/tests/test_ibkr_helper_unit.py
@@ -424,11 +424,58 @@ def test_unresolvable_stock_conid_uses_negative_cache(monkeypatch, tmp_path):
     with pytest.raises(RuntimeError, match="Unable to resolve IBKR conid"):
         ibkr_helper._resolve_conid(asset=asset, quote=quote, exchange=None)
 
-    assert calls["secdef"] == 1
+    assert calls["secdef"] == 2
     assert (tmp_path / "ibkr" / "conids_negative.json").exists()
     assert "stock|ARCH-DEFUNCT-2838|USD||" in ibkr_helper._NEGATIVE_CONID_CACHE
 
     with pytest.raises(RuntimeError, match="Unable to resolve IBKR conid"):
         ibkr_helper._resolve_conid(asset=asset, quote=quote, exchange=None)
 
-    assert calls["secdef"] == 1
+    assert calls["secdef"] == 2
+
+
+def test_stock_conid_resolution_prefers_stock_contract_for_ambiguous_symbol(monkeypatch, tmp_path):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    monkeypatch.setattr(ibkr_helper, "LUMIBOT_CACHE_FOLDER", tmp_path.as_posix())
+    ibkr_helper._RUNTIME_CONID_CACHE.clear()
+    ibkr_helper._NEGATIVE_CONID_CACHE.clear()
+    monkeypatch.setattr(ibkr_helper, "_NEGATIVE_CONID_CACHE_LOADED", False)
+
+    seen_queries = []
+
+    def fake_queue_request(url: str, querystring, headers=None, timeout=None):
+        if url.endswith("/ibkr/iserver/secdef/search"):
+            seen_queries.append(dict(querystring))
+            if querystring.get("secType") == "STK":
+                return [
+                    {
+                        "conid": 265598,
+                        "symbol": "MHO",
+                        "sections": [{"secType": "STK", "exchange": "NYSE"}],
+                    }
+                ]
+            return [
+                {
+                    "conid": 569790685,
+                    "symbol": "MHO",
+                    "sections": [{"secType": "FUT", "exchange": "NYMEX"}],
+                },
+                {
+                    "conid": 265598,
+                    "symbol": "MHO",
+                    "sections": [{"secType": "STK", "exchange": "NYSE"}],
+                },
+            ]
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr(ibkr_helper, "queue_request", fake_queue_request)
+
+    asset = Asset(symbol="MHO", asset_type=Asset.AssetType.STOCK)
+    quote = Asset(symbol="USD", asset_type=Asset.AssetType.FOREX)
+
+    conid = ibkr_helper._resolve_conid(asset=asset, quote=quote, exchange=None)
+
+    assert conid == 265598
+    assert seen_queries == [{"symbol": "MHO", "secType": "STK"}]
+    assert ibkr_helper._RUNTIME_CONID_CACHE["stock|MHO|USD||"] == 265598


### PR DESCRIPTION
## Summary
- release LumiBot 4.5.25
- filter IBKR secdef stock/index conid lookups by requested asset type
- add regression coverage for ambiguous stock ticker MHO resolving away from a futures contract

## Tests
- pytest -q tests/test_ibkr_helper_unit.py tests/test_ibkr_helper_futures_unit.py
- python3 -m build --wheel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IBKR REST stock/index ticker lookups to correctly filter by asset type, preventing mis-resolution to futures contracts.
  * Improved handling of unresolvable stock/index conid lookups with negative caching.

* **Chores**
  * Updated PyPI releases to build wheel-only artifacts to optimize storage.
  * Bumped version to 4.5.25.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->