### PR TITLE
v4.5.27 - AI agent runtime hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.5.27 - Unreleased
 
+### Fixed
+- **AI agent runs now have a hard wall-clock timeout.** `LUMIBOT_AGENT_RUN_TIMEOUT_SECONDS` bounds the full ADK/model/tool call, defaulting to 300 seconds, so a live or backtest strategy skips a stalled agent iteration instead of hanging indefinitely inside a provider or built-in tool call.
+
 ## 4.5.26 - 2026-05-19
 
 Deploy marker: 4.5.26 release commit (`deploy 4.5.26`)

--- a/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
+++ b/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
@@ -385,7 +385,7 @@ Important benchmark runner fixes from this phase:
 
 - The paid benchmark runner now defaults `--max-model-calls` to `80` instead of `8`; the original default only allowed about two committee cycles and caused an artificial `LUMIBOT_AGENT_MAX_MODEL_CALLS` failure.
 - The paid benchmark runner now prints JSON `model_start` and `model_finished` events so long runs are observable.
-- The AI committee example now asks each role to produce a structured handoff under the strategy parameter `handoff_target_chars`, default `24000`. There is no silent truncation path. If a model returns more than `4x` the target, the strategy fails loudly with a handoff-size error so the benchmark does not continue with chopped or misleading evidence.
+- The AI committee example now asks each role to produce a structured handoff under the strategy parameter `handoff_target_tokens`, default `8000`, and applies a reusable Lumibot token-budget helper at `handoff_max_tokens`, default `24000`, before passing text to the next role. If a model ignores the target, the helper middle-truncates with an explicit notice instead of silently chopping or crashing the strategy.
 
 Artifacts:
 

--- a/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
+++ b/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
@@ -385,7 +385,7 @@ Important benchmark runner fixes from this phase:
 
 - The paid benchmark runner now defaults `--max-model-calls` to `80` instead of `8`; the original default only allowed about two committee cycles and caused an artificial `LUMIBOT_AGENT_MAX_MODEL_CALLS` failure.
 - The paid benchmark runner now prints JSON `model_start` and `model_finished` events so long runs are observable.
-- The AI committee example now asks each role to produce a structured handoff under the strategy parameter `handoff_target_tokens`, default `8000`, and applies a reusable Lumibot token-budget helper at `handoff_max_tokens`, default `24000`, before passing text to the next role. If a model ignores the target, the helper middle-truncates with an explicit notice instead of silently chopping or crashing the strategy.
+- The AI committee example now asks each role to produce a structured handoff under the strategy parameter `handoff_target_tokens`, default `24000`, and applies a reusable Lumibot token-budget helper at `handoff_max_tokens`, default `32000`, before passing text to the next role. If a model ignores the target, the helper middle-truncates with an explicit notice instead of silently chopping or crashing the strategy. A higher target does not force the model to use the full budget; the prompt explicitly says not to pad the handoff just to fill the token budget.
 
 Artifacts:
 

--- a/docsrc/agents.rst
+++ b/docsrc/agents.rst
@@ -214,6 +214,55 @@ LumiBot handles all the common instructions internally through its base prompt. 
 
 Do not repeat instructions about position sizing, time safety, or tool usage. LumiBot already covers those in the base prompt.
 
