### PR TITLE
v4.5.28 - Broker cash event history polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## 4.5.28 - Unreleased
+## 4.5.28 - 2026-05-20
+
+Deploy marker: 4.5.28 release commit (`deploy 4.5.28`)
+
+### Fixed
+- **Broker cash-event polling now requests full available history on first successful cloud poll.** Strategies no longer limit the first cloud cash-event fetch to the last seven days, so restarted BotSpot live bots can replay available broker deposit/withdrawal history into the listener.
+- **Alpaca journal classifications now match the broker activity contract used for cash-flow adjustment.** `JNLC` cash journals are classified as external deposits/withdrawals by sign, while `JNLS` stock journals remain internal non-cash-flow activity.
+- **Tradier transfer/journal classifications now distinguish external funding from internal bookkeeping.** ACH, wire, and check funding activity is treated as deposits/withdrawals, while fee, subscription, and transfer bookkeeping descriptions stay internal unless they match cash/account movement patterns.
+
+### Operations
+- **AI committee benchmark notes now record the enforced-qualifier and three-month launch results.** The benchmark plan documents the latest qualifier outcomes and launch artifacts for the provider-comparison work.
 
 ## 4.5.27 - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.28 - Unreleased
+
 ## 4.5.27 - 2026-05-20
 
 Deploy marker: 4.5.27 release commit (`deploy 4.5.27`)

--- a/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
+++ b/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
@@ -415,10 +415,24 @@ Results so far:
 - Fixed-budget rerun state: Qwen rerun with 4K tool-result budget and 900-second per-agent timeout started in `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260520_144512`. DeepSeek, Gemini, Kimi, OpenAI, and Cerebras fixed-budget reruns started in `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260520_144705`.
 - Cerebras fixed-budget rerun failed immediately with provider billing error: `Payment required to access this resource`. Earlier Cerebras qualifier passed mechanically, so the integration works, but the account/key needs billing credits before Cerebras can be included in the final three-month benchmark.
 - Tool-call discipline fix: even with 4K tool-result caps, DeepSeek used `65` tools in the first evidence call. The AI Investment Committee example now passes prompt-level budgets for research/follow-up/portfolio tool calls (`24` / `8` / `6`), and the runtime enforces those budgets by returning a budget-exceeded notice after the role uses its allowed calls. This keeps the benchmark from measuring uncontrolled tool spraying.
+- Enforced-budget 14-day qualifier artifacts:
+  - Summary JSON: `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/enforced_14d_compact_summary.json`.
+  - Summary Markdown: `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/enforced_14d_summary.md`.
+  - Shared root for OpenAI, DeepSeek, Kimi, and partial Gemini: `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260520_145742`.
+  - Qwen root: `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260520_145816`.
+
+Enforced-budget 14-day qualifier results:
+
+- `openai/gpt-5.4-mini`: passed mechanically. Wall time `629.9s`; calls `13`; tool calls `125`; input `378,434`, cached input `276,096`, output `7,740`; estimated cost `$0.318655` no-cache / `$0.132291` cache-adjusted. Stayed entirely in cash, total return `0%`.
+- `deepseek/deepseek-v4-flash`: passed mechanically. Wall time `2295.0s`; calls `13`; tool calls `122`; input `1,052,857`, cached input `896,512`, output `47,393`; estimated cost `$0.160670` no-cache / `$0.037669` cache-adjusted. Stayed entirely in cash, total return `0%`.
+- `together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput`: passed mechanically. Wall time `2077.2s`; calls `13`; tool calls `88`; input `518,011`, output `6,300`; estimated cost `$0.107382`. Stayed entirely in cash, total return `0%`.
+- `together_ai/moonshotai/Kimi-K2.5`: passed mechanically. Wall time `3500.2s`; calls `13`; tool calls `90`; input `506,210`, cached input `304,256`, output `26,157`; estimated cost `$0.326345`. Stayed entirely in cash, total return `0%`.
+- `gemini-3.5-flash`: did not complete the enforced 14-day qualifier in a reasonable wall-clock window and was stopped after provider demand/retry noise. Partial stats before stop: calls `7`, tool calls `170`, input `922,275`, cached input `392,443`, output `16,759`. The key/model string works, but this workload is operationally too slow/noisy in the current run.
 
 Current interpretation:
 
