### PR TITLE
Expand AI trading team ETF universe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Cache files
 lumibot/cache
+.lumibot/
 *cache*
 !lumibot/tools/backtest_cache.py
 !lumibot/tools/parquet_series_cache.py

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ export GEMINI_API_KEY='your-key-here'
 Then save this as `ai_trading_team.py` and run `python ai_trading_team.py`. If the key is missing or invalid, Lumibot stops the backtest and prints a clear `GEMINI_API_KEY` error with a link to create a key.
 
 ```python
+import os
 from datetime import datetime
 
 from lumibot.strategies.strategy import Strategy
@@ -122,34 +123,35 @@ from lumibot.strategies.strategy import Strategy
 
 class AITradingTeamStrategy(Strategy):
     parameters = {
-        "universe": ["TQQQ", "SQQQ", "SOXL", "SOXS", "UPRO", "SPXU", "TECL", "TECS"],
+        "universe": ["TQQQ", "SQQQ", "UPRO", "SPXU", "UDOW", "SDOW", "TNA", "TZA", "TECL", "TECS", "SOXL", "SOXS", "WEBL", "WEBS", "FAS", "FAZ", "LABU", "LABD", "ERX", "ERY", "GUSH", "DRIP", "DRN", "DRV", "TMF", "TMV", "NUGT", "DUST"],
     }
 
     def initialize(self):
         self.sleeptime = "1D"
+        model = os.environ.get("AI_TRADING_TEAM_MODEL", "gemini-3.1-flash-lite")
         # The first three agents are read-only. They can reason, but cannot trade.
         self.agents.create(
             name="researcher",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=False,
             system_prompt="Rank the ETFs by upside. Be direct.",
         )
         self.agents.create(
             name="bull",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=False,
             system_prompt="Argue for the strongest money-making trade.",
         )
         self.agents.create(
             name="bear",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=False,
             system_prompt="Point out the biggest risk, briefly.",
         )
         # Only this final agent can submit orders through Lumibot.
         self.agents.create(
             name="trader",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=True,
             system_prompt="Buy one ETF from the universe aggressively. Use nearly all cash.",
         )

--- a/docs/ai-trading-team-provider-benchmarks-2026-05-25.md
+++ b/docs/ai-trading-team-provider-benchmarks-2026-05-25.md
@@ -1,0 +1,143 @@
+# AI Trading Team Provider Benchmarks - 2026-05-25
+
+This note records the first provider comparison for the simple `AITradingTeamStrategy`
+example in `lumibot/example_strategies/ai_trading_team.py`.
+
+Strategy universe:
+
+`TQQQ`, `SQQQ`, `UPRO`, `SPXU`, `UDOW`, `SDOW`, `TNA`, `TZA`, `TECL`, `TECS`, `SOXL`, `SOXS`, `WEBL`, `WEBS`, `FAS`, `FAZ`, `LABU`, `LABD`, `ERX`, `ERY`, `GUSH`, `DRIP`, `DRN`, `DRV`, `TMF`, `TMV`, `NUGT`, `DUST`
+
+Models tested:
+
+- `deepseek/deepseek-v4-flash`
+- `deepseek/deepseek-v4-pro`
+- `gemini-3.1-flash-lite`
+
+Artifact roots:
+
+- One-day smoke: `/Users/robertgrzesik/Development/lumibot/artifacts/ai_trading_team_provider_benchmarks/20260524_232138`
+- Seven-day window: `/Users/robertgrzesik/Development/lumibot/artifacts/ai_trading_team_provider_benchmarks/20260524_235130`
+
+Pricing source:
+
+- Static provider pricing table embedded in `scripts/run_ai_committee_provider_benchmark.py` as of 2026-05-24.
+- Cost estimates below use raw trace usage, including cached input tokens when the provider reports them.
+
+## One-Day Smoke
+
+Window: 2026-05-21 to 2026-05-22.
+
+`deepseek/deepseek-v4-flash`
+
+- Status: passed
+- Wall time: 13.10 minutes
+- Return: -5.09%
+- Max drawdown: 5.09%
+- Model calls: 4
+- Tool calls: 305
+- Input tokens: 2,701,037
+- Cached input tokens: 2,135,296
+- Output tokens: 60,751
+- Cache hit rate: 79.05%
+- Estimated cost with cache pricing: $0.102193
+- Estimated cost without cache pricing: $0.395155
+- Final position: 496 shares of `SOXL`, with about $15,055 cash
+- Submitted orders: one market buy for `SOXL`
+
+`deepseek/deepseek-v4-pro`
+
+- Status: passed
+- Wall time: 14.24 minutes
+- Return: 0.00%
+- Max drawdown: 0.00%
+- Model calls: 4
+- Tool calls: 109
+- Input tokens: 607,650
+- Cached input tokens: 419,328
+- Output tokens: 35,602
+- Cache hit rate: 69.01%
+- Estimated cost with cache pricing: $0.114414
+- Estimated cost without cache pricing: $0.295301
+- Final position: all cash
+- Submitted orders: one limit buy for `SOXL` at $161.00; it did not fill in the one-day window
+
+`gemini-3.1-flash-lite`
+
+- Status: passed
+- Wall time: 0.42 minutes
+- Return: -6.37%
+- Max drawdown: 6.37%
+- Model calls: 4
+- Tool calls: 20
+- Input tokens: 157,425
+- Cached input tokens: 88,254
+- Output tokens: 1,676
+- Cache hit rate: 56.06%
+- Estimated cost with cache pricing: $0.022013
+- Estimated cost without cache pricing: $0.041870
+- Final position: 621 shares of `SOXL`, with about -$6,352 cash
+- Submitted orders: one market buy for `SOXL`
+
+## Seven-Day Window
+
+Window: 2026-05-15 to 2026-05-22.
+
+`deepseek/deepseek-v4-flash`
+
+- Status: passed
+- Wall time: 38.74 minutes
+- Return: -4.08%
+- Max drawdown: 22.35%
+- Model calls: 20
+- Tool calls: 1,256
+- Input tokens: 8,128,308
+- Cached input tokens: 6,690,432
+- Output tokens: 237,028
+- Cache hit rate: 82.31%
+- Estimated cost with cache pricing: $0.286404
+- Estimated cost without cache pricing: $1.204331
+- Final position: 508 shares of `TECL`, with about -$123 cash
+- Submitted orders: bought `SOXL`, added `SOXL`, sold `SOXL`, bought `TECL`, added `TECL`
+
+`deepseek/deepseek-v4-pro`
+
+- Status: passed
+- Wall time: 84.10 minutes
+- Return: -6.07%
+- Max drawdown: 16.11%
+- Model calls: 20
+- Tool calls: 1,044
+- Input tokens: 6,053,749
+- Cached input tokens: 4,952,576
+- Output tokens: 216,318
+- Cache hit rate: 81.81%
+- Estimated cost with cache pricing: $0.685160
+- Estimated cost without cache pricing: $2.821577
+- Final position: 2,040 shares of `GUSH`, with about $9,902 cash
+- Submitted orders: bought `SOXL`, sold `SOXL`, bought `GUSH`
+
+`gemini-3.1-flash-lite`
+
+- Status: passed
+- Wall time: 1.79 minutes
+- Return: -3.28%
+- Max drawdown: 20.87%
+- Model calls: 20
+- Tool calls: 95
+- Input tokens: 754,052
+- Cached input tokens: 502,661
+- Output tokens: 9,398
+- Cache hit rate: 66.66%
+- Estimated cost with cache pricing: $0.089511
+- Estimated cost without cache pricing: $0.202610
+- Final position: 547 shares of `SOXL`, with about $8,651 cash
+- Submitted orders: one market buy for `SOXL`
+
+## Takeaways
+
+- All three model paths can run the simple AI Trading Team strategy and submit orders.
+- Caching is working for all three tested paths. DeepSeek cached input pricing materially changes the economics.
+- Gemini 3.1 Flash-Lite is dramatically faster on this exact prompt and universe.
+- DeepSeek V4 Pro used fewer tool calls than Flash in the one-day smoke, but it was slower in the seven-day run.
+- DeepSeek models are currently tool-hungry on the expanded 28-ETF universe. A full three-month benchmark is technically possible, but at the observed seven-day pace it is an overnight or multi-day job, not a same-turn interactive benchmark.
+- The current prompt does not force market orders. DeepSeek V4 Pro used a limit buy in the one-day smoke, which did not fill. That is valid agent behavior, but it affects short-window comparisons.

--- a/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
+++ b/docs/investigations/2026-05-20_AI_COMMITTEE_PROVIDER_BENCHMARK_PLAN.md
@@ -1095,3 +1095,67 @@ Next step:
 
 - Launch three-month runs for the same three models using the corrected
   telemetry and DeepSeek input-pruning path.
+
+## Three-Month Benchmark Attempt: 2026-05-24
+
+Scope:
+
+- Window: `2026-01-02` through `2026-04-02`.
+- Models: `gemini-3.1-flash-lite`, `deepseek/deepseek-v4-flash`, and
+  `deepseek/deepseek-v4-pro`.
+- Prompt: unchanged AI Investment Committee prompt.
+- DeepSeek runtime path: DeepSeek-only input/context pruning remained enabled
+  to stay under DeepSeek's `1,048,576` token context window. No tool-call budget
+  or output truncation was used.
+
+Completed result:
+
+- `gemini-3.1-flash-lite` completed successfully.
+- Artifact:
+  `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260524_150814/gemini-3.1-flash-lite/result.json`
+- Runtime: `799.3s`.
+- Agent calls: `248`.
+- Tool calls: `657`.
+- Input tokens: `6,513,913`.
+- Cached input tokens: `3,306,171`.
+- Uncached input tokens: `3,207,742`.
+- Cache hit rate: `50.8%`.
+- Output tokens: `128,077`.
+- Estimated cost: `$1.820594` no-cache, `$1.076705` cache-adjusted.
+- Return: `-2.698%`.
+- Max drawdown: `3.168%`.
+- Sharpe: `-2.8718`.
+- Final positions: cash plus `96` SGOV.
+
+DeepSeek three-month attempt:
+
+- Artifact root:
+  `/Users/robertgrzesik/Development/lumibot/artifacts/ai_committee_provider_benchmarks/20260524_172355`
+- Both DeepSeek runs were stopped by DeepSeek API `402 Payment Required` /
+  `Insufficient Balance` errors. This was a provider-account funding failure,
+  not a Lumibot context-window failure.
+- `deepseek/deepseek-v4-flash` reached `92` completed agent calls before the
+  balance failure. Partial raw-trace telemetry: `76,940,450` input tokens,
+  `67,948,800` cached input tokens, `8,991,650` uncached input tokens,
+  `1,383,146` output tokens, `594,822` thinking tokens, `88.3%` cache hit
+  rate, about `$1.022944` cache-adjusted estimated cost versus `$2.735254`
+  estimated no-cache cost.
+- `deepseek/deepseek-v4-pro` reached `58` completed agent calls before the
+  balance failure. Partial raw-trace telemetry: `16,405,431` input tokens,
+  `13,604,608` cached input tokens, `2,800,823` uncached input tokens,
+  `599,321` output tokens, `267,386` thinking tokens, `82.9%` cache hit rate,
+  about `$1.789084` cache-adjusted estimated cost versus `$7.657772` estimated
+  no-cache cost.
+
+Interpretation:
+
+- Provider-side caching is working and is now measurable from raw traces.
+- DeepSeek cache savings are material: the failed long run showed roughly
+  `82.9%` to `88.3%` cached input before the balance stopped the run.
+- DeepSeek remains much slower than Gemini for this exact committee workload.
+  The failed long run had been running for roughly three hours before the
+  provider balance stopped it, and neither DeepSeek model had reached the full
+  three-month endpoint.
+- The next valid DeepSeek three-month attempt requires funded DeepSeek credit
+  first. Rerun from the same artifact-aware benchmark command; do not change
+  the prompt if the goal is model-to-model comparability.

--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -163,6 +163,7 @@ Then save this as ``ai_trading_team.py`` and run ``python ai_trading_team.py``. 
 
 .. code-block:: python
 
+    import os
     from datetime import datetime
 
     from lumibot.strategies.strategy import Strategy
@@ -170,34 +171,35 @@ Then save this as ``ai_trading_team.py`` and run ``python ai_trading_team.py``. 
 
     class AITradingTeamStrategy(Strategy):
         parameters = {
-            "universe": ["TQQQ", "SQQQ", "SOXL", "SOXS", "UPRO", "SPXU", "TECL", "TECS"],
+            "universe": ["TQQQ", "SQQQ", "UPRO", "SPXU", "UDOW", "SDOW", "TNA", "TZA", "TECL", "TECS", "SOXL", "SOXS", "WEBL", "WEBS", "FAS", "FAZ", "LABU", "LABD", "ERX", "ERY", "GUSH", "DRIP", "DRN", "DRV", "TMF", "TMV", "NUGT", "DUST"],
         }
 
         def initialize(self):
             self.sleeptime = "1D"
+            model = os.environ.get("AI_TRADING_TEAM_MODEL", "gemini-3.1-flash-lite")
             # The first three agents are read-only. They can reason, but cannot trade.
             self.agents.create(
                 name="researcher",
-                model="gemini-3.1-flash-lite",
+                model=model,
                 allow_trading=False,
                 system_prompt="Rank the ETFs by upside. Be direct.",
             )
             self.agents.create(
                 name="bull",
-                model="gemini-3.1-flash-lite",
+                model=model,
                 allow_trading=False,
                 system_prompt="Argue for the strongest money-making trade.",
             )
             self.agents.create(
                 name="bear",
-                model="gemini-3.1-flash-lite",
+                model=model,
                 allow_trading=False,
                 system_prompt="Point out the biggest risk, briefly.",
             )
             # Only this final agent can submit orders through Lumibot.
             self.agents.create(
                 name="trader",
-                model="gemini-3.1-flash-lite",
+                model=model,
                 allow_trading=True,
                 system_prompt="Buy one ETF from the universe aggressively. Use nearly all cash.",
             )

--- a/lumibot/example_strategies/ai_trading_team.py
+++ b/lumibot/example_strategies/ai_trading_team.py
@@ -4,6 +4,7 @@ Set GEMINI_API_KEY, then run:
     python ai_trading_team.py
 """
 
+import os
 from datetime import datetime
 
 from lumibot.strategies.strategy import Strategy
@@ -11,34 +12,36 @@ from lumibot.strategies.strategy import Strategy
 
 class AITradingTeamStrategy(Strategy):
     parameters = {
-        "universe": ["TQQQ", "SQQQ", "SOXL", "SOXS", "UPRO", "SPXU", "TECL", "TECS"],
+        # Bull/bear leveraged ETFs across broad indexes, sectors, rates, and gold miners.
+        "universe": ["TQQQ", "SQQQ", "UPRO", "SPXU", "UDOW", "SDOW", "TNA", "TZA", "TECL", "TECS", "SOXL", "SOXS", "WEBL", "WEBS", "FAS", "FAZ", "LABU", "LABD", "ERX", "ERY", "GUSH", "DRIP", "DRN", "DRV", "TMF", "TMV", "NUGT", "DUST"],
     }
 
     def initialize(self):
         self.sleeptime = "1D"
+        model = os.environ.get("AI_TRADING_TEAM_MODEL", "gemini-3.1-flash-lite")
         # The first three agents are read-only. They can reason, but cannot trade.
         self.agents.create(
             name="researcher",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=False,
             system_prompt="Rank the ETFs by upside. Be direct.",
         )
         self.agents.create(
             name="bull",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=False,
             system_prompt="Argue for the strongest money-making trade.",
         )
         self.agents.create(
             name="bear",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=False,
             system_prompt="Point out the biggest risk, briefly.",
         )
         # Only this final agent can submit orders through Lumibot.
         self.agents.create(
             name="trader",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=True,
             system_prompt="Buy one ETF from the universe aggressively. Use nearly all cash.",
         )

--- a/scripts/run_ai_trading_team_provider_benchmark.py
+++ b/scripts/run_ai_trading_team_provider_benchmark.py
@@ -209,7 +209,7 @@ def main() -> None:
         details = "; ".join(f"{model}: {label}" for model, label in missing.items())
         raise RuntimeError(f"Missing required provider API key(s): {details}")
 
-    run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S_%f')}_{os.getpid()}"
     root = ARTIFACT_ROOT / run_id
     root.mkdir(parents=True, exist_ok=True)
     results = []

--- a/scripts/run_ai_trading_team_provider_benchmark.py
+++ b/scripts/run_ai_trading_team_provider_benchmark.py
@@ -1,0 +1,243 @@
+"""Run paid AI Trading Team benchmarks across provider/model strings.
+
+Set provider keys in an ignored env file or the shell, then opt into paid calls:
+
+    LUMIBOT_ALLOW_PAID_AI_TRADING_TEAM_BACKTEST=1 \
+    python scripts/run_ai_trading_team_provider_benchmark.py --models gemini-3.1-flash-lite
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import traceback
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+os.environ.setdefault("BACKTESTING_DATA_SOURCE", "none")
+os.environ.setdefault("LUMIBOT_DISABLE_DOTENV", "1")
+os.environ.setdefault("LUMIBOT_DISABLE_BACKTEST_PERFORMANCE_TRACKING", "1")
+
+from lumibot.backtesting import YahooDataBacktesting
+from lumibot.entities import Asset
+from lumibot.example_strategies.ai_trading_team import AITradingTeamStrategy
+from scripts.run_ai_committee_provider_benchmark import (
+    _estimate_cost,
+    _json_safe,
+    _load_env_file,
+    _missing_key_label,
+    _parse_date,
+    _read_agent_usage,
+    _slug,
+)
+
+
+ARTIFACT_ROOT = Path("artifacts") / "ai_trading_team_provider_benchmarks"
+DEFAULT_MODELS = [
+    "deepseek/deepseek-v4-flash",
+    "deepseek/deepseek-v4-pro",
+    "gemini-3.1-flash-lite",
+]
+
+
+def _run_one_model(model: str, args: argparse.Namespace, root: Path) -> dict[str, Any]:
+    run_dir = root / _slug(model)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    print(
+        json.dumps(
+            {
+                "event": "model_start",
+                "model": model,
+                "artifact_dir": str(run_dir.resolve()),
+                "window": {"start": args.start, "end": args.end},
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+
+    previous_model = os.environ.get("AI_TRADING_TEAM_MODEL")
+    os.environ["AI_TRADING_TEAM_MODEL"] = model
+    os.environ["LUMIBOT_CACHE_FOLDER"] = str(run_dir / "cache")
+    os.environ["LUMIBOT_MEMORY_DIR"] = str(run_dir / "memory")
+    if args.max_run_attempts is not None:
+        os.environ["LUMIBOT_AGENT_MAX_RUN_ATTEMPTS"] = str(args.max_run_attempts)
+    if args.agent_run_timeout_seconds:
+        os.environ["LUMIBOT_AGENT_RUN_TIMEOUT_SECONDS"] = str(args.agent_run_timeout_seconds)
+
+    stats_file = run_dir / "stats.csv"
+    trades_file = run_dir / "trades.csv"
+    settings_file = run_dir / "settings.json"
+    logfile = run_dir / "backtest.log"
+    started = time.perf_counter()
+    try:
+        result, strategy = AITradingTeamStrategy.run_backtest(
+            datasource_class=YahooDataBacktesting,
+            backtesting_start=_parse_date(args.start),
+            backtesting_end=_parse_date(args.end),
+            benchmark_asset=Asset("SPY", Asset.AssetType.STOCK),
+            quote_asset=Asset("USD", Asset.AssetType.FOREX),
+            budget=args.budget,
+            stats_file=str(stats_file),
+            trades_file=str(trades_file),
+            settings_file=str(settings_file),
+            logfile=str(logfile),
+            analyze_backtest=False,
+            show_plot=False,
+            save_tearsheet=False,
+            show_tearsheet=False,
+            show_indicators=False,
+            save_logfile=True,
+            show_progress_bar=False,
+            quiet_logs=True,
+        )
+    finally:
+        if previous_model is None:
+            os.environ.pop("AI_TRADING_TEAM_MODEL", None)
+        else:
+            os.environ["AI_TRADING_TEAM_MODEL"] = previous_model
+
+    wall_ms = int((time.perf_counter() - started) * 1000)
+    detail = _read_agent_usage(run_dir)
+    positions = [repr(position) for position in strategy.get_positions(include_cash_positions=True)]
+    payload = {
+        "model": model,
+        "status": "passed",
+        "artifact_dir": str(run_dir.resolve()),
+        "window": {"start": args.start, "end": args.end},
+        "wall_ms": wall_ms,
+        "backtest_result": _json_safe(result),
+        "positions": positions,
+        "stats_file": str(stats_file.resolve()) if stats_file.exists() else None,
+        "trades_file": str(trades_file.resolve()) if trades_file.exists() else None,
+        "settings_file": str(settings_file.resolve()) if settings_file.exists() else None,
+        "logfile": str(logfile.resolve()) if logfile.exists() else None,
+        "agent_detail": detail,
+        "cost": _estimate_cost(model, detail.get("usage") or {}),
+    }
+    (run_dir / "result.json").write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "event": "model_finished",
+                "model": model,
+                "status": "passed",
+                "wall_ms": wall_ms,
+                "call_count": detail.get("call_count"),
+                "tool_call_count": detail.get("tool_call_count"),
+                "estimated_usd": payload["cost"].get("estimated_usd"),
+                "cache_adjusted_estimated_usd": payload["cost"].get("cache_adjusted_estimated_usd"),
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+    return payload
+
+
+def _failure_payload(model: str, root: Path, args: argparse.Namespace, exc: BaseException) -> dict[str, Any]:
+    run_dir = root / _slug(model)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "model": model,
+        "status": "failed",
+        "artifact_dir": str(run_dir.resolve()),
+        "window": {"start": args.start, "end": args.end},
+        "error": {
+            "type": exc.__class__.__name__,
+            "message": str(exc),
+            "traceback": traceback.format_exc() if sys.exc_info()[0] is not None else "",
+        },
+    }
+    (run_dir / "result.json").write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "event": "model_finished",
+                "model": model,
+                "status": "failed",
+                "error_type": exc.__class__.__name__,
+                "error_message": str(exc),
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+    return payload
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run AI trading team provider benchmarks with paid model calls.")
+    parser.add_argument("--models", nargs="*", default=DEFAULT_MODELS, help="Provider-prefixed model strings to test.")
+    parser.add_argument("--start", default="2026-05-21", help="Backtest start date, YYYY-MM-DD.")
+    parser.add_argument("--end", default="2026-05-22", help="Backtest end date, YYYY-MM-DD.")
+    parser.add_argument("--budget", type=float, default=100000.0)
+    parser.add_argument("--max-run-attempts", type=int, default=2)
+    parser.add_argument(
+        "--agent-run-timeout-seconds",
+        type=int,
+        default=1800,
+        help="Per-agent runtime timeout for slow providers.",
+    )
+    parser.add_argument("--env-file", default=".env.local", help="Local ignored env file to load before key checks.")
+    parser.add_argument("--allow-missing-keys", action="store_true", help="Record failures instead of stopping on missing keys.")
+    parser.add_argument("--continue-on-error", action="store_true", help="Continue to the next model if one run fails.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.env_file:
+        env_path = Path(args.env_file)
+        if not env_path.is_absolute():
+            env_path = REPO_ROOT / env_path
+        _load_env_file(env_path)
+    if os.environ.get("LUMIBOT_ALLOW_PAID_AI_TRADING_TEAM_BACKTEST") != "1":
+        raise RuntimeError(
+            "This script makes real paid model calls. Set "
+            "LUMIBOT_ALLOW_PAID_AI_TRADING_TEAM_BACKTEST=1 before running."
+        )
+
+    missing = {model: _missing_key_label(model) for model in args.models}
+    missing = {model: label for model, label in missing.items() if label}
+    if missing and not args.allow_missing_keys:
+        details = "; ".join(f"{model}: {label}" for model, label in missing.items())
+        raise RuntimeError(f"Missing required provider API key(s): {details}")
+
+    run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+    root = ARTIFACT_ROOT / run_id
+    root.mkdir(parents=True, exist_ok=True)
+    results = []
+    for model in args.models:
+        if missing.get(model):
+            exc = RuntimeError(f"Missing required provider API key(s): {missing[model]}")
+            results.append(_failure_payload(model, root, args, exc))
+            if not args.continue_on_error:
+                break
+            continue
+        try:
+            results.append(_run_one_model(model, args, root))
+        except BaseException as exc:  # noqa: BLE001 - benchmark artifact should capture provider failures
+            results.append(_failure_payload(model, root, args, exc))
+            if not args.continue_on_error:
+                break
+
+    summary = {
+        "run_id": run_id,
+        "artifact_dir": str(root.resolve()),
+        "models": args.models,
+        "window": {"start": args.start, "end": args.end},
+        "max_run_attempts": args.max_run_attempts,
+        "results": results,
+    }
+    (root / "summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({"artifact_dir": str(root.resolve()), "summary": str((root / "summary.json").resolve())}, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expand the AI Trading Team example to a broader bull/bear leveraged ETF universe
- keep the README and docs snippets compact with a single inline symbol list
- add a paid benchmark runner for the AI Trading Team example that reuses existing provider usage/cost accounting

## Tests
- python3 -m py_compile scripts/run_ai_trading_team_provider_benchmark.py lumibot/example_strategies/ai_trading_team.py
- python3 -m pytest tests/test_ai_trading_team_example.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the AI Trading Team strategy's ETF universe.
  * Made LLM model selection configurable via environment variable (with sensible default).
  * Added a runnable provider benchmark tool to execute per-model backtests and produce per-model artifacts and summaries.

* **Documentation**
  * Updated examples and benchmark notes to show the new configuration and present recent benchmark results.

* **Chores**
  * Updated ignore rules to exclude local tooling/cache directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1062?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->