### PR TITLE
v4.5.36 - Schwab order refresh hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.36 - Unreleased
+
 ## 4.5.35 - 2026-05-28
 
 Deploy marker: 4.5.35 release commit (`deploy 4.5.35`)

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -47,6 +47,7 @@ class Schwab(Broker):
 
     NAME = "Schwab"
     UNSUPPORTED_ORDER_LEG_TYPES = {"BOND", "MUTUAL_FUND"}
+    UNSUPPORTED_ORDER_TYPES = {"EXERCISE"}
     POLL_EVENT = PollingStream.POLL_EVENT
 
     def __init__(
@@ -786,6 +787,13 @@ class Schwab(Broker):
                 # If we get here and have child orders, return the first one
                 if child_order_objects:
                     return child_order_objects[0]
+            elif response.get("orderType") in self.UNSUPPORTED_ORDER_TYPES:
+                logger.info(colored(
+                    f"Skipping unsupported Schwab order type: {response.get('orderType')} "
+                    f"for order ID: {response.get('orderId', '')}",
+                    "yellow",
+                ))
+                return None
             else:
                 # Process simple order
                 simple_orders = self._parse_simple_order(response, strategy_name)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.35",
+    version="4.5.36",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_schwab_positions_unit.py
+++ b/tests/test_schwab_positions_unit.py
@@ -215,6 +215,26 @@ def test_schwab_parse_broker_order_skips_unsupported_only_order_history():
     assert broker._parse_broker_order(order, strategy_name="unit-test") is None
 
 
+def test_schwab_parse_broker_order_skips_unsupported_exercise_order_history():
+    broker = Schwab.__new__(Schwab)
+    order = {
+        "orderId": "exercise-activity",
+        "enteredTime": "2026-05-22T15:30:00+0000",
+        "orderType": "EXERCISE",
+        "status": "FILLED",
+        "orderLegCollection": [
+            {
+                "instruction": "BUY",
+                "quantity": 1,
+                "orderLegType": "OPTION",
+                "instrument": {"symbol": "SPY   260522C00500000"},
+            },
+        ],
+    }
+
+    assert broker._parse_broker_order(order, strategy_name="unit-test") is None
+
+
 def test_schwab_cancel_order_calls_client_with_order_id_then_account_hash():
     client = _CancelClient()
     stream = _Stream()


### PR DESCRIPTION
## What / Why
This hotfix keeps Schwab order refresh from being polluted by unsupported account/order-history records with `orderType: EXERCISE`. Titus's live logs showed repeated `Unknown order type: EXERCISE` warnings during broker order parsing, separate from the 4.5.35 mutual-fund leg handling.

## Risk
Low. This only skips Schwab `EXERCISE` history records that LumiBot cannot represent as active tradable orders. Normal stock/option limit/market/stop orders still parse through the existing path.

## Tests run
- `pytest tests/test_schwab_positions_unit.py tests/test_strategy_live_order_accessors.py -q`

## Docs/Prompts
No user docs or prompt change needed. This is a broker adapter parsing hotfix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schwab broker now handles exercise orders in order history.

* **Tests**
  * Added unit test for exercise order handling.

* **Chores**
  * Version bumped to 4.5.36.
  * Updated changelog.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->