-- Cerebras is worth keeping in the slate. It is dramatically faster than the other currently tested providers, but its all-cash result means it should be judged on trace quality before moving to a full 3-month run.
-- Qwen is mechanically viable after bounded handoffs, but it is slow enough that 14-day and longer runs should be model-by-model with larger command timeouts or detached logs.
-- Kimi and DeepSeek should not run the 14-day qualifier until the capped handoff fix is included, because they would otherwise risk the same context blow-up.
-- For the next run, use model-by-model commands with provider-specific command timeouts: Cerebras around `30m`, Qwen at least `2h`, Kimi at least `2h`, DeepSeek at least `3h`.
+- OpenAI, DeepSeek Flash, Qwen throughput, and Kimi K2.5 are mechanically viable through ADK 2 with the enforced budgets.
+- The current AI Investment Committee settings are too conservative for a meaningful performance benchmark: every mechanically successful enforced 14-day qualifier stayed entirely in cash. A three-month run from this exact configuration would likely measure provider cost/latency more than trading quality.
+- Before spending hours on a three-month slate, either relax the portfolio manager's trade threshold / require at least one small position when the evidence is acceptable, or split the benchmark into two tracks: `mechanical/tool discipline` and `trade-seeking committee`.
+- Cerebras should remain in the slate after billing is fixed. The earlier qualifier passed mechanically and was much faster, but the current account/key hit a provider billing gate on rerun.
+- Gemini 3.5 Flash should not be included in the first three-month run unless the goal is specifically to measure Google provider availability under load; it did not finish the 14-day qualifier here.

--- a/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
+++ b/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
@@ -436,3 +436,25 @@ Current interpretation:
 - Before spending hours on a three-month slate, either relax the portfolio manager's trade threshold / require at least one small position when the evidence is acceptable, or split the benchmark into two tracks: `mechanical/tool discipline` and `trade-seeking committee`.
 - Cerebras should remain in the slate after billing is fixed. The earlier qualifier passed mechanically and was much faster, but the current account/key hit a provider billing gate on rerun.
 - Gemini 3.5 Flash should not be included in the first three-month run unless the goal is specifically to measure Google provider availability under load; it did not finish the 14-day qualifier here.
+
+## Three-Month Benchmark Run: 2026-05-20
+
+Window: `2026-01-02` through `2026-04-02`.
+
+Launched models:
+
+- `openai/gpt-5.4-mini`
+- `deepseek/deepseek-v4-flash`
+- `together_ai/moonshotai/Kimi-K2.5`
+- `together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput`
+
+Excluded models:
+
+- `gemini-3.5-flash`: excluded because it did not complete the enforced 14-day qualifier in a reasonable wall-clock window.
+- `cerebras/gpt-oss-120b`: excluded because the current key/account hit a Cerebras billing gate on rerun, even though an earlier 14-day qualifier passed mechanically.
+
+Artifact root: `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260520_160534`.
+
+Parallel launcher root: `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/parallel_3m_enforced_20260520_160510`.
+
+Launch status: all four models printed `model_start`; no key/config failure on launch.

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -126,7 +126,7 @@ class Alpaca(Broker):
     TAX_ACTIVITY_TYPES = {"DIVWH", "WH"}
     FEE_ACTIVITY_TYPES = {"CFEE", "FEE"}
     INTEREST_ACTIVITY_TYPES = {"INT", "INTPNL"}
