### PR TITLE
Harden broker OAuth runtime refresh

### DIFF
--- a/docs/investigations/2026-02-07_tradier-oauth-refresh.md
+++ b/docs/investigations/2026-02-07_tradier-oauth-refresh.md
@@ -28,6 +28,7 @@ BotSpot injects:
 - `TRADIER_REFRESH_TOKEN` (optional)
 - `TRADIER_OAUTH_CLIENT_ID` (required to refresh)
 - `TRADIER_OAUTH_CLIENT_SECRET` (required to refresh)
+- `BOTSPOT_TRADIER_TOKEN_ROTATION_PATH` (internal BotSpot runtime handoff path)
 
 Notes:
 
@@ -49,12 +50,16 @@ File: `lumibot/brokers/tradier.py`
 - When a refresh succeeds, the broker updates the access token across:
   - broker’s `lumiwealth_tradier` client
   - data source’s `lumiwealth_tradier` client
+- When `BOTSPOT_TRADIER_TOKEN_ROTATION_PATH` is configured, a successful refresh
+  also writes a 0600 JSON handoff file containing only allowlisted rotated token
+  fields for BotManager's audited Vault rotation path.
 
 ## Limitations / Operational Notes
 
-- If Tradier rotates the refresh token on refresh, the new refresh token cannot be persisted back into task env vars.
-  - The code logs a warning if refresh-token rotation is detected.
-  - If rotation happens, users may need to re-link after the old refresh token becomes invalid.
+- Task environment variables are still ephemeral. Durability comes from
+  BotManager reading the handoff file after the run and calling the platform's
+  narrow token-rotation endpoint.
+- If the handoff path is not configured, refresh remains in-process only.
 
 ## Tests
 
@@ -63,4 +68,4 @@ File: `tests/test_tradier.py`
 - Added unit tests for:
   - decoding OAuth payload into `access_token`
   - refreshing token when payload is expired (requests mocked; no network)
-
+  - writing the token-rotation handoff file without logging token values

--- a/docsrc/brokers.schwab.rst
+++ b/docsrc/brokers.schwab.rst
@@ -153,18 +153,25 @@ To use Schwab with Lumibot, you need to set the following environment variables 
 
 .. important::
    `SCHWAB_TOKEN` is only read **once** (on first run) to build `token.json`.
-   After that, automatic refresh keeps the file current; you do **not** need to
-   rotate the env-var every 7 days.
+   After that, automatic refresh keeps the token current.  For local or
+   persistent-filesystem deployments, that updates `token.json`.  In BotSpot
+   scheduled deployments, credentials are refreshed in Vault before each
+   invocation; the scheduled runtime payload is used for the current invocation
+   and no `token.json` persists across invocations.
 
 Token Life-cycle & Auto-refresh
 -------------------------------
 
 * Access-token ≈ 30 min, refresh-token ≈ 7 days (per Schwab policy).
 * Lumibot configures an `OAuth2Session` with ``auto_refresh_url`` so that tokens
-  refresh themselves quietly in the background every ~25 min.
-* The refreshed token is written back to `token.json`; it rolls the 7-day window
-  forward.  As long as the bot is running (or restarted at least once a week)
-  you never need to log in again.
+  refresh as needed during broker API calls.
+* When running as a scheduled BotSpot task (``LUMIBOT_SCHEDULED_EXECUTION=true``),
+  BotSpot refreshes the saved Schwab broker credential in Vault before issuing
+  the short-lived runtime secret.  The ephemeral task does not persist OAuth
+  token files across invocations.
+* Outside BotSpot-managed credentials, place `token.json` on durable storage if
+  the runtime filesystem is ephemeral.  A refreshed local token file is only
+  useful across restarts when the file survives the restart.
 * Only if the service is **offline for >7 days** will the refresh-token expire.
   In that case repeat the browser login once and redeploy the new payload or
   token file.

--- a/docsrc/brokers.tradier.rst
+++ b/docsrc/brokers.tradier.rst
@@ -75,10 +75,11 @@ refresh tokens as non-expiring. LumiBot can refresh an OAuth payload when
 ``TRADIER_TOKEN`` includes a ``refresh_token`` and
 ``TRADIER_OAUTH_CLIENT_ID`` / ``TRADIER_OAUTH_CLIENT_SECRET`` are configured.
 
-For BotSpot scheduled deployments, the platform refreshes the canonical Tradier
-OAuth credential in Vault before each short-lived runtime secret is issued. The
-scheduled container should treat the runtime credential as ephemeral and should
-not be the durable source of truth for refreshed tokens.
+For BotSpot managed runtimes, LumiBot writes refreshed OAuth token material to a
+BotSpot-provided handoff file when ``BOTSPOT_TRADIER_TOKEN_ROTATION_PATH`` is
+set. BotManager then forwards only allowlisted rotated token fields through the
+platform's audited token-rotation path. User strategies should treat runtime
+credentials as ephemeral and should not persist refreshed tokens themselves.
 
 Then you can run your strategy as you normally would:
 

--- a/docsrc/brokers.tradier.rst
+++ b/docsrc/brokers.tradier.rst
@@ -63,6 +63,23 @@ To run your strategy, you'll first need to instantiate your chosen broker with t
 
     broker = Tradier(config=TRADIER_CONFIG)
 
+Token Lifetime Notes
+--------------------
+
+Tradier dashboard API tokens, such as ``TRADIER_ACCESS_TOKEN`` from the API
+Access page, do not expire under Tradier's current token model.
+
+Tradier partner OAuth access tokens are different: they expire after 24 hours.
+Approved partner apps can receive refresh tokens, and Tradier documents those
+refresh tokens as non-expiring. LumiBot can refresh an OAuth payload when
+``TRADIER_TOKEN`` includes a ``refresh_token`` and
+``TRADIER_OAUTH_CLIENT_ID`` / ``TRADIER_OAUTH_CLIENT_SECRET`` are configured.
+
+For BotSpot scheduled deployments, the platform refreshes the canonical Tradier
+OAuth credential in Vault before each short-lived runtime secret is issued. The
+scheduled container should treat the runtime credential as ephemeral and should
+not be the durable source of truth for refreshed tokens.
+
 Then you can run your strategy as you normally would:
 
 .. code-block:: python

