### PR TITLE
v4.5.43 - scheduled runs and Schwab advanced-order cancel fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.5.43 - Unreleased
 
+### Added
+- **Exact BotManager scheduled runs now wait locally for `targetRunAt`.** Scheduled one-shot live runs can initialize early, wait immediately before `on_trading_iteration()`, write timing telemetry, skip late iterations that exceed the drift budget, and drain post-iteration broker events before exit.
+
 ## 4.5.42 - Unreleased
 
 Deploy marker: `deploy 4.5.42`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.43 - Unreleased
+
 ## 4.5.42 - Unreleased
 
 Deploy marker: `deploy 4.5.42`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 4.5.42 - Unreleased
+## 4.5.43 - Unreleased
+
+### Fixed
+- **Schwab advanced-order cancels now terminalize local child legs.** When Schwab accepts canceling an OTO, OCO, or bracket parent order, LumiBot marks the local parent and child orders canceled so strategy active-order guards do not keep seeing canceled advanced orders as active.
+
+### Tests
+- **Rob-owned Schwab live smoke now mirrors Titus-style option cancel and broker-native hedge structures.** The smoke submits a TSLL option limit order, waits four seconds, cancels and verifies the canceled broker state, then submits/read/cancels OTO and bracket option structures against Schwab.
+
+## 4.5.42 - 2026-06-01
 
 Deploy marker: `deploy 4.5.42`
 

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -85,6 +85,11 @@ This page documents environment variables used by LumiBot, with an emphasis on *
 ## Live scheduled execution (BotSpot/BotManager)
 
 - `LUMIBOT_SCHEDULED_EXECUTION`: internal BotManager flag. Truthy values (`1`, `true`, `yes`, `y`, `on`) make `Strategy.run_live()` run one live iteration and exit.
+- `LUMIBOT_SCHEDULED_TARGET_RUN_AT`: UTC ISO-8601 target time for exact scheduled runs. When present, LumiBot initializes the strategy/broker first, waits locally until this timestamp immediately before `on_trading_iteration()`, and skips the iteration if the drift budget is exceeded.
+- `LUMIBOT_SCHEDULED_PRE_START_AT`: UTC ISO-8601 pre-start time used by BotManager telemetry to compare scheduler launch timing with the requested target.
+- `LUMIBOT_SCHEDULED_MAX_TARGET_DRIFT_MS`: maximum allowed late drift in milliseconds for exact scheduled runs. Defaults to `1000`.
+- `LUMIBOT_SCHEDULED_POST_ITERATION_SECONDS`: drain window after the one live iteration. During this window LumiBot continues processing broker/order queue events before exiting.
+- `LUMIBOT_SCHEDULED_TIMING_FILE`: local JSON timing file written by LumiBot for BotManager bootstrap telemetry.
 - `LUMIBOT_SCHEDULED_STATE_BACKEND`: external state backend prepared by BotManager: `s3`, `dynamodb`, or `none`. `none` disables scheduled `self.vars` file load/save.
 - `LUMIBOT_SCHEDULED_STATE_FILE`: local JSON file managed by BotManager/bootstrap code to restore and persist `self.vars` for one scheduled live run. State is restored before scheduled lifecycle hooks.
 

--- a/docsrc/environment_variables.rst
+++ b/docsrc/environment_variables.rst
@@ -99,6 +99,11 @@ Live scheduled execution (BotSpot/BotManager)
 ---------------------------------------------
 
 - ``LUMIBOT_SCHEDULED_EXECUTION``: internal BotManager flag. Truthy values (``1``, ``true``, ``yes``, ``y``, ``on``) make ``Strategy.run_live()`` run one live iteration and exit.
+- ``LUMIBOT_SCHEDULED_TARGET_RUN_AT``: UTC ISO-8601 target time for exact scheduled runs. When present, LumiBot initializes the strategy/broker first, waits locally until this timestamp immediately before ``on_trading_iteration()``, and skips the iteration if the drift budget is exceeded.
+- ``LUMIBOT_SCHEDULED_PRE_START_AT``: UTC ISO-8601 pre-start time used by BotManager telemetry to compare scheduler launch timing with the requested target.
+- ``LUMIBOT_SCHEDULED_MAX_TARGET_DRIFT_MS``: maximum allowed late drift in milliseconds for exact scheduled runs. Defaults to ``1000``.
+- ``LUMIBOT_SCHEDULED_POST_ITERATION_SECONDS``: drain window after the one live iteration. During this window LumiBot continues processing broker/order queue events before exiting.
+- ``LUMIBOT_SCHEDULED_TIMING_FILE``: local JSON timing file written by LumiBot for BotManager bootstrap telemetry.
 - ``LUMIBOT_SCHEDULED_STATE_BACKEND``: external state backend prepared by BotManager: ``s3``, ``dynamodb``, or ``none``. ``none`` disables scheduled ``self.vars`` file load/save.
 - ``LUMIBOT_SCHEDULED_STATE_FILE``: local JSON file managed by BotManager/bootstrap code to restore and persist ``self.vars`` for one scheduled live run. State is restored before scheduled lifecycle hooks.
 

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -2302,12 +2302,20 @@ class Schwab(Broker):
 
         logger.info(colored(f"Schwab cancel accepted for order {order.identifier}.", "green"))
 
+        self._mark_order_tree_canceled(order)
+
         if getattr(self, "stream", None) and hasattr(self.stream, "dispatch"):
             self.stream.dispatch(self.CANCELED_ORDER, wait_until_complete=True, order=order)
         else:
-            order.status = self.CANCELED_ORDER
             order.set_canceled()
         return None
+
+    def _mark_order_tree_canceled(self, order: Order) -> None:
+        """Mark a canceled Schwab parent order and all local child legs terminal."""
+        order.status = self.CANCELED_ORDER
+        order.set_canceled()
+        for child_order in getattr(order, "child_orders", []) or []:
+            self._mark_order_tree_canceled(child_order)
 
     def _launch_stream(self):
         """Set the asynchronous actions to be executed when events are sent via socket streams"""

