### PR TITLE
v4.5.40 - Schwab order lifecycle fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Changelog
 
-## 4.5.38 - 2026-05-29
+## 4.5.39 - 2026-05-29
 
 ### Fixed
 - **Schwab simple stock and option order replacement now builds broker specs correctly.** `modify_order()` now reuses the same Schwab stock/option order builders used for new submissions instead of calling missing replacement helper methods, and it safely tracks previous order IDs when Schwab returns a replacement ID.
+
+### Tests
+- **Schwab live option replace smoke coverage now exercises the Titus failure path.** The live API test submits a TSLL option limit order, reads it directly and from the active order list, replaces it through Schwab's order-replace endpoint, reads the replacement, cancels it, and confirms the canceled state.
+
+## 4.5.38 - 2026-05-29
+
+Deploy marker: 4.5.38 release commit (`Bump LumiBot to 4.5.38`)
 
 ## 4.5.37 - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.5.38 - 2026-05-29
+
+### Fixed
+- **Schwab simple stock and option order replacement now builds broker specs correctly.** `modify_order()` now reuses the same Schwab stock/option order builders used for new submissions instead of calling missing replacement helper methods, and it safely tracks previous order IDs when Schwab returns a replacement ID.
+
 ## 4.5.37 - Unreleased
 
 ## 4.5.36 - Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Changelog
 
-## 4.5.39 - 2026-05-29
+## 4.5.40 - 2026-05-29
 
 ### Fixed
+- **Schwab market-order reconciliation no longer leaves missing live hedge orders active forever.** Active local market orders missing from Schwab's broad order list now go through direct broker lookup like other active orders; if the broker still returns no order after the existing new-order grace window, Lumibot marks the local order `UNKNOWN` and non-active instead of letting it block future active-order checks.
 - **Schwab simple stock and option order replacement now builds broker specs correctly.** `modify_order()` now reuses the same Schwab stock/option order builders used for new submissions instead of calling missing replacement helper methods, and it safely tracks previous order IDs when Schwab returns a replacement ID.
+- **Known Schwab account-history rows are quieter.** Schwab `MUTUAL_FUND` position rows and `EXERCISE` order-history rows are preserved without noisy unknown-warning spam, while truly new/unknown asset and order types still warn and preserve raw broker data.
 
 ### Tests
 - **Schwab live option replace smoke coverage now exercises the Titus failure path.** The live API test submits a TSLL option limit order, reads it directly and from the active order list, replaces it through Schwab's order-replace endpoint, reads the replacement, cancels it, and confirms the canceled state.
+- **Market-order broad-list miss regression coverage was added.** Unit tests cover active market orders missing from non-empty and empty broker order lists, including direct filled reconciliation and unresolved missing-order terminalization to non-active `UNKNOWN`.
+
+## 4.5.39 - 2026-05-29
+
+Canceled release candidate. Do not deploy.
 
 ## 4.5.38 - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.5.40 - 2026-05-29
 
