### PR TITLE
v4.5.30 - AI agent trading retry safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 - **AI agent runs now default to a 30-minute timeout.** `LUMIBOT_AGENT_RUN_TIMEOUT_SECONDS` still overrides the full ADK/model/tool-call timeout, and non-positive values still disable it, but the unset default is now 1800 seconds so slower multi-tool agents are not treated as failed after only five minutes.
+- **Trading-enabled AI agent runs no longer retry the whole run by default when mutating order tools are available.** This prevents duplicate broker-side effects when a provider/runtime error happens after `orders_submit_order`, `orders_cancel_order`, or `orders_modify_order` has already executed. Read-only research agents keep the larger retry budget, and `LUMIBOT_AGENT_MAX_RUN_ATTEMPTS` can still explicitly override the default.
+
+### Fixed
+- **AI agent tool outputs now coerce UUIDs and other non-JSON scalars before they reach Google ADK/provider serialization.** Submitted order identifiers and similar broker payload fields are converted to JSON-safe values instead of causing `Object of type UUID is not JSON serializable` failures after an order side effect.
 
 ## 4.5.29 - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.5.30 - Unreleased
 
+### Changed
+- **AI agent runs now default to a 30-minute timeout.** `LUMIBOT_AGENT_RUN_TIMEOUT_SECONDS` still overrides the full ADK/model/tool-call timeout, and non-positive values still disable it, but the unset default is now 1800 seconds so slower multi-tool agents are not treated as failed after only five minutes.
+
 ## 4.5.29 - 2026-05-20
 
 Deploy marker: 4.5.29 release commit (`deploy 4.5.29`)

--- a/docs/AI_AGENT_FLOWS.md
+++ b/docs/AI_AGENT_FLOWS.md
@@ -158,6 +158,12 @@ strategy should not parse the agent's prose and submit a second Python order
 afterward. Use deterministic Python execution only for an explicit hybrid design
 where the final agent is advisory or returns validated structured JSON.
 
+When mutating order tools are available, LumiBot defaults the whole-agent retry
+budget to one attempt. This is intentional: if a broker-side effect succeeds and
+a provider/runtime error happens afterward, retrying the entire agent run can
+submit, cancel, or modify orders a second time. Research-only agents keep the
+larger retry budget because they do not mutate broker state.
+
 ## Related Docs
 
 - `docs/AI_INVESTMENT_COMMITTEE.md`: one concrete four-agent example.

--- a/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
+++ b/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
@@ -654,3 +654,27 @@ Together billing follow-up:
 - Interpretation: Together API access is now working for the local key. The
   earlier `Credit limit exceeded` result was likely billing propagation or
   provider account state, not a LumiBot integration failure.
+
+Qwen one-day no-trade diagnosis:
+
+- Backtest window was `2026-03-30` through `2026-03-31`, which produced one
+  daily committee cycle at `2026-03-30 09:30 America/New_York`.
+- Evidence Researcher used `62` tools. It screened SPY, QQQ, NVDA, AAPL, MSFT,
+  AMZN, META, GOOGL, and TSLA, then selected NVDA as the top long candidate.
+  It cited strong NVDA fundamentals and AI leadership, but also bearish
+  technicals, elevated inventory, customer concentration, and missing news/macro
+  data.
+- Bull Researcher used `16` tools. It argued NVDA was the strongest buy
+  candidate because of AI/GPU leadership, strong profitability, buybacks, and a
+  potentially oversold RSI around `35.8`.
+- Bear Researcher used `23` tools. It challenged the trade because NVDA was
+  below its 50-day and 200-day moving averages, MACD was negative, inventory was
+  elevated, and customer concentration risk was unresolved.
+- Portfolio Manager used `14` tools. It checked portfolio/positions, NVDA price
+  and indicators, filings, company facts, and history. It did not call
+  `orders_submit_order`.
+- Final Portfolio Manager decision: no trade. It explicitly said NVDA's
+  fundamentals and oversold RSI were not enough because the stock was below key
+  moving averages, structural bearishness was not resolved, inventory/customer
+  concentration risks remained, and there was no macro or news context. Capital
+  stayed in cash pending clearer signals.