--- a/lumibot/strategies/scheduled_timing.py
+++ b/lumibot/strategies/scheduled_timing.py
@@ -1,0 +1,170 @@
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class ScheduledRunTiming:
+    """Timing recorder for exact one-shot scheduled trading iterations."""
+
+    def __init__(self, logger=None):
+        self.logger = logger
+        self._timing = {}
+
+    @staticmethod
+    def truthy(value):
+        return str(value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+    def exact_enabled(self):
+        return self.truthy(os.environ.get("LUMIBOT_SCHEDULED_EXECUTION")) and bool(
+            os.environ.get("LUMIBOT_SCHEDULED_TARGET_RUN_AT")
+        )
+
+    @staticmethod
+    def parse_datetime(raw_value):
+        if raw_value in (None, ""):
+            return None
+        value = str(raw_value).strip()
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    @staticmethod
+    def now_utc():
+        return datetime.now(timezone.utc)
+
+    @staticmethod
+    def iso(value):
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    @staticmethod
+    def int_env(name, default):
+        try:
+            return int(os.environ.get(name, default))
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def timing_path():
+        raw_path = os.environ.get("LUMIBOT_SCHEDULED_TIMING_FILE")
+        return Path(raw_path) if raw_path else None
+
+    def record(self, **fields):
+        if not self.exact_enabled():
+            return
+        payload = {key: value for key, value in fields.items() if value is not None}
+        self._timing.update(payload)
+        self.write()
+
+    def write(self):
+        path = self.timing_path()
+        if not path:
+            return
+        payload = {
+            "target_run_at": os.environ.get("LUMIBOT_SCHEDULED_TARGET_RUN_AT"),
+            "pre_start_at": os.environ.get("LUMIBOT_SCHEDULED_PRE_START_AT"),
+            "max_target_drift_ms": self.int_env("LUMIBOT_SCHEDULED_MAX_TARGET_DRIFT_MS", 1000),
+            "post_iteration_seconds": self.int_env("LUMIBOT_SCHEDULED_POST_ITERATION_SECONDS", 0),
+            **self._timing,
+        }
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = path.with_suffix(path.suffix + ".tmp")
+            tmp_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+            tmp_path.replace(path)
+        except Exception as exc:
+            if self.logger:
+                self.logger.warning("Failed to write scheduled timing JSON: %s", exc)
+
+    def wait_until_target(self, now_utc=None, monotonic=None, sleep=None, log_message=None):
+        if not self.exact_enabled():
+            return True
+
+        now_utc = now_utc or self.now_utc
+        monotonic = monotonic or time.monotonic
+        sleep = sleep or time.sleep
+
+        target = self.parse_datetime(os.environ.get("LUMIBOT_SCHEDULED_TARGET_RUN_AT"))
+        if target is None:
+            return True
+
+        max_drift_ms = self.int_env("LUMIBOT_SCHEDULED_MAX_TARGET_DRIFT_MS", 1000)
+        wait_started = now_utc()
+        monotonic_started = monotonic()
+        self.record(
+            wait_started_at=self.iso(wait_started),
+            status="waiting_for_target",
+            exact_timing_verified=False,
+        )
+
+        while True:
+            now = now_utc()
+            remaining_seconds = (target - now).total_seconds()
+            if remaining_seconds <= 0:
+                break
+            sleep_seconds = min(1.0, remaining_seconds)
+            if remaining_seconds > 0.05:
+                sleep_seconds = min(sleep_seconds, max(remaining_seconds - 0.05, 0.001))
+            sleep(max(sleep_seconds, 0.0))
+
+        wait_finished = now_utc()
+        drift_ms = int(round((wait_finished - target).total_seconds() * 1000))
+        local_wait_seconds = max(monotonic() - monotonic_started, 0)
+        if drift_ms > max_drift_ms:
+            if log_message:
+                log_message(f"Scheduled target missed by {drift_ms}ms; skipping trading iteration", color="red")
+            self.record(
+                wait_finished_at=self.iso(wait_finished),
+                local_wait_seconds=local_wait_seconds,
+                target_drift_ms=drift_ms,
+                status="missed_target",
+                exact_timing_verified=False,
+            )
+            return False
+
+        self.record(
+            wait_finished_at=self.iso(wait_finished),
+            local_wait_seconds=local_wait_seconds,
+            target_drift_ms=drift_ms,
+            status="target_reached",
+            exact_timing_verified=True,
+        )
+        return True
+
+    def drain_after_iteration(self, stop_event, process_queue, now_utc=None, monotonic=None, sleep=None):
+        if not self.truthy(os.environ.get("LUMIBOT_SCHEDULED_EXECUTION")):
+            return
+
+        post_iteration_seconds = self.int_env("LUMIBOT_SCHEDULED_POST_ITERATION_SECONDS", 0)
+        if post_iteration_seconds <= 0:
+            return
+
+        now_utc = now_utc or self.now_utc
+        monotonic = monotonic or time.monotonic
+        sleep = sleep or time.sleep
+
+        drain_started = now_utc()
+        deadline = monotonic() + post_iteration_seconds
+        self.record(
+            drain_started_at=self.iso(drain_started),
+            status="draining",
+        )
+        while not stop_event.is_set():
+            process_queue()
+            remaining_seconds = deadline - monotonic()
+            if remaining_seconds <= 0:
+                break
+            sleep(min(0.5, remaining_seconds))
+        process_queue()
+        self.record(
+            drain_finished_at=self.iso(now_utc()),
+            status="drained",
+        )

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -112,9 +112,6 @@ class StrategyExecutor(Thread):
             else self.strategy.on_trading_iteration
         )
 
-    def _scheduled_exact_enabled(self):
-        return self._scheduled_timing.exact_enabled()
-
     def _scheduled_now_utc(self):
         return self._scheduled_timing.now_utc()
 

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -1,14 +1,12 @@
 import inspect
-import json
 import logging
 import math
 import os
 import time
 import traceback
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from decimal import Decimal
 from functools import wraps
-from pathlib import Path
 from queue import Empty, Queue
 from threading import Event, Lock, Thread
 
@@ -22,6 +20,7 @@ from apscheduler.triggers.cron import CronTrigger
 from lumibot.constants import LUMIBOT_DEFAULT_PYTZ
 from lumibot.entities import Asset, Order
 from lumibot.entities import Asset
+from lumibot.strategies.scheduled_timing import ScheduledRunTiming
 from lumibot.tools import append_locals, get_trading_days, staticdecorator
 from lumibot.tools.smart_limit_utils import (
     build_price_ladder,
@@ -59,7 +58,7 @@ class StrategyExecutor(Thread):
         # Store any exception that occurs during execution
         self.exception = None
         self._run_once_requested = False
-        self._scheduled_timing = {}
+        self._scheduled_timing = ScheduledRunTiming(logger=self.strategy.logger)
 
         # Create a dictionary of job stores. A job store is where the scheduler persists its jobs. In this case,
         # we create an in-memory job store for "default" and "On_Trading_Iteration" which is the job store we will
@@ -113,149 +112,37 @@ class StrategyExecutor(Thread):
             else self.strategy.on_trading_iteration
         )
 