--- a/docsrc/environment_variables.rst
+++ b/docsrc/environment_variables.rst
@@ -401,6 +401,13 @@ TRADIER_IS_PAPER
 - Values: ``true`` (paper) / ``false`` (live).
 - Default: ``true`` (paper trading).
 
+BOTSPOT_TRADIER_TOKEN_ROTATION_PATH
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: BotSpot-managed runtime handoff file for refreshed Tradier OAuth tokens.
+- Values: Absolute file path provided by BotSpot runtime.
+- Note: Internal platform variable. User strategies should not set it.
+
 Interactive Brokers
 -------------------
 

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -33,6 +33,13 @@ from lumibot.trading_builtins import PollingStream
 LUMI_DEFAULT_APP_KEY = "RfUVxotUc8p6CbeCwFmophgNZSat0TLv"
 LUMI_DEFAULT_CALLBACK = "https://api.botspot.trade/broker_oauth/schwab"
 
+def _should_delete_token_file_after_init_error(error):
+    if isinstance(error, json.JSONDecodeError):
+        return True
+    message = str(error or "").lower()
+    corrupt_markers = ("corrupt", "malformed", "invalid token", "token file", "json", "decode")
+    return any(marker in message for marker in corrupt_markers)
+
 class Schwab(Broker):
     """
     Broker implementation for Schwab API.
@@ -169,9 +176,34 @@ class Schwab(Broker):
             logger.warning(f"[Schwab] Could not create token directory {token_path.parent}: {_mkdir_e}")
 
         token_available_and_valid = False
+        scheduled_execution_value = (
+            config.get("LUMIBOT_SCHEDULED_EXECUTION")
+            or os.environ.get("LUMIBOT_SCHEDULED_EXECUTION", "")
+        )
+        scheduled_execution = str(scheduled_execution_value).strip().lower() in {"1", "true", "yes", "on"}
 
-        if token_payload_env:
-            logger.info("[Schwab] SCHWAB_TOKEN environment variable found. Processing it.")
+        def _use_existing_token_file():
+            nonlocal token_available_and_valid
+            if token_available_and_valid or not token_path.exists() or token_path.stat().st_size <= 0:
+                return
+            logger.info(f"[Schwab] Existing token file found at {token_path}. Validating...")
+            try:
+                SchwabHelper._ensure_token_metadata(token_path)
+                if SchwabHelper._is_token_valid_for_schwab_py(token_path):
+                    token_available_and_valid = True
+                    logger.info(f"[Schwab] Existing token file {token_path} is valid after metadata check.")
+                else:
+                    logger.warning(f"[Schwab] Existing token file {token_path} is invalid after checks. Deleting.")
+                    token_path.unlink(missing_ok=True)
+            except Exception as e:
+                logger.warning(f"[Schwab] Error validating/fixing existing token file {token_path}: {e}. Deleting.")
+                if token_path.exists(): token_path.unlink(missing_ok=True)
+
+        def _seed_token_file_from_payload():
+            nonlocal token_available_and_valid
+            if token_available_and_valid or not token_payload_env:
+                return
+            logger.info("[Schwab] SCHWAB_TOKEN environment variable found and no valid token file exists. Processing it.")
             try:
                 SchwabHelper._save_payload_str_to_token_file(token_payload_env, token_path)
                 if SchwabHelper._is_token_valid_for_schwab_py(token_path):
@@ -189,19 +221,17 @@ class Schwab(Broker):
                 logger.error(f"[Schwab] Error processing SCHWAB_TOKEN: {e}")
                 if token_path.exists(): token_path.unlink(missing_ok=True)
 
-        if not token_available_and_valid and token_path.exists() and token_path.stat().st_size > 0:
-            logger.info(f"[Schwab] Existing token file found at {token_path}. Validating...")
-            try:
-                SchwabHelper._ensure_token_metadata(token_path)
-                if SchwabHelper._is_token_valid_for_schwab_py(token_path):
-                    token_available_and_valid = True
-                    logger.info(f"[Schwab] Existing token file {token_path} is valid after metadata check.")
-                else:
-                    logger.warning(f"[Schwab] Existing token file {token_path} is invalid after checks. Deleting.")
-                    token_path.unlink(missing_ok=True)
-            except Exception as e:
-                logger.warning(f"[Schwab] Error validating/fixing existing token file {token_path}: {e}. Deleting.")
-                if token_path.exists(): token_path.unlink(missing_ok=True)
+        payload_seed_attempted = False
+        if scheduled_execution and token_payload_env:
+            logger.info("[Schwab] Scheduled execution detected; using SCHWAB_TOKEN runtime payload before any local token file.")
+            _seed_token_file_from_payload()
+            payload_seed_attempted = True
+
+        if not token_available_and_valid:
+            _use_existing_token_file()
+
+        if not token_available_and_valid and token_payload_env and not payload_seed_attempted:
+            _seed_token_file_from_payload()
 
         if not token_available_and_valid:
             logger.info("[Schwab] No valid token found. Initiating user authorization flow to obtain token payload.")
@@ -242,15 +272,42 @@ class Schwab(Broker):
             def _update_token(updated_token):
                 """Write refreshed token back to token.json so it persists across restarts."""
                 try:
+                    updated_token = dict(updated_token or {})
+                    now_ms = int(time.time() * 1000)
+                    existing_refresh_token = token_dict_for_session.get("refresh_token")
+                    updated_refresh_token = updated_token.get("refresh_token")
+                    updated_token.setdefault("issued_at", now_ms)
+                    updated_token.setdefault("expires_in", token_dict_for_session.get("expires_in", 1800))
+                    updated_token.setdefault(
+                        "refresh_token_expires_in",
+                        token_dict_for_session.get(
+                            "refresh_token_expires_in",
+                            SchwabHelper.REFRESH_TOKEN_EXPIRES_IN_SECONDS,
+                        ),
+                    )
+                    updated_token.setdefault("token_type", token_dict_for_session.get("token_type", "Bearer"))
+                    updated_token.setdefault("scope", token_dict_for_session.get("scope", "api"))
+                    if updated_refresh_token and updated_refresh_token != existing_refresh_token:
+                        updated_token["refresh_token_issued_at"] = now_ms
+                    elif token_dict_for_session.get("refresh_token_issued_at") is not None:
+                        updated_token["refresh_token_issued_at"] = token_dict_for_session["refresh_token_issued_at"]
+                    else:
+                        updated_token.pop("refresh_token_issued_at", None)
+                    if not updated_token.get("refresh_token") and existing_refresh_token:
+                        updated_token["refresh_token"] = existing_refresh_token
+                    updated_token.pop("id_token", None)
                     wrapped = {
                         "creation_timestamp": int(time.time()),
                         "token": updated_token,
                     }
-                    with open(token_path, "w", encoding="utf-8") as fp:
-                        json.dump(wrapped, fp)
+                    SchwabHelper._write_token_file(token_path, wrapped)
+                    token_dict_for_session.clear()
+                    token_dict_for_session.update(updated_token)
                     logger.info(f"[Schwab] Token automatically refreshed and written to {token_path}")
+                    return updated_token
                 except Exception as e_write:
                     logger.error(f"[Schwab] Failed to write refreshed token to file: {e_write}")
+                    raise
 
             # Build kwargs for token refresh – only include client_secret if it actually exists
             refresh_kwargs = {
@@ -261,25 +318,31 @@ class Schwab(Broker):
             if client_secret_env:
                 refresh_kwargs["client_secret"] = client_secret_env
 
-            #add expires_at to token_dict_for_session. This is needed for the auto_refresh to work. Otherwise oauth2session always thinks it expires 30min from startup
-            token_dict_for_session['expires_at'] = int(token_dict_for_session['issued_at']/1000 + (token_dict_for_session['expires_in']) - 30) #30 second buffer
-            
-            oauth_session = _OAS(
-                client_id=api_key,
-                token=token_dict_for_session,
-                auto_refresh_url="https://api.schwabapi.com/v1/oauth/token",
-                auto_refresh_kwargs=refresh_kwargs,
-                token_updater=_update_token,
-            )
+            def _prepare_token_for_session(token_dict):
+                # add expires_at to token_dict_for_session. This is needed for the auto_refresh to work. Otherwise oauth2session always thinks it expires 30min from startup
+                token_dict["expires_at"] = int(token_dict["issued_at"] / 1000 + token_dict["expires_in"] - 30) #30 second buffer
+                return token_dict
 
-            if api_key and client_secret_env:
-                def _refresh_token_hook(token_url, headers, body):
-                    headers['Authorization'] = f"Basic {base64.b64encode(f'{api_key}:{client_secret_env}'.encode()).decode()}"
-                    logger.info(f"[Schwab] Refreshing token with auth headers")
-                    return token_url, headers, body
+            def _build_oauth_session(token_dict):
+                session = _OAS(
+                    client_id=api_key,
+                    token=_prepare_token_for_session(token_dict),
+                    auto_refresh_url="https://api.schwabapi.com/v1/oauth/token",
+                    auto_refresh_kwargs=refresh_kwargs,
+                    token_updater=_update_token,
+                )
 
-                #create refresh hook. This is beacuse oa2session does not perform refreshes with auth headers, only with json bodies. 
-                oauth_session.register_compliance_hook("refresh_token_request", _refresh_token_hook)
+                if api_key and client_secret_env:
+                    def _refresh_token_hook(token_url, headers, body):
+                        headers['Authorization'] = f"Basic {base64.b64encode(f'{api_key}:{client_secret_env}'.encode()).decode()}"
+                        logger.info(f"[Schwab] Refreshing token with auth headers")
+                        return token_url, headers, body
+
+                    # Create refresh hook because OAuth2Session does not add Schwab's auth header by default.
+                    session.register_compliance_hook("refresh_token_request", _refresh_token_hook)
+                return session
+
+            oauth_session = _build_oauth_session(token_dict_for_session)
 
             # NOTE: schwab-py >=1.6 removed the app_secret parameter from the Client constructor.
             # Passing it raises: TypeError: BaseClient.__init__() got an unexpected keyword argument 'app_secret'.
@@ -297,9 +360,11 @@ class Schwab(Broker):
         except Exception as e:
             logger.error(colored(f"[Schwab] Error initializing Schwab client from token file {token_path}: {e}", "red"))
             logger.error(traceback.format_exc())
-            if token_path.exists():
+            if token_path.exists() and _should_delete_token_file_after_init_error(e):
                 logger.warning(f"[Schwab] Deleting potentially corrupt token file: {token_path}")
                 token_path.unlink(missing_ok=True)
+            elif token_path.exists():
+                logger.warning(f"[Schwab] Preserving token file after non-corrupt initialization error: {token_path}")
             self.schwab_authorization_error = True
             raise ConnectionError(
                 f"Failed to initialize Schwab client: {e}. "

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -180,7 +180,7 @@ class Schwab(Broker):
             config.get("LUMIBOT_SCHEDULED_EXECUTION")
             or os.environ.get("LUMIBOT_SCHEDULED_EXECUTION", "")
         )
-        scheduled_execution = str(scheduled_execution_value).strip().lower() in {"1", "true", "yes", "on"}
+        scheduled_execution = str(scheduled_execution_value).strip().lower() in {"1", "true", "yes", "y", "on"}
 
         def _use_existing_token_file():
             nonlocal token_available_and_valid

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -120,6 +120,39 @@ class Tradier(Broker):
                 pass
             _update_client(getattr(ds, "tradier", None))
 
+    def _write_oauth_rotation_file(self, *, access_token: str, refresh_token: str | None) -> None:
+        """Best-effort handoff for BotManager's narrow token-rotation path."""
+        path = os.environ.get("BOTSPOT_TRADIER_TOKEN_ROTATION_PATH")
+        if not path or not access_token:
+            return
+        payload = {"TRADIER_ACCESS_TOKEN": access_token}
+        if refresh_token:
+            payload["TRADIER_REFRESH_TOKEN"] = refresh_token
+        try:
+            parent = os.path.dirname(path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+                os.chmod(parent, 0o700)
+            tmp_path = f"{path}.tmp"
+            fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    fd = None
+                    json.dump(payload, handle)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(tmp_path, path)
+                os.chmod(path, 0o600)
+            finally:
+                if fd is not None:
+                    os.close(fd)
+        except Exception as exc:
+            try:
+                os.unlink(f"{path}.tmp")
+            except Exception:
+                pass
+            logger.warning("[Tradier] Could not write OAuth token rotation handoff file: %s", exc.__class__.__name__)
+
     def _refresh_oauth_token(self, *, force: bool = False) -> bool:
         """Refresh Tradier OAuth token if possible. Returns True on successful refresh."""
         if not self._oauth_enabled():
@@ -181,7 +214,7 @@ class Tradier(Broker):
             # Refresh token is typically stable for Tradier partner apps, but handle the case where it changes.
             new_refresh_token = token_json.get("refresh_token")
             if new_refresh_token and new_refresh_token != refresh_token:
-                logger.warning("[Tradier] OAuth refresh rotated refresh_token; rotation is not persisted in env vars and may require re-linking later.")
+                logger.warning("[Tradier] OAuth refresh rotated refresh_token; handing off for runtime token rotation when configured.")
                 self._oauth_refresh_token = new_refresh_token
 
             expires_in = token_json.get("expires_in")
@@ -198,6 +231,10 @@ class Tradier(Broker):
                 pass
 
             self._apply_access_token(new_access_token)
+            self._write_oauth_rotation_file(
+                access_token=new_access_token,
+                refresh_token=self._oauth_refresh_token,
+            )
             return True
 
     def _install_oauth_refresh_hooks(self) -> None:

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -318,15 +318,19 @@ class Tradier(Broker):
             self._oauth_client_secret = os.environ.get("TRADIER_OAUTH_CLIENT_SECRET")
 
             try:
-                issued_at_ms = int(token_json.get("issued_at") or 0)
+                issued_at_raw = token_json.get("issued_at")
+                issued_at_ms = (
+                    int(issued_at_raw)
+                    if issued_at_raw not in (None, "")
+                    else int(time.time() * 1000)
+                )
                 expires_in = token_json.get("expires_in")
                 expires_in_s = (
                     int(float(expires_in))
                     if expires_in is not None
                     else self._OAUTH_DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECONDS
                 )
-                if issued_at_ms:
-                    self._oauth_token_expires_at = issued_at_ms / 1000.0 + expires_in_s
+                self._oauth_token_expires_at = issued_at_ms / 1000.0 + expires_in_s
             except Exception:
                 # No reliable expiry metadata; refresh-on-401 hook still applies.
                 pass

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -56,6 +56,7 @@ class Tradier(Broker):
     # OAuth refresh endpoint (only available for approved Tradier partner apps).
     _OAUTH_REFRESH_URL = "https://api.tradier.com/v1/oauth/refreshtoken"
     _OAUTH_REFRESH_SKEW_SECONDS = 60  # Refresh a bit early to avoid edge-of-expiry failures.
+    _OAUTH_DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECONDS = 24 * 60 * 60
 
     @staticmethod
     def _decode_base64url_json(payload_str: str) -> dict:
@@ -80,7 +81,7 @@ class Tradier(Broker):
     def _oauth_token_needs_refresh(self) -> bool:
         expires_at = getattr(self, "_oauth_token_expires_at", None)
         if not expires_at:
-            return False
+            return True
         return time.time() >= float(expires_at) - self._OAUTH_REFRESH_SKEW_SECONDS
 
     def _apply_access_token(self, new_access_token: str) -> None:
@@ -186,9 +187,12 @@ class Tradier(Broker):
             expires_in = token_json.get("expires_in")
             try:
                 issued_at_ms = int(token_json.get("issued_at"))
-                expires_in_s = int(float(expires_in)) if expires_in is not None else None
-                if expires_in_s:
-                    self._oauth_token_expires_at = issued_at_ms / 1000.0 + expires_in_s
+                expires_in_s = (
+                    int(float(expires_in))
+                    if expires_in is not None
+                    else self._OAUTH_DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECONDS
+                )
+                self._oauth_token_expires_at = issued_at_ms / 1000.0 + expires_in_s
             except Exception:
                 # If we can't parse expiry, keep existing best-effort expiry (or none).
                 pass
@@ -315,8 +319,13 @@ class Tradier(Broker):
 
             try:
                 issued_at_ms = int(token_json.get("issued_at") or 0)
-                expires_in_s = int(float(token_json.get("expires_in"))) if token_json.get("expires_in") is not None else None
-                if issued_at_ms and expires_in_s:
+                expires_in = token_json.get("expires_in")
+                expires_in_s = (
+                    int(float(expires_in))
+                    if expires_in is not None
+                    else self._OAUTH_DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECONDS
+                )
+                if issued_at_ms:
                     self._oauth_token_expires_at = issued_at_ms / 1000.0 + expires_in_s
             except Exception:
                 # No reliable expiry metadata; refresh-on-401 hook still applies.

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -3301,6 +3301,10 @@ class _Strategy:
             "x-api-key": f"{self.lumiwealth_api_key}",
             "Content-Type": "application/json",
         }