+Token-Budgeted Agent Handoffs
+-----------------------------
+
+Multi-agent strategies often pass one agent's output into the next agent. For
+example, an evidence researcher may hand a research pack to a bull researcher,
+then a bear researcher, then a portfolio manager. These handoffs should be
+large enough to preserve useful evidence, but they must stay inside the model's
+context window.
+
+Use prompt instructions for the normal behavior and token budgeting as the
+safety rail:
+
+.. code-block:: python
+
+    from lumibot.components.agents.context_budget import budget_text_by_tokens
+
+    result = self.agents["evidence_researcher"].run(
+        task_prompt=(
+            "Build a structured evidence handoff. "
+            "Keep it under context.handoff_target_tokens tokens. "
+            "Do not pad the answer just to fill the budget."
+        ),
+        context={"handoff_target_tokens": 24000},
+    )
+
+    evidence_pack = budget_text_by_tokens(
+        result.summary or result.text,
+        max_tokens=32000,
+        label="evidence_pack",
+    ).text
+
+``handoff_target_tokens`` is the prompt target. It does not force the model to
+use that many tokens. It tells the model the upper bound for a complete,
+structured handoff. A good model can still return 5,000 or 8,000 tokens when
+that is enough.
+
+``max_tokens`` is the hard safety rail before the next agent sees the handoff.
+If the text exceeds the budget, LumiBot keeps the beginning and end and inserts
+an explicit notice that token-budget truncation happened. This prevents a
+single verbose agent from pushing the next agent beyond a provider context
+window.
+
+For 128K-context models, think about the combined context, not just one
+handoff. If the portfolio manager receives evidence, bull, and bear handoffs,
+three 32K-token handoffs can already consume roughly 96K tokens before the
+system prompt, tool schemas, runtime context, and the portfolio manager's own
+output. Larger budgets can be reasonable for bigger-context models, but they
+should be chosen intentionally.
+
 DuckDB and Time-Series Data
 ----------------------------
 

