### PR TITLE
deploy 4.5.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
 # Changelog
 
-## 4.5.27 - Unreleased
+## 4.5.27 - 2026-05-20
+
+Deploy marker: 4.5.27 release commit (`deploy 4.5.27`)
 
 ### Fixed
 - **AI agent runs now have a hard wall-clock timeout.** `LUMIBOT_AGENT_RUN_TIMEOUT_SECONDS` bounds the full ADK/model/tool call, defaulting to 300 seconds, so a live or backtest strategy skips a stalled agent iteration instead of hanging indefinitely inside a provider or built-in tool call.
+- **Large AI agent tool results are now token-budgeted before re-entering model context.** Tool responses that would consume too much context are replaced with an explicit bounded excerpt and a truncation notice, preventing raw SEC/fundamental/news payloads from blowing up committee-style agent turns.
+
+### Changed
+- **AI agent tool-result budgeting is configurable.** `LUMIBOT_AGENT_TOOL_RESULT_MAX_TOKENS` overrides the default 4,000-token per-result budget for benchmark or large-context-provider runs.
+- **The AI Investment Committee example now includes runtime-enforced tool-call discipline.** Research, follow-up, and portfolio-manager agents receive explicit tool-call budgets, and the runtime returns a budget-exceeded notice after the configured call count so benchmark runs measure targeted research instead of uncontrolled tool spraying.
+
+### Operations
+- **AI committee provider benchmark tooling was expanded.** The benchmark runner can set per-agent timeout overrides and emit fixed-budget provider reruns, and `scripts/summarize_ai_committee_provider_benchmarks.py` summarizes per-model `result.json` artifacts into compact JSON/Markdown reports.
+- **AI committee benchmark documentation now records provider pricing sources, updated cost estimates, observed context-window failures, and the new tool-result/tool-call controls.**
 
 ## 4.5.26 - 2026-05-19
 


### PR DESCRIPTION
What / Why: Final deploy-marker PR for LumiBot 4.5.27 after the AI agent runtime hardening and AI committee budgeting changes merged. This updates CHANGELOG.md from Unreleased to the dated 4.5.27 release entry.\n\nRisk: Documentation-only deploy marker. Runtime changes already merged in PRs #1051 and #1052.\n\nTests run:\n- ../bin/safe-timeout 300s python3 -m pytest tests/test_agent_runtime_provider_keys.py\n- ../bin/safe-timeout 60s python3 -m py_compile lumibot/components/agents/runtime.py scripts/run_ai_committee_provider_benchmark.py scripts/summarize_ai_committee_provider_benchmarks.py\n- ../bin/safe-timeout 1800s python3 -m pytest -m "not apitest and not downloader" --tb=short -q --durations=30 (timed out after 30 minutes; several tests progressed/passed before timeout; GitHub CI remains the release gate per DEPLOYMENT.md)\n\nDocs: CHANGELOG.md release entry for 4.5.27.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hard wall-clock timeouts now enforced for AI agent runs
  * Large tool results are token-budgeted before returning to model context

* **Changed**
  * Tool-result budgeting is now configurable
  * Tool-call discipline documentation expanded

* **Documentation**
  * Provider pricing sources and cost estimates documented
  * Context-window failure observations added
  * AI committee provider benchmark tooling enhanced

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->