### PR TITLE
Release LumiBot 4.5.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.5.31 - Unreleased
 
+### Changed
+- **AI Investment Committee example now supports explicit cash parking.** The example keeps growth equities and defensive cash-parking ETFs separate, defaults cash-parking symbols to `SGOV`, `BIL`, and `SHV`, and asks the Portfolio Manager to consider short-duration Treasury/cash ETFs when no growth-equity candidate clears the risk/reward bar.
+
 ## 4.5.30 - Unreleased
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.31 - Unreleased
+
 ## 4.5.30 - Unreleased
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.31 - Unreleased
+## 4.5.31 - 2026-05-23
+
+Deploy marker: 4.5.31 release commit (`deploy 4.5.31`)
 
 ### Changed
 - **AI Investment Committee example now supports explicit cash parking.** The example keeps growth equities and defensive cash-parking ETFs separate, defaults cash-parking symbols to `SGOV`, `BIL`, and `SHV`, and asks the Portfolio Manager to consider short-duration Treasury/cash ETFs when no growth-equity candidate clears the risk/reward bar.
@@ -8,6 +10,9 @@
 ### Fixed
 - **Live broker position sync now refreshes broker mark fields on existing positions.** When a broker refresh updates an already-tracked asset, Lumibot now copies current price, market value, P&L, side, and related broker fields instead of only updating quantity, preventing impossible BotSpot position snapshots such as hundreds of shares with a stale two-share market value.
 - **Live FRED macro requests no longer use tomorrow's real-time date after UTC midnight.** Default FRED/ALFRED requests clamp the live as-of date to FRED's current Central-time date, preventing after-hours agents from receiving 400 errors while preserving explicit historical `as_of` backtest requests.
+
+### Operations
+- **AI committee benchmark notes now record the context-budget follow-up plan.** The investigation doc captures the recommended runtime input-budget layer, affected provider context limits, and the rerun sequence after context-failure review.
 
 ## 4.5.30 - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - **Live broker position sync now refreshes broker mark fields on existing positions.** When a broker refresh updates an already-tracked asset, Lumibot now copies current price, market value, P&L, side, and related broker fields instead of only updating quantity, preventing impossible BotSpot position snapshots such as hundreds of shares with a stale two-share market value.
+- **Live FRED macro requests no longer use tomorrow's real-time date after UTC midnight.** Default FRED/ALFRED requests clamp the live as-of date to FRED's current Central-time date, preventing after-hours agents from receiving 400 errors while preserving explicit historical `as_of` backtest requests.
 
 ## 4.5.30 - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - **AI Investment Committee example now supports explicit cash parking.** The example keeps growth equities and defensive cash-parking ETFs separate, defaults cash-parking symbols to `SGOV`, `BIL`, and `SHV`, and asks the Portfolio Manager to consider short-duration Treasury/cash ETFs when no growth-equity candidate clears the risk/reward bar.
 
+### Fixed
+- **Live broker position sync now refreshes broker mark fields on existing positions.** When a broker refresh updates an already-tracked asset, Lumibot now copies current price, market value, P&L, side, and related broker fields instead of only updating quantity, preventing impossible BotSpot position snapshots such as hundreds of shares with a stale two-share market value.
+
 ## 4.5.30 - Unreleased
 
 ### Changed

--- a/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
+++ b/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
@@ -838,3 +838,101 @@ Next required fix before another full paid slate:
   This should be structured evidence, narrower tool outputs, and/or provider
   aware compact research modes, not hidden middle truncation or tool-call
   blocking.