--- a/lumibot/components/agents/context_budget.py
+++ b/lumibot/components/agents/context_budget.py
@@ -1,0 +1,91 @@
+"""Helpers for keeping agent handoffs inside a token budget."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+_FALLBACK_CHARS_PER_TOKEN = 4
+
+
+@dataclass(frozen=True)
+class TokenBudgetedText:
+    text: str
+    estimated_tokens: int
+    was_truncated: bool
+    original_estimated_tokens: int
+
+
+def estimate_token_count(value: Any, *, model: str | None = None) -> int:
+    """Estimate token count for prompt budgeting.
+
+    Uses LiteLLM/tiktoken when available, then falls back to the common rough
+    English heuristic of four characters per token.
+    """
+
+    text = "" if value is None else str(value)
+    if not text:
+        return 0
+    try:
+        import litellm
+
+        token_count = litellm.token_counter(model=model or "gpt-4o-mini", text=text)
+        if token_count is not None:
+            return max(int(token_count), 0)
+    except Exception:
+        pass
+    return max((len(text) + _FALLBACK_CHARS_PER_TOKEN - 1) // _FALLBACK_CHARS_PER_TOKEN, 1)
+
+
+def budget_text_by_tokens(
+    value: Any,
+    *,
+    max_tokens: int,
+    label: str = "agent handoff",
+    model: str | None = None,
+) -> TokenBudgetedText:
+    """Return text no larger than ``max_tokens`` using middle truncation.
+
+    The caller should still prompt the model to be concise. This helper is a
+    last-resort safety rail for provider context windows.
+    """
+
+    text = "" if value is None else str(value)
+    max_tokens = max(int(max_tokens), 256)
+    original_tokens = estimate_token_count(text, model=model)
+    if original_tokens <= max_tokens:
+        return TokenBudgetedText(
+            text=text,
+            estimated_tokens=original_tokens,
+            was_truncated=False,
+            original_estimated_tokens=original_tokens,
+        )
+
+    notice = (
+        f"\n\n[Token-budget safety truncation: {label} was about {original_tokens} tokens; "
+        f"retained the beginning and end within a {max_tokens} token budget.]\n\n"
+    )
+    notice_tokens = estimate_token_count(notice, model=model)
+    remaining_tokens = max(max_tokens - notice_tokens, 256)
+    head_tokens = max(int(remaining_tokens * 0.65), 128)
+    tail_tokens = max(remaining_tokens - head_tokens, 128)
+
+    try:
+        import tiktoken
+
+        encoding = tiktoken.encoding_for_model(model or "gpt-4o-mini")
+        encoded = encoding.encode(text)
+        truncated = encoding.decode(encoded[:head_tokens]) + notice + encoding.decode(encoded[-tail_tokens:])
+    except Exception:
+        chars_per_token = max(len(text) // max(original_tokens, 1), 1)
+        head_chars = head_tokens * chars_per_token
+        tail_chars = tail_tokens * chars_per_token
+        truncated = text[:head_chars] + notice + text[-tail_chars:]
+
+    return TokenBudgetedText(
+        text=truncated,
+        estimated_tokens=estimate_token_count(truncated, model=model),
+        was_truncated=True,
+        original_estimated_tokens=original_tokens,
+    )

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -946,7 +946,7 @@ class GoogleADKRuntime:
     async def _run_async_with_timeout(self, request: RuntimeRequest, timeout_seconds: float) -> AgentRunResult:
         try:
             return await asyncio.wait_for(self._run_async(request), timeout=timeout_seconds)
-        except TimeoutError as exc:
+        except (TimeoutError, asyncio.TimeoutError) as exc:
             raise TimeoutError(
                 f"Agent run exceeded {timeout_seconds:g}s timeout "
                 f"(model={request.model!r}, agent={request.agent_name!r})."

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import asyncio
 import hashlib
 import importlib
 import logging
@@ -925,21 +926,43 @@ class GoogleADKRuntime:
         return GoogleADKRuntime._MAX_RUN_ATTEMPTS
 
     @staticmethod
+    def _run_timeout_seconds_for_request(request: RuntimeRequest) -> float | None:
+        raw = os.environ.get("LUMIBOT_AGENT_RUN_TIMEOUT_SECONDS")
+        if raw:
+            try:
+                timeout_seconds = float(raw)
+                return timeout_seconds if timeout_seconds > 0 else None
+            except Exception:
+                pass
+        return 300.0
+
+    @staticmethod
     def _is_non_retryable(exc: BaseException) -> bool:
         # Use the shared classifier: only transient and unknown errors retry.
         # auth / config / billing surface immediately so we don't waste ~5
         # minutes of retry budget on a wrong API key.
         return _classify_agent_error(exc) not in ("transient", "unknown")
 
+    async def _run_async_with_timeout(self, request: RuntimeRequest, timeout_seconds: float) -> AgentRunResult:
+        try:
+            return await asyncio.wait_for(self._run_async(request), timeout=timeout_seconds)
+        except TimeoutError as exc:
+            raise TimeoutError(
+                f"Agent run exceeded {timeout_seconds:g}s timeout "
+                f"(model={request.model!r}, agent={request.agent_name!r})."
+            ) from exc
+
     def run(self, request: RuntimeRequest) -> AgentRunResult:
-        import asyncio
         import time as _time
 
         last_exc: BaseException | None = None
         max_attempts = self._max_attempts_for_request(request)
+        timeout_seconds = self._run_timeout_seconds_for_request(request)
         for attempt in range(1, max_attempts + 1):
             try:
-                return asyncio.run(self._run_async(request))
+                if timeout_seconds is None:
+                    return asyncio.run(self._run_async(request))
+                return asyncio.run(self._run_async_with_timeout(request, timeout_seconds))
             except (KeyboardInterrupt, SystemExit):
                 raise
             except BaseException as exc:  # noqa: BLE001 - intentional broad catch for retry

--- a/lumibot/example_strategies/ai_investment_committee.py
+++ b/lumibot/example_strategies/ai_investment_committee.py
@@ -31,24 +31,17 @@ Requirements:
 
 import os
 
+from lumibot.components.agents.context_budget import budget_text_by_tokens
 from lumibot.strategies.strategy import Strategy
 
 
 DEFAULT_UNIVERSE = ["AAPL", "MSFT", "NVDA", "AMZN", "META", "GOOGL", "TSLA", "SPY", "QQQ"]
-DEFAULT_HANDOFF_TARGET_CHARS = 24000
-HANDOFF_HARD_LIMIT_MULTIPLIER = 4
+DEFAULT_HANDOFF_TARGET_TOKENS = 8000
+DEFAULT_HANDOFF_MAX_TOKENS = 24000
 
 
-def _prepare_handoff_text(value, *, label: str, target_chars: int) -> str:
-    text = "" if value is None else str(value)
-    limit = max(int(target_chars), 4000) * HANDOFF_HARD_LIMIT_MULTIPLIER
-    if len(text) > limit:
-        raise ValueError(
-            f"AI committee {label} handoff was {len(text)} characters, above the {limit} character safety limit. "
-            "The model ignored the concise handoff contract; rerun with a stricter prompt or a model that follows "
-            "bounded structured outputs."
-        )
-    return text
+def _prepare_handoff_text(value, *, label: str, max_tokens: int) -> str:
+    return budget_text_by_tokens(value, max_tokens=max_tokens, label=label).text
 
 
 class AIInvestmentCommitteeStrategy(Strategy):
@@ -56,7 +49,8 @@ class AIInvestmentCommitteeStrategy(Strategy):
         "universe": DEFAULT_UNIVERSE,
         "max_position_pct": 0.20,
         "max_new_positions_per_run": 2,
-        "handoff_target_chars": DEFAULT_HANDOFF_TARGET_CHARS,
+        "handoff_target_tokens": DEFAULT_HANDOFF_TARGET_TOKENS,
+        "handoff_max_tokens": DEFAULT_HANDOFF_MAX_TOKENS,
         "enable_notifications": False,
     }
 
@@ -106,9 +100,10 @@ class AIInvestmentCommitteeStrategy(Strategy):
             "universe": universe,
             "max_position_pct": self.parameters.get("max_position_pct", 0.20),
             "max_new_positions_per_run": self.parameters.get("max_new_positions_per_run", 2),
-            "handoff_target_chars": self.parameters.get("handoff_target_chars", DEFAULT_HANDOFF_TARGET_CHARS),
+            "handoff_target_tokens": self.parameters.get("handoff_target_tokens", DEFAULT_HANDOFF_TARGET_TOKENS),
             "datetime": self.get_datetime().isoformat(),
         }
+        handoff_max_tokens = self.parameters.get("handoff_max_tokens", DEFAULT_HANDOFF_MAX_TOKENS)
 
         evidence = self.agents["evidence_researcher"].run(
             task_prompt=(
@@ -121,7 +116,7 @@ class AIInvestmentCommitteeStrategy(Strategy):
         self.vars.last_evidence_pack = _prepare_handoff_text(
             evidence.summary or evidence.text,
             label="evidence_pack",
-            target_chars=context["handoff_target_chars"],
+            max_tokens=handoff_max_tokens,
         )
 
         bull = self.agents["bull_researcher"].run(
@@ -131,7 +126,7 @@ class AIInvestmentCommitteeStrategy(Strategy):
         self.vars.last_bull_case = _prepare_handoff_text(
             bull.summary or bull.text,
             label="bull_case",
-            target_chars=context["handoff_target_chars"],
+            max_tokens=handoff_max_tokens,
         )
 
         bear = self.agents["bear_researcher"].run(
@@ -145,7 +140,7 @@ class AIInvestmentCommitteeStrategy(Strategy):
         self.vars.last_bear_case = _prepare_handoff_text(
             bear.summary or bear.text,
             label="bear_case",
-            target_chars=context["handoff_target_chars"],
+            max_tokens=handoff_max_tokens,
         )
 
         decision = self.agents["portfolio_manager"].run(
@@ -168,7 +163,7 @@ class AIInvestmentCommitteeStrategy(Strategy):
 You are the Evidence Researcher for a Lumibot AI investment committee.
 
 You cannot place, modify, or cancel trades. You are responsible for building a compact, source-backed evidence pack.
-Your answer is a handoff to the other committee members. Keep the final answer under context.handoff_target_chars characters.
+Your answer is a handoff to the other committee members. Keep the final answer under context.handoff_target_tokens tokens.
 Do not paste raw tool payloads, long tables, SEC excerpts, or full time series. Synthesize the important facts and cite tool names/sources.
 
 For each candidate symbol, gather:
@@ -200,7 +195,7 @@ You are the Bull Researcher. You cannot place, modify, or cancel trades.
 
 Build the strongest long-only case from the evidence pack. You may use read-only tools to dig deeper.
 Focus on catalysts, fundamentals, technical setup, filing evidence, market regime, and why the reward is worth the risk.
-Your answer is a handoff to the Bear Researcher and Portfolio Manager. Keep the final answer under context.handoff_target_chars characters.
+Your answer is a handoff to the Bear Researcher and Portfolio Manager. Keep the final answer under context.handoff_target_tokens tokens.
 Do not repeat the full evidence pack. Extract only the strongest investable thesis and the supporting facts.
 
 Return:
@@ -219,7 +214,7 @@ You are the Bear Researcher. You cannot place, modify, or cancel trades.
 
 Attack the long case. Find reasons the portfolio manager should avoid, delay, reduce size, or demand more evidence.
 Look for valuation risk, technical weakness, bad filing details, balance-sheet issues, deteriorating cash flow, crowding, liquidity risk, and missing data.
-Your answer is a handoff to the Portfolio Manager. Keep the final answer under context.handoff_target_chars characters.
+Your answer is a handoff to the Portfolio Manager. Keep the final answer under context.handoff_target_tokens tokens.
 Do not repeat the full evidence pack or bull case. Extract the highest-impact objections, what would change your mind, and the risk controls needed.
 
 Return:

--- a/lumibot/example_strategies/ai_investment_committee.py
+++ b/lumibot/example_strategies/ai_investment_committee.py
@@ -36,8 +36,8 @@ from lumibot.strategies.strategy import Strategy
 
 
 DEFAULT_UNIVERSE = ["AAPL", "MSFT", "NVDA", "AMZN", "META", "GOOGL", "TSLA", "SPY", "QQQ"]
-DEFAULT_HANDOFF_TARGET_TOKENS = 8000
-DEFAULT_HANDOFF_MAX_TOKENS = 24000
+DEFAULT_HANDOFF_TARGET_TOKENS = 24000
+DEFAULT_HANDOFF_MAX_TOKENS = 32000
 
 
 def _prepare_handoff_text(value, *, label: str, max_tokens: int) -> str:
@@ -164,6 +164,7 @@ You are the Evidence Researcher for a Lumibot AI investment committee.
 
 You cannot place, modify, or cancel trades. You are responsible for building a compact, source-backed evidence pack.
 Your answer is a handoff to the other committee members. Keep the final answer under context.handoff_target_tokens tokens.
+Do not pad the answer to fill the token budget; shorter is better when the important evidence is complete.
 Do not paste raw tool payloads, long tables, SEC excerpts, or full time series. Synthesize the important facts and cite tool names/sources.
 
 For each candidate symbol, gather:
@@ -196,6 +197,7 @@ You are the Bull Researcher. You cannot place, modify, or cancel trades.
 Build the strongest long-only case from the evidence pack. You may use read-only tools to dig deeper.
 Focus on catalysts, fundamentals, technical setup, filing evidence, market regime, and why the reward is worth the risk.
 Your answer is a handoff to the Bear Researcher and Portfolio Manager. Keep the final answer under context.handoff_target_tokens tokens.
+Do not pad the answer to fill the token budget; shorter is better when the investment case is complete.
 Do not repeat the full evidence pack. Extract only the strongest investable thesis and the supporting facts.
 
 Return:
@@ -215,6 +217,7 @@ You are the Bear Researcher. You cannot place, modify, or cancel trades.
 Attack the long case. Find reasons the portfolio manager should avoid, delay, reduce size, or demand more evidence.
 Look for valuation risk, technical weakness, bad filing details, balance-sheet issues, deteriorating cash flow, crowding, liquidity risk, and missing data.
 Your answer is a handoff to the Portfolio Manager. Keep the final answer under context.handoff_target_tokens tokens.
+Do not pad the answer to fill the token budget; shorter is better when the risk case is complete.
 Do not repeat the full evidence pack or bull case. Extract the highest-impact objections, what would change your mind, and the risk controls needed.
 
 Return:

--- a/tests/test_agent_context_budget.py
+++ b/tests/test_agent_context_budget.py
@@ -1,0 +1,25 @@
+from lumibot.components.agents.context_budget import budget_text_by_tokens, estimate_token_count
+
+
+def test_estimate_token_count_uses_positive_budget():
+    assert estimate_token_count("hello world") > 0
+
+
+def test_budget_text_by_tokens_keeps_small_text():
+    result = budget_text_by_tokens("short handoff", max_tokens=1000, label="handoff")
+
+    assert result.text == "short handoff"
+    assert result.was_truncated is False
+    assert result.estimated_tokens <= 1000
+
+
+def test_budget_text_by_tokens_middle_truncates_large_text():
+    text = "alpha " * 20000
+
+    result = budget_text_by_tokens(text, max_tokens=1000, label="evidence_pack")
+
+    assert result.was_truncated is True
+    assert result.original_estimated_tokens > result.estimated_tokens
+    assert result.estimated_tokens <= 1100
+    assert "Token-budget safety truncation" in result.text
+    assert "evidence_pack" in result.text

--- a/tests/test_agent_runtime_provider_keys.py
+++ b/tests/test_agent_runtime_provider_keys.py
@@ -1,6 +1,9 @@
 import os
 import sys
 import types
+import asyncio
+
+import pytest
 
 from lumibot.components.agents.runtime import (
     GoogleADKRuntime,
@@ -248,6 +251,31 @@ def test_runtime_prompt_only_names_available_tools():
     assert "Available Tools JSON" in user_text
     assert "list_fred_series" not in user_text
     assert "alpaca_news" not in user_text
+
+
+def test_runtime_enforces_agent_run_timeout(monkeypatch):
+    runtime = GoogleADKRuntime()
+
+    async def never_finishes(_request):
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(runtime, "_run_async", never_finishes)
+    monkeypatch.setenv("LUMIBOT_AGENT_RUN_TIMEOUT_SECONDS", "0.01")
+    monkeypatch.setenv("LUMIBOT_AGENT_MAX_RUN_ATTEMPTS", "1")
+
+    request = RuntimeRequest(
+        agent_name="researcher",
+        model="gemini-3.5-flash",
+        system_prompt="System prompt",
+        task_prompt="Do work",
+        context=None,
+        runtime_context={"mode": "backtesting"},
+        memory_notes=[],
+        bound_tools=[],
+    )
+
+    with pytest.raises(TimeoutError, match="Agent run exceeded 0.01s timeout"):
+        runtime.run(request)
 
 
 def test_gemini_native_path_uses_plain_model_id_for_implicit_or_adk_context_cache():

--- a/tests/test_ai_investment_committee_example.py
+++ b/tests/test_ai_investment_committee_example.py
@@ -16,8 +16,8 @@ def test_ai_committee_example_uses_normal_lumibot_iteration_flow():
 def test_ai_committee_example_exposes_expected_risk_controls():
     assert AIInvestmentCommitteeStrategy.parameters["max_position_pct"] == 0.20
     assert AIInvestmentCommitteeStrategy.parameters["max_new_positions_per_run"] == 2
-    assert AIInvestmentCommitteeStrategy.parameters["handoff_target_tokens"] == 8000
-    assert AIInvestmentCommitteeStrategy.parameters["handoff_max_tokens"] == 24000
+    assert AIInvestmentCommitteeStrategy.parameters["handoff_target_tokens"] == 24000
+    assert AIInvestmentCommitteeStrategy.parameters["handoff_max_tokens"] == 32000
     assert AIInvestmentCommitteeStrategy.parameters["enable_notifications"] is False
 
 

--- a/tests/test_ai_investment_committee_example.py
+++ b/tests/test_ai_investment_committee_example.py
@@ -3,8 +3,6 @@ from lumibot.example_strategies.ai_investment_committee import (
     _prepare_handoff_text,
 )
 
-import pytest
-
 
 def test_ai_committee_example_uses_normal_lumibot_iteration_flow():
     parameter_names = set(AIInvestmentCommitteeStrategy.parameters)
@@ -18,18 +16,22 @@ def test_ai_committee_example_uses_normal_lumibot_iteration_flow():
 def test_ai_committee_example_exposes_expected_risk_controls():
     assert AIInvestmentCommitteeStrategy.parameters["max_position_pct"] == 0.20
     assert AIInvestmentCommitteeStrategy.parameters["max_new_positions_per_run"] == 2
-    assert AIInvestmentCommitteeStrategy.parameters["handoff_target_chars"] == 24000
+    assert AIInvestmentCommitteeStrategy.parameters["handoff_target_tokens"] == 8000
+    assert AIInvestmentCommitteeStrategy.parameters["handoff_max_tokens"] == 24000
     assert AIInvestmentCommitteeStrategy.parameters["enable_notifications"] is False
 
 
-def test_ai_committee_handoff_text_fails_loudly_when_unbounded():
-    text = "a" * 20000
+def test_ai_committee_handoff_text_is_token_budgeted():
+    text = "word " * 10000
 
-    with pytest.raises(ValueError, match="evidence_pack handoff"):
-        _prepare_handoff_text(text, label="evidence_pack", target_chars=4000)
+    handoff = _prepare_handoff_text(text, label="evidence_pack", max_tokens=1000)
+
+    assert len(handoff) < len(text)
+    assert "Token-budget safety truncation" in handoff
+    assert "evidence_pack" in handoff
 
 
 def test_ai_committee_handoff_text_passes_without_truncation():
     text = "source-backed summary"
 
-    assert _prepare_handoff_text(text, label="evidence_pack", target_chars=4000) == text
+    assert _prepare_handoff_text(text, label="evidence_pack", max_tokens=4000) == text


### PR DESCRIPTION
What / Why

This release hardens AI agent strategy runs before BotSpot deploys more Gemini-backed strategies. It includes the existing AI committee handoff token-budget work on the version branch plus a new wall-clock timeout around full ADK/model/tool agent calls. The timeout is configurable through LUMIBOT_AGENT_RUN_TIMEOUT_SECONDS and defaults to 300 seconds, so a provider or built-in tool stall skips the agent iteration instead of freezing a live or backtest run indefinitely.

Risk

The main risk is that an unusually slow but valid agent call may now time out and produce a no-op/skipped agent result unless the runtime sets a higher timeout. This is safer for live trading than hanging indefinitely, and the env var can be raised or disabled with a non-positive value if a controlled long-running benchmark needs it.

Tests run

- ../bin/safe-timeout 180s python3 -m pytest tests/test_agent_runtime_provider_keys.py
- ../bin/safe-timeout 60s python3 -m py_compile lumibot/components/agents/runtime.py

Docs

- CHANGELOG.md updated for 4.5.27.
- Investigation notes already document AI committee benchmark/runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent runs now enforce a hard wall-clock timeout (default 300s) to avoid indefinite hanging.
  * Token-based budgeting for agent handoffs with automatic middle-truncation and an explicit truncation notice when limits are exceeded.

* **Documentation**
  * AI committee handoff guidance updated to use token budgets (soft target + hard max) and “do not pad” guidance for prompts.

* **Tests**
  * Added tests covering token budgeting behavior and runtime timeout enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->