+        redacted_headers = {
+            key: ("<redacted>" if key.lower() == "x-api-key" else value)
+            for key, value in headers.items()
+        }
 
         data = {
             "data_type": "portfolio_event",
@@ -3344,7 +3348,7 @@ class _Strategy:
             json_data = json.dumps(data, default=str)
             data_size_kb = len(json_data.encode('utf-8')) / 1024
             self.logger.debug(f"Sending {data_size_kb:.2f} KB of data to {LUMIWEALTH_URL}")
-            self.logger.debug(f"Request headers: {headers}")
+            self.logger.debug(f"Request headers: {redacted_headers}")
 
             response = requests.post(LUMIWEALTH_URL, headers=headers, data=json_data)
 

--- a/lumibot/tools/schwab_helper.py
+++ b/lumibot/tools/schwab_helper.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import base64
 import json
+import os
+import tempfile
 import time
 import traceback
 import urllib.parse
@@ -16,6 +18,38 @@ from .lumibot_logger import get_logger
 logger = get_logger(__name__)
 
 class SchwabHelper:
+    REFRESH_TOKEN_EXPIRES_IN_SECONDS = 7 * 24 * 3600
+
+    @staticmethod
+    def _write_token_file(token_path: Path, token_data: dict):
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f"{token_path.name}.",
+            suffix=".tmp",
+            dir=str(token_path.parent),
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            os.chmod(tmp_path, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as fp:
+                fd = None
+                json.dump(token_data, fp)
+                fp.flush()
+                os.fsync(fp.fileno())
+            os.replace(tmp_path, token_path)
+            os.chmod(token_path, 0o600)
+        except Exception:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except Exception:
+                pass
+            raise
+
     @staticmethod
     def _ensure_token_metadata(token_path: Path):
         """
@@ -50,7 +84,7 @@ class SchwabHelper:
                 "issued_at": now_ms,
                 "refresh_token_issued_at": now_ms,
                 "expires_in": 1800,
-                "refresh_token_expires_in": 90 * 24 * 3600, # Changed from 7776000 for clarity (90 days)
+                "refresh_token_expires_in": SchwabHelper.REFRESH_TOKEN_EXPIRES_IN_SECONDS,
                 "token_type": "Bearer",
                 "scope": "api",
             }
@@ -64,9 +98,7 @@ class SchwabHelper:
                 "creation_timestamp": creation_ts,
                 "token": tok,
             }
-            # Use 'w' mode to overwrite the file completely
-            with token_path.open("w", encoding="utf-8") as fp:
-                json.dump(wrapped, fp)
+            SchwabHelper._write_token_file(token_path, wrapped)
             logger.info(f"[DEBUG] Token file successfully written and wrapped by _ensure_token_metadata to {token_path}")
 
         except Exception as e:
@@ -244,7 +276,10 @@ class SchwabHelper:
             "issued_at": now_ms,
             "refresh_token_issued_at": now_ms,
             "expires_in": token_data_from_payload.get("expires_in", 1800),
-            "refresh_token_expires_in": token_data_from_payload.get("refresh_token_expires_in", 7776000),
+            "refresh_token_expires_in": token_data_from_payload.get(
+                "refresh_token_expires_in",
+                SchwabHelper.REFRESH_TOKEN_EXPIRES_IN_SECONDS,
+            ),
             "token_type": token_data_from_payload.get("token_type", "Bearer"),
             "scope": token_data_from_payload.get("scope", "api"),
         }
@@ -259,8 +294,7 @@ class SchwabHelper:
             "creation_timestamp": int(time.time()),
             "token": final_token_data,
         }
-        with token_path.open("w", encoding="utf-8") as fp:
-            json.dump(wrapped_token, fp)
+        SchwabHelper._write_token_file(token_path, wrapped_token)
         logger.info(f"Token payload processed and saved to {token_path}")
 
 __all__ = [

--- a/lumibot/tools/schwab_helper.py
+++ b/lumibot/tools/schwab_helper.py
@@ -66,7 +66,21 @@ class SchwabHelper:
         try: # Add try-except around file operations
             with token_path.open("r+", encoding="utf-8") as fp:
                 tok_raw = json.load(fp)
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            logger.error(f"[DEBUG] Token file is not valid JSON and will be deleted: {e}")
+            logger.error(traceback.format_exc())
+            try:
+                token_path.unlink(missing_ok=True)
+                logger.warning(f"[DEBUG] Deleted corrupted token file: {token_path}")
+            except Exception as unlink_e:
+                logger.error(f"[DEBUG] Failed to delete corrupted token file: {unlink_e}")
+            return
+        except Exception as e:
+            logger.error(f"[DEBUG] Could not read token file; preserving it: {e}")
+            logger.error(traceback.format_exc())
+            return
 
+        try:
             # If already wrapped, just update the token part
             if "creation_timestamp" in tok_raw and "token" in tok_raw:
                 creation_ts = tok_raw["creation_timestamp"]
@@ -104,12 +118,7 @@ class SchwabHelper:
         except Exception as e:
             logger.error(f"[DEBUG] Error in _ensure_token_metadata: {e}")
             logger.error(traceback.format_exc())
-            # If error occurs, try to delete the potentially corrupted file
-            try:
-                token_path.unlink(missing_ok=True)
-                logger.warning(f"[DEBUG] Deleted potentially corrupted token file due to error in _ensure_token_metadata: {token_path}")
-            except Exception as unlink_e:
-                logger.error(f"[DEBUG] Failed to delete token file after error in _ensure_token_metadata: {unlink_e}")
+            logger.warning(f"[DEBUG] Preserving existing token file after metadata rewrite failure: {token_path}")
 
     @staticmethod
     def _initiate_schwab_auth_and_get_token_payload(api_key: str, backend_callback_url: str, token_path: Path) -> bool:

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -1,6 +1,12 @@
 """
 Simple test cases for broker initialization error handling.
 """
+import base64
+import json
+import stat
+import sys
+import time
+
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -72,3 +78,261 @@ class TestBrokerInitializationSimple:
         except Exception as e:
             # Other exceptions are acceptable for this test since we're only testing the broker None case
             pass
+
+
+def _install_fake_schwab_runtime(monkeypatch, refreshed_token=None, refresh_results=None):
+    from lumibot.brokers.broker import Broker
+    import lumibot.brokers.schwab as schwab_module
+
+    refresh_results = list(refresh_results or [])
+
+    class FakeAccountNumbersResponse:
+        status_code = 200
+
+        def json(self):
+            return [{"accountNumber": "12345678", "hashValue": "hash-123"}]
+
+    class FakeClient:
+        class Account:
+            class Fields:
+                POSITIONS = "positions"
+
+        def __init__(self, api_key, session):
+            self.api_key = api_key
+            self.session = session
+
+        def get_account_numbers(self):
+            return FakeAccountNumbersResponse()
+
+    class FakeOAuth2Session:
+        instances = []
+
+        def __init__(self, client_id, token, auto_refresh_url, auto_refresh_kwargs, token_updater):
+            self.client_id = client_id
+            self.token = token
+            self.auto_refresh_url = auto_refresh_url
+            self.auto_refresh_kwargs = auto_refresh_kwargs
+            self.token_updater = token_updater
+            self.refresh_calls = []
+            self.hooks = []
+            self.instances.append(self)
+
+        def register_compliance_hook(self, hook_type, hook):
+            self.hooks.append((hook_type, hook))
+
+        def refresh_token(self, token_url, refresh_token, **kwargs):
+            self.refresh_calls.append((token_url, refresh_token, kwargs))
+            if refresh_results:
+                result = refresh_results.pop(0)
+                if isinstance(result, Exception):
+                    raise result
+                self.token = result
+            else:
+                self.token = refreshed_token or {
+                    "access_token": "refreshed-access",
+                    "refresh_token": "rotated-refresh",
+                    "issued_at": int(time.time() * 1000),
+                    "expires_in": 1800,
+                    "token_type": "Bearer",
+                    "scope": "api",
+                }
+            return self.token
+
+    def fake_broker_init(self, name="", data_source=None, config=None, **_kwargs):
+        self.name = name
+        self.data_source = data_source
+        self.config = config
+        self.quote_assets = set()
+
+    monkeypatch.setattr(Broker, "__init__", fake_broker_init)
+    monkeypatch.setattr(schwab_module, "Client", FakeClient)
+    monkeypatch.setattr(schwab_module.Schwab, "_finish_initialization", lambda self, *_args, **_kwargs: None)
+    monkeypatch.setattr("requests_oauthlib.OAuth2Session", FakeOAuth2Session)
+    return FakeOAuth2Session
+
+
+def _write_schwab_token(path, *, access_token="existing-access", refresh_token="existing-refresh"):
+    path.write_text(
+        json.dumps(
+            {
+                "creation_timestamp": int(time.time()),
+                "token": {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                    "issued_at": int(time.time() * 1000),
+                    "expires_in": 1800,
+                    "token_type": "Bearer",
+                    "scope": "api",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _schwab_payload_b64(payload):
+    raw = json.dumps(payload).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _assert_private_posix_file(path):
+    if sys.platform != "win32":
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_schwab_prefers_existing_token_file_over_stale_env_payload(monkeypatch, tmp_path):
+    from lumibot.brokers.schwab import Schwab
+    from lumibot.tools import SchwabHelper
+
+    token_path = tmp_path / "schwab_token.json"
+    _write_schwab_token(token_path, access_token="fresh-access", refresh_token="fresh-refresh")
+    _install_fake_schwab_runtime(monkeypatch)
+    monkeypatch.setenv("SCHWAB_TOKEN", "stale-original-payload")
+    monkeypatch.delenv("LUMIBOT_SCHEDULED_EXECUTION", raising=False)
+
+    save_payload = MagicMock(side_effect=AssertionError("SCHWAB_TOKEN should only seed a missing token file"))
+    monkeypatch.setattr(SchwabHelper, "_save_payload_str_to_token_file", save_payload)
+
+    Schwab(
+        config={
+            "SCHWAB_ACCOUNT_NUMBER": "12345678",
+            "SCHWAB_APP_KEY": "app-key",
+            "SCHWAB_APP_SECRET": "app-secret",
+            "SCHWAB_TOKEN_PATH": str(token_path),
+        },
+        data_source=object(),
+    )
+
+    assert save_payload.call_count == 0
+    token_data = json.loads(token_path.read_text(encoding="utf-8"))
+    assert token_data["token"]["refresh_token"] == "fresh-refresh"
+    assert token_data["token"]["refresh_token_expires_in"] == 604800
+    _assert_private_posix_file(token_path)
+
+
+def test_schwab_scheduled_runtime_payload_overrides_existing_token_file(monkeypatch, tmp_path):
+    from lumibot.brokers.schwab import Schwab
+
+    token_path = tmp_path / "schwab_token.json"
+    _write_schwab_token(token_path, access_token="old-file-access", refresh_token="old-file-refresh")
+    _install_fake_schwab_runtime(monkeypatch)
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_EXECUTION", "true")
+    monkeypatch.setenv(
+        "SCHWAB_TOKEN",
+        _schwab_payload_b64(
+            {
+                "access_token": "runtime-access",
+                "refresh_token": "runtime-refresh",
+            }
+        ),
+    )
+
+    Schwab(
+        config={
+            "SCHWAB_ACCOUNT_NUMBER": "12345678",
+            "SCHWAB_APP_KEY": "app-key",
+            "SCHWAB_APP_SECRET": "app-secret",
+            "SCHWAB_TOKEN_PATH": str(token_path),
+        },
+        data_source=object(),
+    )
+
+    token_data = json.loads(token_path.read_text(encoding="utf-8"))
+    assert token_data["token"]["access_token"] == "runtime-access"
+    assert token_data["token"]["refresh_token"] == "runtime-refresh"
+    assert token_data["token"]["refresh_token_expires_in"] == 604800
+    _assert_private_posix_file(token_path)
+
+
+def test_schwab_scheduled_startup_does_not_force_refresh(monkeypatch, tmp_path):
+    from lumibot.brokers.schwab import Schwab
+
+    token_path = tmp_path / "schwab_token.json"
+    _write_schwab_token(token_path, access_token="runtime-access", refresh_token="runtime-refresh")
+    fake_session_cls = _install_fake_schwab_runtime(monkeypatch)
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_EXECUTION", "true")
+
+    Schwab(
+        config={
+            "SCHWAB_ACCOUNT_NUMBER": "12345678",
+            "SCHWAB_APP_KEY": "app-key",
+            "SCHWAB_APP_SECRET": "app-secret",
+            "SCHWAB_TOKEN_PATH": str(token_path),
+        },
+        data_source=object(),
+    )
+
+    session = fake_session_cls.instances[0]
+    assert session.refresh_calls == []
+    token_data = json.loads(token_path.read_text(encoding="utf-8"))
+    assert token_data["token"]["access_token"] == "runtime-access"
+    assert token_data["token"]["refresh_token"] == "runtime-refresh"
+    assert token_data["token"]["refresh_token_expires_in"] == 604800
+    _assert_private_posix_file(token_path)
+
+
+def test_schwab_token_updater_preserves_refresh_token_metadata(monkeypatch, tmp_path):
+    from lumibot.brokers.schwab import Schwab
+
+    token_path = tmp_path / "schwab_token.json"
+    _write_schwab_token(token_path, access_token="runtime-access", refresh_token="runtime-refresh")
+    fake_session_cls = _install_fake_schwab_runtime(monkeypatch)
+
+    Schwab(
+        config={
+            "SCHWAB_ACCOUNT_NUMBER": "12345678",
+            "SCHWAB_APP_KEY": "app-key",
+            "SCHWAB_APP_SECRET": "app-secret",
+            "SCHWAB_TOKEN_PATH": str(token_path),
+        },
+        data_source=object(),
+    )
+
+    original_token_data = json.loads(token_path.read_text(encoding="utf-8"))
+    original_refresh_issued_at = original_token_data["token"]["refresh_token_issued_at"]
+
+    session = fake_session_cls.instances[0]
+    session.token_updater({
+        "access_token": "new-access",
+        "expires_in": 1800,
+        "token_type": "Bearer",
+        "scope": "api",
+    })
+
+    token_data = json.loads(token_path.read_text(encoding="utf-8"))
+    assert token_data["token"]["access_token"] == "new-access"
+    assert token_data["token"]["refresh_token"] == "runtime-refresh"
+    assert token_data["token"]["refresh_token_issued_at"] == original_refresh_issued_at
+    assert token_data["token"]["refresh_token_expires_in"] == 604800
+    _assert_private_posix_file(token_path)
+
+
+def test_schwab_preserves_token_file_when_client_init_fails_transiently(monkeypatch, tmp_path):
+    import lumibot.brokers.schwab as schwab_module
+    from lumibot.brokers.schwab import Schwab
+
+    token_path = tmp_path / "schwab_token.json"
+    _write_schwab_token(token_path, access_token="runtime-access", refresh_token="runtime-refresh")
+    _install_fake_schwab_runtime(monkeypatch)
+
+    class FailingClient:
+        def __init__(self, *_args, **_kwargs):
+            raise TimeoutError("network timeout while initializing client")
+
+    monkeypatch.setattr(schwab_module, "Client", FailingClient)
+
+    with pytest.raises(ConnectionError):
+        Schwab(
+            config={
+                "SCHWAB_ACCOUNT_NUMBER": "12345678",
+                "SCHWAB_APP_KEY": "app-key",
+                "SCHWAB_APP_SECRET": "app-secret",
+                "SCHWAB_TOKEN_PATH": str(token_path),
+            },
+            data_source=object(),
+        )
+
+    token_data = json.loads(token_path.read_text(encoding="utf-8"))
+    assert token_data["token"]["access_token"] == "runtime-access"
+    assert token_data["token"]["refresh_token"] == "runtime-refresh"
+    _assert_private_posix_file(token_path)

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -216,7 +216,7 @@ def test_schwab_scheduled_runtime_payload_overrides_existing_token_file(monkeypa
     token_path = tmp_path / "schwab_token.json"
     _write_schwab_token(token_path, access_token="old-file-access", refresh_token="old-file-refresh")
     _install_fake_schwab_runtime(monkeypatch)
-    monkeypatch.setenv("LUMIBOT_SCHEDULED_EXECUTION", "true")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_EXECUTION", "y")
     monkeypatch.setenv(
         "SCHWAB_TOKEN",
         _schwab_payload_b64(
@@ -242,6 +242,24 @@ def test_schwab_scheduled_runtime_payload_overrides_existing_token_file(monkeypa
     assert token_data["token"]["refresh_token"] == "runtime-refresh"
     assert token_data["token"]["refresh_token_expires_in"] == 604800
     _assert_private_posix_file(token_path)
+
+
+def test_schwab_metadata_rewrite_failure_preserves_existing_token(monkeypatch, tmp_path):
+    from lumibot.tools import SchwabHelper
+
+    token_path = tmp_path / "schwab_token.json"
+    _write_schwab_token(token_path, access_token="runtime-access", refresh_token="runtime-refresh")
+    original_contents = token_path.read_text(encoding="utf-8")
+
+    def _fail_write(*_args, **_kwargs):
+        raise OSError("simulated atomic rewrite failure")
+
+    monkeypatch.setattr(SchwabHelper, "_write_token_file", _fail_write)
+
+    SchwabHelper._ensure_token_metadata(token_path)
+
+    assert token_path.exists()
+    assert token_path.read_text(encoding="utf-8") == original_contents
 
 
 def test_schwab_scheduled_startup_does_not_force_refresh(monkeypatch, tmp_path):

--- a/tests/test_cloud_account_snapshot.py
+++ b/tests/test_cloud_account_snapshot.py
@@ -5,8 +5,11 @@ from lumibot.strategies._strategy import _Strategy
 
 
 class _Logger:
+    def __init__(self):
+        self.debug_messages = []
+
     def debug(self, *args, **kwargs):
-        pass
+        self.debug_messages.append(" ".join(str(arg) for arg in args))
 
     def info(self, *args, **kwargs):
         pass
@@ -84,6 +87,22 @@ def test_cloud_update_refreshes_positions_before_publish(monkeypatch):
     assert payloads[0]["positions"] == []
     assert payloads[0]["positions_snapshot_status"] == "verified"
     assert payloads[0]["positions_snapshot_source"] == "broker_positions_refresh"
+
+
+def test_cloud_update_redacts_listener_key_from_debug_headers(monkeypatch):
+    strategy = _fake_strategy(balances_updated=True)
+
+    def fake_post(url, headers=None, data=None, **kwargs):
+        return _Response()
+
+    monkeypatch.setattr("lumibot.strategies._strategy.requests.post", fake_post)
+
+    result = _Strategy.send_update_to_cloud(strategy)
+
+    assert result is not False
+    debug_text = "\n".join(strategy.logger.debug_messages)
+    assert "test-api-key" not in debug_text
+    assert "'x-api-key': '<redacted>'" in debug_text
 
 
 def test_cloud_update_omits_positions_when_position_refresh_fails(monkeypatch):

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -139,6 +139,47 @@ class TestTradierBroker:
 
         assert broker._tradier_access_token == "new-access"
 
+    def test_oauth_refreshes_on_startup_when_expiry_metadata_missing(self, monkeypatch):
+        token_json = {
+            "access_token": "old-access",
+            "refresh_token": "oauth-refresh",
+        }
+        monkeypatch.setenv("TRADIER_TOKEN", self._b64url(token_json))
+        monkeypatch.setenv("TRADIER_REFRESH_TOKEN", "oauth-refresh")
+        monkeypatch.setenv("TRADIER_OAUTH_CLIENT_ID", "cid")
+        monkeypatch.setenv("TRADIER_OAUTH_CLIENT_SECRET", "secret")
+
+        class _Resp:
+            ok = True
+            status_code = 200
+            text = ""
+
+            def json(self):
+                return {
+                    "access_token": "new-access",
+                    "expires_in": 86400,
+                    "issued_at": int(time.time() * 1000),
+                }
+
+        from lumibot.brokers import tradier as tradier_module
+
+        calls = []
+
+        def _fake_post(*args, **kwargs):
+            calls.append((args, kwargs))
+            return _Resp()
+
+        monkeypatch.setattr(tradier_module.requests, "post", _fake_post)
+
+        broker = Tradier(
+            config={"ACCESS_TOKEN": None, "ACCOUNT_NUMBER": "1234", "PAPER": True},
+            connect_stream=False,
+        )
+
+        assert calls
+        assert broker._tradier_access_token == "new-access"
+        assert broker._oauth_token_expires_at is not None
+
     def test_modify_order(self, mocker):
         broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True, connect_stream=False)
         mock_modify = mocker.patch.object(broker.tradier.orders, "modify")

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -139,46 +139,31 @@ class TestTradierBroker:
 
         assert broker._tradier_access_token == "new-access"
 
-    def test_oauth_refreshes_on_startup_when_expiry_metadata_missing(self, monkeypatch):
+    def test_oauth_defaults_expiry_when_issued_at_missing(self, monkeypatch):
         token_json = {
             "access_token": "old-access",
             "refresh_token": "oauth-refresh",
         }
         monkeypatch.setenv("TRADIER_TOKEN", self._b64url(token_json))
-        monkeypatch.setenv("TRADIER_REFRESH_TOKEN", "oauth-refresh")
-        monkeypatch.setenv("TRADIER_OAUTH_CLIENT_ID", "cid")
-        monkeypatch.setenv("TRADIER_OAUTH_CLIENT_SECRET", "secret")
-
-        class _Resp:
-            ok = True
-            status_code = 200
-            text = ""
-
-            def json(self):
-                return {
-                    "access_token": "new-access",
-                    "expires_in": 86400,
-                    "issued_at": int(time.time() * 1000),
-                }
-
         from lumibot.brokers import tradier as tradier_module
 
         calls = []
 
         def _fake_post(*args, **kwargs):
             calls.append((args, kwargs))
-            return _Resp()
+            raise AssertionError("OAuth token should not refresh immediately when best-effort expiry is seeded")
 
         monkeypatch.setattr(tradier_module.requests, "post", _fake_post)
 
+        before = time.time()
         broker = Tradier(
             config={"ACCESS_TOKEN": None, "ACCOUNT_NUMBER": "1234", "PAPER": True},
             connect_stream=False,
         )
 
-        assert calls
-        assert broker._tradier_access_token == "new-access"
-        assert broker._oauth_token_expires_at is not None
+        assert calls == []
+        assert broker._tradier_access_token == "old-access"
+        assert before + 86300 <= broker._oauth_token_expires_at <= time.time() + 86500
 
     def test_modify_order(self, mocker):
         broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True, connect_stream=False)

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -139,6 +139,50 @@ class TestTradierBroker:
 
         assert broker._tradier_access_token == "new-access"
 
+    def test_oauth_refresh_writes_rotation_handoff_file(self, monkeypatch, tmp_path):
+        token_json = {
+            "access_token": "old-access",
+            "refresh_token": "oauth-refresh",
+            "expires_in": 1,
+            "issued_at": int((time.time() - 3600) * 1000),
+        }
+        rotation_path = tmp_path / "tradier-token-rotation.json"
+        monkeypatch.setenv("TRADIER_TOKEN", self._b64url(token_json))
+        monkeypatch.setenv("TRADIER_REFRESH_TOKEN", "oauth-refresh")
+        monkeypatch.setenv("TRADIER_OAUTH_CLIENT_ID", "cid")
+        monkeypatch.setenv("TRADIER_OAUTH_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("BOTSPOT_TRADIER_TOKEN_ROTATION_PATH", str(rotation_path))
+
+        class _Resp:
+            ok = True
+            status_code = 200
+            text = ""
+
+            def json(self):
+                return {
+                    "access_token": "new-access",
+                    "refresh_token": "new-refresh",
+                    "expires_in": 86400,
+                    "issued_at": int(time.time() * 1000),
+                }
+
+        from lumibot.brokers import tradier as tradier_module
+
+        monkeypatch.setattr(tradier_module.requests, "post", lambda *_args, **_kwargs: _Resp())
+
+        broker = Tradier(
+            config={"ACCESS_TOKEN": None, "ACCOUNT_NUMBER": "1234", "PAPER": True},
+            connect_stream=False,
+        )
+
+        assert broker._tradier_access_token == "new-access"
+        handoff = json.loads(rotation_path.read_text(encoding="utf-8"))
+        assert handoff == {
+            "TRADIER_ACCESS_TOKEN": "new-access",
+            "TRADIER_REFRESH_TOKEN": "new-refresh",
+        }
+        assert oct(rotation_path.stat().st_mode & 0o777) == "0o600"
+
     def test_oauth_defaults_expiry_when_issued_at_missing(self, monkeypatch):
         token_json = {
             "access_token": "old-access",


### PR DESCRIPTION
## Summary
- Prefer BotSpot scheduled Schwab runtime payloads for the current invocation, while preserving refreshed local token files for persistent deployments.
- Write Schwab token files atomically with private permissions, preserve refresh-token metadata, and avoid deleting token files on transient client initialization failures.
- Refresh Tradier OAuth payloads when expiry metadata is missing and document scheduled credential ownership for Schwab and Tradier.

## Tests
- `.venv/bin/python -m pytest -m "not apitest and not downloader" --tb=short -q tests/test_broker_initialization.py tests/test_tradier.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced Schwab docs with clearer token lifecycle and environment-specific guidance
  * Added Tradier token lifetime notes and BotSpot handoff documentation
  * Documented BotSpot token-rotation path environment variable

* **Improvements**
  * More robust OAuth expiry/refresh handling and deterministic token selection for scheduled runs
  * Safer token persistence with atomic writes and restricted permissions
  * Redacted sensitive headers in cloud update logging

* **Tests**
  * Expanded Schwab initialization tests and added Tradier rotation/expiry tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1057?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->