-    @staticmethod
-    def _scheduled_truthy(value):
-        return str(value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
-
     def _scheduled_exact_enabled(self):
-        return self._scheduled_truthy(os.environ.get("LUMIBOT_SCHEDULED_EXECUTION")) and bool(
-            os.environ.get("LUMIBOT_SCHEDULED_TARGET_RUN_AT")
-        )
-
-    @staticmethod
-    def _scheduled_parse_datetime(raw_value):
-        if raw_value in (None, ""):
-            return None
-        value = str(raw_value).strip()
-        if value.endswith("Z"):
-            value = value[:-1] + "+00:00"
-        parsed = datetime.fromisoformat(value)
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
-        return parsed.astimezone(timezone.utc)
+        return self._scheduled_timing.exact_enabled()
 
     def _scheduled_now_utc(self):
-        return datetime.now(timezone.utc)
+        return self._scheduled_timing.now_utc()
 
     @staticmethod
     def _scheduled_iso(value):
-        if value is None:
-            return None
-        if value.tzinfo is None:
-            value = value.replace(tzinfo=timezone.utc)
-        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-
-    def _scheduled_int_env(self, name, default):
-        try:
-            return int(os.environ.get(name, default))
-        except (TypeError, ValueError):
-            return default
-
-    def _scheduled_timing_path(self):
-        raw_path = os.environ.get("LUMIBOT_SCHEDULED_TIMING_FILE")
-        return Path(raw_path) if raw_path else None
+        return ScheduledRunTiming.iso(value)
 
     def _scheduled_record_timing(self, **fields):
-        if not self._scheduled_exact_enabled():
-            return
-        payload = {
-            key: value
-            for key, value in fields.items()
-            if value is not None
-        }
-        self._scheduled_timing.update(payload)
-        self._scheduled_write_timing()
+        self._scheduled_timing.record(**fields)
 
     def _scheduled_write_timing(self):
-        path = self._scheduled_timing_path()
-        if not path:
-            return
-        target_run_at = os.environ.get("LUMIBOT_SCHEDULED_TARGET_RUN_AT")
-        payload = {
-            "target_run_at": target_run_at,
-            "pre_start_at": os.environ.get("LUMIBOT_SCHEDULED_PRE_START_AT"),
-            "max_target_drift_ms": self._scheduled_int_env("LUMIBOT_SCHEDULED_MAX_TARGET_DRIFT_MS", 1000),
-            "post_iteration_seconds": self._scheduled_int_env("LUMIBOT_SCHEDULED_POST_ITERATION_SECONDS", 0),
-            **self._scheduled_timing,
-        }
-        try:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            tmp_path = path.with_suffix(path.suffix + ".tmp")
-            tmp_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
-            tmp_path.replace(path)
-        except Exception as exc:
-            self.strategy.logger.warning("Failed to write scheduled timing JSON: %s", exc)
+        self._scheduled_timing.write()
 
     def _scheduled_wait_until_target(self):
-        if not self._scheduled_exact_enabled():
-            return True
-        target = self._scheduled_parse_datetime(os.environ.get("LUMIBOT_SCHEDULED_TARGET_RUN_AT"))
-        if target is None:
-            return True
-        max_drift_ms = self._scheduled_int_env("LUMIBOT_SCHEDULED_MAX_TARGET_DRIFT_MS", 1000)
-        wait_started = self._scheduled_now_utc()
-        monotonic_started = time.monotonic()
-        self._scheduled_record_timing(
-            wait_started_at=self._scheduled_iso(wait_started),
-            status="waiting_for_target",
-            exact_timing_verified=False,
+        return self._scheduled_timing.wait_until_target(
+            now_utc=self._scheduled_now_utc,
+            monotonic=time.monotonic,
+            sleep=time.sleep,
+            log_message=self.strategy.log_message,
         )
-        while True:
-            now = self._scheduled_now_utc()
-            remaining_seconds = (target - now).total_seconds()
-            if remaining_seconds <= 0:
-                break
-            sleep_seconds = min(1.0, remaining_seconds)
-            if remaining_seconds > 0.05:
-                sleep_seconds = min(sleep_seconds, max(remaining_seconds - 0.05, 0.001))
-            time.sleep(max(sleep_seconds, 0.0))
-
-        wait_finished = self._scheduled_now_utc()
-        drift_ms = int(round((wait_finished - target).total_seconds() * 1000))
-        local_wait_seconds = max(time.monotonic() - monotonic_started, 0)
-        if drift_ms > max_drift_ms:
-            self.strategy.log_message(
-                f"Scheduled target missed by {drift_ms}ms; skipping trading iteration", color="red"
-            )
-            self._scheduled_record_timing(
-                wait_finished_at=self._scheduled_iso(wait_finished),
-                local_wait_seconds=local_wait_seconds,
-                target_drift_ms=drift_ms,
-                status="missed_target",
-                exact_timing_verified=False,
-            )
-            return False
-        self._scheduled_record_timing(
-            wait_finished_at=self._scheduled_iso(wait_finished),
-            local_wait_seconds=local_wait_seconds,
-            target_drift_ms=drift_ms,
-            status="target_reached",
-            exact_timing_verified=True,
-        )
-        return True
 
     def _scheduled_drain_after_iteration(self):
-        if not self._scheduled_truthy(os.environ.get("LUMIBOT_SCHEDULED_EXECUTION")):
-            return
-        post_iteration_seconds = self._scheduled_int_env("LUMIBOT_SCHEDULED_POST_ITERATION_SECONDS", 0)
-        if post_iteration_seconds <= 0:
-            return
-        drain_started = self._scheduled_now_utc()
-        deadline = time.monotonic() + post_iteration_seconds
-        self._scheduled_record_timing(
-            drain_started_at=self._scheduled_iso(drain_started),
-            status="draining",
-        )
-        while not self.stop_event.is_set():
-            self.process_queue()
-            remaining_seconds = deadline - time.monotonic()
-            if remaining_seconds <= 0:
-                break
-            time.sleep(min(0.5, remaining_seconds))
-        self.process_queue()
-        self._scheduled_record_timing(
-            drain_finished_at=self._scheduled_iso(self._scheduled_now_utc()),
-            status="drained",
+        self._scheduled_timing.drain_after_iteration(
+            stop_event=self.stop_event,
+            process_queue=self.process_queue,
+            now_utc=self._scheduled_now_utc,
+            monotonic=time.monotonic,
+            sleep=time.sleep,
         )
 
     def _is_continuous_market(self, market_name):

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -1,12 +1,14 @@
 import inspect
+import json
 import logging
 import math
 import os
 import time
 import traceback
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from functools import wraps
+from pathlib import Path
 from queue import Empty, Queue
 from threading import Event, Lock, Thread
 
@@ -57,6 +59,7 @@ class StrategyExecutor(Thread):
         # Store any exception that occurs during execution
         self.exception = None
         self._run_once_requested = False
+        self._scheduled_timing = {}
 
         # Create a dictionary of job stores. A job store is where the scheduler persists its jobs. In this case,
         # we create an in-memory job store for "default" and "On_Trading_Iteration" which is the job store we will
@@ -108,6 +111,151 @@ class StrategyExecutor(Thread):
             append_locals(self.strategy.on_trading_iteration)
             if self._capture_locals
             else self.strategy.on_trading_iteration
+        )
+
+    @staticmethod
+    def _scheduled_truthy(value):
+        return str(value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+    def _scheduled_exact_enabled(self):
+        return self._scheduled_truthy(os.environ.get("LUMIBOT_SCHEDULED_EXECUTION")) and bool(
+            os.environ.get("LUMIBOT_SCHEDULED_TARGET_RUN_AT")
+        )
+
+    @staticmethod
+    def _scheduled_parse_datetime(raw_value):
+        if raw_value in (None, ""):
+            return None
+        value = str(raw_value).strip()
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    def _scheduled_now_utc(self):
+        return datetime.now(timezone.utc)
+
+    @staticmethod
+    def _scheduled_iso(value):
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    def _scheduled_int_env(self, name, default):
+        try:
+            return int(os.environ.get(name, default))
+        except (TypeError, ValueError):
+            return default
+
+    def _scheduled_timing_path(self):
+        raw_path = os.environ.get("LUMIBOT_SCHEDULED_TIMING_FILE")
+        return Path(raw_path) if raw_path else None
+
+    def _scheduled_record_timing(self, **fields):
+        if not self._scheduled_exact_enabled():
+            return
+        payload = {
+            key: value
+            for key, value in fields.items()
+            if value is not None
+        }
+        self._scheduled_timing.update(payload)
+        self._scheduled_write_timing()
+
+    def _scheduled_write_timing(self):
+        path = self._scheduled_timing_path()
+        if not path:
+            return
+        target_run_at = os.environ.get("LUMIBOT_SCHEDULED_TARGET_RUN_AT")
+        payload = {
+            "target_run_at": target_run_at,
+            "pre_start_at": os.environ.get("LUMIBOT_SCHEDULED_PRE_START_AT"),
+            "max_target_drift_ms": self._scheduled_int_env("LUMIBOT_SCHEDULED_MAX_TARGET_DRIFT_MS", 1000),
+            "post_iteration_seconds": self._scheduled_int_env("LUMIBOT_SCHEDULED_POST_ITERATION_SECONDS", 0),
+            **self._scheduled_timing,
+        }
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = path.with_suffix(path.suffix + ".tmp")
+            tmp_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+            tmp_path.replace(path)
+        except Exception as exc:
+            self.strategy.logger.warning("Failed to write scheduled timing JSON: %s", exc)
+
+    def _scheduled_wait_until_target(self):
+        if not self._scheduled_exact_enabled():
+            return True
+        target = self._scheduled_parse_datetime(os.environ.get("LUMIBOT_SCHEDULED_TARGET_RUN_AT"))
+        if target is None:
+            return True
+        max_drift_ms = self._scheduled_int_env("LUMIBOT_SCHEDULED_MAX_TARGET_DRIFT_MS", 1000)
+        wait_started = self._scheduled_now_utc()
+        monotonic_started = time.monotonic()
+        self._scheduled_record_timing(
+            wait_started_at=self._scheduled_iso(wait_started),
+            status="waiting_for_target",
+            exact_timing_verified=False,
+        )
+        while True:
+            now = self._scheduled_now_utc()
+            remaining_seconds = (target - now).total_seconds()
+            if remaining_seconds <= 0:
+                break
+            sleep_seconds = min(1.0, remaining_seconds)
+            if remaining_seconds > 0.05:
+                sleep_seconds = min(sleep_seconds, max(remaining_seconds - 0.05, 0.001))
+            time.sleep(max(sleep_seconds, 0.0))
+
+        wait_finished = self._scheduled_now_utc()
+        drift_ms = int(round((wait_finished - target).total_seconds() * 1000))
+        local_wait_seconds = max(time.monotonic() - monotonic_started, 0)
+        if drift_ms > max_drift_ms:
+            self.strategy.log_message(
+                f"Scheduled target missed by {drift_ms}ms; skipping trading iteration", color="red"
+            )
+            self._scheduled_record_timing(
+                wait_finished_at=self._scheduled_iso(wait_finished),
+                local_wait_seconds=local_wait_seconds,
+                target_drift_ms=drift_ms,
+                status="missed_target",
+                exact_timing_verified=False,
+            )
+            return False
+        self._scheduled_record_timing(
+            wait_finished_at=self._scheduled_iso(wait_finished),
+            local_wait_seconds=local_wait_seconds,
+            target_drift_ms=drift_ms,
+            status="target_reached",
+            exact_timing_verified=True,
+        )
+        return True
+
+    def _scheduled_drain_after_iteration(self):
+        if not self._scheduled_truthy(os.environ.get("LUMIBOT_SCHEDULED_EXECUTION")):
+            return
+        post_iteration_seconds = self._scheduled_int_env("LUMIBOT_SCHEDULED_POST_ITERATION_SECONDS", 0)
+        if post_iteration_seconds <= 0:
+            return
+        drain_started = self._scheduled_now_utc()
+        deadline = time.monotonic() + post_iteration_seconds
+        self._scheduled_record_timing(
+            drain_started_at=self._scheduled_iso(drain_started),
+            status="draining",
+        )
+        while not self.stop_event.is_set():
+            self.process_queue()
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                break
+            time.sleep(min(0.5, remaining_seconds))
+        self.process_queue()
+        self._scheduled_record_timing(
+            drain_finished_at=self._scheduled_iso(self._scheduled_now_utc()),
+            status="drained",
         )
 
     def _is_continuous_market(self, market_name):
@@ -2032,9 +2180,25 @@ class StrategyExecutor(Thread):
 
         self.cron_count_target = 1
         self.cron_count = 0
+        if not self._scheduled_wait_until_target():
+            return False
         try:
+            self._scheduled_record_timing(
+                iteration_started_at=self._scheduled_iso(self._scheduled_now_utc()),
+                status="iteration_started",
+            )
             self._on_trading_iteration()
+            self._scheduled_record_timing(
+                iteration_finished_at=self._scheduled_iso(self._scheduled_now_utc()),
+                status="iteration_finished",
+            )
             self.process_queue()
+            self._scheduled_drain_after_iteration()
+            self._scheduled_record_timing(
+                status="completed",
+                exact_timing_verified=True,
+            )
+            return True
         finally:
             self._in_trading_iteration = False
 
@@ -2046,12 +2210,17 @@ class StrategyExecutor(Thread):
 
             self._initialize()
             self.broker.initialize_market_calendars(get_trading_days(self.broker.market))
-            self._run_live_once()
-            self._on_strategy_end()
+            self._scheduled_record_timing(
+                strategy_initialized_at=self._scheduled_iso(self._scheduled_now_utc()),
+                status="strategy_initialized",
+            )
+            iteration_ran = self._run_live_once()
+            if iteration_ran:
+                self._on_strategy_end()
 
             self.result = self.strategy._analysis
             self.gracefully_exit()
-            return True
+            return bool(iteration_ran)
         except Exception as e:
             try:
                 self.strategy.logger.error(e)

--- a/scripts/schwab_titus_workflow_smoke.py
+++ b/scripts/schwab_titus_workflow_smoke.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Rob-owned live Schwab smoke for Titus-style option cancel and hedge flows.
+
+This script intentionally uses the real Schwab broker adapter and a real
+account. It places low-priced option limit orders that should rest, then cancels
+them and verifies broker state by direct order lookup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from lumibot.brokers.schwab import Schwab
+from lumibot.entities import Asset, Order
+from lumibot.tools.schwab_helper import SchwabHelper
+
+
+TERMINAL_STATUSES = {"CANCELED", "CANCELLED", "FILLED", "REJECTED", "EXPIRED"}
+
+
+def _suffix(value: Any, length: int = 8) -> str:
+    if value is None:
+        return "<none>"
+    text = str(value)
+    return text[-length:] if len(text) > length else text
+
+
+def _status(raw: dict | None) -> str:
+    return str((raw or {}).get("status") or "").upper()
+
+
+def _order_snapshot(broker: Schwab, order_id: str, strategy_name: str) -> dict[str, Any]:
+    raw = broker._pull_broker_order(order_id)
+    parsed = broker._parse_broker_order(raw, strategy_name) if raw else None
+    return {
+        "id_suffix": _suffix(order_id),
+        "status": _status(raw),
+        "active": bool(parsed and parsed.is_active()),
+        "canceled": bool(parsed and parsed.is_canceled()),
+        "filled": bool(parsed and parsed.is_filled()),
+        "strategy_type": (raw or {}).get("orderStrategyType"),
+        "child_count": len((raw or {}).get("childOrderStrategies") or []),
+    }
+
+
+def _poll_until(
+    broker: Schwab,
+    order_id: str,
+    strategy_name: str,
+    predicate,
+    *,
+    timeout_seconds: float = 8.0,
+    interval_seconds: float = 0.5,
+) -> dict[str, Any]:
+    deadline = time.perf_counter() + timeout_seconds
+    last = None
+    while time.perf_counter() < deadline:
+        last = _order_snapshot(broker, order_id, strategy_name)
+        if predicate(last):
+            return last
+        time.sleep(interval_seconds)
+    return last or _order_snapshot(broker, order_id, strategy_name)
+
+
+def _select_account_by_suffix(broker: Schwab, account_suffix: str) -> dict[str, str]:
+    response = broker.client.get_account_numbers()
+    response.raise_for_status()
+    accounts = response.json()
+    matches = [
+        row for row in accounts
+        if str(row.get("accountNumber", "")).endswith(str(account_suffix))
+    ]
+    if len(matches) != 1:
+        safe_suffixes = [_suffix(row.get("accountNumber"), 4) for row in accounts]
+        raise RuntimeError(
+            f"Expected exactly one Schwab account ending in {account_suffix}; "
+            f"found {len(matches)} among suffixes {safe_suffixes}"
+        )
+    account = matches[0]
+    broker.account_number = str(account["accountNumber"])
+    broker.hash_value = account["hashValue"]
+    if getattr(broker, "data_source", None) is not None:
+        broker.data_source.client = broker.client
+    return {
+        "account_suffix": _suffix(account["accountNumber"], 4),
+        "hash_suffix": _suffix(account["hashValue"], 6),
+    }
+
+
+def _make_broker(token_path: Path, token_payload: str | None, account_suffix: str) -> tuple[Schwab, dict[str, str]]:
+    if token_payload:
+        SchwabHelper._save_payload_str_to_token_file(token_payload, token_path)
+        token_path.chmod(0o600)
+
+    if not token_path.exists():
+        raise RuntimeError(f"Missing Schwab token file: {token_path}")
+
+    Schwab._launch_stream = lambda self: None
+    broker = Schwab(
+        config={
+            "SCHWAB_TOKEN_PATH": str(token_path),
+            "SCHWAB_ACCOUNT_NUMBER": account_suffix,
+            "MARKET": "NASDAQ",
+        }
+    )
+    account_meta = _select_account_by_suffix(broker, account_suffix)
+    return broker, account_meta
+
+
+def _select_tsll_call_asset(broker: Schwab) -> Asset:
+    underlying = Asset("TSLL", asset_type=Asset.AssetType.STOCK)
+    chains = broker.data_source.get_chains(underlying, strike_count=20)
+    calls = (chains or {}).get("Chains", {}).get("CALL", {})
+    if not calls:
+        raise RuntimeError("No TSLL call option chain returned by Schwab.")
+
+    today = date.today()
+    expirations = sorted(exp for exp in calls if date.fromisoformat(exp) >= today)
+    if not expirations:
+        raise RuntimeError("No future TSLL call expiration returned by Schwab.")
+
+    quote = broker.data_source.get_quote(underlying)
+    last_price = float(getattr(quote, "price", None) or broker.data_source.get_last_price(underlying))
+    if last_price <= 0:
+        raise RuntimeError("Could not get TSLL last price.")
+
+    expiration = expirations[0]
+    strike = min(calls[expiration], key=lambda value: abs(float(value) - last_price))
+    return Asset(
+        "TSLL",
+        asset_type=Asset.AssetType.OPTION,
+        expiration=date.fromisoformat(expiration),
+        strike=float(strike),
+        right="CALL",
+    )
+
+
+def _safe_cancel(broker: Schwab, order: Order | None, strategy_name: str) -> dict[str, Any] | None:
+    if not order or not order.identifier:
+        return None
+    try:
+        raw = broker._pull_broker_order(order.identifier)
+        if _status(raw) not in TERMINAL_STATUSES:
+            broker.cancel_order(order)
+    except Exception as exc:
+        return {"cleanup_error": str(exc), "id_suffix": _suffix(order.identifier)}
+    return _poll_until(
+        broker,
+        order.identifier,
+        strategy_name,
+        lambda snap: snap["status"] in TERMINAL_STATUSES or snap["canceled"],
+        timeout_seconds=8.0,
+    )
+
+
+def run_titus_style_cancel(broker: Schwab, asset: Asset, limit_price: float, wait_seconds: float) -> dict[str, Any]:
+    strategy_name = "rob-titus-style-cancel-smoke"
+    order = Order(
+        strategy=strategy_name,
+        asset=asset,
+        quantity=1,
+        side=Order.OrderSide.BUY_TO_OPEN,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=limit_price,
+        time_in_force="day",
+        tag=strategy_name,
+    )
+    submitted = None
+    started = time.perf_counter()
+    samples: list[dict[str, Any]] = []
+    try:
+        submitted = broker._submit_order(order)
+        if not submitted or not submitted.identifier:
+            raise RuntimeError("Schwab did not return an order id for Titus-style cancel smoke.")
+
+        while time.perf_counter() - started < wait_seconds:
+            snap = _order_snapshot(broker, submitted.identifier, strategy_name)
+            snap["elapsed_seconds"] = round(time.perf_counter() - started, 3)
+            samples.append(snap)
+            time.sleep(0.5)
+
+        broker.cancel_order(submitted)
+        final = _poll_until(
+            broker,
+            submitted.identifier,
+            strategy_name,
+            lambda snap: snap["canceled"] or snap["status"] in {"CANCELED", "CANCELLED"},
+            timeout_seconds=8.0,
+        )
+        final["elapsed_seconds"] = round(time.perf_counter() - started, 3)
+        return {
+            "name": "titus_style_cancel",
+            "order_id_suffix": _suffix(submitted.identifier),
+            "samples": samples,
+            "final": final,
+            "pass": bool(final["canceled"] or final["status"] in {"CANCELED", "CANCELLED"}),
+        }
+    finally:
+        cleanup = _safe_cancel(broker, submitted, strategy_name)
+        if cleanup:
+            samples.append({"cleanup": cleanup})
+
+
+def run_oto_structure(broker: Schwab, asset: Asset, parent_limit: float, child_limit: float) -> dict[str, Any]:
+    strategy_name = "rob-titus-oto-hedge-smoke"
+    child = Order(
+        strategy=strategy_name,
+        asset=asset,
+        quantity=1,
+        side=Order.OrderSide.SELL_TO_CLOSE,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=child_limit,
+        time_in_force="day",
+        tag=strategy_name,
+    )
+    order = Order(
+        strategy=strategy_name,
+        asset=asset,
+        quantity=1,
+        side=Order.OrderSide.BUY_TO_OPEN,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=parent_limit,
+        order_class=Order.OrderClass.OTO,
+        child_orders=[child],
+        time_in_force="day",
+        tag=strategy_name,
+    )
+    submitted = None
+    try:
+        submitted = broker._submit_order(order)
+        if not submitted or not submitted.identifier:
+            raise RuntimeError("Schwab did not return an order id for OTO smoke.")
+        initial = _order_snapshot(broker, submitted.identifier, strategy_name)
+        broker.cancel_order(submitted)
+        local_child_active = [child_order.is_active() for child_order in submitted.child_orders]
+        final = _poll_until(
+            broker,
+            submitted.identifier,
+            strategy_name,
+            lambda snap: snap["canceled"] or snap["status"] in {"CANCELED", "CANCELLED"},
+            timeout_seconds=8.0,
+        )
+        return {
+            "name": "oto_structure",
+            "order_id_suffix": _suffix(submitted.identifier),
+            "initial": initial,
+            "final": final,
+            "local_child_active_after_cancel": local_child_active,
+            "pass": (
+                initial["strategy_type"] == "TRIGGER"
+                and initial["child_count"] == 1
+                and not any(local_child_active)
+                and bool(final["canceled"] or final["status"] in {"CANCELED", "CANCELLED"})
+            ),
+        }
+    finally:
+        _safe_cancel(broker, submitted, strategy_name)
+
+
+def run_bracket_structure(broker: Schwab, asset: Asset, parent_limit: float, take_profit: float, stop_loss: float) -> dict[str, Any]:
+    strategy_name = "rob-titus-bracket-hedge-smoke"
+    take_profit_order = Order(
+        strategy=strategy_name,
+        asset=asset,
+        quantity=1,
+        side=Order.OrderSide.SELL_TO_CLOSE,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=take_profit,
+        time_in_force="day",
+        tag=strategy_name,
+    )
+    stop_order = Order(
+        strategy=strategy_name,
+        asset=asset,
+        quantity=1,
+        side=Order.OrderSide.SELL_TO_CLOSE,
+        order_type=Order.OrderType.STOP,
+        stop_price=stop_loss,
+        time_in_force="day",
+        tag=strategy_name,
+    )
+    order = Order(
+        strategy=strategy_name,
+        asset=asset,
+        quantity=1,
+        side=Order.OrderSide.BUY_TO_OPEN,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=parent_limit,
+        order_class=Order.OrderClass.BRACKET,
+        child_orders=[take_profit_order, stop_order],
+        time_in_force="day",
+        tag=strategy_name,
+    )
+    submitted = None
+    try:
+        submitted = broker._submit_order(order)
+        if not submitted or not submitted.identifier:
+            raise RuntimeError("Schwab did not return an order id for bracket smoke.")
+        initial = _order_snapshot(broker, submitted.identifier, strategy_name)
+        broker.cancel_order(submitted)
+        local_child_active = [child_order.is_active() for child_order in submitted.child_orders]
+        final = _poll_until(
+            broker,
+            submitted.identifier,
+            strategy_name,
+            lambda snap: snap["canceled"] or snap["status"] in {"CANCELED", "CANCELLED"},
+            timeout_seconds=8.0,
+        )
+        return {
+            "name": "bracket_structure",
+            "order_id_suffix": _suffix(submitted.identifier),
+            "initial": initial,
+            "final": final,
+            "local_child_active_after_cancel": local_child_active,
+            "pass": (
+                initial["strategy_type"] == "TRIGGER"
+                and initial["child_count"] == 1
+                and not any(local_child_active)
+                and bool(final["canceled"] or final["status"] in {"CANCELED", "CANCELLED"})
+            ),
+        }
+    finally:
+        _safe_cancel(broker, submitted, strategy_name)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--account-suffix", default="4364", help="Schwab account suffix to trade in.")
+    parser.add_argument("--token-path", default="schwab_token.json", help="Gitignored Schwab token JSON path.")
+    parser.add_argument("--token-payload", default=None, help="Optional fresh BotSpot/LumiBot Schwab payload string.")
+    parser.add_argument("--wait-seconds", type=float, default=4.0, help="Cancel timeout to mirror Titus workflow.")
+    parser.add_argument("--option-limit", type=float, default=0.01, help="Low limit intended to rest, not fill.")
+    parser.add_argument("--child-limit", type=float, default=0.50, help="OTO/bracket take-profit child limit.")
+    parser.add_argument("--stop-loss", type=float, default=0.01, help="Bracket stop-loss child stop price.")
+    parser.add_argument("--summary-path", default=None, help="Optional JSON summary path.")
+    args = parser.parse_args()
+
+    token_path = Path(args.token_path).expanduser().resolve()
+    broker, account_meta = _make_broker(token_path, args.token_payload, args.account_suffix)
+    asset = _select_tsll_call_asset(broker)
+
+    summary = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "account": account_meta,
+        "asset": {
+            "symbol": asset.symbol,
+            "expiration": asset.expiration.isoformat() if asset.expiration else None,
+            "strike": asset.strike,
+            "right": asset.right,
+        },
+        "tests": [],
+    }
+
+    for runner in (
+        lambda: run_titus_style_cancel(broker, asset, args.option_limit, args.wait_seconds),
+        lambda: run_oto_structure(broker, asset, args.option_limit, args.child_limit),
+        lambda: run_bracket_structure(broker, asset, args.option_limit, args.child_limit, args.stop_loss),
+    ):
+        result = runner()
+        summary["tests"].append(result)
+        print(json.dumps(result, indent=2, sort_keys=True))
+
+    summary_path = Path(args.summary_path or f"tmp/schwab_titus_workflow_smoke_{int(time.time())}.json")
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+    print(f"Wrote summary: {summary_path.resolve()}")
+
+    return 0 if all(test.get("pass") for test in summary["tests"]) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.42",
+    version="4.5.43",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_scheduled_run_once.py
+++ b/tests/test_scheduled_run_once.py
@@ -4,6 +4,7 @@ import logging
 from types import SimpleNamespace
 
 from lumibot.strategies import strategy as strategy_module
+from lumibot.strategies import strategy_executor as strategy_executor_module
 from lumibot.strategies._strategy import Vars, _Strategy
 from lumibot.strategies.strategy_executor import StrategyExecutor
 from lumibot.traders.trader import Trader
@@ -146,6 +147,71 @@ def test_strategy_executor_run_once_runs_one_live_iteration(monkeypatch):
     assert strategy.backups >= 1
     assert strategy.broker.closed is True
     assert executor.result == {"iterations": 1}
+
+
+def test_scheduled_exact_run_waits_after_initialization_and_writes_timing(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "lumibot.strategies.strategy_executor.get_trading_days",
+        lambda market: [{"date": datetime.date(2026, 5, 11)}],
+    )
+    fake_mono = {"value": 0.0}
+    base = datetime.datetime(2026, 5, 11, 13, 30, tzinfo=datetime.timezone.utc)
+    target = base + datetime.timedelta(seconds=1)
+    timing_file = tmp_path / "scheduled_timing.json"
+    strategy = _DummyStrategy()
+    executor = StrategyExecutor(strategy)
+    executor.sync_broker = lambda: None
+
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_EXECUTION", "true")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_TARGET_RUN_AT", target.isoformat().replace("+00:00", "Z"))
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_MAX_TARGET_DRIFT_MS", "1000")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_POST_ITERATION_SECONDS", "0")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_TIMING_FILE", str(timing_file))
+    monkeypatch.setattr(StrategyExecutor, "_scheduled_now_utc", lambda self: base + datetime.timedelta(seconds=fake_mono["value"]))
+    monkeypatch.setattr(strategy_executor_module.time, "monotonic", lambda: fake_mono["value"])
+    monkeypatch.setattr(strategy_executor_module.time, "sleep", lambda seconds: fake_mono.__setitem__("value", fake_mono["value"] + seconds))
+
+    assert executor.run_once() is True
+
+    assert strategy.initialized == 1
+    assert strategy.iterations == 1
+    timing = json.loads(timing_file.read_text(encoding="utf-8"))
+    assert timing["strategy_initialized_at"] == "2026-05-11T13:30:00Z"
+    assert timing["wait_started_at"] == "2026-05-11T13:30:00Z"
+    assert timing["iteration_started_at"] == "2026-05-11T13:30:01Z"
+    assert timing["target_drift_ms"] == 0
+    assert timing["status"] == "completed"
+    assert timing["exact_timing_verified"] is True
+
+
+def test_scheduled_exact_run_skips_when_target_drift_exceeds_budget(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "lumibot.strategies.strategy_executor.get_trading_days",
+        lambda market: [{"date": datetime.date(2026, 5, 11)}],
+    )
+    now = datetime.datetime(2026, 5, 11, 13, 30, 2, tzinfo=datetime.timezone.utc)
+    target = datetime.datetime(2026, 5, 11, 13, 30, tzinfo=datetime.timezone.utc)
+    timing_file = tmp_path / "scheduled_timing.json"
+    strategy = _DummyStrategy()
+    executor = StrategyExecutor(strategy)
+    executor.sync_broker = lambda: None
+
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_EXECUTION", "true")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_TARGET_RUN_AT", target.isoformat().replace("+00:00", "Z"))
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_MAX_TARGET_DRIFT_MS", "1000")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_TIMING_FILE", str(timing_file))
+    monkeypatch.setattr(StrategyExecutor, "_scheduled_now_utc", lambda self: now)
+    monkeypatch.setattr(strategy_executor_module.time, "monotonic", lambda: 10.0)
+
+    assert executor.run_once() is False
+
+    assert strategy.initialized == 1
+    assert strategy.iterations == 0
+    assert strategy.ended == 0
+    timing = json.loads(timing_file.read_text(encoding="utf-8"))
+    assert timing["status"] == "missed_target"
+    assert timing["target_drift_ms"] == 2000
+    assert timing["exact_timing_verified"] is False
 
 
 def test_trader_run_all_run_once_uses_executor_run_once():