-    JOURNAL_ACTIVITY_TYPES = {"JNLC", "JNLS"}
+    JOURNAL_ACTIVITY_TYPES = {"JNL", "JNLC", "JNLS"}
     EXTERNAL_CASH_ACTIVITY_TYPES = {"ACATC", "ACATS", "CSD", "CSW"}
     TRADE_LIKE_ACTIVITY_TYPES = {"FXTRD", "OPTRD"}
     ADJUSTMENT_ACTIVITY_TYPES = {
@@ -1159,6 +1159,8 @@ class Alpaca(Broker):
             return "fee", False
         if normalized_raw_type in cls.INTEREST_ACTIVITY_TYPES:
             return "interest", False
+        if normalized_raw_type == "JNLC":
+            return ("deposit" if amount >= 0 else "withdrawal"), True
         if normalized_raw_type in cls.JOURNAL_ACTIVITY_TYPES:
             return "journal", False
         if normalized_raw_type in cls.ADJUSTMENT_ACTIVITY_TYPES:

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -805,9 +805,43 @@ class Tradier(Broker):
             return None
         if "tax" in normalized_description:
             return "tax"
-        if "fee" in normalized_description:
+        if "fee" in normalized_description or "subscription" in normalized_description:
             return "fee"
         return None
+
+    @staticmethod
+    def _is_tradier_external_transfer(raw_type: str, description: str | None) -> bool:
+        normalized_raw_type = str(raw_type or "").strip().lower()
+        normalized_description = str(description or "").strip().lower()
+
+        if normalized_raw_type in {"ach", "wire", "check"}:
+            return True
+        if normalized_raw_type == "journal":
+            return "journal to account" in normalized_description or "journal from account" in normalized_description
+        if normalized_raw_type != "transfer":
+            return False
+
+        internal_markers = (
+            "annual ira fee",
+            "pro subscription",
+            "clearing fee",
+            "clearing fees",
+            "mark to market",
+            "tfr to type",
+            "tfr from type",
+        )
+        if any(marker in normalized_description for marker in internal_markers):
+            return False
+
+        external_markers = (
+            "journal to account",
+            "journal from account",
+            "cash transfer",
+            "account transfer",
+            "wire transfer",
+            "ach transfer",
+        )
+        return any(marker in normalized_description for marker in external_markers)
 
     @classmethod
     def _map_cash_event_type(cls, raw_type: str, amount: float, description: str | None = None) -> tuple[str, bool]:
@@ -815,8 +849,13 @@ class Tradier(Broker):
         description_override = cls._override_cash_event_type_from_description(description)
         if description_override is not None:
             return description_override, False
-        if normalized_raw_type in {"ach", "wire", "check", "transfer"}:
-            return ("deposit" if amount >= 0 else "withdrawal"), True
+        if normalized_raw_type in {"ach", "wire", "check", "transfer", "journal"}:
+            if cls._is_tradier_external_transfer(normalized_raw_type, description):
+                return ("deposit" if amount >= 0 else "withdrawal"), True
+            if normalized_raw_type == "journal":
+                return "journal", False
+            if normalized_raw_type == "transfer":
+                return "adjustment", False
         if normalized_raw_type == "dividend":
             return "dividend", False
         if normalized_raw_type == "interest":

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -329,10 +329,13 @@ class _Strategy:
         self._cash_financing_events = 0
         self._cash_financing_last_credit_rate_used = None
         self._cash_financing_last_debit_rate_used = None
+        self._cash_event_initial_history_loaded = False
         self._cash_event_poll_lookback_days = 7
+        self._cash_event_initial_poll_lookback_days = None
         self._cash_event_poll_interval_seconds = 300
         self._cash_event_cloud_emit_limit = 50
         self._cash_event_fetch_limit = 100
+        self._cash_event_initial_fetch_limit = 5000
         self._cash_event_dedupe_capacity = 1000
         self._cash_event_last_poll_at = None
         self._cash_event_pending_for_cloud = []
@@ -3128,9 +3131,19 @@ class _Strategy:
         ):
             return []
 