--- a/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
+++ b/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
@@ -552,3 +552,91 @@ Interpretation:
 - Together needs account credits before rerunning Kimi/Qwen. Based on partial usage, Kimi can consume credits quickly because it kept trying tools heavily; Qwen was lighter before the account stopped it.
 - Cerebras should be rerun after billing is fixed because the earlier 14-day run proved mechanical compatibility and it remains the only provider that looked truly fast. Do not judge Cerebras quality from the current final slate because it was excluded by billing, not model behavior.
 - Gemini 3.5 Flash should stay out of the next performance slate unless the purpose is specifically to test Google provider availability under this heavy agent workload.
+
+## Clean Post-Guardrail Smoke And Qualifier: 2026-05-21
+
+Baseline:
+
+- LumiBot `4.5.29` was deployed through BotManager to remove the hidden
+  tool-call and truncation controls from `4.5.28`.
+- Local checkout for this run was `version/4.5.30`.
+- These runs used the current paid benchmark runner with raw-trace usage
+  aggregation. No runtime tool-call blocker was added for this rerun.
+
+One-day smoke window: `2026-03-30` through `2026-03-31`.
+
+Artifact roots:
+
+- Together/Cerebras smoke:
+  `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260521_135112`.
+- OpenAI/Gemini/DeepSeek smoke:
+  `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260521_135217`.
+
+One-day smoke results:
+
+- `openai/gpt-5.4-mini`: passed. Wall time `82.0s`; calls `4`; tool calls
+  `112`; input `284,810`, cached input `174,464`, output `8,244`; estimated
+  cost `$0.250706` no-cache / `$0.132942` cache-adjusted. It bought `39`
+  AAPL and finished `+1.396%`.
+- `gemini-3.5-flash`: passed. Wall time `325.4s`; calls `4`; tool calls
+  `87`; input `1,785,112`, cached input `1,104,597`, output `11,671`,
+  thinking `18,542`; estimated cost `$2.782707` no-cache / `$1.291501`
+  cache-adjusted. It bought `3` GOOGL and `2` MSFT and finished `+0.010%`.
+- `deepseek/deepseek-v4-flash`: failed with `ContextWindowExceededError`.
+  DeepSeek rejected a downstream committee request of about `1,676,815`
+  tokens against its `1,048,576` token context limit. This is a committee
+  context-design failure, not an API key failure.
+- `together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput`: failed before a useful
+  model run with Together `Credit limit exceeded`. Rob had added credits, but
+  the API still rejected the request. Do not repeatedly retry this until the
+  Together billing page confirms usable balance.
+- `cerebras/gpt-oss-120b`: failed before a useful model run with Cerebras
+  `Payment required to access this resource`. Earlier Cerebras runs proved
+  compatibility, so this is currently an account/billing gate.
+
+14-day qualifier window: `2026-03-16` through `2026-04-02`.
+
+14-day artifacts:
+
+- First OpenAI/Gemini parallel attempt:
+  `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260521_135919`.
+- Clean OpenAI rerun with higher file-descriptor limit:
+  `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260521_142158`.
+
+14-day results:
+
+- `openai/gpt-5.4-mini`: clean rerun passed. Wall time `704.8s`; calls `52`;
+  tool calls `839`; input `2,482,864`, cached input `1,614,720`, output
+  `77,426`; estimated cost `$2.210565` no-cache / `$1.120629`
+  cache-adjusted. It bought `32` GOOGL on the first committee cycle, held it,
+  and finished `-8.5166%`. The clean rerun backtest log had no error/timeout
+  matches.
+- `gemini-3.5-flash`: 14-day run was stopped after repeated 300-second
+  per-agent timeouts. Partial usage before stop: calls `6`, tool calls `164`,
+  input `3,336,568`, cached input `2,485,246`, output `15,667`, thinking
+  `25,023`; estimated partial cost `$5.145855` no-cache / `$1.790773`
+  cache-adjusted. Treat this as operationally invalid for 14-day comparison.
+- First parallel OpenAI attempt also passed but is superseded by the clean
+  rerun because the parallel run hit `Too many open files` transient errors and
+  skipped several later agent iterations.
+
+Current interpretation after the clean rerun:
+
+- The benchmark now proves the current committee can trade with OpenAI and
+  Gemini under the post-guardrail code path. The earlier all-cash conclusion is
+  no longer true for the clean smoke/qualifier.
+- OpenAI GPT-5.4 Mini is the current usable baseline: it completed the one-day
+  and 14-day runs, called tools heavily, submitted an order, and produced
+  raw-trace cost accounting.
+- Gemini 3.5 Flash can trade in the one-day smoke, but it is too slow and
+  expensive in the current committee shape to include in a full three-month run
+  without first reducing per-agent latency/context size.
+- Direct DeepSeek V4 Flash is blocked by context size under the no-truncation
+  path. It needs a real structured handoff / narrower-tool design, not a hidden
+  truncation or tool-call budget.
+- Together and Cerebras are blocked by provider account billing, not Lumibot
+  model-string wiring.
+- Do not launch a new three-month multi-model benchmark until Together and
+  Cerebras billing are fixed and DeepSeek/Gemini have an explicit context/latency
+  design. The next safe long run is OpenAI-only, or a two-model run after the
+  blocked providers are unblocked.