--- a/tests/test_scheduled_run_once.py
+++ b/tests/test_scheduled_run_once.py
@@ -208,10 +208,45 @@ def test_scheduled_exact_run_skips_when_target_drift_exceeds_budget(tmp_path, mo
     assert strategy.initialized == 1
     assert strategy.iterations == 0
     assert strategy.ended == 0
+    assert strategy.backups >= 1
+    assert strategy.broker.closed is True
     timing = json.loads(timing_file.read_text(encoding="utf-8"))
     assert timing["status"] == "missed_target"
     assert timing["target_drift_ms"] == 2000
     assert timing["exact_timing_verified"] is False
+
+
+def test_scheduled_exact_run_drains_after_iteration(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "lumibot.strategies.strategy_executor.get_trading_days",
+        lambda market: [{"date": datetime.date(2026, 5, 11)}],
+    )
+    fake_mono = {"value": 0.0}
+    queue_calls = {"count": 0}
+    base = datetime.datetime(2026, 5, 11, 13, 30, tzinfo=datetime.timezone.utc)
+    timing_file = tmp_path / "scheduled_timing.json"
+    strategy = _DummyStrategy()
+    executor = StrategyExecutor(strategy)
+    executor.sync_broker = lambda: None
+    executor.process_queue = lambda: queue_calls.__setitem__("count", queue_calls["count"] + 1)
+
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_EXECUTION", "true")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_TARGET_RUN_AT", base.isoformat().replace("+00:00", "Z"))
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_MAX_TARGET_DRIFT_MS", "1000")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_POST_ITERATION_SECONDS", "1")
+    monkeypatch.setenv("LUMIBOT_SCHEDULED_TIMING_FILE", str(timing_file))
+    monkeypatch.setattr(StrategyExecutor, "_scheduled_now_utc", lambda self: base + datetime.timedelta(seconds=fake_mono["value"]))
+    monkeypatch.setattr(strategy_executor_module.time, "monotonic", lambda: fake_mono["value"])
+    monkeypatch.setattr(strategy_executor_module.time, "sleep", lambda seconds: fake_mono.__setitem__("value", fake_mono["value"] + seconds))
+
+    assert executor.run_once() is True
+
+    timing = json.loads(timing_file.read_text(encoding="utf-8"))
+    assert strategy.iterations == 1
+    assert queue_calls["count"] >= 4
+    assert timing["drain_started_at"] == "2026-05-11T13:30:00Z"
+    assert timing["drain_finished_at"] == "2026-05-11T13:30:01Z"
+    assert timing["status"] == "completed"
 
 
 def test_trader_run_all_run_once_uses_executor_run_once():

