### PR TITLE
Release LumiBot 4.5.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,20 @@
 # Changelog
 
-## 4.5.43 - Unreleased
+## 4.5.44 - Unreleased
 
 ### Added
 - **Exact BotManager scheduled runs now wait locally for `targetRunAt`.** Scheduled one-shot live runs can initialize early, wait immediately before `on_trading_iteration()`, write timing telemetry, skip late iterations that exceed the drift budget, and drain post-iteration broker events before exit.
 
 ### Fixed
 - **Schwab advanced-order cancels now terminalize local child legs.** When Schwab accepts canceling an OTO, OCO, or bracket parent order, LumiBot marks the local parent and child orders canceled so strategy active-order guards do not keep seeing canceled advanced orders as active.
+- **Scheduled timing setup now works with lightweight strategy stubs.** `StrategyExecutor` falls back to the module logger when a minimal strategy object has no `logger`, restoring existing unit/backtest test compatibility.
 
 ### Tests
 - **Rob-owned Schwab live smoke now mirrors Titus-style option cancel and broker-native hedge structures.** The smoke submits a TSLL option limit order, waits four seconds, cancels and verifies the canceled broker state, then submits/read/cancels OTO and bracket option structures against Schwab.
+
+## 4.5.43 - 2026-06-01
+
+Canceled release candidate. Do not deploy.
 
 ## 4.5.42 - 2026-06-01
 

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -58,7 +58,8 @@ class StrategyExecutor(Thread):
         # Store any exception that occurs during execution
         self.exception = None
         self._run_once_requested = False
-        self._scheduled_timing = ScheduledRunTiming(logger=self.strategy.logger)
+        strategy_logger = getattr(self.strategy, "logger", logger)
+        self._scheduled_timing = ScheduledRunTiming(logger=strategy_logger)
 
         # Create a dictionary of job stores. A job store is where the scheduler persists its jobs. In this case,
         # we create an in-memory job store for "default" and "On_Trading_Iteration" which is the job store we will

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.43",
+    version="4.5.44",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",


### PR DESCRIPTION
## Summary
- Bump LumiBot to 4.5.44 after the 4.5.43 release candidate was blocked by CI.
- Keep the exact BotManager scheduled-run support and Schwab advanced-order cancel fix from 4.5.43.
- Fix the scheduler logger regression by falling back to the module logger when lightweight strategy stubs do not define `strategy.logger`.

## Verification
- `python3 -m pytest tests/test_backtesting_capture_locals_env_toggle.py::test_backtesting_capture_locals_default_off -q` -> 1 passed
- `python3 -m pytest tests/test_scheduled_run_once.py tests/test_schwab_positions_unit.py tests/test_backtesting_capture_locals_env_toggle.py -q` -> 41 passed
- `python3 -m pytest tests/backtest/test_strategy_executor_backtest_end_clamp.py::test_strategy_executor_does_not_await_market_close_past_backtest_end tests/test_strategy_executor_filled_order_zero_portfolio.py::test_strategy_executor_filled_order_does_not_divide_by_zero tests/test_backtesting_capture_locals_env_toggle.py -q` -> 4 passed
- Release preflight from `docs/DEPLOYMENT.md` passed after pushing `origin/version/4.5.44`.

## Live Schwab evidence carried from 4.5.43
- Rob-owned Schwab smoke against account suffix 4364 passed.
- Titus-style TSLL option limit submit/read/wait/cancel verified `CANCELED`.
- Schwab OTO and bracket option submit/read/cancel verified `CANCELED` and local child legs no longer remain active.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved strategy logging reliability with automatic fallback mechanism.

* **Tests**
  * Expanded test coverage for trading strategy execution scenarios.

* **Documentation**
  * Updated changelog for version 4.5.44.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->