+
+## Follow-Up Plan After Context-Failure Review: 2026-05-22
+
+Scope: Rob explicitly rejected globally smaller tool outputs and rejected
+changing the AI committee prompt for the next fair benchmark. The least
+destructive fix is therefore model-input budgeting at the runtime boundary, not
+tool-output rewriting and not benchmark-specific prompt changes.
+
+Light cost audit:
+
+- The OpenAI dashboard screenshot for `2026-05-22` showed about `$9.68` of
+  BotSpot project spend for the day. That is consistent with the artifact
+  estimates once cached input pricing is considered.
+- The `20260522` OpenAI benchmark artifacts estimate about `$0.120560`
+  cache-adjusted for the one-day smoke, `$1.476303` cache-adjusted for the
+  14-day qualifier, and `$6.736714` cache-adjusted for the three-month run.
+  That totals about `$8.33` for the visible OpenAI benchmark legs before any
+  tiny preflights and unrelated BotSpot OpenAI traffic.
+- Conclusion: the cache-adjusted estimate is probably the useful number for
+  OpenAI spend planning. The no-cache number is a worst-case stress estimate,
+  not what the dashboard appears to be charging for these repeated prompts.
+
+Provider facts checked from official docs:
+
+- OpenAI pricing currently lists `gpt-5.4-mini` at `$0.75/M` input,
+  `$0.075/M` cached input, and `$4.50/M` output.
+- Google Gemini docs list `gemini-3-flash-preview` at a `1M / 64k` context and
+  `$0.50/M` input, `$0.05/M` cached input, and `$3/M` output. The docs did not
+  expose a clearly named `gemini-3.5-flash` API pricing row in the pages checked
+  during this pass, so any `gemini-3.5-flash` long-run decision should be
+  validated against the actual billing page or a fresh 7-day usage sample.
+- DeepSeek official docs list `deepseek-v4-flash` and `deepseek-v4-pro` at
+  `1M` context, max `384K` output, JSON output support, and tool-call support.
+  The official CNY prices are much cheaper than Gemini/OpenAI for Flash.
+- Together official serverless docs list
+  `Qwen/Qwen3-235B-A22B-Instruct-2507-tput` at `262144` context,
+  `$0.20/M` input, `$0.60/M` output, no cached input price, function calling
+  yes, and structured outputs yes.
+
+Recommended context fix:
+
+1. Add a runtime input-budget layer before the ADK call, inside the path that
+   builds the user message. Preserve the Lumibot base system prompt, strategy
+   system prompt, tool declarations, and task instructions.
+2. Estimate tokens for `instruction + user/context` using a cheap estimator
+   such as `tiktoken` when available and a conservative fallback otherwise.
+   Reserve room for output, tool schemas, ADK overhead, and tokenizer error.
+3. Resolve a model context limit from a small model registry seeded from
+   provider docs, with a user override for unknown/new models. Known current
+   limits needed for this benchmark: Qwen throughput `262144`, DeepSeek V4
+   Flash `1048576`, OpenAI GPT-5.4 Mini `400000`, Gemini Flash-family `1M`.
+4. If the request is within budget, do nothing. OpenAI/Gemini/good models keep
+   the full context.
+5. If the request is over budget, compact only the variable input sections:
+   runtime context extras, persistent memory notes, and oversized values inside
+   `User Context JSON` such as prior committee handoffs. Do not cut the base
+   prompt, strategy prompt, task text, or tool list.
+6. Keep JSON valid by truncating individual large string values before
+   `json.dumps`, not by slicing the final JSON text in the middle. Include
+   explicit metadata such as `truncated_for_model_context`, original estimated
+   tokens, target tokens, and affected context paths.
+7. Emit an artifact/log warning whenever this happens. It should be observable
+   and auditable, not hidden.
+
+This should be a general Lumibot agent-runtime feature, not an AI committee
+special case. It fixes the guaranteed provider rejection path while avoiding a
+global reduction in tool outputs for stronger models.
+
+Benchmark sequence after that fix:
+
+1. Unit tests for the input-budget layer: system prompt preserved, tool list
+   preserved, JSON remains valid, warning emitted, and no truncation below the
+   limit.
+2. One-day reruns only for the broken/affected models first:
+   `deepseek/deepseek-v4-flash` and
+   `together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput`.
+3. One cheap one-day OpenAI control run only if the input-budget code path is
+   shared enough that regression risk is real.
+4. Seven-day qualifier instead of 14 days for the next paid ladder. Use it to
+   estimate tokens, cost, wall time, tool discipline, and whether the model
+   trades or defensibly parks cash.
+5. Three-month finalist runs only after the 7-day qualifier passes. Do not
+   rerun the three-month OpenAI baseline unless the runtime change materially
+   changes OpenAI inputs.
+6. Keep Kimi K2.6 out of the immediate ladder until budget is explicitly
+   approved. Keep Cerebras out until the account `Payment required` block is
+   resolved.
+
+Prompt-control API follow-up:
+
+- Current Lumibot code lets users pass `system_prompt`/`prompt` to
+  `self.agents.create`, but the Lumibot base system prompt is always prepended.
+  Docs explain that the user prompt can override the default investor style, but
+  they do not document a supported way to remove or replace the base prompt.
+- A future API should expose this deliberately, for example
+  `base_prompt="default" | "minimal" | "none"` or
+  `include_lumibot_base_prompt=False`, with clear docs about the risks of
+  removing backtest safety and execution guidance.