--- a/tests/test_schwab_positions_unit.py
+++ b/tests/test_schwab_positions_unit.py
@@ -923,6 +923,32 @@ def test_schwab_cancel_order_marks_canceled_without_stream_after_success():
     assert order.is_canceled()
 
 
+def test_schwab_cancel_order_marks_advanced_order_children_canceled():
+    client = _CancelClient()
+    stream = _Stream()
+    broker = _broker_for_cancel(client=client, stream=stream)
+    order = Order(
+        strategy="unit-test",
+        asset=Asset("LW"),
+        quantity=1,
+        side=Order.OrderSide.SELL,
+        limit_price=999,
+        stop_price=1,
+        order_class=Order.OrderClass.OCO,
+        identifier="oco-parent",
+        status=Order.OrderStatus.SUBMITTED,
+    )
+
+    assert order.is_active()
+
+    broker.cancel_order(order)
+
+    assert client.cancel_calls == [("oco-parent", "account-hash")]
+    assert order.is_canceled()
+    assert all(child.is_canceled() for child in order.child_orders)
+    assert not order.is_active()
+
+
 def test_schwab_cancel_order_noops_for_terminal_orders():
     client = _CancelClient()
     broker = _broker_for_cancel(client=client)


### PR DESCRIPTION
## Summary
- add exact scheduled one-shot target timing support for BotManager live runs
- keep BotManager-visible timing hooks on `StrategyExecutor`, with the timing state machine isolated in `ScheduledRunTiming`
- write scheduled timing JSON with drift, iteration, and drain timestamps
- fix Schwab advanced-order cancel state so OTO/OCO/bracket child legs are marked canceled locally after Schwab accepts the cancel
- add a Rob-owned live Schwab smoke helper for the Titus-style 4-second option cancel path plus OTO/bracket option order read/cancel checks
- document the scheduled timing env vars and add regression coverage