+Deploy marker: `deploy 4.5.40`
+
 ### Fixed
 - **Schwab market-order reconciliation no longer leaves missing live hedge orders active forever.** Active local market orders missing from Schwab's broad order list now go through direct broker lookup like other active orders; if the broker still returns no order after the existing new-order grace window, Lumibot marks the local order `UNKNOWN` and non-active instead of letting it block future active-order checks.
 - **Schwab simple stock and option order replacement now builds broker specs correctly.** `modify_order()` now reuses the same Schwab stock/option order builders used for new submissions instead of calling missing replacement helper methods, and it safely tracks previous order IDs when Schwab returns a replacement ID.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -76,13 +76,17 @@ Release order for tearsheet metric changes:
 Run this before changing versions, tagging, creating a release, or triggering BotManager deploys:
 
 ```bash
+set -e
+
 branch="$(git branch --show-current)"
 setup_version="$(python3 - <<'PY'
 import re
 from pathlib import Path
 text = Path("setup.py").read_text()
 match = re.search(r'version=["\']([^"\']+)["\']', text)
-raise SystemExit(match.group(1) if match else "MISSING")
+if not match:
+    raise SystemExit("MISSING setup.py version")
+print(match.group(1))
 PY
 )"
 expected_branch="version/${setup_version}"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 > Release/deployment workflow for LumiBot (version branches, changelog, tags, and GitHub releases).
 
-**Last Updated:** 2026-05-14
+**Last Updated:** 2026-05-29
 **Status:** Active
 **Audience:** Developers + AI Agents
 
@@ -10,15 +10,16 @@
 
 ## TL;DR (do this in order)
 
-1) **First, make the release branch contain everything safe to ship.** Dirty files, untracked files, and local-only commits are not excuses to skip work. Review them, commit them, test them, push them, and include them in the `version/X.Y.Z` PR unless they are unsafe, secret-bearing, broken, generated junk, or explicitly out of scope.
-2) Get the `version/X.Y.Z` PR **green** after that full inclusion sweep.
-3) Merge latest `dev` into `version/X.Y.Z` and re-check CI (prevents drift / missing commits from other engineers).
-4) Merge the PR into `dev` (no direct pushes to `dev`).
-5) Tag the **merge commit on `dev`** as `vX.Y.Z` (this triggers GitHub Actions to publish to PyPI + create a GitHub Release).
-6) Verify `pip install lumibot==X.Y.Z` works.
-7) **Switch your LOCAL checkout to `version/X.Y.(Z+1)`** after the release. Carry-over is only for work that appeared after the release was tagged/published, or work intentionally excluded because it was unsafe or out of scope. Verify with `git branch --show-current`, `grep version= setup.py`, and `git status --porcelain=v1` before doing anything else. This is NOT optional. There are zero exceptions.
-8) Trigger BotManager deploys (dev then prod) only after step 7 is complete — this takes ~30 minutes and should be the last step.
-9) Post-deploy: run an MCP backtest against prod and assert `settings.json.lumibot_version == "X.Y.Z"`. See step 8.
+1) **Run the release preflight first.** If branch, `setup.py`, `CHANGELOG.md`, tag, or `dev` state is inconsistent, stop. Do not tag. Do not deploy BotManager. Fix the branch first.
+2) **Make the release branch contain everything safe to ship.** Dirty files, untracked files, and local-only commits are not excuses to skip work. Review them, commit them, test them, push them, and include them in the `version/X.Y.Z` PR unless they are unsafe, secret-bearing, broken, generated junk, or explicitly out of scope.
+3) Get the `version/X.Y.Z` PR **green** after that full inclusion sweep.
+4) Merge latest `dev` into `version/X.Y.Z` and re-check CI (prevents drift / missing commits from other engineers).
+5) Merge the PR into `dev` (no direct pushes to `dev`).
+6) Tag the **merge commit on `dev`** as `vX.Y.Z` (this triggers GitHub Actions to publish to PyPI + create a GitHub Release).
+7) Verify `pip install lumibot==X.Y.Z` works.
+8) **Switch your LOCAL checkout to `version/X.Y.(Z+1)`** after the release. Carry-over is only for work that appeared after the release was tagged/published, or work intentionally excluded because it was unsafe or out of scope. Verify with `git branch --show-current`, `grep version= setup.py`, and `git status --porcelain=v1` before doing anything else. This is NOT optional. There are zero exceptions.
+9) Trigger BotManager deploys (dev then prod) only after step 8 is complete — this takes ~30 minutes and should be the last step.
+10) Post-deploy: run an MCP backtest against prod and assert `settings.json.lumibot_version == "X.Y.Z"`. See step 8.
 
 ## The `dev` Branch Is Sacred (CRITICAL)
 
@@ -67,7 +68,62 @@ Release order for tearsheet metric changes:
 - `setup.py` **must** match the version branch name (`X.Y.Z`).
   - When you start a new version branch, bump immediately and commit: `chore: start X.Y.Z`.
   - **Never downgrade** versions. If a bump was wrong, bump forward (and document why).
+- If `setup.py` is ahead of the current branch suffix, stop immediately. Do not keep committing on that stale branch. Create or switch to the matching `version/X.Y.Z` branch, verify it, and push it.
 - After a version branch is merged to `dev`, **immediately start the next version branch** (see Step 7).
+
+## Release Preflight Hard Stop (MANDATORY)
+
+Run this before changing versions, tagging, creating a release, or triggering BotManager deploys:
+
+```bash
+branch="$(git branch --show-current)"
+setup_version="$(python3 - <<'PY'
+import re
+from pathlib import Path
+text = Path("setup.py").read_text()
+match = re.search(r'version=["\']([^"\']+)["\']', text)
+raise SystemExit(match.group(1) if match else "MISSING")
+PY
+)"
+expected_branch="version/${setup_version}"
+latest_tag="$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)"
+
+echo "branch=${branch}"
+echo "setup.py=${setup_version}"
+echo "expected_branch=${expected_branch}"
+echo "latest_tag=${latest_tag}"
+git fetch origin dev --tags --prune
+git status --porcelain=v1
+
+test "${branch}" = "${expected_branch}" || {
+  echo "ERROR: branch/setup.py mismatch. Switch to ${expected_branch} or fix setup.py before release."
+  exit 1
+}
+
+test -z "$(git status --porcelain=v1)" || {
+  echo "ERROR: dirty or untracked files. Review, commit, or manually remove before release."
+  exit 1
+}
+
+git merge-base --is-ancestor origin/dev HEAD || {
+  echo "ERROR: release branch is not based on origin/dev."
+  exit 1
+}
+
+git log --oneline "origin/${branch}..HEAD"
+```
+
+If this preflight fails, the release is blocked. Do not "just bump setup.py" on the old branch. Do not tag from the old branch. Do not deploy BotManager while this is failing.
+
+Known bad state example:
+
+```text
+branch=version/4.5.37
+setup.py=4.5.40
+expected_branch=version/4.5.40
+```
+
+That state means the checkout is stale. Create or switch to the correct branch before doing anything else.
 
 ---
 
@@ -169,6 +225,7 @@ Publishing is **tag-driven** via `.github/workflows/release.yml`.
 - Optional: configure the GitHub environment `pypi` to require approvals (human gate).
 
 0) **Preflight: “ship everything safe” + security/hygiene sweep**
+   - Run the mandatory release preflight above. If it fails, stop. Fix branch/version state before release work continues.
    - The release branch must contain every safe change in the checkout before tagging:
      - `git status --porcelain=v1`
      - `git log --oneline origin/version/X.Y.Z..HEAD`
@@ -221,6 +278,10 @@ Publishing is **tag-driven** via `.github/workflows/release.yml`.
 0) **Sync your local repo**
    - `git switch dev && git pull --ff-only`
    - `git switch version/X.Y.Z && git pull --ff-only`
+   - Confirm branch and package version match:
+     - `git branch --show-current` must print `version/X.Y.Z`.
+     - `grep 'version=' setup.py | head -1` must print `version="X.Y.Z",`.
+     - If these disagree, stop and fix the branch. Do not keep working.
    - Confirm clean tree: `git status --porcelain=v1` (must be empty because all safe local work has already been committed and pushed)
    - **IMPORTANT (multi-agent safety):** ensure *everyone* working on `version/X.Y.Z` has pushed their commits. Do not release while known safe work is stranded in someone else’s clone.
 
@@ -262,6 +323,10 @@ Publishing is **tag-driven** via `.github/workflows/release.yml`.
    - Why we merge to `dev` *before* tagging: tagging the `dev` merge commit guarantees `dev` includes exactly what shipped,
      and the next `version/*` branch cut from `dev` cannot “miss” released commits.
    - Create an annotated tag `vX.Y.Z` pointing at the *merge commit on `dev`* (or the deploy-marker commit if it was fast-forwarded).
+   - Before tagging, verify you are tagging `dev`, not a stale version branch:
+     - `git branch --show-current` must print `dev`.
+     - `grep 'version=' setup.py | head -1` must print `version="X.Y.Z",`.
+     - `git merge-base --is-ancestor HEAD origin/dev` must pass.
    - Push the tag to GitHub.
    - Let `.github/workflows/release.yml` run:
      - validates tag ↔ `setup.py`,
@@ -344,6 +409,26 @@ Publishing is **tag-driven** via `.github/workflows/release.yml`.
 
      If any of those three checks is wrong, STOP and fix before proceeding. Do not trigger BotManager deploy on the wrong local branch state.
 
+     If GitHub Actions created the next branch but your local checkout is still on the released branch, fix your local checkout immediately:
+
+     ```bash
+     git fetch origin
+     git switch version/X.Y.(Z+1)
+     git pull --ff-only
+     ```
+
+     If the next branch does not exist, create it from `dev`, not from the released branch:
+
+     ```bash
+     git switch dev
+     git pull --ff-only
+     git switch -c version/X.Y.(Z+1)
+     # bump setup.py and CHANGELOG.md
+     git add setup.py CHANGELOG.md
+     git commit -m "chore: start X.Y.(Z+1)"
+     git push -u origin version/X.Y.(Z+1)
+     ```
+
    6f) **Push** anything you cherry-picked:
 
      ```bash
@@ -415,6 +500,9 @@ Publishing is **tag-driven** via `.github/workflows/release.yml`.
 - **Version drift (`setup.py` doesn’t match the branch name)** breaks traceability and confuses deployments.
   - Fix: enforce “`setup.py` == `version/X.Y.Z`” as a hard invariant.
   - Never downgrade versions; always bump forward if something went wrong.
+- **Continuing work on a stale version branch after bumping `setup.py` creates fake releases.**
+  - Symptom: the branch says `version/4.5.37`, `setup.py` says `4.5.40`, and tags or BotManager deploys no longer tell you what actually shipped.
+  - Fix: stop immediately, create or switch to the matching branch, push it, and do not tag until that branch is merged back to `dev`.
 - **Publishing to PyPI without pushing the `vX.Y.Z` tag first** breaks traceability.
   - The repo’s release workflow is tag-driven. If the version is already on PyPI, pushing the tag later will
     cause the publish step to fail (PyPI rejects re-uploading the same version), and the GitHub Release step

--- a/docs/investigations/2026-05-29_lumibot_release_branch_drift.md
+++ b/docs/investigations/2026-05-29_lumibot_release_branch_drift.md
@@ -1,0 +1,61 @@
+# LumiBot Release Branch Drift Investigation - 2026-05-29
+
+## Summary
+
+The local LumiBot checkout and pushed active branch drifted from the documented release process.
+The package version is currently `4.5.40`, but the checked-out branch is still `version/4.5.37`.
+This happened because new work and release tags were added on the stale `version/4.5.37` branch after the `v4.5.37` release instead of switching to the next active release branch.
+
+## Evidence
+
+- Current local branch: `version/4.5.37`.
+- Current local `setup.py`: `version="4.5.40"`.
+- `origin/dev`: `745cda0f`, tagged `v4.5.37`, with `setup.py` still at `4.5.37`.
+- `origin/version/4.5.38`: `9b88690c chore: start 4.5.38`, created by GitHub Actions from `origin/dev`.
+- `origin/version/4.5.39`: `261d2226 chore: start 4.5.39`, created by GitHub Actions from `origin/dev`, but its `setup.py` still shows `4.5.37`.
+- Current stale branch history after `v4.5.37`:
+  - `906d7e95 Fix Schwab stream startup race`
+  - `d2c0b2db Bump LumiBot to 4.5.38`
+  - `8b9728de Fix Schwab option order replacement`
+  - `2645b0ec Add Schwab option modify live smoke`
+  - `670df160 Bump LumiBot to 4.5.39`
+  - `b1d49d1f Fix Schwab market order reconciliation`
+  - `111a42ba Add Schwab option timeout cancel live smoke`
+  - `a34118db Handle Schwab numeric live order ids in smoke tests`
+
+## Release Workflow State
+
+- `v4.5.37` release workflow succeeded.
+- `v4.5.38` release workflow succeeded and published to PyPI from commit `d2c0b2db`.
+- `v4.5.39` release workflow was cancelled during tests and did not publish to PyPI.
+- No PRs were found for `4.5.38`, `4.5.39`, or `4.5.40`.
+
+## Root Cause
+
+`docs/DEPLOYMENT.md` says the local checkout must switch to the next version branch after release and that `setup.py` must match the branch name. That did not happen.
+
+The GitHub Actions workflow created next-version branches, but nothing forced local developers or agents to use those branches. The release workflow only validates that the tag matches `setup.py`; it does not verify that the tagged commit came from `dev`, was merged through the documented release path, or was on the correct `version/X.Y.Z` branch before tagging.
+
+## Repair Direction
+
+Do not tag or deploy another LumiBot version from the stale `version/4.5.37` branch.
+
+Recommended repair:
+
+1. Freeze further LumiBot release activity until the branch is normalized.
+2. Create the correct active branch for the next release from `origin/dev`.
+3. Bring the real Schwab fixes from the stale branch onto that correct branch.
+4. Ensure `setup.py`, `CHANGELOG.md`, and the branch suffix all match.
+5. Merge the correct version branch to `dev`.
+6. Tag the merge commit on `dev`.
+7. Confirm PyPI publish and BotManager runtime install.
+8. Confirm the post-release next-version branch exists and switch the canonical checkout to it.
+
+## Follow-up Hardening
+
+Docs were clear enough to detect the mistake, but not enough to prevent it. Add automation guards:
+
+- A branch/version preflight that fails when `version/X.Y.Z` does not match `setup.py`.
+- Release workflow validation that tagged commits are on `origin/dev` or exactly the merged release commit.
+- A post-release verification command that confirms the next branch exists and the canonical checkout is on it.
+- A BotManager deploy preflight that refuses to deploy when the LumiBot branch/version/tag state is inconsistent.

--- a/docsrc/brokers.schwab.rst
+++ b/docsrc/brokers.schwab.rst
@@ -111,6 +111,14 @@ Use enum status filters for active/open order checks:
 Do not use raw string status filters. For duplicate-order guards, filter by
 active status and by the exact asset or option contract.
 
+Simple stock and single-leg option ``self.modify_order(...)`` calls use Schwab's
+replace-order endpoint. Schwab returns a new broker order id for the replacement;
+LumiBot updates the order object's ``identifier`` and keeps the old id in
+``previous_identifiers``. For timeout logic where the intended behavior is to
+remove the order, prefer ``self.cancel_order(order)`` plus a direct
+``self.get_order(order.identifier)`` confirmation instead of modifying the
+order into a different price.
+
 Schwab account history can include rows that are not ordinary strategy orders,
 such as mutual funds, sweep/cash-equivalent records, bonds, option exercise
 records, or future Schwab asset/order/status values. LumiBot preserves

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -942,6 +942,26 @@ class Broker(ABC):
         elif order.is_active():
             self._process_new_order(order)
 
+    def _mark_missing_order_unknown(
+        self,
+        order_lumi,
+        broker_order_count=0,
+        logger_obj=None,
+        reason="direct lookup returned no order",
+    ):
+        """Mark an unresolved missing local order non-active without pretending it canceled."""
+        log = logger_obj or getattr(self, "logger", logger)
+        order_lumi.status = Order.OrderStatus.UNKNOWN
+        order_lumi.error_message = (
+            f"Local active order was missing from the broad broker order list "
+            f"(bkr cnt={broker_order_count}); {reason}."
+        )
+        log.warning(
+            f"Marking missing local order {order_lumi} (id={order_lumi.identifier}) as UNKNOWN/non-active; "
+            f"{reason}."
+        )
+        return True
+
     def _refresh_missing_active_order_from_broker(
         self,
         order_lumi,
@@ -949,6 +969,7 @@ class Broker(ABC):
         strategy_object=None,
         broker_order_count=0,
         logger_obj=None,
+        terminalize_missing=False,
     ):
         """Refresh an active local order by id before treating a broad-list miss as terminal.
 
@@ -972,6 +993,13 @@ class Broker(ABC):
             return False
 
         if not response:
+            if terminalize_missing:
+                return self._mark_missing_order_unknown(
+                    order_lumi,
+                    broker_order_count=broker_order_count,
+                    logger_obj=log,
+                    reason="direct lookup returned no order",
+                )
             log.warning(
                 f"Active order {order_lumi} (id={order_lumi.identifier}) was missing from the broad broker "
                 f"order list (bkr cnt={broker_order_count}), and direct lookup returned no order. "
@@ -1038,8 +1066,6 @@ class Broker(ABC):
         strategy_name = self._strategy_name_from_input(strategy)
         orders_broker = self._pull_all_orders(strategy_name, strategy)
         orders_broker = [order for order in orders_broker if order is not None]
-        if len(orders_broker) == 0:
-            return
 
         changed = False
         orders_lumi = self.get_all_orders()
@@ -1096,19 +1122,15 @@ class Broker(ABC):
                         )
                         continue
 
-                if order_lumi.order_type and order_lumi.order_type == Order.OrderType.MARKET:
-                    logger.info(
-                        f"Market order {order_lumi} (id={order_lumi.identifier}) not found in broker, "
-                        f"likely filled instantly - skipping cancel"
-                    )
-                    continue
-
                 changed = (
                     self._refresh_missing_active_order_from_broker(
                         order_lumi,
                         strategy_name,
                         strategy_object=strategy,
                         broker_order_count=len(orders_broker),
+                        terminalize_missing=(
+                            order_lumi.order_type and order_lumi.order_type == Order.OrderType.MARKET
+                        ),
                     )
                     or changed
                 )

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -1814,6 +1814,146 @@ class Schwab(Broker):
             logger.error(traceback.format_exc())
             return None
 
+    def _build_order_spec_from_builder(self, order_builder, time_in_force=None):
+        """Apply Schwab defaults and return the final API order spec."""
+        if not order_builder:
+            return None
+
+        try:
+            from schwab.orders.common import Duration, Session
+        except ImportError:
+            logger.error(colored("Failed to import Schwab order enums. Make sure the schwab-py library is installed.", "red"))
+            return None
+
+        try:
+            tif = time_in_force or "day"
+            if tif == "day":
+                order_builder = order_builder.set_duration(Duration.DAY)
+            elif tif == "gtc":
+                order_builder = order_builder.set_duration(Duration.GOOD_TILL_CANCEL)
+            elif tif == "opg":
+                order_builder = order_builder.set_duration(Duration.ON_THE_OPEN)
+            elif tif == "cls":
+                order_builder = order_builder.set_duration(Duration.ON_THE_CLOSE)
+
+            order_builder = order_builder.set_session(Session.NORMAL)
+            order_spec = order_builder.build()
+
+            if "order_spec" in order_spec:
+                order_spec = order_spec["order_spec"]
+
+            return order_spec
+        except Exception as e:
+            logger.error(colored(f"Error building Schwab order specification: {e}", "red"))
+            logger.error(traceback.format_exc())
+            return None
+
+    def _prepare_stock_order_spec(self, order, limit_price=None, stop_price=None, tag=None):
+        """
+        Prepare a Schwab replacement order spec for a stock order.
+
+        Schwab modifies orders by replacing them, so this reuses the same
+        builder path used for new stock submissions and only temporarily applies
+        the requested replacement prices while building the spec.
+        """
+        try:
+            from schwab.orders.equities import (
+                equity_buy_limit,
+                equity_buy_market,
+                equity_buy_to_cover_limit,
+                equity_buy_to_cover_market,
+                equity_sell_limit,
+                equity_sell_market,
+                equity_sell_short_limit,
+                equity_sell_short_market,
+            )
+        except ImportError:
+            logger.error(colored("Failed to import Schwab stock order templates. Make sure the schwab-py library is installed.", "red"))
+            return None
+
+        original_limit_price = order.limit_price
+        original_stop_price = order.stop_price
+        original_tag = order.tag
+
+        try:
+            if limit_price is not None:
+                order.limit_price = limit_price
+            if stop_price is not None:
+                order.stop_price = stop_price
+            if tag is not None:
+                order.tag = tag
+
+            order_builder = self._prepare_stock_order_builder(
+                order,
+                equity_buy_market,
+                equity_buy_limit,
+                equity_sell_market,
+                equity_sell_limit,
+                equity_sell_short_market,
+                equity_sell_short_limit,
+                equity_buy_to_cover_market,
+                equity_buy_to_cover_limit,
+            )
+            return self._build_order_spec_from_builder(order_builder, order.time_in_force)
+        finally:
+            order.limit_price = original_limit_price
+            order.stop_price = original_stop_price
+            order.tag = original_tag
+
+    def _prepare_option_order_spec(self, order, limit_price=None, stop_price=None, tag=None):
+        """
+        Prepare a Schwab replacement order spec for an option order.
+
+        This is the replacement-side equivalent of `_prepare_option_order_builder`.
+        It intentionally uses the same Schwab option templates as new submits so
+        option modify/replace does not drift from normal option order creation.
+        """
+        try:
+            from schwab.orders.options import (
+                OptionSymbol,
+                option_buy_to_close_limit,
+                option_buy_to_close_market,
+                option_buy_to_open_limit,
+                option_buy_to_open_market,
+                option_sell_to_close_limit,
+                option_sell_to_close_market,
+                option_sell_to_open_limit,
+                option_sell_to_open_market,
+            )
+        except ImportError:
+            logger.error(colored("Failed to import Schwab option order templates. Make sure the schwab-py library is installed.", "red"))
+            return None
+
+        original_limit_price = order.limit_price
+        original_stop_price = order.stop_price
+        original_tag = order.tag
+
+        try:
+            if limit_price is not None:
+                order.limit_price = limit_price
+            if stop_price is not None:
+                order.stop_price = stop_price
+            if tag is not None:
+                order.tag = tag
+
+            order_builder = self._prepare_option_order_builder(
+                order,
+                option_buy_to_open_market,
+                option_buy_to_open_limit,
+                option_sell_to_open_market,
+                option_sell_to_open_limit,
+                option_buy_to_close_market,
+                option_buy_to_close_limit,
+                option_sell_to_close_market,
+                option_sell_to_close_limit,
+                OptionSymbol,
+            )
+            return self._build_order_spec_from_builder(order_builder, order.time_in_force)
+        finally:
+            order.limit_price = original_limit_price
+            order.stop_price = original_stop_price
+            order.tag = original_tag
+
     def _prepare_futures_order_builder(self, order, OrderBuilder):
         """
         Prepare the order builder for futures orders using Schwab generic order builder.
@@ -1970,7 +2110,7 @@ class Schwab(Broker):
 
             # Update the order with the new identifier
 
-            order.previous_identifiers = order.previous_identifiers or []
+            order.previous_identifiers = getattr(order, "previous_identifiers", None) or []
             order.previous_identifiers.append(order.identifier)
             order.identifier = new_order_id
             # Update price information
@@ -2018,9 +2158,9 @@ class Schwab(Broker):
 
         # Create the replacement order spec based on asset type
         if order.asset.asset_type == Asset.AssetType.STOCK:
-            return self._prepare_stock_order_spec(order, final_limit_price, tag)
+            return self._prepare_stock_order_spec(order, final_limit_price, final_stop_price, tag)
         elif order.asset.asset_type == Asset.AssetType.OPTION:
-            return self._prepare_option_order_spec(order, final_limit_price, tag)
+            return self._prepare_option_order_spec(order, final_limit_price, final_stop_price, tag)
         else:
             logger.error(colored(f"Asset type {order.asset.asset_type} is not supported for order modification", "red"))
             return None

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -569,11 +569,13 @@ class Schwab(Broker):
             "MONEY_MARKET_FUND": Asset.AssetType.FOREX,
             "CASH": Asset.AssetType.FOREX,
         }
+        known_unsupported_asset_types = {"MUTUAL_FUND"}
         mapped_asset_type = known_asset_types.get(raw_asset_type, Asset.AssetType.UNKNOWN)
+        is_known_unsupported = raw_asset_type in known_unsupported_asset_types
         if mapped_asset_type == Asset.AssetType.STOCK:
             symbol = self._normalize_symbol_for_internal(symbol, asset_type=Asset.AssetType.STOCK)
 
-        if mapped_asset_type == Asset.AssetType.UNKNOWN:
+        if mapped_asset_type == Asset.AssetType.UNKNOWN and not is_known_unsupported:
             logger.warning(colored(
                 f"Unknown Schwab asset type {raw_asset_type!r} for {context}; preserving broker row as unknown.",
                 "yellow",
@@ -584,9 +586,11 @@ class Schwab(Broker):
             raw_payload,
             raw_asset_type=raw_asset_type,
             broker_parse_warning=(
-                f"Unknown Schwab asset type: {raw_asset_type}" if mapped_asset_type == Asset.AssetType.UNKNOWN else None
+                f"Unknown Schwab asset type: {raw_asset_type}"
+                if mapped_asset_type == Asset.AssetType.UNKNOWN and not is_known_unsupported
+                else None
             ),
-            broker_parse_degraded=(mapped_asset_type == Asset.AssetType.UNKNOWN),
+            broker_parse_degraded=(mapped_asset_type == Asset.AssetType.UNKNOWN and not is_known_unsupported),
         )
 
     # Position methods
@@ -967,6 +971,10 @@ class Schwab(Broker):
         }
         if raw_order_type in order_type_map:
             return order_type_map[raw_order_type]
+
+        known_non_strategy_history_types = {"EXERCISE"}
+        if raw_order_type in known_non_strategy_history_types:
+            return Order.OrderType.UNKNOWN
 
         logger.warning(colored(
             f"Unknown Schwab order type {raw_order_type!r}; preserving broker order as unknown.",

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -1315,15 +1315,14 @@ class Schwab(Broker):
                 logger.error(traceback.format_exc())
 
     def _run_stream(self):
+        stream = getattr(self, "stream", None)
+        if not stream:
+            logger.warning(colored("Schwab stream object not initialized, skipping stream runner.", "yellow"))
+            return
         self._stream_established()
         try:
-            # Add check to ensure self.stream is initialized
-            if self.stream:
-                logger.info(colored("Starting Schwab stream...", "green"))
-                self.stream._run()
-            else:
-                # Log that the stream object wasn't created, likely due to init failure
-                logger.error(colored("Schwab stream object not initialized, cannot run stream.", "red"))
+            logger.info(colored("Starting Schwab stream...", "green"))
+            stream._run()
         except Exception as e:
             logger.error(f"Error running Schwab stream: {e}")
             logger.error(traceback.format_exc())

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -364,7 +364,7 @@ class StrategyExecutor(Thread):
         orders_broker = self.broker._pull_all_orders(self.name, self.strategy)
         # Filter out None orders to prevent crashes
         orders_broker = [order for order in orders_broker if order is not None]
-        if len(orders_broker) > 0:
+        if len(orders_broker) > 0 or self.broker.get_all_orders():
             orders_lumi = self.broker.get_all_orders()
 
             # Check orders at the broker against those in lumibot.
@@ -505,20 +505,15 @@ class StrategyExecutor(Thread):
                                 )
                                 continue
                         
-                        # Check if it's a market order that might have filled instantly
-                        if order_lumi.order_type and order_lumi.order_type == Order.OrderType.MARKET:
-                            self.strategy.logger.info(
-                                f"Market order {order_lumi} (id={order_lumi.identifier}) not found in broker, "
-                                f"likely filled instantly - skipping cancel"
-                            )
-                            continue
-                        
                         self.broker._refresh_missing_active_order_from_broker(
                             order_lumi,
                             self.strategy.name,
                             strategy_object=self.strategy,
                             broker_order_count=len(orders_broker),
                             logger_obj=self.strategy.logger,
+                            terminalize_missing=(
+                                order_lumi.order_type and order_lumi.order_type == Order.OrderType.MARKET
+                            ),
                         )
 
         self.broker._invalidate_order_caches()

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.37",
+    version="4.5.38",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.38",
+    version="4.5.39",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.39",
+    version="4.5.40",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_schwab_live_refresh_apitest.py
+++ b/tests/test_schwab_live_refresh_apitest.py
@@ -222,3 +222,77 @@ def test_schwab_live_option_modify_read_cancel(monkeypatch):
                     broker.cancel_order(submitted)
             except Exception:
                 pass
+
+
+def test_schwab_live_option_limit_wait_then_cancel_refresh(monkeypatch):
+    """Places a safe option limit order, waits, cancels, and confirms Schwab state.
+
+    This covers the Titus-style path where strategy code submits an option limit
+    order, gives Schwab a short window to fill it, then cancels if it is still
+    open. The low limit is intended to rest instead of filling.
+    """
+
+    broker = _schwab_broker(monkeypatch)
+    strategy_name = "schwab-live-option-timeout-cancel-apitest"
+    asset = _select_tsll_call_asset(broker)
+    submitted = None
+
+    order = Order(
+        strategy=strategy_name,
+        asset=asset,
+        quantity=1,
+        side=Order.OrderSide.BUY_TO_OPEN,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=0.05,
+        time_in_force="day",
+        tag=strategy_name,
+    )
+
+    try:
+        submitted = broker._submit_order(order)
+        assert submitted is not None
+        assert submitted.identifier
+
+        raw_single = broker._pull_broker_order(submitted.identifier)
+        parsed_single = broker._parse_broker_order(raw_single, strategy_name)
+        assert raw_single is not None
+        assert parsed_single is not None
+        assert parsed_single.identifier == submitted.identifier
+
+        raw_all, parsed_all = _poll_all_for_order(broker, submitted.identifier, strategy_name)
+        assert raw_all is not None
+        assert parsed_all is not None
+        assert parsed_all.identifier == submitted.identifier
+
+        time.sleep(4)
+        broker.cancel_order(submitted)
+
+        deadline = time.perf_counter() + 8
+        post_cancel_single = None
+        post_cancel_parsed = None
+        while time.perf_counter() < deadline:
+            post_cancel_single = broker._pull_broker_order(submitted.identifier)
+            post_cancel_parsed = broker._parse_broker_order(post_cancel_single, strategy_name)
+            if post_cancel_parsed and post_cancel_parsed.is_canceled():
+                break
+            time.sleep(0.5)
+
+        assert post_cancel_single is not None
+        assert post_cancel_parsed is not None
+        assert post_cancel_parsed.is_canceled()
+
+        post_cancel_all, post_cancel_all_parsed = _poll_all_for_order(
+            broker, submitted.identifier, strategy_name
+        )
+        assert post_cancel_all is not None
+        assert post_cancel_all_parsed is not None
+        assert post_cancel_all_parsed.is_canceled()
+    finally:
+        if submitted and submitted.identifier:
+            try:
+                raw = broker._pull_broker_order(submitted.identifier)
+                status = str(raw.get("status", "") if raw else "").upper()
+                if status not in {"CANCELED", "CANCELLED", "FILLED", "REJECTED", "EXPIRED"}:
+                    broker.cancel_order(submitted)
+            except Exception:
+                pass

--- a/tests/test_schwab_live_refresh_apitest.py
+++ b/tests/test_schwab_live_refresh_apitest.py
@@ -124,12 +124,12 @@ def test_schwab_live_submit_read_cancel_refresh(monkeypatch):
         parsed_single = broker._parse_broker_order(raw_single, strategy_name)
         assert raw_single is not None
         assert parsed_single is not None
-        assert parsed_single.identifier == submitted.identifier
+        assert str(parsed_single.identifier) == str(submitted.identifier)
 
         raw_all, parsed_all = _poll_all_for_order(broker, submitted.identifier, strategy_name)
         assert raw_all is not None
         assert parsed_all is not None
-        assert parsed_all.identifier == submitted.identifier
+        assert str(parsed_all.identifier) == str(submitted.identifier)
 
         broker.cancel_order(submitted)
 
@@ -187,12 +187,12 @@ def test_schwab_live_option_modify_read_cancel(monkeypatch):
         parsed_single = broker._parse_broker_order(raw_single, strategy_name)
         assert raw_single is not None
         assert parsed_single is not None
-        assert parsed_single.identifier == submitted.identifier
+        assert str(parsed_single.identifier) == str(submitted.identifier)
 
         raw_all, parsed_all = _poll_all_for_order(broker, submitted.identifier, strategy_name)
         assert raw_all is not None
         assert parsed_all is not None
-        assert parsed_all.identifier == submitted.identifier
+        assert str(parsed_all.identifier) == str(submitted.identifier)
 
         original_id = submitted.identifier
         broker._modify_order(submitted, limit_price=0.10)
@@ -205,7 +205,7 @@ def test_schwab_live_option_modify_read_cancel(monkeypatch):
         replaced_parsed = broker._parse_broker_order(replaced_single, strategy_name)
         assert replaced_single is not None
         assert replaced_parsed is not None
-        assert replaced_parsed.identifier == submitted.identifier
+        assert str(replaced_parsed.identifier) == str(submitted.identifier)
 
         broker.cancel_order(submitted)
 
@@ -257,12 +257,12 @@ def test_schwab_live_option_limit_wait_then_cancel_refresh(monkeypatch):
         parsed_single = broker._parse_broker_order(raw_single, strategy_name)
         assert raw_single is not None
         assert parsed_single is not None
-        assert parsed_single.identifier == submitted.identifier
+        assert str(parsed_single.identifier) == str(submitted.identifier)
 
         raw_all, parsed_all = _poll_all_for_order(broker, submitted.identifier, strategy_name)
         assert raw_all is not None
         assert parsed_all is not None
-        assert parsed_all.identifier == submitted.identifier
+        assert str(parsed_all.identifier) == str(submitted.identifier)
 
         time.sleep(4)
         broker.cancel_order(submitted)

--- a/tests/test_schwab_live_refresh_apitest.py
+++ b/tests/test_schwab_live_refresh_apitest.py
@@ -1,5 +1,6 @@
 import os
 import time
+from datetime import date
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -48,6 +49,40 @@ def _poll_all_for_order(broker, order_id, strategy_name, *, timeout_seconds=4.0)
         if raw or time.perf_counter() >= deadline:
             return raw, parsed
         time.sleep(0.25)
+
+
+def _select_tsll_call_asset(broker):
+    underlying = Asset("TSLL", asset_type=Asset.AssetType.STOCK)
+    chains = broker.data_source.get_chains(underlying, strike_count=20)
+    call_chains = (chains or {}).get("Chains", {}).get("CALL", {})
+    if not call_chains:
+        pytest.skip("No TSLL call option chain available from Schwab.")
+
+    today = date.today()
+    expirations = sorted(
+        expiration
+        for expiration in call_chains
+        if date.fromisoformat(expiration) >= today
+    )
+    if not expirations:
+        pytest.skip("No future TSLL call expiration available from Schwab.")
+
+    expiration = expirations[0]
+    strikes = call_chains.get(expiration) or []
+    if not strikes:
+        pytest.skip("No TSLL call strikes available from Schwab.")
+
+    quote = broker.data_source.get_quote(underlying)
+    last_price = float(getattr(quote, "price", None) or broker.data_source.get_last_price(underlying))
+    strike = min(strikes, key=lambda value: abs(float(value) - last_price))
+
+    return Asset(
+        "TSLL",
+        asset_type=Asset.AssetType.OPTION,
+        expiration=date.fromisoformat(expiration),
+        strike=float(strike),
+        right="CALL",
+    )
 
 
 def test_schwab_live_submit_read_cancel_refresh(monkeypatch):
@@ -108,6 +143,76 @@ def test_schwab_live_submit_read_cancel_refresh(monkeypatch):
         )
         assert post_cancel_all["status"] in {"CANCELED", "CANCELLED"}
         assert post_cancel_all_parsed.is_canceled()
+    finally:
+        if submitted and submitted.identifier:
+            try:
+                raw = broker._pull_broker_order(submitted.identifier)
+                status = str(raw.get("status", "") if raw else "").upper()
+                if status not in {"CANCELED", "CANCELLED", "FILLED", "REJECTED", "EXPIRED"}:
+                    broker.cancel_order(submitted)
+            except Exception:
+                pass
+
+
+def test_schwab_live_option_modify_read_cancel(monkeypatch):
+    """Places, replaces, reads, and cancels one real TSLL call limit order.
+
+    This is intentionally marked apitest because it uses the real Schwab API.
+    The limit is deliberately far below the selected option's expected market
+    value so the order should rest, then be replaced, then be canceled.
+    """
+
+    broker = _schwab_broker(monkeypatch)
+    strategy_name = "schwab-live-option-modify-apitest"
+    asset = _select_tsll_call_asset(broker)
+    submitted = None
+
+    order = Order(
+        strategy=strategy_name,
+        asset=asset,
+        quantity=1,
+        side=Order.OrderSide.BUY_TO_OPEN,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=0.05,
+        time_in_force="day",
+        tag=strategy_name,
+    )
+
+    try:
+        submitted = broker._submit_order(order)
+        assert submitted is not None
+        assert submitted.identifier
+
+        raw_single = broker._pull_broker_order(submitted.identifier)
+        parsed_single = broker._parse_broker_order(raw_single, strategy_name)
+        assert raw_single is not None
+        assert parsed_single is not None
+        assert parsed_single.identifier == submitted.identifier
+
+        raw_all, parsed_all = _poll_all_for_order(broker, submitted.identifier, strategy_name)
+        assert raw_all is not None
+        assert parsed_all is not None
+        assert parsed_all.identifier == submitted.identifier
+
+        original_id = submitted.identifier
+        broker._modify_order(submitted, limit_price=0.10)
+        assert submitted.identifier
+        assert submitted.identifier != original_id
+        assert original_id in getattr(submitted, "previous_identifiers", [])
+        assert submitted.limit_price == 0.10
+
+        replaced_single = broker._pull_broker_order(submitted.identifier)
+        replaced_parsed = broker._parse_broker_order(replaced_single, strategy_name)
+        assert replaced_single is not None
+        assert replaced_parsed is not None
+        assert replaced_parsed.identifier == submitted.identifier
+
+        broker.cancel_order(submitted)
+
+        post_cancel_single = broker._pull_broker_order(submitted.identifier)
+        post_cancel_parsed = broker._parse_broker_order(post_cancel_single, strategy_name)
+        assert post_cancel_single["status"] in {"CANCELED", "CANCELLED"}
+        assert post_cancel_parsed.is_canceled()
     finally:
         if submitted and submitted.identifier:
             try:

--- a/tests/test_schwab_positions_unit.py
+++ b/tests/test_schwab_positions_unit.py
@@ -228,6 +228,8 @@ def test_schwab_pull_positions_preserves_mutual_funds_as_unknown_or_cash_like_re
     assert by_symbol["SPY"].quantity == 3
     assert by_symbol["SWVXX"].asset.asset_type == Asset.AssetType.UNKNOWN
     assert by_symbol["SWVXX"].raw_asset_type == "MUTUAL_FUND"
+    assert by_symbol["SWVXX"].broker_parse_warning is None
+    assert by_symbol["SWVXX"].broker_parse_degraded is False
 
 
 def test_schwab_pull_positions_preserves_unknown_asset_types_without_losing_supported_assets():
@@ -396,7 +398,7 @@ def test_schwab_parse_broker_order_preserves_unknown_only_order_history():
     assert parsed.status == Order.OrderStatus.FILLED
 
 
-def test_schwab_parse_broker_order_preserves_unknown_exercise_order_history():
+def test_schwab_parse_broker_order_preserves_known_exercise_order_history_without_warning(caplog):
     broker = Schwab.__new__(Schwab)
     order = {
         "orderId": "exercise-activity",
@@ -413,13 +415,15 @@ def test_schwab_parse_broker_order_preserves_unknown_exercise_order_history():
         ],
     }
 
-    parsed = broker._parse_broker_order(order, strategy_name="unit-test")
+    with caplog.at_level(logging.WARNING):
+        parsed = broker._parse_broker_order(order, strategy_name="unit-test")
 
     assert parsed is not None
     assert parsed.identifier == "exercise-activity"
     assert parsed.order_type == Order.OrderType.UNKNOWN
     assert parsed.raw_order_type == "EXERCISE"
     assert parsed.status == Order.OrderStatus.FILLED
+    assert "Unknown Schwab order type 'EXERCISE'" not in caplog.text
 
 
 def test_schwab_parse_simple_order_preserves_unknown_order_type_without_error_logs(caplog):

--- a/tests/test_schwab_positions_unit.py
+++ b/tests/test_schwab_positions_unit.py
@@ -600,3 +600,13 @@ def test_schwab_cancel_order_raises_on_http_error_without_marking_canceled():
 
     assert client.cancel_calls == [("order-123", "account-hash")]
     assert order.status == Order.OrderStatus.SUBMITTED
+
+
+def test_schwab_run_stream_without_stream_returns_without_traceback(caplog):
+    broker = Schwab.__new__(Schwab)
+    broker.stream = None
+
+    broker._run_stream()
+
+    assert "skipping stream runner" in caplog.text
+    assert "Traceback" not in caplog.text

--- a/tests/test_schwab_positions_unit.py
+++ b/tests/test_schwab_positions_unit.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import date
 from threading import RLock
 from types import SimpleNamespace
 
@@ -84,6 +85,30 @@ class _OrderResponse:
         }
 
 
+class _ReplaceResponse:
+    status_code = 201
+    text = ""
+
+    def __init__(self, order_id="replacement-456"):
+        self.headers = {"Location": f"https://api.schwabapi.com/trader/v1/accounts/hash/orders/{order_id}"}
+
+
+class _ReplaceClient:
+    def __init__(self, original_order=None, response=None):
+        self.original_order = original_order if original_order is not None else _option_order_payload()
+        self.response = response if response is not None else _ReplaceResponse()
+        self.get_order_calls = []
+        self.replace_calls = []
+
+    def get_order(self, order_id, account_hash):
+        self.get_order_calls.append((order_id, account_hash))
+        return SimpleNamespace(status_code=200, json=lambda: self.original_order)
+
+    def replace_order(self, account_hash, order_id, order_spec):
+        self.replace_calls.append((account_hash, order_id, order_spec))
+        return self.response
+
+
 class _Stream:
     def __init__(self):
         self.dispatched = []
@@ -141,6 +166,50 @@ def _order(status=Order.OrderStatus.SUBMITTED, identifier="order-123"):
         order_type=Order.OrderType.LIMIT,
         identifier=identifier,
         status=status,
+    )
+
+
+def _option_asset():
+    return Asset(
+        "LW",
+        asset_type=Asset.AssetType.OPTION,
+        expiration=date(2026, 5, 29),
+        strike=38.0,
+        right="CALL",
+    )
+
+
+def _option_order_payload(order_id="order-123", status="WORKING"):
+    return {
+        "orderId": order_id,
+        "orderType": "LIMIT",
+        "status": status,
+        "orderLegCollection": [
+            {
+                "instruction": "BUY_TO_OPEN",
+                "quantity": 1,
+                "orderLegType": "OPTION",
+                "instrument": {
+                    "assetType": "OPTION",
+                    "symbol": "LW    260529C00038000",
+                    "putCall": "CALL",
+                    "underlyingSymbol": "LW",
+                },
+            },
+        ],
+    }
+
+
+def _option_order(identifier="order-123", limit_price=4.84):
+    return Order(
+        strategy="unit-test",
+        asset=_option_asset(),
+        quantity=1,
+        side=Order.OrderSide.BUY_TO_OPEN,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=limit_price,
+        identifier=identifier,
+        status=Order.OrderStatus.SUBMITTED,
     )
 
 
@@ -261,6 +330,44 @@ def test_schwab_parse_simple_order_preserves_unknown_legs_without_dropping_suppo
     assert by_symbol["SPY"].identifier == "12345"
     assert by_symbol["SPY"].side == Order.OrderSide.BUY
     assert by_symbol["SPY"].asset.asset_type == Asset.AssetType.STOCK
+
+
+def test_schwab_option_replacement_uses_option_builder_and_updates_identifier():
+    client = _ReplaceClient()
+    broker = Schwab.__new__(Schwab)
+    broker.schwab_authorization_error = False
+    broker.client = client
+    broker.hash_value = "account-hash"
+    order = _option_order()
+
+    broker._modify_order(order, limit_price=4.75)
+
+    assert client.get_order_calls == [("order-123", "account-hash")]
+    assert len(client.replace_calls) == 1
+    account_hash, original_id, replacement_spec = client.replace_calls[0]
+    assert account_hash == "account-hash"
+    assert original_id == "order-123"
+    assert replacement_spec["orderType"] == "LIMIT"
+    assert replacement_spec["price"] == "4.75"
+    assert replacement_spec["duration"] == "DAY"
+    assert replacement_spec["session"] == "NORMAL"
+    assert replacement_spec["orderLegCollection"][0]["instruction"] == "BUY_TO_OPEN"
+    assert replacement_spec["orderLegCollection"][0]["instrument"]["assetType"] == "OPTION"
+    assert replacement_spec["orderLegCollection"][0]["instrument"]["symbol"] == "LW    260529C00038000"
+    assert order.previous_identifiers == ["order-123"]
+    assert order.identifier == "replacement-456"
+    assert order.limit_price == 4.75
+
+
+def test_schwab_prepare_option_replacement_spec_restores_order_on_failure(monkeypatch):
+    broker = Schwab.__new__(Schwab)
+    order = _option_order(limit_price=4.84)
+
+    monkeypatch.setattr(broker, "_build_order_spec_from_builder", lambda *_args, **_kwargs: None)
+
+    assert broker._prepare_option_order_spec(order, limit_price=4.75, tag="replacement") is None
+    assert order.limit_price == 4.84
+    assert order.tag == ""
 
 
 def test_schwab_parse_broker_order_preserves_unknown_only_order_history():

--- a/tests/test_strategy_live_order_accessors.py
+++ b/tests/test_strategy_live_order_accessors.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from threading import RLock
 
 import pytest
@@ -115,13 +116,13 @@ def _strategy():
     return strategy, broker
 
 
-def _order(strategy_name, identifier, status, symbol="SPY"):
+def _order(strategy_name, identifier, status, symbol="SPY", order_type=Order.OrderType.LIMIT):
     return Order(
         strategy=strategy_name,
         asset=Asset(symbol, asset_type=Asset.AssetType.STOCK),
         quantity=1,
         side=Order.OrderSide.BUY,
-        order_type=Order.OrderType.LIMIT,
+        order_type=order_type,
         identifier=identifier,
         status=status,
     )
@@ -229,6 +230,61 @@ def test_live_order_list_miss_without_direct_match_does_not_fake_cancel():
 
     assert refreshed is tracked
     assert refreshed.status == Order.OrderStatus.OPEN
+
+
+def test_live_market_order_list_miss_uses_direct_lookup_before_terminal_update():
+    strategy, broker = _strategy()
+    tracked = _order(
+        strategy.name,
+        "market-1",
+        Order.OrderStatus.OPEN,
+        order_type=Order.OrderType.MARKET,
+    )
+    tracked.created_at = datetime.now() - timedelta(seconds=30)
+    broker._new_orders.append(tracked)
+    broker.broker_orders = [_order(strategy.name, "other-order", Order.OrderStatus.OPEN)]
+    broker.direct_orders["market-1"] = _order(strategy.name, "market-1", Order.OrderStatus.FILLED)
+
+    active_orders = strategy.get_orders(statuses=Order.ACTIVE_STATUSES)
+
+    assert "market-1" not in {order.identifier for order in active_orders}
+    assert tracked.status == Order.OrderStatus.FILLED
+
+
+def test_live_market_order_list_miss_without_direct_match_becomes_non_active_unknown():
+    strategy, broker = _strategy()
+    tracked = _order(
+        strategy.name,
+        "market-1",
+        Order.OrderStatus.OPEN,
+        order_type=Order.OrderType.MARKET,
+    )
+    tracked.created_at = datetime.now() - timedelta(seconds=30)
+    broker._new_orders.append(tracked)
+    broker.broker_orders = [_order(strategy.name, "other-order", Order.OrderStatus.OPEN)]
+
+    active_orders = strategy.get_orders(statuses=Order.ACTIVE_STATUSES)
+
+    assert "market-1" not in {order.identifier for order in active_orders}
+    assert tracked.status == Order.OrderStatus.UNKNOWN
+
+
+def test_live_market_order_list_miss_with_empty_broad_list_is_reconciled():
+    strategy, broker = _strategy()
+    tracked = _order(
+        strategy.name,
+        "market-1",
+        Order.OrderStatus.OPEN,
+        order_type=Order.OrderType.MARKET,
+    )
+    tracked.created_at = datetime.now() - timedelta(seconds=30)
+    broker._new_orders.append(tracked)
+    broker.broker_orders = []
+
+    active_orders = strategy.get_orders(statuses=Order.ACTIVE_STATUSES)
+
+    assert active_orders == []
+    assert tracked.status == Order.OrderStatus.UNKNOWN
 
 
 def test_live_get_positions_refreshes_every_call_by_default():


### PR DESCRIPTION
## What / Why
Release LumiBot 4.5.40 with Schwab order lifecycle fixes needed for live order cancellation, option replacement, market-order reconciliation, and clearer release branch guardrails.

## Risk
Touches Schwab live order parsing/replacement/cancel reconciliation and broker live order state handling. Main risk is broker-specific order-state regressions. Detection: Schwab live smoke tests, order accessor tests, and BotSpot deployment smoke after BotManager rollout.

## Tests run
- python3 -m pytest tests/test_schwab_positions_unit.py tests/test_strategy_live_order_accessors.py -q: 39 passed
- python3 -m pytest -m "not apitest and not downloader" --tb=short -q --durations=30: timed out locally at 900s after acceptance tests dirtied performance history CSV; cleaned generated CSV and will gate on GitHub release CI.
- Agent 1 live Schwab account 4364 smoke reported: read-only Schwab smoke passed, TSLL option 4-second cancel passed, stale market order reconciliation passed, manual cancel reconciliation passed; option replace attempt filled immediately, so Schwab correctly refused cancel of FILLED order.

## Docs
- docs/DEPLOYMENT.md adds mandatory branch/setup.py preflight and stale-branch hard-stop guidance.
- docs/investigations/2026-05-29_lumibot_release_branch_drift.md documents the branch drift root cause and repair direction.
- docsrc/brokers.schwab.rst documents Schwab order lifecycle behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Schwab market-order reconciliation to properly track missing orders.
  * Enhanced order replacement handling for Schwab orders.
  * Fixed handling of Schwab mutual fund and exercise order types.
  * Added safety checks for stream initialization.

* **Documentation**
  * Enhanced deployment runbook with mandatory preflight checks.
  * Added Schwab order modification behavior documentation.

* **Tests**
  * Added live option order replacement and cancellation test coverage.
  * Expanded market order edge-case testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lumiwealth/lumibot/pull/1068?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->