--- a/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
+++ b/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
@@ -640,3 +640,17 @@ Current interpretation after the clean rerun:
   Cerebras billing are fixed and DeepSeek/Gemini have an explicit context/latency
   design. The next safe long run is OpenAI-only, or a two-model run after the
   blocked providers are unblocked.
+
+Together billing follow-up:
+
+- Rob confirmed the Together console showed remaining credit, then a tiny
+  LiteLLM call with the local key succeeded.
+- Reran `together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput` one-day smoke at
+  `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260521_144017`.
+- Result: passed. Wall time `713.8s`; calls `4`; tool calls `115`; input
+  `751,068`, output `7,407`; estimated cost `$0.154658`. It stayed in cash
+  with `0%` return. No error/timeout/credit messages appeared in the backtest
+  log.
+- Interpretation: Together API access is now working for the local key. The
+  earlier `Credit limit exceeded` result was likely billing propagation or
+  provider account state, not a LumiBot integration failure.

--- a/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
+++ b/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
@@ -678,3 +678,29 @@ Qwen one-day no-trade diagnosis:
   moving averages, structural bearishness was not resolved, inventory/customer
   concentration risks remained, and there was no macro or news context. Capital
   stayed in cash pending clearer signals.
+
+Additional one-day provider checks:
+
+- Official Together serverless docs checked on `2026-05-21` list
+  `moonshotai/Kimi-K2.6`, `deepseek-ai/DeepSeek-V4-Pro`,
+  `openai/gpt-oss-120b`, and `Qwen/Qwen3-235B-A22B-Instruct-2507-tput` as
+  function-calling chat models.
+- Tiny LiteLLM checks with the local Together key:
+  - `together_ai/openai/gpt-oss-120b`: succeeded.
+  - `together_ai/moonshotai/Kimi-K2.6`: failed with Together
+    `Credit limit exceeded`, even for a 3-token test.
+  - `together_ai/deepseek-ai/DeepSeek-V4-Pro`: failed with Together
+    `Credit limit exceeded`, even for a 3-token test.
+- Tiny Cerebras checks:
+  - `cerebras/gpt-oss-120b`: failed with Cerebras `Payment required`.
+  - `cerebras/zai-glm-4.7`: failed with Cerebras `Payment required`.
+- Reran `together_ai/openai/gpt-oss-120b` one-day smoke at
+  `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260521_191259`.
+- GPT-OSS result: passed. Wall time `103.4s`; calls `4`; tool calls `52`;
+  input `70,177`, output `13,391`; estimated cost `$0.018561`. It stayed in
+  cash with `0%` return.
+- GPT-OSS trace quality note: evidence researcher used all `52` tool calls, but
+  bull researcher, bear researcher, and portfolio manager used zero tools. The
+  final decision was no trade. Treat it as mechanically compatible and cheap,
+  but weaker than Qwen/OpenAI for this committee because the later committee
+  roles did not independently verify the handoff.

--- a/lumibot/components/agents/replay_cache.py
+++ b/lumibot/components/agents/replay_cache.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from enum import Enum
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 from lumibot.constants import LUMIBOT_CACHE_FOLDER
 