--- a/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
+++ b/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
@@ -728,3 +728,113 @@ reason for no trade.
 Do not include Kimi K2.6 in the immediate run because of Together budget risk.
 Run preflight, one-day smoke, 14-day qualifier, and then the three-month
 benchmark for the affordable/current slate only.
+
+## Cash-Parking Benchmark Run Results: 2026-05-22
+
+Code checkpoint:
+
+- Commit `b4c6d4de` added explicit cash-parking support to the AI Investment
+  Committee example.
+- Focused tests passed:
+  `/Users/robertgrzesik/Development/bin/safe-timeout 300s .venv/bin/python -m pytest tests/test_ai_investment_committee_example.py tests/test_agent_runtime_provider_keys.py`.
+
+Provider preflight:
+
+- `deepseek/deepseek-v4-flash`: tiny provider call passed.
+- `deepseek/deepseek-v4-pro`: tiny provider call passed, but the one-day smoke
+  was too slow/expensive for the immediate long slate.
+- `together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput`: tiny provider call
+  passed and emitted a tool call.
+- `cerebras/gpt-oss-120b`: blocked by Cerebras `Payment required`.
+- `cerebras/zai-glm-4.7`: blocked by Cerebras `Payment required`.
+
+One-day smoke root:
+`/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260522_022521`.
+
+One-day smoke results:
+
+- `openai/gpt-5.4-mini`: passed. Wall time `86.5s`; calls `4`; tool calls
+  `109`; estimated cost `$0.243075` no-cache / `$0.120560`
+  cache-adjusted. Stayed in cash.
+- `gemini-3.5-flash`: passed. Wall time `574.8s`; calls `4`; tool calls
+  `124`; estimated cost `$4.515954` no-cache / `$2.075280`
+  cache-adjusted. Bought `5` MSFT and `3` META, return `+0.0774%`.
+- `deepseek/deepseek-v4-flash`: passed. Wall time `416.9s`; calls `4`;
+  tool calls `157`; estimated cost `$0.255643` no-cache / `$0.042076`
+  cache-adjusted. Bought `99` SGOV, return `-0.1095%`.
+- `deepseek/deepseek-v4-pro`: passed. Wall time `1262.0s`; calls `4`; tool
+  calls `136`; estimated cost `$1.533062` no-cache / `$0.381919`
+  cache-adjusted. Stayed in cash. Excluded from longer runs because it was
+  much slower and more expensive than Flash without a better one-day result.
+- `together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput`: passed. Wall time
+  `119.0s`; calls `4`; tool calls `79`; estimated cost `$0.063686`. Stayed in
+  cash.
+
+14-day qualifier roots:
+
+- OpenAI, DeepSeek, Qwen:
+  `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260522_030741`.
+- Gemini:
+  `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260522_032215`.
+
+14-day qualifier results:
+
+- `openai/gpt-5.4-mini`: passed. Wall time `768.5s`; calls `52`; tool calls
+  `1244`; estimated cost `$3.163435` no-cache / `$1.476303`
+  cache-adjusted. Return `-0.9592%`; max drawdown `1.034%`; final positions
+  included `99` SGOV and `4` GOOGL, but the final USD cash position was
+  negative. This exposed that prompt-only risk controls are not enough.
+- `gemini-3.5-flash`: passed but was operationally poor. Wall time `5454.9s`
+  (`90.9m`); calls `52`; tool calls `1579`; estimated cost `$48.208215`
+  no-cache / `$17.093065` cache-adjusted. Return `-1.1493%`; max drawdown
+  `1.538%`; final positions included AAPL plus SGOV/BIL/SHV. Do not run a
+  three-month Gemini benchmark until the committee workload is made cheaper and
+  faster.
+- `together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput`: failed with
+  `ContextWindowExceededError`. Together rejected an input of about
+  `2,986,192` tokens against the model's `262,144` context window. Partial raw
+  traces before failure: calls `7`; tool calls `143`; prompt tokens
+  `1,336,749`; output tokens `10,388`.
+- `deepseek/deepseek-v4-flash`: failed with `ContextWindowExceededError`.
+  DeepSeek rejected an input of about `2,052,201` tokens against the model's
+  `1,048,576` context window. Partial raw traces before failure: calls `42`;
+  tool calls `1412`; prompt tokens `15,678,494`; output tokens `340,125`;
+  cached input tokens `13,932,928`. DeepSeek also hallucinated
+  `get_spy_indicators`, which is not an available tool name.
+
+Three-month benchmark root:
+`/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260522_034259`.
+
+Three-month result:
+
+- `openai/gpt-5.4-mini`: passed mechanically over `2026-01-02` through
+  `2026-04-02` with `--max-model-calls 320`. Wall time `3432.8s` (`57.2m`);
+  calls `248`; tool calls `5320`; input tokens `15,566,873`; output tokens
+  `452,604`; cached input tokens `10,333,568`; estimated cost `$13.711873`
+  no-cache / `$6.736714` cache-adjusted. Return `-28.672%`; max drawdown
+  `30.908%`; Sharpe `-2.1924`.
+
+Critical interpretation:
+
+- The cash-parking prompt worked mechanically: DeepSeek Flash bought SGOV in
+  the one-day smoke, and Gemini bought SGOV/BIL/SHV in the 14-day qualifier.
+- The current committee is still not safe enough as an autonomous trading
+  example because the OpenAI long runs ended with negative USD cash despite the
+  prompt risk limits. The benchmark caught a real issue: the example needs
+  code-level order/risk validation, not just system-prompt instructions.
+- Qwen and direct DeepSeek Flash cannot be taken to three months with the
+  current committee/tool payload shape. Their provider keys and one-day tool
+  paths work, but multi-day committee context exceeds model limits.
+- Gemini can complete 14 days, but its observed 14-day cost and wall time make
+  a three-month run irresponsible until the workload is reduced.
+- Cerebras remains blocked by account billing, not by the Lumibot integration.
+
+Next required fix before another full paid slate:
+
+- Add code-level order validation to the AI Investment Committee example so the
+  Portfolio Manager cannot exceed available cash, max position size, or the
+  maximum number of new positions merely because the prompt asked it not to.
+- Redesign the committee context/tool payload shape for smaller-context models.
+  This should be structured evidence, narrower tool outputs, and/or provider
+  aware compact research modes, not hidden middle truncation or tool-call
+  blocking.

