### PR TITLE
Improve AI trading team live examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,26 @@ In this pattern, each agent has a job:
 3. **Bear Agent:** challenges the thesis, looks for risk, and argues for avoiding, delaying, or reducing the trade.
 4. **Trader / Portfolio Manager Agent:** checks cash, positions, open orders, and risk limits, then decides whether to trade.
 
-The copy-paste example below implements that exact team. It uses Gemini Flash Lite because it is fast and inexpensive for experiments. Set `GEMINI_API_KEY` first:
+The copy-paste example below implements that exact team. It uses Gemini Flash Lite because it is fast and inexpensive for experiments.
+
+To run it with a broker in paper mode, set your AI and Alpaca credentials and run the file:
 
 ```bash
 export GEMINI_API_KEY='your-key-here'
+export ALPACA_API_KEY='your-alpaca-key'
+export ALPACA_API_SECRET='your-alpaca-secret'
+export ALPACA_IS_PAPER=true
+python ai_trading_team_bull_bear_leveraged_etf.py
 ```
 
-Then save this as `ai_trading_team_bull_bear_leveraged_etf.py` and run `python ai_trading_team_bull_bear_leveraged_etf.py`. If the key is missing or invalid, Lumibot stops the backtest and prints a clear `GEMINI_API_KEY` error with a link to create a key.
+To backtest the same strategy instead, change `IS_BACKTESTING = False` to `IS_BACKTESTING = True` in the runner:
+
+```bash
+export GEMINI_API_KEY='your-key-here'
+python ai_trading_team_bull_bear_leveraged_etf.py
+```
+
+Save this as `ai_trading_team_bull_bear_leveraged_etf.py`. If an AI key is missing or invalid, Lumibot stops and prints a clear provider key error with a link to create a key.
 
 ```python
 import os
@@ -161,13 +174,32 @@ class AITradingTeamBullBearLeveragedETFStrategy(Strategy):
 
 
 if __name__ == "__main__":
-    from lumibot.backtesting import YahooDataBacktesting
+    IS_BACKTESTING = False
 
-    AITradingTeamBullBearLeveragedETFStrategy.backtest(
-        YahooDataBacktesting,
-        datetime(2026, 4, 7),
-        datetime(2026, 5, 22),
-    )
+    if IS_BACKTESTING:
+        from lumibot.backtesting import YahooDataBacktesting
+
+        AITradingTeamBullBearLeveragedETFStrategy.backtest(
+            YahooDataBacktesting,
+            datetime(2026, 4, 7),
+            datetime(2026, 5, 22),
+        )
+    else:
+        from lumibot.brokers import Alpaca
+        from lumibot.traders import Trader
+
+        ALPACA_CONFIG = {
+            "API_KEY": os.environ["ALPACA_API_KEY"],
+            "API_SECRET": os.environ["ALPACA_API_SECRET"],
+            "PAPER": os.environ.get("ALPACA_IS_PAPER", "true").lower() != "false",
+        }
+
+        broker = Alpaca(ALPACA_CONFIG)
+        strategy = AITradingTeamBullBearLeveragedETFStrategy(broker=broker)
+
+        trader = Trader()
+        trader.add_strategy(strategy)
+        trader.run_all()
 ```
 
 Example backtest artifact from this sample strategy:
@@ -176,39 +208,18 @@ Example backtest artifact from this sample strategy:
   <img src="docs/assets/ai-trading-team-example/ai-trading-team-tearsheet-rob-crop-2026-05-24.png" alt="AI trading team backtest tear sheet compared to SPY" width="100%">
 </p>
 
-Backtests are not expected future performance. The point is that the full AI trading team runs inside Lumibot's normal backtest loop, so the decisions, orders, and artifacts are inspectable before you connect a broker.
+Backtests are not expected future performance. The point is that the full AI trading team runs inside Lumibot's normal broker and backtest loops, so the decisions, orders, and artifacts are inspectable before you connect real money.
 
 ### More AI Trading Team Examples
 
-These examples use the same pattern: one Lumibot strategy, multiple AI agents with specific jobs, and only the final trading or portfolio-manager agent allowed to submit orders.
+These examples show different ways to organize an AI trading team. Each page explains the inspiration, the agent flow, how to run it with a broker in paper mode, and how to backtest it.
 