@@ -37,6 +38,8 @@ def _normalize_json(value: Any) -> Any:
         return [_normalize_json(item) for item in value]
     if isinstance(value, (datetime, date)):
         return value.isoformat()
+    if isinstance(value, UUID):
+        return str(value)
     if isinstance(value, Decimal):
         return float(value)
     data = getattr(value, "__dict__", None)
@@ -52,7 +55,7 @@ def _normalize_json(value: Any) -> Any:
             return _normalize_json(value.to_minimal_dict())
         except Exception:
             return str(value)
-    return value
+    return str(value)
 
 
 def _cache_root() -> Path:

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -16,8 +16,9 @@ import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
+from enum import Enum
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from .schemas import AgentRunResult, AgentTraceEvent, BoundTool, MCPServer
 
@@ -132,6 +133,10 @@ def _json_safe_value(value: Any) -> Any:
         return value if math.isfinite(value) else None
     if isinstance(value, (datetime, date)):
         return value.isoformat()
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, Enum):
+        return _json_safe_value(value.value)
     if isinstance(value, list):
         return [_json_safe_value(item) for item in value]
     if isinstance(value, tuple):
@@ -152,7 +157,7 @@ def _json_safe_value(value: Any) -> Any:
             pass
         else:
             return coerced if math.isfinite(coerced) else None
-    return value
+    return str(value)
 
 
 def _to_serializable_dict(value: Any) -> dict[str, Any] | None:
@@ -483,6 +488,8 @@ def _classify_agent_error(exc: BaseException) -> str:
     if "invalid model" in message_lower or "model not found" in message_lower:
         return "config"
     if "context length" in message_lower or "context_length" in message_lower or "context window" in message_lower:
+        return "config"
+    if "not json serializable" in message_lower or "not json-serializable" in message_lower:
         return "config"
 
     return "unknown"
@@ -916,6 +923,12 @@ class GoogleADKRuntime:
                 return max(int(raw), 1)
             except Exception:
                 pass
+        mutating_order_tools = {"orders_submit_order", "orders_cancel_order", "orders_modify_order"}
+        if any(tool.name in mutating_order_tools for tool in request.bound_tools):
+            # Retrying the whole agent run after a broker-side effect can duplicate orders.
+            # Research-only agents keep the larger retry budget; trading agents fail fast
+            # and let the next scheduled/bar iteration re-evaluate from current broker state.
+            return 1
         mode = ""
         if isinstance(request.runtime_context, dict):
             mode = str(request.runtime_context.get("mode") or "").strip().lower()

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -905,6 +905,7 @@ class GoogleADKRuntime:
     # AgentHandle.run) catches the failure and skips this iteration so
     # the strategy stays alive and retries on the next bar.
     _MAX_RUN_ATTEMPTS = 10
+    _DEFAULT_RUN_TIMEOUT_SECONDS = 1800.0
     _RETRY_BACKOFF_SECONDS = (2.0, 3.0, 5.0, 10.0, 20.0, 30.0, 45.0, 60.0, 60.0, 60.0)
 
     @staticmethod
@@ -934,7 +935,10 @@ class GoogleADKRuntime:
                 return timeout_seconds if timeout_seconds > 0 else None
             except Exception:
                 pass
-        return 300.0
+        # Agentic trading/research runs can legitimately spend many minutes
+        # across model calls and tool calls. Keep the default high enough for
+        # realistic multi-tool agents while still preventing indefinite hangs.
+        return GoogleADKRuntime._DEFAULT_RUN_TIMEOUT_SECONDS
 
     @staticmethod
     def _is_non_retryable(exc: BaseException) -> bool:

--- a/tests/test_agent_runtime_provider_keys.py
+++ b/tests/test_agent_runtime_provider_keys.py
@@ -2,6 +2,7 @@ import os
 import sys
 import types
 import asyncio
+from uuid import UUID
 
 import pytest
 
@@ -15,6 +16,7 @@ from lumibot.components.agents.runtime import (
     _sync_gemini_api_key_alias,
     _sync_together_api_key_alias,
     _sync_xai_api_key_alias,
+    _classify_agent_error,
     _wrap_tool_callable,
 )
 from lumibot.components.agents.schemas import BoundTool
