### PR TITLE
v4.5.26 - Resume PyPI releases after storage cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.26 - Unreleased
+
 ## 4.5.25 - 2026-05-15
 
 Deploy marker: 4.5.25 release commit (`deploy 4.5.25`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 4.5.26 - Unreleased
+## 4.5.26 - 2026-05-19
+
+Deploy marker: 4.5.26 release commit (`deploy 4.5.26`)
+
+### Operations
+- **PyPI project storage was cleaned up for wheel-only releases.** Historical source distributions that had matching wheels were removed from PyPI so new LumiBot releases can publish again under the project storage quota. The package release remains wheel-only.
+- **4.5.26 republishes the safe dotenv and lazy-startup release path after the 4.5.25 PyPI quota blocker.** This keeps the deployment path moving without force-moving the stale `v4.5.25` tag.
 
 ## 4.5.25 - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Deploy marker: 4.5.26 release commit (`deploy 4.5.26`)
 ### Operations
 - **PyPI project storage was cleaned up for wheel-only releases.** Historical source distributions that had matching wheels were removed from PyPI so new LumiBot releases can publish again under the project storage quota. The package release remains wheel-only.
 - **4.5.26 republishes the safe dotenv and lazy-startup release path after the 4.5.25 PyPI quota blocker.** This keeps the deployment path moving without force-moving the stale `v4.5.25` tag.
+- **Google ADK is pinned below 2.0 for release stability.** CI exposed a `google-adk` 2.0 function-declaration schema change that drops the expected `parameters` object for the built-in indicator tool. LumiBot keeps the previously passing 1.x range until the 2.x schema contract is reviewed deliberately.
 
 ## 4.5.25 - 2026-05-15
 

--- a/docs/investigations/2026-05-19_RELEASE_4_5_25_PYPI_BLOCKER.md
+++ b/docs/investigations/2026-05-19_RELEASE_4_5_25_PYPI_BLOCKER.md
@@ -1,0 +1,52 @@
+# RELEASE 4.5.25 PYPI BLOCKER
+
+> Release status for the 4.5.25 dotenv/lazy-import startup release and the remaining package-publish blocker.
+
+**Last Updated:** 2026-05-19
+**Status:** Active
+**Audience:** Developers + AI Agents
+
+---
+
+## Summary
+
+PR #1047 merged `version/4.5.25` into `dev` with green CI, including docs build, lint, unit shards, backtest shards, aggregate `LintAndTest`, and CodeRabbit.
+
+The code is on `dev`, but the normal Lumibot package release is blocked before BotManager rollout because PyPI is rejecting new Lumibot uploads with the project storage quota error:
+
+```text
+400 Project size too large. Limit for project 'lumibot' total size is 10 GB.
+```
+
+Do not update BotManager to a new LumiBot version until a published, installable LumiBot artifact exists and `python3 -m pip install --no-deps "lumibot==X.Y.Z"` succeeds.
+
+---
+
+## Verified
+
+- `version/4.5.25` PR: https://github.com/Lumiwealth/lumibot/pull/1047
+- `dev` merge commit: `e35e2a314e4258a445268cc58afdf48fffbb4c7c`
+- Deploy marker on version branch: `8ae3baece0ddea2971f292bfa25e1744101c3483`
+- CI on deploy marker: green
+- Existing remote tag `v4.5.25`: points to older merge commit `a29e3eba01ccad44aa04d56223210ae539ac350f`
+- Existing `v4.5.25` release workflow run: https://github.com/Lumiwealth/lumibot/actions/runs/25943116545
+- PyPI index on 2026-05-19 still listed latest Lumibot as `4.5.23`, not `4.5.25`.
+
+The older `v4.5.25` release workflow validated, tested, and built successfully, then failed during `Publish to PyPI` because of the PyPI project size limit. No GitHub Release was created.
+
+---
+
+## Risk Notes
+
+- Do not silently move or reuse the existing `v4.5.25` tag without explicitly deciding how to handle the failed prior release run.
+- Do not point BotManager at `LumiBot dev`. BotManager's deployment docs say `LUMIBOT_VERSION` must select a published wheel.
+- BotManager currently has `LUMIBOT_VERSION` set to a GitHub archive URL, but its Docker templates still render `lumibot==LUMIBOT_VERSION_PLACEHOLDER`; that is not the documented package install path and should not be treated as a verified deploy path.
+
+---
+
+## Next Options
+
+1. Resolve PyPI storage: delete old unnecessary release files or request a project size increase, then publish a new Lumibot version from the current `dev` merge.
+2. If choosing to preserve `4.5.25`, intentionally retarget `v4.5.25` to `e35e2a31` only after confirming no package or GitHub Release was published from the old tag.
+3. If avoiding tag movement, bump and release `4.5.26` instead once PyPI can accept uploads.
+4. Only after PyPI installability is confirmed, update BotManager `LUMIBOT_VERSION`, trigger dev/prod workflows, and run the required BotSpot backtest version smoke.

--- a/docs/investigations/2026-05-19_RELEASE_4_5_25_PYPI_BLOCKER.md
+++ b/docs/investigations/2026-05-19_RELEASE_4_5_25_PYPI_BLOCKER.md
@@ -34,6 +34,13 @@ Do not update BotManager to a new LumiBot version until a published, installable
 
 The older `v4.5.25` release workflow validated, tested, and built successfully, then failed during `Publish to PyPI` because of the PyPI project size limit. No GitHub Release was created.
 
+PyPI public JSON on 2026-05-19 showed Lumibot package files total approximately `10.71 GB` decimal. PyPI's documented default project limit is `10.0 GB`, so the project needs cleanup before another upload can succeed.
+
+Official PyPI storage docs:
+- Project storage settings page: `https://pypi.org/manage/project/lumibot/settings/`
+- Release management page: `https://pypi.org/manage/project/lumibot/releases/`
+- Deleting or yanking are different: yanking does not free storage; deleting files does free storage but is permanent and can break downstream pinned installs.
+
 ---
 
 ## Risk Notes
@@ -41,6 +48,32 @@ The older `v4.5.25` release workflow validated, tested, and built successfully, 
 - Do not silently move or reuse the existing `v4.5.25` tag without explicitly deciding how to handle the failed prior release run.
 - Do not point BotManager at `LumiBot dev`. BotManager's deployment docs say `LUMIBOT_VERSION` must select a published wheel.
 - BotManager currently has `LUMIBOT_VERSION` set to a GitHub archive URL, but its Docker templates still render `lumibot==LUMIBOT_VERSION_PLACEHOLDER`; that is not the documented package install path and should not be treated as a verified deploy path.
+
+---
+
+## Recommended PyPI Cleanup
+
+Prefer deleting old source distributions only when the same version still has a universal wheel. Do not delete whole releases unless there is a separate deprecation decision.
+
+First cleanup target:
+
+- Delete individual `.tar.gz` source distribution files for `4.4.45` through `4.5.22`.
+- Keep the matching `py3-none-any.whl` files for those versions.
+- Expected reclaimed storage from this first target: about `1.47 GB` decimal across `39` source distribution files.
+- Expected result: enough headroom for the blocked wheel-only Lumibot release and several follow-up releases without breaking normal wheel installs for those pinned versions.
+
+If more headroom is needed later, the broader cleanup target is all `.tar.gz` source distributions that have a matching wheel. Public JSON showed `581` such files totaling about `6.77 GB` decimal.
+
+Chrome DevTools MCP was attempted on 2026-05-19 to drive the PyPI UI with Rob logging in, but `list_pages` timed out. Do not launch a separate browser or touch personal browser profiles as a workaround. If Chrome MCP is restored, the safe UI flow is:
+
+1. Rob logs into PyPI and completes 2FA.
+2. Navigate to `https://pypi.org/manage/project/lumibot/releases/`.
+3. For each target release, use `Options` -> `Manage`.
+4. Delete only the target `lumibot-X.Y.Z.tar.gz` file.
+5. Confirm the matching `lumibot-X.Y.Z-py3-none-any.whl` remains.
+6. Re-check `https://pypi.org/manage/project/lumibot/settings/` for current project size.
+
+Do not automate deletion unless the target file list is visible and confirmed. PyPI file deletion is permanent.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ databento>=0.42.0
 holidays
 psutil
 openai
-google-adk>=1.19.0
+google-adk>=1.19.0,<2.0.0
 google-genai>=1.68.0
 anyio>=4.10.0
 mcp>=1.26.0

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setuptools.setup(
         "holidays",
         "psutil",
         "openai",
-        "google-adk>=1.19.0",
+        "google-adk>=1.19.0,<2.0.0",
         "google-genai>=1.68.0",
         "litellm>=1.77.0",
         "anyio>=4.10.0",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.25",
+    version="4.5.26",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",


### PR DESCRIPTION
## What / Why
Release 4.5.26 carries the already-merged dotenv safety and lazy-startup import release forward after the stale v4.5.25 tag failed to publish because PyPI project storage was full. This branch bumps setup.py to 4.5.26, documents the PyPI blocker/cleanup, and marks the deploy release.

## Risk
Low code risk: no runtime code changes beyond what already merged through #1047 with green CI. Operational risk is release/package-publish only. Do not deploy BotManager until PyPI installability is verified.

## Tests run
- #1047 CI was green before merge to dev.
- PyPI cleanup verified via PyPI JSON: 584 wheels, 0 source distributions, approximately 3.94 GB total.
- This PR still needs normal GitHub CI before merge.

## Docs
- CHANGELOG.md
- docs/investigations/2026-05-19_RELEASE_4_5_25_PYPI_BLOCKER.md

## Prompts
No BotSpot agent prompt changes needed; this is package/release plumbing and docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release 4.5.26 published; package restored to be installable via pip and packaging/upload reliability improved.
  * Dependency constraint added to avoid a major breaking upgrade (pins a third‑party SDK below v2.0).

* **Documentation**
  * Added an investigation report documenting the prior PyPI quota/upload issue and recommended cleanup steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->