-1. **[Citadel sector pods AI trading team](https://lumibot.lumiwealth.com/agents_example_citadel_sector_pods.html):** sector-specific pod agents research technology, healthcare, financials, industrials, consumer stocks, and macro context before a portfolio manager allocates capital. Source: [`ai_trading_team_citadel_sector_pods.py`](lumibot/example_strategies/ai_trading_team_citadel_sector_pods.py).
-2. **[Warren Buffett value AI trading team](https://lumibot.lumiwealth.com/agents_example_warren_buffett_value.html):** value-focused agents study business quality, financial strength, valuation, and margin of safety before making a long-term stock decision. Source: [`ai_trading_team_warren_buffett_value.py`](lumibot/example_strategies/ai_trading_team_warren_buffett_value.py).
-3. **[Ray Dalio idea meritocracy AI trading team](https://lumibot.lumiwealth.com/agents_example_ray_dalio_idea_meritocracy.html):** independent agents argue macro, equity, rates, and risk perspectives before a decision agent weighs the arguments. Source: [`ai_trading_team_ray_dalio_idea_meritocracy.py`](lumibot/example_strategies/ai_trading_team_ray_dalio_idea_meritocracy.py).
-4. **[Bill Ackman concentrated AI trading team](https://lumibot.lumiwealth.com/agents_example_bill_ackman_concentrated.html):** agents look for durable, high-conviction large-cap opportunities and challenge the thesis before taking a focused position. Source: [`ai_trading_team_bill_ackman_concentrated.py`](lumibot/example_strategies/ai_trading_team_bill_ackman_concentrated.py).
-5. **[Bull/bear leveraged ETF AI trading team](https://lumibot.lumiwealth.com/agents_example_bull_bear_leveraged_etf.html):** researcher, bull, bear, and trader agents choose between leveraged long and inverse ETFs. Source: [`ai_trading_team_bull_bear_leveraged_etf.py`](lumibot/example_strategies/ai_trading_team_bull_bear_leveraged_etf.py).
-6. **[Bull/bear large-cap stocks AI trading team](https://lumibot.lumiwealth.com/agents_example_bull_bear_large_cap_stocks.html):** the same bull/bear debate pattern applied to large-cap equities instead of leveraged ETFs. Source: [`ai_trading_team_bull_bear_large_cap_stocks.py`](lumibot/example_strategies/ai_trading_team_bull_bear_large_cap_stocks.py).
-
-To run the same strategy in paper trading or live trading, keep the strategy class and replace the `if __name__ == "__main__":` block with a broker runner:
-
-```python
-if __name__ == "__main__":
-    from lumibot.brokers import Alpaca
-    from lumibot.traders import Trader
-
-    ALPACA_CONFIG = {
-        "API_KEY": "YOUR_ALPACA_API_KEY",
-        "API_SECRET": "YOUR_ALPACA_SECRET",
-        "PAPER": True,
-    }
-
-    broker = Alpaca(ALPACA_CONFIG)
-    strategy = AITradingTeamBullBearLeveragedETFStrategy(broker=broker)
-
-    trader = Trader()
-    trader.add_strategy(strategy)
-    trader.run_all()
-```
+1. **[Citadel sector pods AI trading team](https://lumibot.lumiwealth.com/agents_example_citadel_sector_pods.html):** inspired by the pod-style structure associated with Ken Griffin's Citadel: sector specialists pitch their best ideas, a risk manager challenges crowding and drawdown risk, and a portfolio manager rotates into the strongest sector ETF. Source: [`ai_trading_team_citadel_sector_pods.py`](lumibot/example_strategies/ai_trading_team_citadel_sector_pods.py).
+2. **[Warren Buffett value AI trading team](https://lumibot.lumiwealth.com/agents_example_warren_buffett_value.html):** uses AI agents like a patient value-investing desk: one agent digs into business quality and annual reports, one demands valuation discipline, and the portfolio manager only buys the best long-term compounder. Source: [`ai_trading_team_warren_buffett_value.py`](lumibot/example_strategies/ai_trading_team_warren_buffett_value.py).
+3. **[Ray Dalio idea meritocracy AI trading team](https://lumibot.lumiwealth.com/agents_example_ray_dalio_idea_meritocracy.html):** turns Bridgewater-style thoughtful disagreement into a macro ETF workflow, with growth, inflation, liquidity, and disagreement agents arguing before the trader acts. Source: [`ai_trading_team_ray_dalio_idea_meritocracy.py`](lumibot/example_strategies/ai_trading_team_ray_dalio_idea_meritocracy.py).
+4. **[Bill Ackman concentrated AI trading team](https://lumibot.lumiwealth.com/agents_example_bill_ackman_concentrated.html):** inspired by Pershing Square-style concentrated investing: find one great business, make the activist bull case, attack it like a short seller, then let the portfolio manager take a focused position if the thesis survives. Source: [`ai_trading_team_bill_ackman_concentrated.py`](lumibot/example_strategies/ai_trading_team_bill_ackman_concentrated.py).
+5. **[Bull/bear leveraged ETF AI trading team](https://lumibot.lumiwealth.com/agents_example_bull_bear_leveraged_etf.html):** a fast, aggressive demo where bull and bear agents debate leveraged long and inverse ETFs before the trader rotates into one high-conviction ETF. Source: [`ai_trading_team_bull_bear_leveraged_etf.py`](lumibot/example_strategies/ai_trading_team_bull_bear_leveraged_etf.py).
+6. **[Bull/bear large-cap stocks AI trading team](https://lumibot.lumiwealth.com/agents_example_bull_bear_large_cap_stocks.html):** the same debate structure applied to familiar large-cap stocks, which makes it easier to inspect each agent's reasoning before using more volatile instruments. Source: [`ai_trading_team_bull_bear_large_cap_stocks.py`](lumibot/example_strategies/ai_trading_team_bull_bear_large_cap_stocks.py).
 
 ## Run Lumibot Without Managing Servers
 

--- a/docs/AI_TRADING_TEAM_EXAMPLES.md
+++ b/docs/AI_TRADING_TEAM_EXAMPLES.md
@@ -1,32 +1,66 @@
 # AI Trading Team Examples
 
-Lumibot includes several copy-paste AI trading team examples. Each one uses the same simple pattern:
+Lumibot includes several copy-paste AI trading team examples. Each one keeps the
+strategy code intentionally simple:
 
-- read-only agents research or debate
-- one final trading-enabled agent can submit orders
-- normal Lumibot backtests, memory, traces, and order artifacts still apply
+- create agents in `initialize()`
+- pass context through those agents in `on_trading_iteration()`
+- allow only the final trader or portfolio-manager agent to submit orders
+- run the same file with a broker by default, or set `IS_BACKTESTING = True`
+  in the runner for the historical demo window
 
-These examples are inspired by public investing styles and firms. They are not affiliated with or endorsed by the investors, firms, or companies named.
+These examples are inspired by public investing styles and firms. They are not
+affiliated with or endorsed by the investors, firms, or companies named.
 
 ## Examples
 
-- `lumibot/example_strategies/ai_trading_team_bull_bear_leveraged_etf.py`
-  Aggressive bull/bear team for leveraged ETF rotation.
-
-- `lumibot/example_strategies/ai_trading_team_bull_bear_large_cap_stocks.py`
-  Large-cap stock team with evidence, bull, bear, and portfolio-manager roles.
-
-- `lumibot/example_strategies/ai_trading_team_ray_dalio_idea_meritocracy.py`
-  Growth, inflation, debt/liquidity, and thoughtful-disagreement agents debate one macro ETF idea.
+- `lumibot/example_strategies/ai_trading_team_citadel_sector_pods.py`
+  Inspired by the pod-style structure associated with Ken Griffin's Citadel:
+  sector specialists pitch their best ETF ideas, a risk manager challenges the
+  setup, and a portfolio manager rotates into the strongest sector.
 
 - `lumibot/example_strategies/ai_trading_team_warren_buffett_value.py`
-  Annual-report, valuation-skeptic, and portfolio-manager flow for business-quality investing.
+  A value-investing team where one agent reads for business quality and annual
+  report evidence, one agent demands valuation discipline, and the portfolio
+  manager buys only the best long-term compounder.
+
+- `lumibot/example_strategies/ai_trading_team_ray_dalio_idea_meritocracy.py`
+  A Bridgewater-style idea-meritocracy workflow where growth, inflation, and
+  liquidity agents argue, a disagreement agent stress-tests the assumptions,
+  and the trader chooses one macro ETF.
 
 - `lumibot/example_strategies/ai_trading_team_bill_ackman_concentrated.py`
-  Concentrated high-conviction large-cap team with an activist bull case and short-seller bear case.
+  A concentrated investing workflow where a quality researcher, activist bull,
+  and short-seller bear debate whether one high-conviction large-cap position
+  deserves capital.
 
-- `lumibot/example_strategies/ai_trading_team_citadel_sector_pods.py`
-  Sector-pod team with technology, financials, healthcare, energy, consumer, risk, and portfolio-manager roles.
+- `lumibot/example_strategies/ai_trading_team_bull_bear_leveraged_etf.py`
+  An aggressive bull/bear demo where agents debate leveraged long and inverse
+  ETFs before rotating into one high-conviction ETF.
+
+- `lumibot/example_strategies/ai_trading_team_bull_bear_large_cap_stocks.py`
+  The same bull/bear debate structure applied to familiar large-cap stocks, so
+  the reasoning is easier to inspect before using more volatile instruments.
+
+## Run the examples
+
+Each example defaults to broker-connected execution. With Alpaca, it runs in
+paper mode unless `ALPACA_IS_PAPER=false`.
+
+```bash
+export GEMINI_API_KEY='your-key-here'
+export ALPACA_API_KEY='your-alpaca-key'
+export ALPACA_API_SECRET='your-alpaca-secret'
+export ALPACA_IS_PAPER=true
+python lumibot/example_strategies/ai_trading_team_citadel_sector_pods.py
+```
+
+Backtest the same file by changing `IS_BACKTESTING = False` to `IS_BACKTESTING = True` in the runner:
+
+```bash
+export GEMINI_API_KEY='your-key-here'
+python lumibot/example_strategies/ai_trading_team_citadel_sector_pods.py
+```
 
 ## Workflow diagrams
 
@@ -37,4 +71,6 @@ These examples are inspired by public investing styles and firms. They are not a
 - `docs/assets/ai-trading-team-workflows/bill-ackman-concentrated.png`
 - `docs/assets/ai-trading-team-workflows/citadel-sector-pods.png`
 
-`lumibot/example_strategies/ai_trading_team.py` remains the shortest alias for the leveraged ETF example. New code should prefer the descriptive filenames above.
+`lumibot/example_strategies/ai_trading_team.py` remains the shortest alias for
+the leveraged ETF example. New code should prefer the descriptive filenames
+above.

--- a/docsrc/agents_example_bill_ackman_concentrated.rst
+++ b/docsrc/agents_example_bill_ackman_concentrated.rst
@@ -1,20 +1,51 @@
-Bill Ackman Concentrated Trading Team
-=====================================
+Bill Ackman Concentrated AI Trading Team
+========================================
 
 .. image:: ../docs/assets/ai-trading-team-workflows/bill-ackman-concentrated.png
    :alt: AI trading team workflow for Bill Ackman concentrated style investing
    :width: 100%
 
-This example models a concentrated idea process: quality research, catalyst
-analysis, an adversarial bear case, then one final position decision.
+This strategy is inspired by Bill Ackman and Pershing Square-style concentrated
+investing: do deep work on a small number of understandable, high-quality
+businesses, make a strong bull case, invite a brutal bear case, and then act
+with conviction if the thesis survives.
 
-Agent flow
-----------
+The team is intentionally adversarial. The quality researcher finds the best
+candidate, the activist bull looks for catalysts and value creation, the
+short-seller bear attacks the thesis, and the portfolio manager decides whether
+one concentrated position is still justified.
 
-* ``quality_researcher`` finds the best high-quality large-cap business.
+How the team works
+------------------
+
+* ``quality_researcher`` finds the best high-quality large-cap candidate.
 * ``activist_bull`` argues for catalysts, pricing power, and value creation.
-* ``short_seller_bear`` attacks the thesis.
-* ``portfolio_manager`` builds one concentrated position with trading permission.
+* ``short_seller_bear`` attacks leverage, governance, accounting, competition, and valuation risk.
+* ``portfolio_manager`` builds one concentrated position and is the only agent allowed to trade.
+
+Run it with a broker
+--------------------
+
+The file defaults to broker-connected execution. With Alpaca, it runs in paper
+mode unless you set ``ALPACA_IS_PAPER=false``.
+
+.. code-block:: bash
+
+   export GEMINI_API_KEY='your-key-here'
+   export ALPACA_API_KEY='your-alpaca-key'
+   export ALPACA_API_SECRET='your-alpaca-secret'
+   export ALPACA_IS_PAPER=true
+   python lumibot/example_strategies/ai_trading_team_bill_ackman_concentrated.py
+
+Backtest it
+-----------
+
+Use the same strategy class and change ``IS_BACKTESTING = False`` to ``IS_BACKTESTING = True`` in the runner:
+
+.. code-block:: bash
+
+   export GEMINI_API_KEY='your-key-here'
+   python lumibot/example_strategies/ai_trading_team_bill_ackman_concentrated.py
 
 Example code
 ------------

--- a/docsrc/agents_example_bull_bear_large_cap_stocks.rst
+++ b/docsrc/agents_example_bull_bear_large_cap_stocks.rst
@@ -1,21 +1,51 @@
-Bull/Bear Large-Cap Stocks Trading Team
-=======================================
+Bull/Bear Large-Cap Stocks AI Trading Team
+==========================================
 
 .. image:: ../docs/assets/ai-trading-team-workflows/bull-bear-large-cap-stocks.png
    :alt: AI trading team workflow for bull/bear large-cap stocks
    :width: 100%
 
-This example applies the same bull/bear debate pattern to large-cap stocks. It
-keeps the flow intentionally small so the agent behavior is easy to inspect in
-backtest traces.
+This strategy uses the same simple bull/bear pattern as the leveraged ETF demo,
+but applies it to familiar large-cap stocks. It is a cleaner starting point for
+people who want to understand the AI agent behavior before using more volatile
+leveraged instruments.
 
-Agent flow
-----------
+The researcher picks the strongest stock, the bull agent argues the upside
+case, the bear agent forces a risk check, and the trader decides whether to
+rotate into the pick. Because the symbols are recognizable, it is easier to
+read the trace and decide whether the agents are making sensible arguments.
+
+How the team works
+------------------
 
 * ``researcher`` ranks the large-cap stock universe.
 * ``bull`` argues for the strongest upside case.
 * ``bear`` flags the biggest risk.
-* ``trader`` sells non-picks and buys the chosen stock with trading permission.
+* ``trader`` sells non-picks, buys the chosen stock, and is the only agent allowed to trade.
+
+Run it with a broker
+--------------------
+
+The file defaults to broker-connected execution. With Alpaca, it runs in paper
+mode unless you set ``ALPACA_IS_PAPER=false``.
+
+.. code-block:: bash
+
+   export GEMINI_API_KEY='your-key-here'
+   export ALPACA_API_KEY='your-alpaca-key'
+   export ALPACA_API_SECRET='your-alpaca-secret'
+   export ALPACA_IS_PAPER=true
+   python lumibot/example_strategies/ai_trading_team_bull_bear_large_cap_stocks.py
+
+Backtest it
+-----------
+
+Use the same strategy class and change ``IS_BACKTESTING = False`` to ``IS_BACKTESTING = True`` in the runner:
+
+.. code-block:: bash
+
+   export GEMINI_API_KEY='your-key-here'
+   python lumibot/example_strategies/ai_trading_team_bull_bear_large_cap_stocks.py
 
 Example code
 ------------

--- a/docsrc/agents_example_bull_bear_leveraged_etf.rst
+++ b/docsrc/agents_example_bull_bear_leveraged_etf.rst
@@ -1,21 +1,52 @@
-Bull/Bear Leveraged ETF Trading Team
-====================================
+Bull/Bear Leveraged ETF AI Trading Team
+=======================================
 
 .. image:: ../docs/assets/ai-trading-team-workflows/bull-bear-leveraged-etf.png
    :alt: AI trading team workflow for bull/bear leveraged ETFs
    :width: 100%
 
-This example rotates across leveraged and inverse ETFs. A researcher picks the
-strongest ETF, a bull agent makes the upside case, a bear agent challenges the
-risk, and the trader agent is the only agent allowed to submit orders.
+This is the fast, dramatic AI trading team demo. It gives the agents a universe
+of leveraged long and inverse ETFs, then asks them to rotate aggressively into
+one ETF. The purpose is not subtle portfolio construction. The purpose is to
+show the full trading-team loop clearly: research, upside case, risk challenge,
+and final execution.
 
-Agent flow
-----------
+Because the universe includes both bull and bear instruments, the team can
+choose risk-on or risk-off exposure. That makes the decision trail easy to
+audit: you can inspect why the agents liked a sector, why the bear agent
+objected, and why the final trader still bought or sold.
+
+How the team works
+------------------
 
 * ``researcher`` ranks the leveraged ETF universe.
 * ``bull`` argues for the strongest money-making trade.
 * ``bear`` points out the biggest risk.
-* ``trader`` sells non-picks and buys the chosen ETF with trading permission.
+* ``trader`` sells non-picks, buys the chosen ETF, and is the only agent allowed to trade.
+
+Run it with a broker
+--------------------
+
+The file defaults to broker-connected execution. With Alpaca, it runs in paper
+mode unless you set ``ALPACA_IS_PAPER=false``.
+
+.. code-block:: bash
+
+   export GEMINI_API_KEY='your-key-here'
+   export ALPACA_API_KEY='your-alpaca-key'
+   export ALPACA_API_SECRET='your-alpaca-secret'
+   export ALPACA_IS_PAPER=true
+   python lumibot/example_strategies/ai_trading_team_bull_bear_leveraged_etf.py
+
+Backtest it
+-----------
+
+Use the same strategy class and change ``IS_BACKTESTING = False`` to ``IS_BACKTESTING = True`` in the runner:
+
+.. code-block:: bash
+
+   export GEMINI_API_KEY='your-key-here'
+   python lumibot/example_strategies/ai_trading_team_bull_bear_leveraged_etf.py
 
 Example code
 ------------

--- a/docsrc/agents_example_citadel_sector_pods.rst
+++ b/docsrc/agents_example_citadel_sector_pods.rst
@@ -1,24 +1,56 @@
-Citadel Sector-Pods Trading Team
-================================
+Citadel Sector Pods AI Trading Team
+===================================
 
 .. image:: ../docs/assets/ai-trading-team-workflows/citadel-sector-pods.png
    :alt: AI trading team workflow for Citadel-style sector pods
    :width: 100%
 
-This example shows a specialist-desk pattern. Several sector pods independently
-pitch a sector ETF, a risk manager compares the tradeoffs, and the portfolio
-manager rotates into the strongest sector.
+This strategy is inspired by the pod-style structure associated with Ken
+Griffin's Citadel and other multi-manager platforms. The idea is simple: do not
+ask one generalist to understand every market at once. Give each specialist a
+clear lane, let them pitch their strongest idea, then put a risk manager and
+portfolio manager above the debate.
 
-Agent flow
-----------
+In Lumibot, that becomes an AI trading team. Sector pods study different parts
+of the market, a risk manager challenges the strongest pitches, and only the
+portfolio manager has permission to submit orders. It is a good example when
+you want to test whether specialist agents can create better decisions than one
+single broad prompt.
 
-* ``technology_pod`` ranks technology and communications.
-* ``financials_pod`` ranks financial and rate-sensitive sectors.
-* ``healthcare_pod`` ranks healthcare and defensive growth.
-* ``energy_pod`` ranks energy and commodity-sensitive sectors.
-* ``consumer_pod`` ranks consumer and housing-sensitive sectors.
-* ``risk_manager`` challenges crowding, drawdown, macro, and reversal risks.
-* ``portfolio_manager`` rotates into the strongest sector ETF with trading permission.
+How the team works
+------------------
+
+* ``technology_pod`` looks at technology and communications exposure.
+* ``financials_pod`` looks at financials and rate-sensitive exposure.
+* ``healthcare_pod`` looks at healthcare and defensive growth.
+* ``energy_pod`` looks at energy and commodity-sensitive exposure.
+* ``consumer_pod`` looks at consumer and housing-sensitive exposure.
+* ``risk_manager`` challenges crowding, drawdown, macro, and reversal risk.
+* ``portfolio_manager`` rotates into the strongest sector ETF and is the only agent allowed to trade.
+
+Run it with a broker
+--------------------
+
+The file defaults to broker-connected execution. With Alpaca, it runs in paper
+mode unless you set ``ALPACA_IS_PAPER=false``.
+
+.. code-block:: bash
+
+   export GEMINI_API_KEY='your-key-here'
+   export ALPACA_API_KEY='your-alpaca-key'
+   export ALPACA_API_SECRET='your-alpaca-secret'
+   export ALPACA_IS_PAPER=true
+   python lumibot/example_strategies/ai_trading_team_citadel_sector_pods.py
+
+Backtest it
+-----------
+
+Use the same strategy class and change ``IS_BACKTESTING = False`` to ``IS_BACKTESTING = True`` in the runner:
+
+.. code-block:: bash
+
+   export GEMINI_API_KEY='your-key-here'
+   python lumibot/example_strategies/ai_trading_team_citadel_sector_pods.py
 
 Example code
 ------------

--- a/docsrc/agents_example_ray_dalio_idea_meritocracy.rst
+++ b/docsrc/agents_example_ray_dalio_idea_meritocracy.rst
@@ -1,22 +1,53 @@
-Ray Dalio Idea-Meritocracy Trading Team
-=======================================
+Ray Dalio Idea Meritocracy AI Trading Team
+==========================================
 
 .. image:: ../docs/assets/ai-trading-team-workflows/ray-dalio-idea-meritocracy.png
    :alt: AI trading team workflow for Ray Dalio idea-meritocracy style macro debate
    :width: 100%
 
-This example uses independent macro viewpoints and an explicit disagreement
-step. The point is not to imitate a specific fund product; it is to show how
-specialists can argue from different macro assumptions before one final trade.
+This strategy is inspired by Ray Dalio's public writing about idea meritocracy
+and thoughtful disagreement. It is not an "All Weather" clone. The important
+idea is the operating system: independent thinkers argue from different models
+of the world, the disagreement is explicit, and the final decision should be
+stronger because weak assumptions were challenged.
 
-Agent flow
-----------
+In Lumibot, that turns into a macro trading team. One agent argues from growth,
+one argues from inflation and rates, one argues from debt, liquidity, currency,
+and policy pressure, then a disagreement agent stress-tests all three before
+the trader picks one ETF.
 
-* ``growth_agent`` argues from a growth-surprise view.
-* ``inflation_agent`` argues from rates and inflation.
+How the team works
+------------------
+
+* ``growth_agent`` asks what wins if growth improves.
+* ``inflation_agent`` asks what wins or loses if inflation and rates surprise.
 * ``debt_liquidity_agent`` argues from debt, liquidity, currency, and policy pressure.
-* ``thoughtful_disagreement`` stress-tests all views.
-* ``trader`` chooses one macro ETF idea with trading permission.
+* ``thoughtful_disagreement`` challenges the other agents and names the strongest idea.
+* ``trader`` buys the best macro ETF idea and is the only agent allowed to trade.
+
+Run it with a broker
+--------------------
+
+The file defaults to broker-connected execution. With Alpaca, it runs in paper
+mode unless you set ``ALPACA_IS_PAPER=false``.
+
+.. code-block:: bash
+
+   export GEMINI_API_KEY='your-key-here'
+   export ALPACA_API_KEY='your-alpaca-key'
+   export ALPACA_API_SECRET='your-alpaca-secret'
+   export ALPACA_IS_PAPER=true
+   python lumibot/example_strategies/ai_trading_team_ray_dalio_idea_meritocracy.py
+
+Backtest it
+-----------
+
+Use the same strategy class and change ``IS_BACKTESTING = False`` to ``IS_BACKTESTING = True`` in the runner:
+
+.. code-block:: bash
+
+   export GEMINI_API_KEY='your-key-here'
+   python lumibot/example_strategies/ai_trading_team_ray_dalio_idea_meritocracy.py
 
 Example code
 ------------

--- a/docsrc/agents_example_warren_buffett_value.rst
+++ b/docsrc/agents_example_warren_buffett_value.rst
@@ -1,20 +1,52 @@
-Warren Buffett Value Trading Team
-=================================
+Warren Buffett Value AI Trading Team
+====================================
 
 .. image:: ../docs/assets/ai-trading-team-workflows/warren-buffett-value.png
    :alt: AI trading team workflow for Warren Buffett value style investing
    :width: 100%
 
-This example is a long-term business-quality flow. It asks one agent to find the
-best business, one agent to require valuation discipline, and one final
-portfolio manager to trade only if the idea survives.
+This strategy is inspired by Warren Buffett's public investing style: understand
+the business first, read the filings, care about durability, avoid overpaying,
+and only act when the idea is strong enough to own. The point is not to clone
+Buffett. The point is to show how AI agents can divide a value-investing process
+into research, skepticism, and final portfolio action.
 
-Agent flow
-----------
+The first agent behaves like an annual-report reader. It looks for business
+quality, cash generation, balance-sheet strength, and durability. The second
+agent plays valuation skeptic and asks whether the price still leaves a margin
+of safety. The portfolio manager only trades if the business-quality case and
+valuation discipline both survive.
 
-* ``annual_report_reader`` looks for business quality, cash flow, balance-sheet strength, and durability.
-* ``valuation_skeptic`` challenges valuation and requires a margin of safety.
-* ``portfolio_manager`` buys the best long-term compounder with trading permission.
+How the team works
+------------------
+
+* ``annual_report_reader`` studies business quality, cash flow, filings, and durability.
+* ``valuation_skeptic`` challenges valuation and asks for a margin of safety.
+* ``portfolio_manager`` buys the best long-term compounder and is the only agent allowed to trade.
+
+Run it with a broker
+--------------------
+
+The file defaults to broker-connected execution. With Alpaca, it runs in paper
+mode unless you set ``ALPACA_IS_PAPER=false``.
+
+.. code-block:: bash
+
+   export GEMINI_API_KEY='your-key-here'
+   export ALPACA_API_KEY='your-alpaca-key'
+   export ALPACA_API_SECRET='your-alpaca-secret'
+   export ALPACA_IS_PAPER=true
+   python lumibot/example_strategies/ai_trading_team_warren_buffett_value.py
+
+Backtest it
+-----------
+
+Use the same strategy class and change ``IS_BACKTESTING = False`` to ``IS_BACKTESTING = True`` in the runner:
+
+.. code-block:: bash
+
+   export GEMINI_API_KEY='your-key-here'
+   python lumibot/example_strategies/ai_trading_team_warren_buffett_value.py
 
 Example code
 ------------

--- a/docsrc/agents_examples.rst
+++ b/docsrc/agents_examples.rst
@@ -3,7 +3,9 @@ AI Trading Team Examples
 
 LumiBot includes several copy-paste AI trading team examples. Each one keeps the
 Python simple: create agents in ``initialize()``, pass context through them in
-``on_trading_iteration()``, and let only the final portfolio-manager agent trade.
+``on_trading_iteration()``, and let only the final portfolio-manager or trader
+agent submit orders. The same file runs with a broker by default, or backtests
+when you set ``IS_BACKTESTING = True`` in the flat runner.
 
 .. toctree::
    :maxdepth: 1
@@ -21,26 +23,33 @@ affiliated with or endorsed by the investors, firms, or companies named.
 Examples
 --------
 
-``ai_trading_team_bull_bear_leveraged_etf.py``
-   Aggressive bull/bear team for leveraged ETF rotation.
-
-``ai_trading_team_bull_bear_large_cap_stocks.py``
-   Large-cap stock team with evidence, bull, bear, and portfolio-manager roles.
-
-``ai_trading_team_ray_dalio_idea_meritocracy.py``
-   Macro specialists argue growth, inflation, debt, and liquidity, then a
-   disagreement agent stress-tests the views before the trader acts.
+``ai_trading_team_citadel_sector_pods.py``
+   Inspired by the pod-style structure associated with Ken Griffin's Citadel:
+   sector specialists pitch their best ETF ideas, a risk manager challenges the
+   setup, and a portfolio manager rotates into the strongest sector.
 
 ``ai_trading_team_warren_buffett_value.py``
-   Annual-report, valuation, and long-term business-quality team.
+   A value-investing team where one agent reads for business quality and annual
+   report evidence, one agent demands valuation discipline, and the portfolio
+   manager buys only the best long-term compounder.
+
+``ai_trading_team_ray_dalio_idea_meritocracy.py``
+   A Bridgewater-style idea-meritocracy workflow where growth, inflation, and
+   liquidity agents argue, a disagreement agent stress-tests the assumptions,
+   and the trader chooses one macro ETF.
 
 ``ai_trading_team_bill_ackman_concentrated.py``
-   Concentrated high-conviction large-cap team with an activist bull case and
-   short-seller bear case.
+   A concentrated investing workflow where a quality researcher, activist bull,
+   and short-seller bear debate whether one high-conviction large-cap position
+   deserves capital.
 
-``ai_trading_team_citadel_sector_pods.py``
-   Sector-pod team that compares sector ETFs through cyclical, defensive, and
-   risk lenses.
+``ai_trading_team_bull_bear_leveraged_etf.py``
+   An aggressive bull/bear demo where agents debate leveraged long and inverse
+   ETFs before rotating into one high-conviction ETF.
+
+``ai_trading_team_bull_bear_large_cap_stocks.py``
+   The same bull/bear debate structure applied to familiar large-cap stocks, so
+   the reasoning is easier to inspect before using more volatile instruments.
 
 ``ai_trading_team.py`` remains the shortest alias for the leveraged ETF example.
 New code should prefer the descriptive filenames above.

--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -126,18 +126,6 @@ Key AI agent docs:
 - :doc:`agents_canonical_demos` -- three reference demos: news sentiment, macro risk, and M2 liquidity
 - :doc:`agents_observability` -- traces, replay cache, warnings, and debugging workflow
 
-More AI Trading Team Examples
-*****************************
-
-These examples use the same pattern: one Lumibot strategy, multiple AI agents with specific jobs, and only the final trading or portfolio-manager agent allowed to submit orders.
-
-1. :doc:`agents_example_citadel_sector_pods` -- sector-specific pod agents research technology, healthcare, financials, industrials, consumer stocks, and macro context before a portfolio manager allocates capital.
-2. :doc:`agents_example_warren_buffett_value` -- value-focused agents study business quality, financial strength, valuation, and margin of safety before making a long-term stock decision.
-3. :doc:`agents_example_ray_dalio_idea_meritocracy` -- independent agents argue macro, equity, rates, and risk perspectives before a decision agent weighs the arguments.
-4. :doc:`agents_example_bill_ackman_concentrated` -- agents look for durable, high-conviction large-cap opportunities and challenge the thesis before taking a focused position.
-5. :doc:`agents_example_bull_bear_leveraged_etf` -- researcher, bull, bear, and trader agents choose between leveraged long and inverse ETFs.
-6. :doc:`agents_example_bull_bear_large_cap_stocks` -- the same bull/bear debate pattern applied to large-cap equities instead of leveraged ETFs.
-
 Design Your AI Trading Team
 ***************************
 
@@ -165,13 +153,26 @@ In this pattern, each agent has a job:
 3. **Bear Agent:** challenges the thesis, looks for risk, and argues for avoiding, delaying, or reducing the trade.
 4. **Trader / Portfolio Manager Agent:** checks cash, positions, open orders, and risk limits, then decides whether to trade.
 
-The copy-paste example below implements that exact team. It uses Gemini Flash Lite because it is fast and inexpensive for experiments. Set ``GEMINI_API_KEY`` first:
+The copy-paste example below implements that exact team. It uses Gemini Flash Lite because it is fast and inexpensive for experiments.
+
+To run it with a broker in paper mode, set your AI and Alpaca credentials and run the file:
 
 .. code-block:: bash
 
     export GEMINI_API_KEY='your-key-here'
+    export ALPACA_API_KEY='your-alpaca-key'
+    export ALPACA_API_SECRET='your-alpaca-secret'
+    export ALPACA_IS_PAPER=true
+    python ai_trading_team_bull_bear_leveraged_etf.py
 
-Then save this as ``ai_trading_team_bull_bear_leveraged_etf.py`` and run ``python ai_trading_team_bull_bear_leveraged_etf.py``. If the key is missing or invalid, LumiBot stops the backtest and prints a clear ``GEMINI_API_KEY`` error with a link to create a key.
+To backtest the same strategy instead, change ``IS_BACKTESTING = False`` to ``IS_BACKTESTING = True`` in the runner:
+
+.. code-block:: bash
+
+    export GEMINI_API_KEY='your-key-here'
+    python ai_trading_team_bull_bear_leveraged_etf.py
+
+Save this as ``ai_trading_team_bull_bear_leveraged_etf.py``. If an AI key is missing or invalid, LumiBot stops and prints a clear provider key error with a link to create a key.
 
 .. code-block:: python
 
@@ -241,13 +242,32 @@ Then save this as ``ai_trading_team_bull_bear_leveraged_etf.py`` and run ``pytho
 
 
     if __name__ == "__main__":
-        from lumibot.backtesting import YahooDataBacktesting
+        IS_BACKTESTING = False
 
-        AITradingTeamBullBearLeveragedETFStrategy.backtest(
-            YahooDataBacktesting,
-            datetime(2026, 4, 7),
-            datetime(2026, 5, 22),
-        )
+        if IS_BACKTESTING:
+            from lumibot.backtesting import YahooDataBacktesting
+
+            AITradingTeamBullBearLeveragedETFStrategy.backtest(
+                YahooDataBacktesting,
+                datetime(2026, 4, 7),
+                datetime(2026, 5, 22),
+            )
+        else:
+            from lumibot.brokers import Alpaca
+            from lumibot.traders import Trader
+
+            ALPACA_CONFIG = {
+                "API_KEY": os.environ["ALPACA_API_KEY"],
+                "API_SECRET": os.environ["ALPACA_API_SECRET"],
+                "PAPER": os.environ.get("ALPACA_IS_PAPER", "true").lower() != "false",
+            }
+
+            broker = Alpaca(ALPACA_CONFIG)
+            strategy = AITradingTeamBullBearLeveragedETFStrategy(broker=broker)
+
+            trader = Trader()
+            trader.add_strategy(strategy)
+            trader.run_all()
 
 Example backtest artifact from this sample strategy:
 
@@ -255,28 +275,19 @@ Example backtest artifact from this sample strategy:
    :alt: AI trading team backtest tear sheet compared to SPY
    :width: 100%
 
-The result is intentionally eye-catching, but the exact percentage is not the point. The point is that the full AI trading team runs inside Lumibot's normal backtest loop, so the decisions, orders, and artifacts are inspectable before you connect a broker. Backtests are not expected future performance.
+The result is intentionally eye-catching, but the exact percentage is not the point. The point is that the full AI trading team runs inside Lumibot's normal broker and backtest loops, so the decisions, orders, and artifacts are inspectable before you connect real money. Backtests are not expected future performance.
 
-To run the same strategy in paper trading or live trading, keep the strategy class and replace the ``if __name__ == "__main__":`` block with a broker runner:
+More AI Trading Team Examples
+*****************************
 
-.. code-block:: python
+These examples show different ways to organize an AI trading team. Each page explains the inspiration, the agent flow, how to run it with a broker in paper mode, and how to backtest it.
 
-    if __name__ == "__main__":
-        from lumibot.brokers import Alpaca
-        from lumibot.traders import Trader
-
-        ALPACA_CONFIG = {
-            "API_KEY": "YOUR_ALPACA_API_KEY",
-            "API_SECRET": "YOUR_ALPACA_SECRET",
-            "PAPER": True,
-        }
-
-        broker = Alpaca(ALPACA_CONFIG)
-        strategy = AITradingTeamBullBearLeveragedETFStrategy(broker=broker)
-
-        trader = Trader()
-        trader.add_strategy(strategy)
-        trader.run_all()
+1. :doc:`agents_example_citadel_sector_pods` -- inspired by the pod-style structure associated with Ken Griffin's Citadel: sector specialists pitch their best ideas, a risk manager challenges crowding and drawdown risk, and a portfolio manager rotates into the strongest sector ETF.
+2. :doc:`agents_example_warren_buffett_value` -- uses AI agents like a patient value-investing desk: one agent digs into business quality and annual reports, one demands valuation discipline, and the portfolio manager only buys the best long-term compounder.
+3. :doc:`agents_example_ray_dalio_idea_meritocracy` -- turns Bridgewater-style thoughtful disagreement into a macro ETF workflow, with growth, inflation, liquidity, and disagreement agents arguing before the trader acts.
+4. :doc:`agents_example_bill_ackman_concentrated` -- inspired by Pershing Square-style concentrated investing: find one great business, make the activist bull case, attack it like a short seller, then let the portfolio manager take a focused position if the thesis survives.
+5. :doc:`agents_example_bull_bear_leveraged_etf` -- a fast, aggressive demo where bull and bear agents debate leveraged long and inverse ETFs before the trader rotates into one high-conviction ETF.
+6. :doc:`agents_example_bull_bear_large_cap_stocks` -- the same debate structure applied to familiar large-cap stocks, which makes it easier to inspect each agent's reasoning before using more volatile instruments.
 
 Cash Accounting
 ***************

--- a/lumibot/example_strategies/ai_trading_team_bill_ackman_concentrated.py
+++ b/lumibot/example_strategies/ai_trading_team_bill_ackman_concentrated.py
@@ -4,8 +4,10 @@ This example is inspired by public descriptions of concentrated, high-quality
 large-cap investing. It is not affiliated with or endorsed by Bill Ackman,
 Pershing Square, or related companies.
 
-Set GEMINI_API_KEY, then run:
+Set GEMINI_API_KEY plus Alpaca credentials, then run paper trading:
     python ai_trading_team_bill_ackman_concentrated.py
+
+Set IS_BACKTESTING=True in the runner to run the historical example instead.
 """
 
 import os
@@ -65,10 +67,29 @@ class AITradingTeamBillAckmanConcentratedStrategy(Strategy):
 
 
 if __name__ == "__main__":
-    from lumibot.backtesting import YahooDataBacktesting
+    IS_BACKTESTING = False
 
-    AITradingTeamBillAckmanConcentratedStrategy.backtest(
-        YahooDataBacktesting,
-        datetime(2026, 4, 7),
-        datetime(2026, 5, 22),
-    )
+    if IS_BACKTESTING:
+        from lumibot.backtesting import YahooDataBacktesting
+
+        AITradingTeamBillAckmanConcentratedStrategy.backtest(
+            YahooDataBacktesting,
+            datetime(2026, 4, 7),
+            datetime(2026, 5, 22),
+        )
+    else:
+        from lumibot.brokers import Alpaca
+        from lumibot.traders import Trader
+
+        ALPACA_CONFIG = {
+            "API_KEY": os.environ["ALPACA_API_KEY"],
+            "API_SECRET": os.environ["ALPACA_API_SECRET"],
+            "PAPER": os.environ.get("ALPACA_IS_PAPER", "true").lower() != "false",
+        }
+
+        broker = Alpaca(ALPACA_CONFIG)
+        strategy = AITradingTeamBillAckmanConcentratedStrategy(broker=broker)
+
+        trader = Trader()
+        trader.add_strategy(strategy)
+        trader.run_all()

--- a/lumibot/example_strategies/ai_trading_team_bull_bear_large_cap_stocks.py
+++ b/lumibot/example_strategies/ai_trading_team_bull_bear_large_cap_stocks.py
@@ -1,9 +1,12 @@
 """Bull/bear large-cap stock AI trading team example.
 
-Set GEMINI_API_KEY, then run:
+Set GEMINI_API_KEY plus Alpaca credentials, then run paper trading:
     python ai_trading_team_bull_bear_large_cap_stocks.py
+
+Set IS_BACKTESTING=True in the runner to run the historical example instead.
 """
 
+import os
 from datetime import datetime
 
 from lumibot.strategies.strategy import Strategy
@@ -16,27 +19,28 @@ class AITradingTeamBullBearLargeCapStocksStrategy(Strategy):
 
     def initialize(self):
         self.sleeptime = "1D"
+        model = os.environ.get("AI_TRADING_TEAM_MODEL", "gemini-3.1-flash-lite")
         self.agents.create(
             name="researcher",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=False,
             system_prompt="Rank the large-cap stocks by upside. Be direct.",
         )
         self.agents.create(
             name="bull",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=False,
             system_prompt="Argue for the strongest money-making stock.",
         )
         self.agents.create(
             name="bear",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=False,
             system_prompt="Point out the biggest risk, briefly.",
         )
         self.agents.create(
             name="trader",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=True,
             system_prompt="Buy one stock from the universe aggressively. Use nearly all cash.",
         )
@@ -56,10 +60,29 @@ class AITradingTeamBullBearLargeCapStocksStrategy(Strategy):
 
 
 if __name__ == "__main__":
-    from lumibot.backtesting import YahooDataBacktesting
+    IS_BACKTESTING = False
 
-    AITradingTeamBullBearLargeCapStocksStrategy.backtest(
-        YahooDataBacktesting,
-        datetime(2026, 4, 7),
-        datetime(2026, 5, 22),
-    )
+    if IS_BACKTESTING:
+        from lumibot.backtesting import YahooDataBacktesting
+
+        AITradingTeamBullBearLargeCapStocksStrategy.backtest(
+            YahooDataBacktesting,
+            datetime(2026, 4, 7),
+            datetime(2026, 5, 22),
+        )
+    else:
+        from lumibot.brokers import Alpaca
+        from lumibot.traders import Trader
+
+        ALPACA_CONFIG = {
+            "API_KEY": os.environ["ALPACA_API_KEY"],
+            "API_SECRET": os.environ["ALPACA_API_SECRET"],
+            "PAPER": os.environ.get("ALPACA_IS_PAPER", "true").lower() != "false",
+        }
+
+        broker = Alpaca(ALPACA_CONFIG)
+        strategy = AITradingTeamBullBearLargeCapStocksStrategy(broker=broker)
+
+        trader = Trader()
+        trader.add_strategy(strategy)
+        trader.run_all()

--- a/lumibot/example_strategies/ai_trading_team_bull_bear_leveraged_etf.py
+++ b/lumibot/example_strategies/ai_trading_team_bull_bear_leveraged_etf.py
@@ -1,7 +1,9 @@
 """Bull/bear leveraged ETF AI trading team example.
 
-Set GEMINI_API_KEY, then run:
+Set GEMINI_API_KEY plus Alpaca credentials, then run paper trading:
     python ai_trading_team_bull_bear_leveraged_etf.py
+
+Set IS_BACKTESTING=True in the runner to run the historical example instead.
 """
 
 import os
@@ -62,13 +64,32 @@ class AITradingTeamBullBearLeveragedETFStrategy(Strategy):
 
 
 if __name__ == "__main__":
-    from lumibot.backtesting import YahooDataBacktesting
+    IS_BACKTESTING = False
 
-    AITradingTeamBullBearLeveragedETFStrategy.backtest(
-        YahooDataBacktesting,
-        datetime(2026, 4, 7),
-        datetime(2026, 5, 22),
-    )
+    if IS_BACKTESTING:
+        from lumibot.backtesting import YahooDataBacktesting
+
+        AITradingTeamBullBearLeveragedETFStrategy.backtest(
+            YahooDataBacktesting,
+            datetime(2026, 4, 7),
+            datetime(2026, 5, 22),
+        )
+    else:
+        from lumibot.brokers import Alpaca
+        from lumibot.traders import Trader
+
+        ALPACA_CONFIG = {
+            "API_KEY": os.environ["ALPACA_API_KEY"],
+            "API_SECRET": os.environ["ALPACA_API_SECRET"],
+            "PAPER": os.environ.get("ALPACA_IS_PAPER", "true").lower() != "false",
+        }
+
+        broker = Alpaca(ALPACA_CONFIG)
+        strategy = AITradingTeamBullBearLeveragedETFStrategy(broker=broker)
+
+        trader = Trader()
+        trader.add_strategy(strategy)
+        trader.run_all()
 
 
 AITradingTeamStrategy = AITradingTeamBullBearLeveragedETFStrategy

--- a/lumibot/example_strategies/ai_trading_team_citadel_sector_pods.py
+++ b/lumibot/example_strategies/ai_trading_team_citadel_sector_pods.py
@@ -4,8 +4,10 @@ This example is inspired by public descriptions of sector-specialist equities
 teams. It is not affiliated with or endorsed by Citadel, Surveyor Capital, or
 related companies.
 
-Set GEMINI_API_KEY, then run:
+Set GEMINI_API_KEY plus Alpaca credentials, then run paper trading:
     python ai_trading_team_citadel_sector_pods.py
+
+Set IS_BACKTESTING=True in the runner to run the historical example instead.
 """
 
 import os
@@ -86,10 +88,29 @@ class AITradingTeamCitadelSectorPodsStrategy(Strategy):
 
 
 if __name__ == "__main__":
-    from lumibot.backtesting import YahooDataBacktesting
+    IS_BACKTESTING = False
 
-    AITradingTeamCitadelSectorPodsStrategy.backtest(
-        YahooDataBacktesting,
-        datetime(2026, 4, 7),
-        datetime(2026, 5, 22),
-    )
+    if IS_BACKTESTING:
+        from lumibot.backtesting import YahooDataBacktesting
+
+        AITradingTeamCitadelSectorPodsStrategy.backtest(
+            YahooDataBacktesting,
+            datetime(2026, 4, 7),
+            datetime(2026, 5, 22),
+        )
+    else:
+        from lumibot.brokers import Alpaca
+        from lumibot.traders import Trader
+
+        ALPACA_CONFIG = {
+            "API_KEY": os.environ["ALPACA_API_KEY"],
+            "API_SECRET": os.environ["ALPACA_API_SECRET"],
+            "PAPER": os.environ.get("ALPACA_IS_PAPER", "true").lower() != "false",
+        }
+
+        broker = Alpaca(ALPACA_CONFIG)
+        strategy = AITradingTeamCitadelSectorPodsStrategy(broker=broker)
+
+        trader = Trader()
+        trader.add_strategy(strategy)
+        trader.run_all()

--- a/lumibot/example_strategies/ai_trading_team_ray_dalio_idea_meritocracy.py
+++ b/lumibot/example_strategies/ai_trading_team_ray_dalio_idea_meritocracy.py
@@ -1,9 +1,12 @@
 """Ray Dalio / Bridgewater-inspired idea-meritocracy AI trading team example.
 
-Set GEMINI_API_KEY, then run:
+Set GEMINI_API_KEY plus Alpaca credentials, then run paper trading:
     python ai_trading_team_ray_dalio_idea_meritocracy.py
+
+Set IS_BACKTESTING=True in the runner to run the historical example instead.
 """
 
+import os
 from datetime import datetime
 
 from lumibot.strategies.strategy import Strategy
@@ -16,33 +19,34 @@ class AITradingTeamRayDalioIdeaMeritocracyStrategy(Strategy):
 
     def initialize(self):
         self.sleeptime = "1D"
+        model = os.environ.get("AI_TRADING_TEAM_MODEL", "gemini-3.1-flash-lite")
         self.agents.create(
             name="growth_agent",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=False,
             system_prompt="Argue which ETFs win if growth improves. Be direct and expose weak assumptions.",
         )
         self.agents.create(
             name="inflation_agent",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=False,
             system_prompt="Argue which ETFs win or lose if inflation and rates surprise. Be direct.",
         )
         self.agents.create(
             name="debt_liquidity_agent",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=False,
             system_prompt="Argue from debt, liquidity, currency, and policy pressure. Be direct.",
         )
         self.agents.create(
             name="thoughtful_disagreement",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=False,
             system_prompt="Challenge all views with thoughtful disagreement. Identify the best idea after stress testing.",
         )
         self.agents.create(
             name="trader",
-            model="gemini-3.1-flash-lite",
+            model=model,
             allow_trading=True,
             system_prompt="Choose the best macro idea after the disagreement. Buy one ETF aggressively with nearly all cash.",
         )
@@ -66,10 +70,29 @@ class AITradingTeamRayDalioIdeaMeritocracyStrategy(Strategy):
 
 
 if __name__ == "__main__":
-    from lumibot.backtesting import YahooDataBacktesting
+    IS_BACKTESTING = False
 
-    AITradingTeamRayDalioIdeaMeritocracyStrategy.backtest(
-        YahooDataBacktesting,
-        datetime(2026, 4, 7),
-        datetime(2026, 5, 22),
-    )
+    if IS_BACKTESTING:
+        from lumibot.backtesting import YahooDataBacktesting
+
+        AITradingTeamRayDalioIdeaMeritocracyStrategy.backtest(
+            YahooDataBacktesting,
+            datetime(2026, 4, 7),
+            datetime(2026, 5, 22),
+        )
+    else:
+        from lumibot.brokers import Alpaca
+        from lumibot.traders import Trader
+
+        ALPACA_CONFIG = {
+            "API_KEY": os.environ["ALPACA_API_KEY"],
+            "API_SECRET": os.environ["ALPACA_API_SECRET"],
+            "PAPER": os.environ.get("ALPACA_IS_PAPER", "true").lower() != "false",
+        }
+
+        broker = Alpaca(ALPACA_CONFIG)
+        strategy = AITradingTeamRayDalioIdeaMeritocracyStrategy(broker=broker)
+
+        trader = Trader()
+        trader.add_strategy(strategy)
+        trader.run_all()

--- a/lumibot/example_strategies/ai_trading_team_warren_buffett_value.py
+++ b/lumibot/example_strategies/ai_trading_team_warren_buffett_value.py
@@ -4,8 +4,10 @@ This example is inspired by public Berkshire Hathaway shareholder letters and
 value-investing principles. It is not affiliated with or endorsed by Warren
 Buffett, Berkshire Hathaway, or related companies.
 
-Set GEMINI_API_KEY, then run:
+Set GEMINI_API_KEY plus Alpaca credentials, then run paper trading:
     python ai_trading_team_warren_buffett_value.py
+
+Set IS_BACKTESTING=True in the runner to run the historical example instead.
 """
 
 import os
@@ -58,10 +60,29 @@ class AITradingTeamWarrenBuffettValueStrategy(Strategy):
 
 
 if __name__ == "__main__":
-    from lumibot.backtesting import YahooDataBacktesting
+    IS_BACKTESTING = False
 
-    AITradingTeamWarrenBuffettValueStrategy.backtest(
-        YahooDataBacktesting,
-        datetime(2026, 4, 7),
-        datetime(2026, 5, 22),
-    )
+    if IS_BACKTESTING:
+        from lumibot.backtesting import YahooDataBacktesting
+
+        AITradingTeamWarrenBuffettValueStrategy.backtest(
+            YahooDataBacktesting,
+            datetime(2026, 4, 7),
+            datetime(2026, 5, 22),
+        )
+    else:
+        from lumibot.brokers import Alpaca
+        from lumibot.traders import Trader
+
+        ALPACA_CONFIG = {
+            "API_KEY": os.environ["ALPACA_API_KEY"],
+            "API_SECRET": os.environ["ALPACA_API_SECRET"],
+            "PAPER": os.environ.get("ALPACA_IS_PAPER", "true").lower() != "false",
+        }
+
+        broker = Alpaca(ALPACA_CONFIG)
+        strategy = AITradingTeamWarrenBuffettValueStrategy(broker=broker)
+
+        trader = Trader()
+        trader.add_strategy(strategy)
+        trader.run_all()


### PR DESCRIPTION
## Summary
- add broker-connected paper/live runners to all AI trading team example files
- make README and docs examples show broker run plus backtest paths
- rewrite AI trading team example descriptions to explain the investor-inspired team design

## Verification
- python3 -m py_compile lumibot/example_strategies/ai_trading_team_*.py
- /Users/robertgrzesik/Development/bin/safe-timeout 300 python3 -m pytest tests/test_ai_trading_team_example.py tests/test_agent_runtime_provider_keys.py
- /Users/robertgrzesik/Development/bin/safe-timeout 300 make -C docsrc html

Docs build succeeds with the existing unrelated Sphinx/docstring warnings in broker/data-source docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced AI Trading Team examples documentation with clearer setup instructions and workflow explanations across all strategy types.
  * Added explicit guidance for running strategies with connected brokers or in backtest mode.

* **New Features**
  * Support for `IS_BACKTESTING` flag to switch between live/paper trading and historical backtesting without code changes.
  * Environment variable-based configuration for Alpaca and Gemini API credentials.
  * Configurable LLM model selection via `AI_TRADING_TEAM_MODEL` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->