@@ -97,6 +99,47 @@ def test_wrapped_tool_does_not_block_repeated_calls():
     assert wrapped()["value"] == 1
     assert wrapped()["value"] == 2
     assert calls["count"] == 2
+
+
+def test_wrapped_tool_coerces_uuid_payloads_before_provider_serialization():
+    order_id = UUID("65616ce1-92f4-4634-af48-a88c296bc0e9")
+
+    def sample_tool():
+        return {
+            "order": {
+                "identifier": order_id,
+                "nested": [order_id],
+            }
+        }
+
+    tool = BoundTool(name="sample_tool", description="sample", function=sample_tool)
+    wrapped = _wrap_tool_callable(tool)
+    result = wrapped()
+
+    assert result["order"]["identifier"] == str(order_id)
+    assert result["order"]["nested"] == [str(order_id)]
+
+
+def test_json_serialization_errors_are_not_retried_as_transient():
+    assert _classify_agent_error(TypeError("Object of type UUID is not JSON serializable")) == "config"
+
+
+def test_mutating_order_tools_disable_whole_run_retries_by_default(monkeypatch):
+    monkeypatch.delenv("LUMIBOT_AGENT_MAX_RUN_ATTEMPTS", raising=False)
+    request = RuntimeRequest(
+        agent_name="pm",
+        model="gemini-3.5-flash",
+        system_prompt="trade",
+        task_prompt="",
+        context=None,
+        runtime_context={"mode": "live"},
+        memory_notes=[],
+        bound_tools=[
+            BoundTool(name="orders_submit_order", description="submit", function=lambda: {"ok": True}),
+        ],
+    )
+
+    assert GoogleADKRuntime._max_attempts_for_request(request) == 1
 
 
 def test_aggregate_usage_metadata_sums_multiple_provider_events():

--- a/tests/test_agent_runtime_provider_keys.py
+++ b/tests/test_agent_runtime_provider_keys.py
@@ -294,6 +294,22 @@ def test_runtime_enforces_agent_run_timeout(monkeypatch):
         runtime.run(request)
 
 
+def test_runtime_default_agent_run_timeout_is_30_minutes(monkeypatch):
+    monkeypatch.delenv("LUMIBOT_AGENT_RUN_TIMEOUT_SECONDS", raising=False)
+    request = RuntimeRequest(
+        agent_name="researcher",
+        model="gemini-3.5-flash",
+        system_prompt="System prompt",
+        task_prompt="Do work",
+        context=None,
+        runtime_context={"mode": "backtesting"},
+        memory_notes=[],
+        bound_tools=[],
+    )
+
+    assert GoogleADKRuntime._run_timeout_seconds_for_request(request) == 1800.0
+
+
 def test_gemini_native_path_uses_plain_model_id_for_implicit_or_adk_context_cache():
     # Gemini stays on ADK's native path. Provider prompt-cache routing kwargs are
     # only for LiteLLM providers; Gemini implicit caching and ADK explicit


### PR DESCRIPTION
## What / Why

This release hardens AI agent live trading after production validation exposed a Gemini/ADK serialization failure after an order side effect. Agent tool outputs now coerce UUID and other non-JSON scalar payloads before provider serialization, and trading-enabled agent runs default to one whole-run attempt whenever mutating order tools are available. Read-only research agents keep the larger retry budget.

## Risk

Main behavior change: a trading-enabled agent will skip the current iteration instead of retrying the whole run after a provider/runtime failure. This is intentional to avoid duplicate order side effects. Watch live logs for agent_runtime_failure_skipped and order telemetry for missing expected retries.

## Tests run

- pytest tests/test_agent_runtime_provider_keys.py tests/test_agent_tool_permissions.py tests/test_agent_runtime_errors.py -q

## Docs

- CHANGELOG.md
- docs/AI_AGENT_FLOWS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON serialization failures for UUID and non-JSON scalar tool outputs that prevented proper broker payload handling.

* **Changed**
  * Increased default timeout for AI agent runs from 5 minutes to 30 minutes (configurable via environment variable).
  * Trading-enabled agents now default to a single retry attempt per run to prevent duplicate broker orders when mutations occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->