## Why
- BotManager scheduled live runs need exact target-time behavior and timing telemetry.
- Schwab advanced orders could cancel successfully at the broker while local child legs stayed active in LumiBot, which can confuse strategy guards and make a bot think an order is still open.
- Titus's workflow needs fast broker-state reconciliation around option orders, quick cancels, and broker-native advanced order structures.

## Tests
- `../bin/safe-timeout 240s python3 -m pytest tests/test_schwab_positions_unit.py tests/test_scheduled_run_once.py -q` -> 39 passed
- `python3 -m py_compile scripts/schwab_titus_workflow_smoke.py`
- live Schwab smoke against Rob-owned account suffix 4364 using gitignored `schwab_token.json`:
  - submitted TSLL option limit order, waited around 4 seconds, canceled, confirmed final Schwab status `CANCELED`
  - submitted TSLL option OTO order, direct read showed advanced order strategy, canceled, verified parent and local child inactive
  - submitted TSLL option bracket order, direct read showed advanced order strategy, canceled, verified parent and local children inactive
- previous scheduler checks from this branch:
  - `tests/test_scheduled_run_once.py -q`
  - py_compile for `strategy_executor.py`, `scheduled_timing.py`, and scheduler tests
  - wheel build verified scheduled timing helpers were included

## Risk Notes
- The live Schwab smoke proves submit/read/cancel for the advanced-order structures, but does not prove fill-trigger behavior because that requires intentionally fillable live orders.
- The cancel-state fix is intentionally local-state only after Schwab accepts cancel; it does not change the Schwab API payload.