-        lookback_days = int(getattr(self, "_cash_event_poll_lookback_days", 7) or 7)
-        fetch_limit = int(getattr(self, "_cash_event_fetch_limit", 100) or 100)
-        fetch_since = now_utc - datetime.timedelta(days=lookback_days)
+        initial_history_loaded = bool(getattr(self, "_cash_event_initial_history_loaded", False))
+        if initial_history_loaded:
+            lookback_days = int(getattr(self, "_cash_event_poll_lookback_days", 7) or 7)
+            fetch_limit = int(getattr(self, "_cash_event_fetch_limit", 100) or 100)
+            fetch_since = now_utc - datetime.timedelta(days=lookback_days)
+        else:
+            initial_lookback_days = getattr(self, "_cash_event_initial_poll_lookback_days", None)
+            fetch_limit = int(getattr(self, "_cash_event_initial_fetch_limit", 5000) or 5000)
+            fetch_since = (
+                now_utc - datetime.timedelta(days=int(initial_lookback_days))
+                if initial_lookback_days
+                else None
+            )
         self._cash_event_last_poll_at = now_utc
 
         try:
@@ -3143,6 +3156,7 @@ class _Strategy:
             )
             self.logger.debug(traceback.format_exc())
             return []
+        self._cash_event_initial_history_loaded = True
 
         sent_ids = getattr(self, "_cash_event_sent_ids", set())
         pending_ids = {

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.27",
+    version="4.5.28",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_cash_events.py
+++ b/tests/test_cash_events.py
@@ -88,6 +88,50 @@ def test_alpaca_activity_normalization_maps_external_and_tax_events():
     assert tax_event.direction == "out"
 
 
+def test_alpaca_cash_journals_are_external_cash_flows_by_sign():
+    cash_journal_in = Alpaca._normalize_activity_to_cash_event(
+        {
+            "id": "evt-journal-in",
+            "activity_type": "JNLC",
+            "date": "2026-04-07",
+            "net_amount": "100000.00",
+            "status": "executed",
+        }
+    )
+    cash_journal_out = Alpaca._normalize_activity_to_cash_event(
+        {
+            "id": "evt-journal-out",
+            "activity_type": "JNLC",
+            "date": "2026-04-08",
+            "net_amount": "-2500.00",
+            "status": "executed",
+        }
+    )
+    stock_journal = Alpaca._normalize_activity_to_cash_event(
+        {
+            "id": "evt-stock-journal",
+            "activity_type": "JNLS",
+            "date": "2026-04-08",
+            "net_amount": "0.00",
+            "status": "executed",
+        }
+    )
+
+    assert cash_journal_in is not None
+    assert cash_journal_in.event_type == "deposit"
+    assert cash_journal_in.is_external_cash_flow is True
+    assert cash_journal_in.direction == "in"
+
+    assert cash_journal_out is not None
+    assert cash_journal_out.event_type == "withdrawal"
+    assert cash_journal_out.is_external_cash_flow is True
+    assert cash_journal_out.direction == "out"
+
+    assert stock_journal is not None
+    assert stock_journal.event_type == "journal"
+    assert stock_journal.is_external_cash_flow is False
+
+
 def test_alpaca_get_cash_events_fetches_transfer_page_and_normalizes():
     requests = []
 
@@ -282,6 +326,57 @@ def test_tradier_history_normalization_extracts_nested_fields_and_overrides_tran
     assert fee_event.is_external_cash_flow is False
     assert fee_event.description == "Annual IRA Fee"
     assert fee_event.direction == "out"
+
+
+def test_tradier_wire_and_transfer_classification_uses_real_account_descriptions():
+    wire_event = Tradier._normalize_history_row_to_cash_event(
+        {
+            "type": "wire",
+            "date": "2025-10-30T00:00:00Z",
+            "amount": "-4000.00",
+            "wire.description": "Journal to account 6YA54069",
+        }
+    )
+    subscription_event = Tradier._normalize_history_row_to_cash_event(
+        {
+            "type": "transfer",
+            "date": "2026-05-04T00:00:00Z",
+            "amount": "-10.00",
+            "transfer.description": "May Pro Subscription",
+        }
+    )
+    internal_type_transfer = Tradier._normalize_history_row_to_cash_event(
+        {
+            "type": "transfer",
+            "date": "2025-11-03T00:00:00Z",
+            "amount": "5681.66",
+            "transfer.description": "TFR FROM TYPE 2",
+        }
+    )
+    account_transfer = Tradier._normalize_history_row_to_cash_event(
+        {
+            "type": "transfer",
+            "date": "2025-11-03T00:00:00Z",
+            "amount": "5681.66",
+            "transfer.description": "Journal from account 6YA46406",
+        }
+    )
+
+    assert wire_event is not None
+    assert wire_event.event_type == "withdrawal"
+    assert wire_event.is_external_cash_flow is True
+
+    assert subscription_event is not None
+    assert subscription_event.event_type == "fee"
+    assert subscription_event.is_external_cash_flow is False
+
+    assert internal_type_transfer is not None
+    assert internal_type_transfer.event_type == "adjustment"
+    assert internal_type_transfer.is_external_cash_flow is False
+
+    assert account_transfer is not None
+    assert account_transfer.event_type == "deposit"
+    assert account_transfer.is_external_cash_flow is True
 
 
 def test_tradier_history_normalization_skips_zero_amount_transfers():
@@ -575,6 +670,26 @@ def test_cash_event_fetch_warning_identifies_broker(caplog):
     assert events == []
     assert "Failed to load broker cash events from tradier (_FailingBroker)" in caplog.text
     assert "string indices must be integers" in caplog.text
+
+
+def test_cloud_cash_event_first_poll_fetches_full_history_then_incremental():
+    calls = []
+
+    def get_cash_events(**kwargs):
+        calls.append(kwargs)
+        return []
+
+    dummy = _cloud_update_dummy(get_cash_events)
+
+    assert _Strategy._collect_cash_events_for_cloud(dummy) == []
+    assert calls[0]["since"] is None
+    assert calls[0]["limit"] == 5000
+    assert dummy._cash_event_initial_history_loaded is True
+
+    dummy._cash_event_last_poll_at = None
+    assert _Strategy._collect_cash_events_for_cloud(dummy) == []
+    assert calls[1]["since"] is not None
+    assert calls[1]["limit"] == 100
 
 
 def test_send_update_to_cloud_includes_cash_events_and_dedupes_on_success(monkeypatch):


### PR DESCRIPTION
## What / Why
Release 4.5.28 fixes BotSpot cash-event production for live broker accounts. The first successful cloud cash-event poll now requests full available history instead of only the last 7 days, Alpaca JNLC cash journals are classified as external deposits/withdrawals, and Tradier funding history is classified conservatively from documented/observed transfer and journal descriptions.

## Risk
Broker cash-event classification affects cash-flow-adjusted performance. The listener also refreshes duplicate cash-event classification on replay, so broker history replays can repair older misclassified rows without deleting data. Watch bot_cash_events event_type/is_external_cash_flow and BotSpot marketplace/detail performance after restarting a selected real-money bot.

## Tests run
- python3 -m pytest tests/test_cash_events.py -q

## Docs / Prompts
- CHANGELOG.md updated for 4.5.28.
- No BotSpot agent prompt change needed: this is broker/listener performance-data plumbing, not a strategy-generation capability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced initial cash-event history retrieval on first cloud poll with expanded lookback range.

* **Bug Fixes**
  * Improved Alpaca journal classification for cash-flow adjustments.
  * Refined Tradier transfer and journal classification rules to better distinguish external funding from internal bookkeeping.

* **Operations**
  * AI committee benchmark notes now record enforced-qualifier and three-month launch results.

* **Chores**
  * Version bump to 4.5.28.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->