--- a/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
+++ b/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
@@ -704,3 +704,27 @@ Additional one-day provider checks:
   final decision was no trade. Treat it as mechanically compatible and cheap,
   but weaker than Qwen/OpenAI for this committee because the later committee
   roles did not independently verify the handoff.
+
+## Cash-Parking Benchmark Update: 2026-05-22
+
+The next benchmark should not treat "stay entirely in cash" as the only
+conservative action. The AI Investment Committee example now exposes
+`cash_parking_symbols`, defaulting to `SGOV`, `BIL`, and `SHV`, separately from
+the growth-equity universe. The Evidence Researcher is instructed to review
+those symbols as short-duration Treasury/cash ETF alternatives using price,
+volatility, drawdown/trend, and macro/rate context rather than corporate SEC
+fundamental analysis. The Portfolio Manager may trade only
+`context.tradable_symbols`, with growth-equity trades coming from
+`context.universe` and defensive cash-parking trades coming from
+`context.cash_parking_symbols`.
+
+This is an explicit example feature, not a hidden benchmark guardrail. A model
+can still decide to do nothing, but it should now explain why both the growth
+case and the cash-parking case are weak, unavailable, or outside risk limits.
+The next model-comparison slate should inspect whether each model either buys a
+reasonable growth candidate, parks cash defensively, or gives a defensible
+reason for no trade.
+
+Do not include Kimi K2.6 in the immediate run because of Together budget risk.
+Run preflight, one-day smoke, 14-day qualifier, and then the three-month
+benchmark for the affordable/current slate only.

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -857,9 +857,7 @@ class Broker(ABC):
             position_lumi = position_lumi[0] if len(position_lumi) > 0 else None
 
             if position_lumi:
-                # Compare to existing lumi position.
-                if position_lumi.quantity != position.quantity:
-                    position_lumi.quantity = position.quantity
+                self._sync_position_fields_from_broker(position_lumi, position)
 
                 # No current brokers have any way to distinguish between strategies for an open position.
                 # Therefore, we will just update the strategy to the current strategy.
@@ -867,7 +865,10 @@ class Broker(ABC):
                 # can create ones that have no strategy attached. This will ensure that all stored positions have a
                 # strategy with subsequent updates.
                 if strategy:
-                    position_lumi.strategy = strategy.name if not isinstance(strategy, str) else strategy
+                    strategy_name = strategy.name if not isinstance(strategy, str) else strategy
+                    if position_lumi.strategy != strategy_name:
+                        position_lumi.strategy = strategy_name
+                        self._filled_positions.revision += 1
             else:
                 # Add to positions in lumibot, position does not exist
                 # in lumibot.
@@ -884,6 +885,46 @@ class Broker(ABC):
                     break
             if not found and (position.asset not in self.quote_assets):
                 self._filled_positions.remove(position)
+
+    def _sync_position_fields_from_broker(self, position_lumi, position_broker):
+        """
+        Refresh an existing tracked position from a broker-sourced position.
+
+        Broker adapters attach mark data such as current_price, market_value,
+        and pnl to the Position object. When the same asset already exists in
+        the local tracker, copying only quantity leaves stale mark fields next
+        to the fresh broker quantity. That produces impossible cloud snapshots
+        like 744 shares with a two-share market value.
+        """
+        changed = False
+        broker_fields = (
+            "quantity",
+            "avg_fill_price",
+            "current_price",
+            "market_value",
+            "pnl",
+            "pnl_percent",
+            "side",
+            "available",
+            "hold",
+            "asset_type",
+            "exchange",
+            "currency",
+            "multiplier",
+        )
+
+        for field in broker_fields:
+            if hasattr(position_broker, field):
+                new_value = getattr(position_broker, field)
+                if getattr(position_lumi, field, None) != new_value:
+                    setattr(position_lumi, field, new_value)
+                    changed = True
+            elif hasattr(position_lumi, field) and field not in {"quantity", "avg_fill_price", "available", "hold"}:
+                delattr(position_lumi, field)
+                changed = True
+
+        if changed:
+            self._filled_positions.revision += 1
 
     # =========Market functions=======================
 

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -1944,7 +1944,7 @@ class Schwab(Broker):
             if key in tracked_dict:
                 # Update existing position
                 tracked_position = tracked_dict[key]
-                tracked_position.quantity = position.quantity
+                self._sync_position_fields_from_broker(tracked_position, position)
             else:
                 # Add new position
                 self._filled_positions.append(position)

--- a/lumibot/example_strategies/ai_investment_committee.py
+++ b/lumibot/example_strategies/ai_investment_committee.py
@@ -35,6 +35,7 @@ from lumibot.strategies.strategy import Strategy
 
 
 DEFAULT_UNIVERSE = ["AAPL", "MSFT", "NVDA", "AMZN", "META", "GOOGL", "TSLA", "SPY", "QQQ"]
+DEFAULT_CASH_PARKING_SYMBOLS = ["SGOV", "BIL", "SHV"]
 DEFAULT_HANDOFF_TARGET_TOKENS = 24000
 
 
@@ -45,6 +46,7 @@ def _prepare_handoff_text(value) -> str:
 class AIInvestmentCommitteeStrategy(Strategy):
     parameters = {
         "universe": DEFAULT_UNIVERSE,
+        "cash_parking_symbols": DEFAULT_CASH_PARKING_SYMBOLS,
         "max_position_pct": 0.20,
         "max_new_positions_per_run": 2,
         "handoff_target_tokens": DEFAULT_HANDOFF_TARGET_TOKENS,
@@ -93,8 +95,12 @@ class AIInvestmentCommitteeStrategy(Strategy):
 
     def on_trading_iteration(self):
         universe = list(self.parameters.get("universe") or DEFAULT_UNIVERSE)
+        cash_parking_symbols = list(self.parameters.get("cash_parking_symbols") or [])
+        tradable_symbols = list(dict.fromkeys([*universe, *cash_parking_symbols]))
         context = {
             "universe": universe,
+            "cash_parking_symbols": cash_parking_symbols,
+            "tradable_symbols": tradable_symbols,
             "max_position_pct": self.parameters.get("max_position_pct", 0.20),
             "max_new_positions_per_run": self.parameters.get("max_new_positions_per_run", 2),
             "handoff_target_tokens": self.parameters.get("handoff_target_tokens", DEFAULT_HANDOFF_TARGET_TOKENS),
@@ -105,7 +111,9 @@ class AIInvestmentCommitteeStrategy(Strategy):
             task_prompt=(
                 "Build the evidence pack for today's committee. Start with the full universe, "
                 "then focus deeply on the best long-only candidates. Use SEC fundamentals, SEC filings, "
-                "news, market data, indicators, and FRED macro data only if FRED tools are available before handing off."
+                "news, market data, indicators, and FRED macro data only if FRED tools are available. "
+                "Also review context.cash_parking_symbols as low-risk cash-parking alternatives, using price, "
+                "volatility, and trend data rather than corporate SEC fundamentals for those ETFs."
             ),
             context=context,
         )
@@ -130,8 +138,10 @@ class AIInvestmentCommitteeStrategy(Strategy):
         decision = self.agents["portfolio_manager"].run(
             task_prompt=(
                 "Make the final long-only portfolio decision. Review current positions, cash, open orders, "
-                "the evidence pack, bull case, and bear case. Trade only symbols in context.universe. Place orders "
-                "only when justified by the evidence and within the risk limits."
+                "the evidence pack, bull case, and bear case. Trade only symbols in context.tradable_symbols. "
+                "If no growth-equity candidate clears the risk/reward bar, consider parking idle cash in a "
+                "short-duration Treasury or cash ETF from context.cash_parking_symbols. Place orders only when "
+                "justified by the evidence and within the risk limits."
             ),
             context={
                 **context,
@@ -158,7 +168,8 @@ For each candidate symbol, gather:
 4. SEC fundamentals using get_income_statement, get_balance_sheet, get_cash_flow, and get_company_facts.
 5. SEC filings using get_filings. For promising or risky names, use search_filing for risks, margins, debt, liquidity, customers, accounting changes, buybacks, dilution, and management commentary.
 6. Macro context using list_fred_series, get_fred_snapshot, and get_fred_latest only when those tools are available for rates, inflation, labor, growth, liquidity, credit spreads, and market risk when relevant.
-7. Any additional read-only tools needed to reduce uncertainty.
+7. Cash-parking context for context.cash_parking_symbols. Treat these as short-duration Treasury/cash ETF alternatives for idle cash; use price, volatility, drawdown/trend, and macro/rate context. Do not run corporate SEC fundamental analysis on cash-parking ETFs.
+8. Any additional read-only tools needed to reduce uncertainty.
 
 Tool discipline:
 - Do not call every tool for every symbol. Screen broadly first, then investigate only the most promising or risky candidates.
@@ -228,10 +239,11 @@ You may place real Lumibot orders, but only within the strategy risk limits. Bef
 1. Check current portfolio, positions, open orders, and prices.
 2. Review the evidence pack, bull case, and bear case.
 3. Respect max_position_pct and max_new_positions_per_run from context.
-4. Trade only symbols in context.universe. Do not buy defensive cash ETFs, alternative symbols, or assets outside the reviewed universe unless the user added them to the universe.
+4. Trade only symbols in context.tradable_symbols. Growth-equity trades must come from context.universe. Defensive cash-parking trades must come from context.cash_parking_symbols.
 5. Do not short. Do not use options in this v1 committee example.
-6. Prefer doing nothing when evidence is weak or contradictory.
-7. If you trade, use remember_decision and optionally notify_user.
+6. If no growth-equity candidate clears the risk/reward bar, consider parking idle cash in a short-duration Treasury or cash ETF from context.cash_parking_symbols instead of leaving all capital idle.
+7. Prefer doing nothing only when both the growth-equity case and the cash-parking case are weak, unavailable, or outside risk limits.
+8. If you trade, use remember_decision and optionally notify_user.
 
 Prefer portfolio/order/price checks over new research. Do not reopen the full research process.
 

--- a/lumibot/macro/fred.py
+++ b/lumibot/macro/fred.py
@@ -6,11 +6,13 @@ import time
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import requests
 
 
 FRED_API_BASE_URL = "https://api.stlouisfed.org/fred"
+FRED_REALTIME_TIMEZONE = ZoneInfo("America/Chicago")
 
 
 CURATED_FRED_SERIES: dict[str, dict[str, str]] = {
@@ -63,6 +65,10 @@ def _date_text(value: Any | None) -> str | None:
     return parsed.date().isoformat()
 
 
+def _fred_realtime_today() -> date:
+    return datetime.now(FRED_REALTIME_TIMEZONE).date()
+
+
 def _safe_float(value: Any) -> float | None:
     text = str(value or "").strip()
     if not text or text == ".":
@@ -107,6 +113,13 @@ class FREDMacroData:
             except Exception:
                 pass
         return datetime.now(timezone.utc)
+
+    def _effective_as_of_date(self, as_of: Any | None) -> date:
+        as_of_dt = _as_of_datetime(as_of) if as_of is not None else self._strategy_as_of()
+        as_of_date = as_of_dt.date()
+        if as_of is None:
+            as_of_date = min(as_of_date, _fred_realtime_today())
+        return as_of_date
 
     def _cache_path(self, *parts: str) -> Path:
         safe = [re.sub(r"[^A-Za-z0-9_.=-]+", "_", str(part)).strip("_") for part in parts]
@@ -158,8 +171,7 @@ class FREDMacroData:
         series = str(series_id or "").strip().upper()
         if not series:
             raise ValueError("series_id is required.")
-        as_of_dt = _as_of_datetime(as_of) if as_of is not None else self._strategy_as_of()
-        as_of_date = as_of_dt.date()
+        as_of_date = self._effective_as_of_date(as_of)
         start_text = _date_text(start)
         end_text = _date_text(end)
         if end_text is None or date.fromisoformat(end_text) > as_of_date:
@@ -190,8 +202,7 @@ class FREDMacroData:
                 values[series_id.upper()] = self.get_latest(series_id, as_of=as_of)["latest"]
             except Exception as exc:
                 errors[series_id.upper()] = str(exc)
-        as_of_dt = _as_of_datetime(as_of) if as_of is not None else self._strategy_as_of()
-        return {"source": "fred", "as_of": as_of_dt.isoformat(), "values": values, "errors": errors}
+        return {"source": "fred", "as_of": self._effective_as_of_date(as_of).isoformat(), "values": values, "errors": errors}
 
     def _get_series_from_api(
         self,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.30",
+    version="4.5.31",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_ai_investment_committee_example.py
+++ b/tests/test_ai_investment_committee_example.py
@@ -1,5 +1,6 @@
 from lumibot.example_strategies.ai_investment_committee import (
     AIInvestmentCommitteeStrategy,
+    DEFAULT_CASH_PARKING_SYMBOLS,
     _prepare_handoff_text,
 )
 
@@ -17,7 +18,19 @@ def test_ai_committee_example_exposes_expected_risk_controls():
     assert AIInvestmentCommitteeStrategy.parameters["max_position_pct"] == 0.20
     assert AIInvestmentCommitteeStrategy.parameters["max_new_positions_per_run"] == 2
     assert AIInvestmentCommitteeStrategy.parameters["handoff_target_tokens"] == 24000
+    assert AIInvestmentCommitteeStrategy.parameters["cash_parking_symbols"] == DEFAULT_CASH_PARKING_SYMBOLS
     assert AIInvestmentCommitteeStrategy.parameters["enable_notifications"] is False
+
+
+def test_ai_committee_prompt_allows_cash_parking_without_expanding_growth_universe():
+    evidence_prompt = AIInvestmentCommitteeStrategy._evidence_researcher_prompt(object())
+    portfolio_prompt = AIInvestmentCommitteeStrategy._portfolio_manager_prompt(object())
+
+    assert "context.cash_parking_symbols" in evidence_prompt
+    assert "Do not run corporate SEC fundamental analysis on cash-parking ETFs" in evidence_prompt
+    assert "context.tradable_symbols" in portfolio_prompt
+    assert "Growth-equity trades must come from context.universe" in portfolio_prompt
+    assert "Defensive cash-parking trades must come from context.cash_parking_symbols" in portfolio_prompt
 
 
 def test_ai_committee_handoff_text_is_not_truncated():

--- a/tests/test_broker_sync_positions.py
+++ b/tests/test_broker_sync_positions.py
@@ -1,0 +1,92 @@
+from lumibot.brokers.broker import Broker
+from lumibot.entities import Asset, Position
+
+
+class _BrokerForSyncTest(Broker):
+    def __init__(self, broker_positions):
+        super().__init__(name="sync-test", data_source=object())
+        self._broker_positions = broker_positions
+
+    def cancel_order(self, order):
+        pass
+
+    def _modify_order(self, order, limit_price=None, stop_price=None):
+        pass
+
+    def _submit_order(self, order):
+        return order
+
+    def _get_balances_at_broker(self, quote_asset, strategy):
+        return (1000.0, 0.0, 1000.0)
+
+    def get_historical_account_value(self):
+        return {}
+
+    def _get_stream_object(self):
+        return None
+
+    def _register_stream_events(self):
+        pass
+
+    def _run_stream(self):
+        pass
+
+    def _pull_positions(self, strategy):
+        return self._broker_positions
+
+    def _pull_position(self, strategy, asset):
+        return None
+
+    def _pull_broker_order(self, identifier):
+        return None
+
+    def _pull_broker_all_orders(self):
+        return []
+
+    def _parse_broker_order(self, response, strategy_name, strategy_object=None):
+        return None
+
+
+class _Strategy:
+    name = "strategy"
+
+
+def _stock_position(quantity, current_price, market_value, pnl):
+    asset = Asset("NVDA")
+    position = Position("strategy", asset, quantity, avg_fill_price=219.78)
+    position.current_price = current_price
+    position.market_value = market_value
+    position.pnl = pnl
+    return position
+
+
+def test_sync_positions_refreshes_broker_mark_fields_for_existing_position():
+    existing = _stock_position(quantity=744, current_price=219.6201, market_value=439.2402, pnl=-0.3198)
+    broker_fresh = _stock_position(quantity=744, current_price=219.6201, market_value=163397.3544, pnl=-118.9656)
+    broker = _BrokerForSyncTest([broker_fresh])
+    broker._filled_positions.append(existing)
+    revision_before = broker._filled_positions.revision
+
+    broker.sync_positions(_Strategy())
+
+    synced = broker._filled_positions.get_list()[0]
+    assert synced.quantity == 744
+    assert synced.current_price == 219.6201
+    assert synced.market_value == 163397.3544
+    assert synced.pnl == -118.9656
+    assert broker._filled_positions.revision > revision_before
+
+
+def test_sync_positions_clears_stale_mark_fields_missing_from_broker_position():
+    existing = _stock_position(quantity=10, current_price=150.0, market_value=1500.0, pnl=25.0)
+    broker_fresh = Position("strategy", Asset("NVDA"), 10, avg_fill_price=149.0)
+    broker = _BrokerForSyncTest([broker_fresh])
+    broker._filled_positions.append(existing)
+
+    broker.sync_positions(_Strategy())
+
+    synced = broker._filled_positions.get_list()[0]
+    assert synced.quantity == 10
+    assert not hasattr(synced, "current_price")
+    assert not hasattr(synced, "market_value")
+    assert not hasattr(synced, "pnl")

--- a/tests/test_fred_macro.py
+++ b/tests/test_fred_macro.py
@@ -1,5 +1,6 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
+import lumibot.macro.fred as fred_module
 from lumibot.macro import FREDMacroData
 
 
@@ -65,6 +66,37 @@ def test_fred_api_mode_uses_vintage_params_and_filters_future_observations(monke
     assert params["realtime_start"] == "2025-01-15"
     assert params["realtime_end"] == "2025-01-15"
     assert params["observation_end"] == "2025-01-15"
+
+
+def test_fred_default_as_of_clamps_to_fred_realtime_today(monkeypatch, tmp_path):
+    calls = []
+
+    class StrategyAfterUtcMidnight:
+        def get_datetime(self):
+            return datetime(2026, 5, 23, 1, 30, tzinfo=timezone.utc)
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return _Response(
+            payload={
+                "observations": [
+                    {"date": "2026-05-21", "value": "4.57", "realtime_start": "2026-05-22", "realtime_end": "2026-05-22"}
+                ]
+            }
+        )
+
+    monkeypatch.setenv("FRED_API_KEY", "test-key")
+    monkeypatch.setattr(fred_module, "_fred_realtime_today", lambda: date(2026, 5, 22))
+    monkeypatch.setattr("lumibot.macro.fred.requests.get", fake_get)
+    fred = FREDMacroData(StrategyAfterUtcMidnight(), cache_dir=tmp_path, min_request_interval_seconds=0)
+
+    result = fred.get_series("DGS10")
+
+    assert result["as_of"] == "2026-05-22"
+    params = calls[0][1]["params"]
+    assert params["realtime_start"] == "2026-05-22"
+    assert params["realtime_end"] == "2026-05-22"
+    assert params["observation_end"] == "2026-05-22"
 
 
 def test_fred_snapshot_reports_per_series_errors(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Adds AI committee cash parking guidance and benchmark notes
- Fixes live broker position mark refresh for existing positions
- Fixes live FRED realtime date clamping after UTC midnight

## Tests
- env LUMIBOT_DISABLE_DOTENV=true FRED_API_KEY= python3 -m pytest tests/test_fred_macro.py tests/test_agent_tool_permissions.py tests/test_broker_sync_positions.py tests/test_ai_investment_committee_example.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI Investment Committee strategy now supports cash parking with defensive ETF symbols (SGOV, BIL, SHV by default).

* **Bug Fixes**
  * Live broker position synchronization now refreshes mark fields (price, market value, P&L) for existing positions.
  * FRED macro requests now correctly clamp dates to the Central-time date to avoid post-midnight API errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1058?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->