### PR TITLE
v4.5.45 - Agent timeout and Schwab smoke updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 4.5.45 - Unreleased
 
+### Added
+- **AI agent model calls now have provider-level request timeouts.** Native Gemini requests pass a Google GenAI HTTP timeout and LiteLLM-backed providers pass a LiteLLM completion timeout, preventing one stalled model request from freezing a strategy for the full agent-run budget.
+- **AI agent timeout settings are configurable from strategy code.** `self.agents.create(...)` and `agent.run(...)` now accept `model_request_timeout_seconds` and `run_timeout_seconds`, with documented defaults of 600 seconds per model request and 1800 seconds for the whole agent run.
+
+### Fixed
+- **Agent runtime traces now log the effective timeout settings and first ADK event latency.** This makes it clear whether a run is stuck waiting on the model provider or actively making progress through ADK/tool events.
+
 ## 4.5.44 - Unreleased
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.45 - Unreleased
+
 ## 4.5.44 - Unreleased
 
 ### Added

--- a/docs/investigations/2026-06-01_titus-schwab-strategy-validation.md
+++ b/docs/investigations/2026-06-01_titus-schwab-strategy-validation.md
@@ -285,3 +285,37 @@ Next market-hours validation:
 3. Confirm the hedge order is submitted immediately, not after the next 1 minute iteration.
 4. Confirm no broad `get_orders()` scan blocks the hedge.
 5. If OTO/bracket is used, confirm Schwab triggers the child order after the parent fill.
+
+## Filled Option To Stock Hedge Proof, June 2, 2026
+
+Rob-owned Schwab account suffix used: `4364`.
+
+Summary file:
+
+- `tmp/schwab_titus_live_fill_hedge_1780429984.json`
+
+Command:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 180s \
+  python3 scripts/schwab_titus_live_fill_hedge_smoke.py \
+  --account-suffix 4364 \
+  --token-path schwab_token.json \
+  --option-qty 1 \
+  --hedge-qty 100 \
+  --fill-timeout-seconds 12 \
+  --summary-path tmp/schwab_titus_live_fill_hedge_1780429984.json
+```
+
+Result:
+
+- selected TSLL `2026-06-05 $15 CALL`,
+- submitted one option contract at a marketable limit,
+- direct exact-order read confirmed the option order filled,
+- submitted the 100-share TSLL hedge `0.661s` after fill detection,
+- direct exact-order read confirmed the hedge filled,
+- restored the 100 TSLL shares,
+- sold to close the option contract,
+- result `pass=true`, `cleanup_pass=true`.
+
+This proves the corrected fast-order structure can run a real Schwab fill-to-hedge path without waiting for the next one-minute strategy cycle. It still does not prove Titus's exact production deployment, because this was a Rob-owned controlled smoke using TSLL instead of Titus's LW symbol.

--- a/docs/investigations/2026-06-01_titus-schwab-strategy-validation.md
+++ b/docs/investigations/2026-06-01_titus-schwab-strategy-validation.md
@@ -1,0 +1,287 @@
+# Titus Schwab Strategy Validation - 2026-06-01
+
+## Scope
+
+Investigate whether Titus's current cancel and hedge issues are still a LumiBot Schwab broker bug or a generated-strategy structure problem. This note intentionally avoids customer secrets and does not include token values.
+
+## Strategy Provenance
+
+The proposed local copy is based on Titus's saved LW ITM call scanner, not a generic scratch strategy.
+
+Evidence checked:
+
+- The saved strategy export at `.codex_tmp_titus_research/lw_itm_call_v18_main.py` has the `LWITMCallScanner` class and the generated-code header for the same refinement thread.
+- The exported conversation includes repeated requests to cancel option orders after 4 seconds if they do not fill.
+- The same conversation includes Schwab cancel failures from before the option cancel fix, including `cancel_order` not being implemented for Schwab option orders.
+- Later generated versions moved toward IOC-style option handling and bounded hedge retries, which matches the workaround path Titus was using after the earlier cancel failures.
+
+That means the proposed copy is addressing the strategy shape Titus was working with: a fast option entry, a short cancel window, and a stock hedge that should fire immediately after the first leg fills.
+
+## Current Finding
+
+The live Schwab broker path is working for the critical primitives:
+
+- A TSLL option limit order can be submitted.
+- The submitted order can be read back by exact order id.
+- A 4 second wait can be followed by `cancel_order`.
+- Schwab returns the order as canceled through direct order lookup.
+- Broker-native OTO and bracket structures can be submitted, read back as Schwab `TRIGGER` orders, and canceled.
+
+The remaining risk is strategy structure, not basic Schwab cancel support.
+
+Update after the latest local strategy pass:
+
+- The proposed Titus strategy copy now uses a 1 second exact-order polling loop during the 4 second cancel window.
+- If the option order fills during that direct polling window, it submits the hedge immediately from the same code path.
+- `on_filled_order()` remains as a backup trigger, but a per-order hedge guard prevents duplicate hedge orders if both direct polling and the callback see the same fill.
+- If the order does not fill, it cancels the exact submitted order id, treats `CANCELLING` / pending-cancel states as an unlock condition, and avoids broad `get_orders()` in the hot path.
+
+## Live Evidence
+
+Rob-owned Schwab account suffix used: `4364`.
+
+Summary files:
+
+- `tmp/schwab_titus_fast_cancel_strategy_1780357004.json`
+- `tmp/schwab_titus_fast_cancel_strategy_1780360399.json`
+- `tmp/schwab_titus_workflow_smoke_1780359992.json`
+
+The most complete workflow smoke ran:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 180s \
+  python3 scripts/schwab_titus_workflow_smoke.py \
+  --account-suffix 4364 \
+  --token-path schwab_token.json \
+  --wait-seconds 4 \
+  --option-limit 0.01 \
+  --child-limit 0.50 \
+  --stop-loss 0.01
+```
+
+Result:
+
+- `titus_style_cancel`: passed.
+- `oto_structure`: passed.
+- `bracket_structure`: passed.
+
+The latest strategy-level fast-cancel rerun used the saved gitignored token path and passed:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 180s \
+  python3 scripts/schwab_titus_fast_cancel_strategy_smoke.py \
+  --account-suffix 4364 \
+  --token-path schwab_token.json \
+  --wait-seconds 4 \
+  --option-limit 0.01 \
+  --measure-broad-orders
+```
+
+Result:
+
+- submitted TSLL option limit order,
+- waited 4 seconds,
+- canceled by exact order id,
+- direct-read final status as `CANCELED`,
+- strategy unlock condition returned true,
+- `used_broad_get_orders_in_hot_path` was false.
+
+Latest rerun:
+
+- summary: `tmp/schwab_titus_fast_cancel_strategy_1780364001.json`
+- result: `pass: true`
+- elapsed time: 5.368 seconds
+- before cancel: `PENDING_ACTIVATION`
+- immediate and final direct reads: `CANCELED`
+- broad order pull was measured separately and took 0.357 seconds, but the strategy hot path did not depend on broad order history.
+
+Because the market was closed by the time the final checks ran, this does not prove a real fill-triggered hedge leg. That needs market-hours validation.
+
+## Titus Strategy Issues Found
+
+### 1. Hedge can wait one full strategy cycle
+
+In the ITM call scanner version:
+
+- `initialize()` sets `self.sleeptime = "1M"`.
+- `_submit_option_order()` sets `self.vars.pending_hedge` when it detects a fill.
+- `on_filled_order()` also only sets `self.vars.pending_hedge`.
+- The hedge is actually placed from the next `on_trading_iteration()`.
+
+That means a fill can legitimately wait close to a minute before the hedge order is submitted. This matches Titus's report that the hedge leg can take about a minute.
+
+Fix direction:
+
+- Submit the hedge immediately inside `on_filled_order()` or immediately after direct fill detection in `_submit_option_order()`.
+- Do not only set `pending_hedge` and wait for the next minute-based iteration.
+- If `pending_hedge` remains as a retry mechanism, reduce `sleeptime` to a much shorter interval, for example `5S`, and keep duplicate-order guards.
+
+### 2. Cancel path can stay locked too conservatively
+
+In the ITM call scanner version:
+
+- The strategy submits an option order.
+- It sleeps 4 seconds.
+- It calls `get_order(submitted.identifier)`.
+- If not filled, it calls `cancel_order(submitted)`.
+- It then checks only a small set of statuses and keeps `pair_lock` if the order still looks active.
+
+This can leave the strategy locked if Schwab is in a canceling or transition state, or if local order state has not fully settled.
+
+Fix direction:
+
+- Track the submitted order id and use direct `get_order(order_id)` in the hot path.
+- After `cancel_order(submitted)`, unlock when any of these are true:
+  - local `submitted.is_canceled()` is true,
+  - direct status is `CANCELED`, `CANCELLED`, `CANCELLING`, or `PENDING_CANCEL`,
+  - direct order lookup says the order is not active.
+- Do not use a broad `get_orders()` scan to decide whether this exact order is still blocking the pair.
+
+### 3. Another generated version avoids option cancel entirely
+
+In the call spread strategy version, `_cancel_stale_live_orders()` explicitly skips manual cancel for options and logs that it is relying on IOC/FOK behavior. That was a workaround for the old Schwab cancel limitation.
+
+That workaround should now be removed for strategies that require "cancel after 4 seconds." The current Schwab option cancel path has been validated live.
+
+## Recommended Strategy Pattern
+
+For Titus's current workflow, the next generated/refined strategy should:
+
+1. Submit one option order and store the returned `submitted.identifier`.
+2. Sleep 4 seconds with `process_pending_orders=True`.
+3. Directly call `get_order(submitted.identifier)`.
+4. If filled, submit the hedge immediately from the same code path or from `on_filled_order()`.
+5. If not filled, call `cancel_order(submitted)`.
+6. Directly re-read that same order id and unlock on canceled, canceling, pending cancel, or non-active state.
+7. Avoid broad `get_orders()` scans in the 4 second submit/cancel/hedge path.
+8. Prefer broker-native OTO/bracket orders for the fastest parent/child behavior once live fill-trigger testing is complete.
+
+## Proposed Local Strategy Copy
+
+A proposed copy was created from the read-only saved Titus strategy:
+
+- source: `.codex_tmp_titus_research/lw_itm_call_v18_main.py`
+- proposed: `.codex_tmp_titus_research/lw_itm_call_v18_proposed_fast_cancel.py`
+
+Changes in the proposed copy:
+
+- changes `self.sleeptime` from `1M` to `1S` so fallback hedge retry is not delayed by a full minute,
+- polls the exact submitted order id once per second during the 4 second fill/cancel window,
+- submits the stock hedge immediately if the exact direct read shows a fill,
+- keeps `on_filled_order()` as a backup path only,
+- adds a duplicate hedge guard keyed by option order id,
+- adds a `_submit_hedge_now(...)` helper,
+- treats Schwab `CANCELLING` as cancel-pending and not as a reason to keep the pair locked forever,
+- unlocks the pair after `cancel_order(...)` when the local order or direct broker read confirms canceled/canceling/non-active state.
+
+Validation performed:
+
+```bash
+python3 -m py_compile \
+  /Users/robertgrzesik/Development/.codex_tmp_titus_research/lw_itm_call_v18_proposed_fast_cancel.py \
+  /Users/robertgrzesik/Development/.codex_tmp_titus_research/validate_lw_itm_fast_cancel.py
+```
+
+```bash
+PYTHONPATH=/Users/robertgrzesik/Development/lumibot \
+  python3 /Users/robertgrzesik/Development/.codex_tmp_titus_research/validate_lw_itm_fast_cancel.py
+```
+
+Result:
+
+- `PASS: proposed Titus fast-cancel strategy control flow`
+
+The fake-control-flow test proves:
+
+- direct exact-order fill detection submits one hedge immediately,
+- callback-first fill handling also submits one hedge immediately,
+- a later fill callback does not submit a duplicate hedge,
+- a later direct poll after the callback does not submit a duplicate hedge,
+- the cancel path sleeps in 1 second increments,
+- `CANCELLING` unlocks `pair_lock` and clears `active_order_id`.
+
+The proposed copy compiles and passes the local control-flow harness. It has not been deployed and has not been written back to Titus's saved strategy.
+
+## Prompt / Skills Follow-up
+
+The shared strategy lifecycle prompt and focused runtime skill were updated in BotSpot Agent:
+
+- `botspot_agent/src/botspot_agent/strategy/prompts/markdown/shared_lifecycle_methods.md`
+- `botspot_agent/src/botspot_agent/strategy/prompts/markdown/shared_notes.md`
+- `botspot_agent/src/botspot_agent/strategy/prompts/markdown/lumibot_fast_order_management.md`
+- `botspot_agent/src/botspot_agent/strategy/skills/lumibot-fast-order-management/SKILL.md`
+- `botspot_agent/src/botspot_agent/runtime.py`
+
+New guidance tells generate/refine to use exact-order polling for very fast live order workflows, avoid broad `get_orders()` as the hot-path truth for a just-submitted order, treat cancel-pending states as in progress, and use an idempotency guard so polling plus `on_filled_order()` cannot place a duplicate hedge. The main strategy agent now has a runtime skill-loading rule for fast live cancels, immediate hedge legs, pair/spread legs, manual-cancel confusion, volatile quotes, and broker-native OTO/OCO/bracket workflows.
+
+This is intentionally short because the guidance is loaded into strategy generation/refinement prompts.
+
+Deployment evidence:
+
+- BotSpot Agent production commit: `8838855d9146ec48abe657edf11fcb8c93548515`
+- GitHub Actions run: `26838995473`
+- Result: CI and production deploy succeeded on June 2, 2026.
+- Focused prompt tests: `71 passed`
+- Full BotSpot Agent test suite: `485 passed, 3 skipped`
+- MyPy: `Success: no issues found in 86 source files`
+
+## Market-Hours Broker Proof, June 2, 2026
+
+Account suffix used: Rob-owned Schwab account `4364`.
+
+Timed cancel smoke:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 180s \
+  python3 scripts/schwab_titus_fast_cancel_strategy_smoke.py \
+  --account-suffix 4364 \
+  --token-path schwab_token.json \
+  --wait-seconds 4 \
+  --option-limit 0.01 \
+  --measure-broad-orders \
+  --summary-path tmp/schwab_titus_fast_cancel_strategy_1780424917.json
+```
+
+Result:
+
+- submitted TSLL `2026-06-05 $15 CALL` limit order at `0.01`,
+- direct order reads showed Schwab status `WORKING` through the 4 second wait,
+- `cancel_order(...)` was accepted by Schwab,
+- immediate direct read showed final status `CANCELED`,
+- `used_broad_get_orders_in_hot_path=false`,
+- broad order pull was measured separately at `0.393s`,
+- result `pass=true`.
+
+OTO/bracket structure smoke:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 180s \
+  python3 scripts/schwab_titus_workflow_smoke.py \
+  --account-suffix 4364 \
+  --token-path schwab_token.json \
+  --wait-seconds 4 \
+  --option-limit 0.01 \
+  --child-limit 0.50 \
+  --stop-loss 0.01 \
+  --summary-path tmp/schwab_titus_workflow_smoke_1780425067.json
+```
+
+Result:
+
+- Titus-style timed cancel: `pass=true`, final status `CANCELED`.
+- OTO structure: Schwab accepted parent as `orderStrategyType=TRIGGER` with one child, then parent canceled; `pass=true`.
+- Bracket structure: Schwab accepted parent as `orderStrategyType=TRIGGER` with child structure, then parent canceled; `pass=true`.
+
+This proves Schwab accepts the order structures and that direct exact-order cancel/read works during market hours. It does not prove parent-fill child-trigger behavior or real filled-option-to-stock-hedge timing.
+
+## Still Needs Market-Hours Proof
+
+The after-hours tests and June 2 market-hours resting-order tests prove submit/read/cancel and order-structure acceptance. They do not prove a real fill event triggering the hedge leg.
+
+Next market-hours validation:
+
+1. Run a Rob-owned strategy using the corrected pattern on a cheap option or stock.
+2. Force or allow one parent fill.
+3. Confirm the hedge order is submitted immediately, not after the next 1 minute iteration.
+4. Confirm no broad `get_orders()` scan blocks the hedge.
+5. If OTO/bracket is used, confirm Schwab triggers the child order after the parent fill.

--- a/docsrc/agents.rst
+++ b/docsrc/agents.rst
@@ -489,13 +489,47 @@ Error Handling and Reliability
 
    This section describes error handling **specific to AI agent calls**. The rest of LumiBot's main-loop error handling (strategy executor, brokers, data sources) is unchanged. The behavior below is scoped to ``AgentHandle.run()`` and ``GoogleADKRuntime.run()``; it does not alter how non-agent code paths react to exceptions.
 
-LumiBot's AI agent stack has three retry/safety layers that together keep live trading alive through provider outages and surface backtest-time bugs clearly:
+LumiBot's AI agent stack has four timeout/retry/safety layers that together keep live trading alive through provider outages and surface backtest-time bugs clearly:
 
-1. **LiteLLM-level HTTP retries.** When using non-Gemini providers, LiteLLM retries each individual HTTP call 3 times with provider-aware backoff (429 Retry-After awareness, capped exponential). Configured automatically in ``_configure_litellm_quietly`` (``num_retries=3``, ``drop_params=True``, ``suppress_debug_info=True``).
+1. **Provider request timeout.** Each individual model request has a default **10 minute** timeout. Native Gemini models receive this as ``google.genai.types.HttpOptions(timeout=...)``. LiteLLM-backed providers receive it as LiteLLM's ``timeout`` argument. This prevents one wedged provider call from freezing an agent for the full run budget.
 
-2. **Runtime-level attempt retries.** ``GoogleADKRuntime.run()`` retries the full agent call up to **10 times** with capped exponential backoff (2s, 3s, 5s, 10s, 20s, 30s, 45s, 60s, 60s, 60s — total budget ~5 minutes). This covers session-setup errors, ADK runner glitches, and provider 5xx storms that LiteLLM's inner retry couldn't fix. Only transient and unknown errors retry; auth/config/billing errors surface immediately so we do not waste 5 minutes retrying a wrong API key.
+2. **LiteLLM-level HTTP retries.** When using non-Gemini providers, LiteLLM retries each individual HTTP call 3 times with provider-aware backoff (429 Retry-After awareness, capped exponential). Configured automatically in ``_configure_litellm_quietly`` (``num_retries=3``, ``drop_params=True``, ``suppress_debug_info=True``).
 
-3. **Strategy-level safety net with live-vs-backtest branch.** ``AgentHandle.run()`` wraps the runtime call in a final catch. Behavior depends on two things: the error category and whether the strategy is in backtest mode or live.
+3. **Runtime-level attempt retries.** ``GoogleADKRuntime.run()`` retries the full agent call up to **10 times** with capped exponential backoff (2s, 3s, 5s, 10s, 20s, 30s, 45s, 60s, 60s, 60s — total budget ~5 minutes). This covers session-setup errors, ADK runner glitches, and provider 5xx storms that LiteLLM's inner retry couldn't fix. Only transient and unknown errors retry; auth/config/billing errors surface immediately so we do not waste 5 minutes retrying a wrong API key.
+
+4. **Strategy-level safety net with live-vs-backtest branch.** ``AgentHandle.run()`` wraps the runtime call in a final catch. Behavior depends on two things: the error category and whether the strategy is in backtest mode or live.
+
+Timeout configuration
+~~~~~~~~~~~~~~~~~~~~~
+
+The provider request timeout is different from the full agent run timeout:
+
+- ``model_request_timeout_seconds`` controls one model/API request. Default: ``600`` seconds.
+- ``run_timeout_seconds`` controls the whole agent run, including model calls, tool calls, and retries. Default: ``1800`` seconds.
+
+Set these when creating an agent:
+
+.. code-block:: python
+
+    self.agents.create(
+        name="researcher",
+        model="gemini-3.5-flash",
+        system_prompt="Research the best trade.",
+        model_request_timeout_seconds=600,
+        run_timeout_seconds=1800,
+    )
+
+Or override them for one call:
+
+.. code-block:: python
+
+    self.agents["researcher"].run(
+        task_prompt="Run a deeper research pass.",
+        model_request_timeout_seconds=900,
+        run_timeout_seconds=2400,
+    )
+
+Advanced operators can also set ``LUMIBOT_AGENT_MODEL_REQUEST_TIMEOUT_SECONDS`` and ``LUMIBOT_AGENT_RUN_TIMEOUT_SECONDS``. A non-positive value disables that timeout. LumiBot logs every cold agent call with the effective timeout values and logs the latency to the first ADK event, which helps distinguish a stuck provider request from an agent that is actively calling tools.
 
 Error classifier buckets
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lumibot/components/agents/manager.py
+++ b/lumibot/components/agents/manager.py
@@ -656,12 +656,16 @@ class AgentHandle:
         runtime: Any | None = None,
         allow_trading: bool = True,
         include_builtin_tools: bool = True,
+        model_request_timeout_seconds: float | None = None,
+        run_timeout_seconds: float | None = None,
     ) -> None:
         self.manager = manager
         self.name = name
         self.system_prompt = system_prompt
         self.default_model = default_model
         self.allow_trading = bool(allow_trading)
+        self.model_request_timeout_seconds = model_request_timeout_seconds
+        self.run_timeout_seconds = run_timeout_seconds
         from .builtins import BuiltinTools
         builtin_tools = self._filter_tools_for_trading_permission(BuiltinTools.all())
         if tools is None:
@@ -1361,11 +1365,25 @@ class AgentHandle:
         task_prompt: str | None = None,
         context: dict[str, Any] | None = None,
         model: str | None = None,
+        model_request_timeout_seconds: float | None = None,
+        run_timeout_seconds: float | None = None,
         **kwargs: Any,
     ) -> AgentRunResult:
         if "task" in kwargs and task_prompt is None:
             task_prompt = kwargs["task"]
+        if "model_request_timeout" in kwargs and model_request_timeout_seconds is None:
+            model_request_timeout_seconds = kwargs["model_request_timeout"]
+        if "run_timeout" in kwargs and run_timeout_seconds is None:
+            run_timeout_seconds = kwargs["run_timeout"]
         model_name = model or self.default_model
+        resolved_model_request_timeout_seconds = (
+            model_request_timeout_seconds
+            if model_request_timeout_seconds is not None
+            else self.model_request_timeout_seconds
+        )
+        resolved_run_timeout_seconds = (
+            run_timeout_seconds if run_timeout_seconds is not None else self.run_timeout_seconds
+        )
         runtime_context = self._runtime_context()
         memory_state = self._memory_state(runtime_context)
         base_system_prompt = self._base_system_prompt(runtime_context)
@@ -1416,6 +1434,8 @@ class AgentHandle:
                 effective_system_prompt=effective_system_prompt,
                 bound_tools=self._ensure_bound_tools(),
             ),
+            model_request_timeout_seconds=resolved_model_request_timeout_seconds,
+            run_timeout_seconds=resolved_run_timeout_seconds,
         )
         self.manager._reserve_model_call(agent_name=self.name, model=model_name)
         # Strategy-level safety net with live-vs-backtest branching.
@@ -2041,6 +2061,8 @@ class AgentManager:
         allow_trading: bool | None = None,
         _runtime: Any | None = None,
         include_builtin_tools: bool = True,
+        model_request_timeout_seconds: float | None = None,
+        run_timeout_seconds: float | None = None,
     ) -> AgentHandle:
         if name in self._agents:
             raise ValueError(f"Agent with name {name!r} already exists.")
@@ -2059,6 +2081,8 @@ class AgentManager:
             runtime=_runtime,
             allow_trading=resolved_allow_trading,
             include_builtin_tools=include_builtin_tools,
+            model_request_timeout_seconds=model_request_timeout_seconds,
+            run_timeout_seconds=run_timeout_seconds,
         )
         if cadence is not None:
             self.strategy.log_message(

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -371,9 +371,31 @@ class RuntimeRequest:
     bound_tools: list[BoundTool]
     model_call_id: str | None = None
     provider_prompt_cache_key: str | None = None
+    model_request_timeout_seconds: float | None = None
+    run_timeout_seconds: float | None = None
 
 
 _LITELLM_CONFIGURED = False
+
+
+def _coerce_positive_timeout_seconds(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        timeout_seconds = float(value)
+    except Exception:
+        return None
+    return timeout_seconds if timeout_seconds > 0 else None
+
+
+def _parse_timeout_seconds(value: Any) -> tuple[bool, float | None]:
+    if value is None:
+        return False, None
+    try:
+        timeout_seconds = float(value)
+    except Exception:
+        return False, None
+    return True, timeout_seconds if timeout_seconds > 0 else None
 
 
 # Error classification for AI agent calls.
@@ -840,7 +862,19 @@ def _strip_thought_parts_from_litellm_request(llm_request: Any) -> None:
         llm_request.contents = updated
 
 
-def _resolve_model_for_adk(model: Any, *, prompt_cache_key: str | None = None) -> Any:
+def _is_native_gemini_model(model: Any) -> bool:
+    if not isinstance(model, str):
+        return False
+    lower = model.strip().lower()
+    return lower.startswith("gemini-") or lower.startswith("models/gemini")
+
+
+def _resolve_model_for_adk(
+    model: Any,
+    *,
+    prompt_cache_key: str | None = None,
+    model_request_timeout_seconds: float | None = None,
+) -> Any:
     # Native Gemini IDs take ADK's fast path as plain strings. Any other
     # provider prefix (e.g. "openai/...", "xai/...", "anthropic/...") is
     # routed through google.adk.models.lite_llm.LiteLlm which normalizes
@@ -848,7 +882,7 @@ def _resolve_model_for_adk(model: Any, *, prompt_cache_key: str | None = None) -
     if not isinstance(model, str):
         return model
     lower = model.strip().lower()
-    if lower.startswith("gemini-") or lower.startswith("models/gemini"):
+    if _is_native_gemini_model(model):
         _sync_gemini_api_key_alias()
         return model
     if lower.startswith("xai/"):
@@ -876,6 +910,11 @@ def _resolve_model_for_adk(model: Any, *, prompt_cache_key: str | None = None) -
                 yield response
 
     kwargs: dict[str, Any] = {}
+    resolved_timeout_seconds = _coerce_positive_timeout_seconds(model_request_timeout_seconds)
+    if resolved_timeout_seconds is not None:
+        # google.adk.models.lite_llm.LiteLlm forwards additional args to
+        # LiteLLM's acompletion call. LiteLLM accepts timeout in seconds.
+        kwargs["timeout"] = resolved_timeout_seconds
     if prompt_cache_key:
         if lower.startswith("openai/"):
             # OpenAI prompt caching is automatic for long shared prefixes. The
@@ -900,10 +939,7 @@ def _supports_explicit_temperature_for_adk_model(model: Any) -> bool:
     Gemini-native path; let LiteLLM providers use their provider defaults unless
     a future explicit per-provider compatibility layer is added.
     """
-    if not isinstance(model, str):
-        return False
-    lower = model.strip().lower()
-    return lower.startswith("gemini-") or lower.startswith("models/gemini")
+    return _is_native_gemini_model(model)
 
 
 class GoogleADKRuntime:
@@ -1130,17 +1166,29 @@ class GoogleADKRuntime:
             "tool_calls": [],
         }
         tools = [function_tool_type(_wrap_tool_callable(tool, active_tool_context)) for tool in request.bound_tools]
-        config_kwargs: dict[str, Any] = {
-            "max_output_tokens": 65535,
-        }
-        if _supports_explicit_temperature_for_adk_model(request.model):
-            config_kwargs["temperature"] = 0.0
+        config_kwargs = self._generate_content_config_kwargs_for_request(request, genai_types)
+        model_request_timeout_seconds = self._model_request_timeout_seconds_for_request(request)
+        run_timeout_seconds = self._run_timeout_seconds_for_request(request)
+        model_timeout_label = (
+            f"{model_request_timeout_seconds:g}s" if model_request_timeout_seconds is not None else "disabled"
+        )
+        run_timeout_label = f"{run_timeout_seconds:g}s" if run_timeout_seconds is not None else "disabled"
+        try:
+            sys.stderr.write(
+                f"[lumibot.agents] starting agent '{request.agent_name}' "
+                f"(model={request.model!r}, model_request_timeout={model_timeout_label}, "
+                f"run_timeout={run_timeout_label}).\n"
+            )
+            sys.stderr.flush()
+        except Exception:
+            pass
         planner = self._maybe_build_gemini_thinking_planner(request.model, genai_types)
         agent = LlmAgentType(
             name=request.agent_name,
             model=_resolve_model_for_adk(
                 request.model,
                 prompt_cache_key=request.provider_prompt_cache_key or _provider_prompt_cache_key(request),
+                model_request_timeout_seconds=model_request_timeout_seconds,
             ),
             instruction=self._instruction_for(request),
             tools=tools,
@@ -1173,6 +1221,15 @@ class GoogleADKRuntime:
             if normalized_events and first_event_perf is None:
                 first_event_perf = time.perf_counter()
                 first_event_at = _utc_iso_timestamp()
+                try:
+                    sys.stderr.write(
+                        f"[lumibot.agents] first ADK event for agent '{request.agent_name}' "
+                        f"(model={request.model!r}) after "
+                        f"{max(int((first_event_perf - started_perf) * 1000), 0)}ms.\n"
+                    )
+                    sys.stderr.flush()
+                except Exception:
+                    pass
             timestamp = _utc_iso_timestamp()
             for normalized_event in normalized_events:
                 normalized_event.timestamp = timestamp
@@ -1223,7 +1280,37 @@ class GoogleADKRuntime:
     # the strategy stays alive and retries on the next bar.
     _MAX_RUN_ATTEMPTS = 10
     _DEFAULT_RUN_TIMEOUT_SECONDS = 1800.0
+    _DEFAULT_MODEL_REQUEST_TIMEOUT_SECONDS = 600.0
     _RETRY_BACKOFF_SECONDS = (2.0, 3.0, 5.0, 10.0, 20.0, 30.0, 45.0, 60.0, 60.0, 60.0)
+
+    @staticmethod
+    def _model_request_timeout_seconds_for_request(request: RuntimeRequest) -> float | None:
+        if request.model_request_timeout_seconds is not None:
+            return _coerce_positive_timeout_seconds(request.model_request_timeout_seconds)
+        raw = os.environ.get("LUMIBOT_AGENT_MODEL_REQUEST_TIMEOUT_SECONDS")
+        if raw is not None:
+            parsed, timeout_seconds = _parse_timeout_seconds(raw)
+            if parsed:
+                return timeout_seconds
+        # This is the provider/model HTTP request timeout, not the full agent
+        # run timeout. Multi-tool agents can still run longer via the outer
+        # run timeout; one wedged model request should not.
+        return GoogleADKRuntime._DEFAULT_MODEL_REQUEST_TIMEOUT_SECONDS
+
+    @staticmethod
+    def _generate_content_config_kwargs_for_request(request: RuntimeRequest, genai_types: Any) -> dict[str, Any]:
+        config_kwargs: dict[str, Any] = {
+            "max_output_tokens": 65535,
+        }
+        if _supports_explicit_temperature_for_adk_model(request.model):
+            config_kwargs["temperature"] = 0.0
+        request_timeout_seconds = GoogleADKRuntime._model_request_timeout_seconds_for_request(request)
+        if _is_native_gemini_model(request.model) and request_timeout_seconds is not None:
+            timeout_millis = max(int(request_timeout_seconds * 1000), 1)
+            http_options_type = getattr(genai_types, "HttpOptions", None)
+            if http_options_type is not None:
+                config_kwargs["http_options"] = http_options_type(timeout=timeout_millis)
+        return config_kwargs
 
     @staticmethod
     def _max_attempts_for_request(request: RuntimeRequest) -> int:
@@ -1251,13 +1338,13 @@ class GoogleADKRuntime:
 
     @staticmethod
     def _run_timeout_seconds_for_request(request: RuntimeRequest) -> float | None:
+        if request.run_timeout_seconds is not None:
+            return _coerce_positive_timeout_seconds(request.run_timeout_seconds)
         raw = os.environ.get("LUMIBOT_AGENT_RUN_TIMEOUT_SECONDS")
-        if raw:
-            try:
-                timeout_seconds = float(raw)
-                return timeout_seconds if timeout_seconds > 0 else None
-            except Exception:
-                pass
+        if raw is not None:
+            parsed, timeout_seconds = _parse_timeout_seconds(raw)
+            if parsed:
+                return timeout_seconds
         # Agentic trading/research runs can legitimately spend many minutes
         # across model calls and tool calls. Keep the default high enough for
         # realistic multi-tool agents while still preventing indefinite hangs.

--- a/scripts/schwab_titus_live_fill_hedge_smoke.py
+++ b/scripts/schwab_titus_live_fill_hedge_smoke.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Live Schwab proof for Titus-style fill-to-hedge timing.
+
+This intentionally creates and cleans up real exposure on Rob's Schwab account.
+It uses a marketable limit for one TSLL option contract, watches that exact
+order id, submits the stock hedge immediately on fill, then restores the stock
+and option positions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from lumibot.entities import Asset, Order
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from schwab_titus_workflow_smoke import (  # noqa: E402
+    _make_broker,
+    _order_snapshot,
+    _poll_until,
+    _safe_cancel,
+    _select_tsll_call_asset,
+    _suffix,
+)
+
+
+TERMINAL = {"CANCELED", "CANCELLED", "FILLED", "REJECTED", "EXPIRED"}
+
+
+def _quote_dict(broker, asset: Asset) -> dict[str, Any]:
+    quote = broker.data_source.get_quote(asset)
+    return {
+        "bid": float(getattr(quote, "bid", 0) or 0),
+        "ask": float(getattr(quote, "ask", 0) or 0),
+        "price": float(getattr(quote, "price", 0) or 0),
+        "mid": float(getattr(quote, "mid_price", 0) or 0),
+    }
+
+
+def _submit_limit(
+    broker,
+    *,
+    strategy_name: str,
+    asset: Asset,
+    quantity: int,
+    side: str,
+    limit_price: float,
+) -> Order:
+    order = Order(
+        strategy=strategy_name,
+        asset=asset,
+        quantity=quantity,
+        side=side,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=round(float(limit_price), 2),
+        time_in_force="day",
+        tag=strategy_name,
+    )
+    submitted = broker._submit_order(order)
+    if not submitted or not submitted.identifier:
+        raise RuntimeError(f"Schwab did not return an order id for {side} {asset}.")
+    return submitted
+
+
+def _wait_for_terminal_or_active(broker, order: Order, strategy_name: str, timeout_seconds: float) -> dict[str, Any]:
+    return _poll_until(
+        broker,
+        order.identifier,
+        strategy_name,
+        lambda snap: snap["status"] in TERMINAL or snap["filled"] or snap["canceled"],
+        timeout_seconds=timeout_seconds,
+        interval_seconds=0.5,
+    )
+
+
+def run_live_fill_hedge_smoke(
+    broker,
+    option_asset: Asset,
+    *,
+    option_qty: int,
+    hedge_qty: int,
+    max_option_ask: float,
+    max_stock_ask: float,
+    fill_timeout_seconds: float,
+) -> dict[str, Any]:
+    strategy_name = "rob-titus-live-fill-hedge-smoke"
+    stock_asset = Asset("TSLL", asset_type=Asset.AssetType.STOCK)
+    option_entry = None
+    hedge_order = None
+    option_exit = None
+    hedge_restore = None
+    events: list[dict[str, Any]] = []
+    started = time.perf_counter()
+
+    option_quote = _quote_dict(broker, option_asset)
+    stock_quote = _quote_dict(broker, stock_asset)
+    if option_quote["ask"] <= 0 or option_quote["ask"] > max_option_ask:
+        raise RuntimeError(f"Option ask outside test bounds: {option_quote}")
+    if stock_quote["ask"] <= 0 or stock_quote["ask"] > max_stock_ask:
+        raise RuntimeError(f"Stock ask outside test bounds: {stock_quote}")
+
+    try:
+        option_entry = _submit_limit(
+            broker,
+            strategy_name=strategy_name,
+            asset=option_asset,
+            quantity=option_qty,
+            side=Order.OrderSide.BUY_TO_OPEN,
+            limit_price=option_quote["ask"] + 0.02,
+        )
+        events.append({
+            "event": "option_entry_submitted",
+            "elapsed": round(time.perf_counter() - started, 3),
+            "order_suffix": _suffix(option_entry.identifier),
+            "limit": round(option_quote["ask"] + 0.02, 2),
+        })
+
+        entry_final = _wait_for_terminal_or_active(broker, option_entry, strategy_name, fill_timeout_seconds)
+        events.append({"event": "option_entry_final", "elapsed": round(time.perf_counter() - started, 3), **entry_final})
+
+        if not entry_final.get("filled"):
+            broker.cancel_order(option_entry)
+            cancel_final = _wait_for_terminal_or_active(broker, option_entry, strategy_name, 8)
+            return {
+                "pass": False,
+                "reason": "option_entry_did_not_fill",
+                "events": events + [{"event": "option_entry_cleanup", **cancel_final}],
+                "option_quote": option_quote,
+                "stock_quote": stock_quote,
+            }
+
+        hedge_started = time.perf_counter()
+        stock_quote_for_hedge = _quote_dict(broker, stock_asset)
+        hedge_order = _submit_limit(
+            broker,
+            strategy_name=strategy_name,
+            asset=stock_asset,
+            quantity=hedge_qty,
+            side=Order.OrderSide.SELL,
+            limit_price=stock_quote_for_hedge["bid"] - 0.03,
+        )
+        hedge_submit_elapsed = time.perf_counter() - hedge_started
+        events.append({
+            "event": "hedge_submitted_after_fill",
+            "elapsed": round(time.perf_counter() - started, 3),
+            "seconds_after_fill_detection": round(hedge_submit_elapsed, 3),
+            "order_suffix": _suffix(hedge_order.identifier),
+            "limit": round(stock_quote_for_hedge["bid"] - 0.03, 2),
+        })
+        hedge_final = _wait_for_terminal_or_active(broker, hedge_order, strategy_name, 10)
+        events.append({"event": "hedge_final", "elapsed": round(time.perf_counter() - started, 3), **hedge_final})
+
+        # Restore the hedge shares first, then close the option contract.
+        stock_quote_for_restore = _quote_dict(broker, stock_asset)
+        hedge_restore = _submit_limit(
+            broker,
+            strategy_name=strategy_name,
+            asset=stock_asset,
+            quantity=hedge_qty,
+            side=Order.OrderSide.BUY,
+            limit_price=stock_quote_for_restore["ask"] + 0.05,
+        )
+        restore_final = _wait_for_terminal_or_active(broker, hedge_restore, strategy_name, 10)
+        events.append({"event": "hedge_restore_final", "elapsed": round(time.perf_counter() - started, 3), **restore_final})
+
+        option_quote_for_exit = _quote_dict(broker, option_asset)
+        option_exit = _submit_limit(
+            broker,
+            strategy_name=strategy_name,
+            asset=option_asset,
+            quantity=option_qty,
+            side=Order.OrderSide.SELL_TO_CLOSE,
+            limit_price=max(0.01, option_quote_for_exit["bid"] - 0.03),
+        )
+        option_exit_final = _wait_for_terminal_or_active(broker, option_exit, strategy_name, 10)
+        events.append({"event": "option_exit_final", "elapsed": round(time.perf_counter() - started, 3), **option_exit_final})
+
+        return {
+            "pass": bool(entry_final.get("filled") and hedge_final.get("filled")),
+            "cleanup_pass": bool(restore_final.get("filled") and option_exit_final.get("filled")),
+            "events": events,
+            "option_quote": option_quote,
+            "stock_quote": stock_quote,
+            "elapsed_seconds": round(time.perf_counter() - started, 3),
+        }
+    finally:
+        for order in (option_exit, hedge_restore, hedge_order, option_entry):
+            _safe_cancel(broker, order, strategy_name)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--account-suffix", default="4364")
+    parser.add_argument("--token-path", default="schwab_token.json")
+    parser.add_argument("--option-qty", type=int, default=1)
+    parser.add_argument("--hedge-qty", type=int, default=100)
+    parser.add_argument("--max-option-ask", type=float, default=0.75)
+    parser.add_argument("--max-stock-ask", type=float, default=20.0)
+    parser.add_argument("--fill-timeout-seconds", type=float, default=12.0)
+    parser.add_argument("--summary-path", default=None)
+    args = parser.parse_args()
+
+    broker, account_meta = _make_broker(Path(args.token_path).expanduser().resolve(), None, args.account_suffix)
+    option_asset = _select_tsll_call_asset(broker)
+    result = run_live_fill_hedge_smoke(
+        broker,
+        option_asset,
+        option_qty=args.option_qty,
+        hedge_qty=args.hedge_qty,
+        max_option_ask=args.max_option_ask,
+        max_stock_ask=args.max_stock_ask,
+        fill_timeout_seconds=args.fill_timeout_seconds,
+    )
+    summary = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "account": account_meta,
+        "asset": {
+            "symbol": option_asset.symbol,
+            "expiration": option_asset.expiration.isoformat() if option_asset.expiration else None,
+            "strike": option_asset.strike,
+            "right": option_asset.right,
+        },
+        "result": result,
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    summary_path = Path(args.summary_path or f"tmp/schwab_titus_live_fill_hedge_{int(time.time())}.json")
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+    print(f"Wrote summary: {summary_path.resolve()}")
+    return 0 if result.get("pass") and result.get("cleanup_pass") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.44",
+    version="4.5.45",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_agent_runtime_provider_keys.py
+++ b/tests/test_agent_runtime_provider_keys.py
@@ -188,6 +188,29 @@ def test_openai_model_forwards_prompt_cache_key_and_24h_retention(monkeypatch):
     assert created["prompt_cache_retention"] == "24h"
 
 
+def test_litellm_model_forwards_model_request_timeout(monkeypatch):
+    created: dict[str, object] = {}
+
+    class FakeLiteLlm:
+        def __init__(self, **kwargs):
+            created.update(kwargs)
+
+    fake_module = types.ModuleType("google.adk.models.lite_llm")
+    fake_module.LiteLlm = FakeLiteLlm
+    monkeypatch.setitem(sys.modules, "google.adk.models.lite_llm", fake_module)
+
+    result = _resolve_model_for_adk(
+        "openai/gpt-5.4-mini",
+        prompt_cache_key="stable-prefix-key",
+        model_request_timeout_seconds=12.5,
+    )
+
+    assert isinstance(result, FakeLiteLlm)
+    assert created["model"] == "openai/gpt-5.4-mini"
+    assert created["timeout"] == 12.5
+    assert created["prompt_cache_key"] == "stable-prefix-key"
+
+
 def test_xai_model_forwards_grok_conversation_cache_header(monkeypatch):
     created: dict[str, object] = {}
 
@@ -357,6 +380,63 @@ def test_runtime_default_agent_run_timeout_is_30_minutes(monkeypatch):
     )
 
     assert GoogleADKRuntime._run_timeout_seconds_for_request(request) == 1800.0
+
+
+def test_runtime_default_model_request_timeout_is_10_minutes(monkeypatch):
+    monkeypatch.delenv("LUMIBOT_AGENT_MODEL_REQUEST_TIMEOUT_SECONDS", raising=False)
+    request = RuntimeRequest(
+        agent_name="researcher",
+        model="gemini-3.5-flash",
+        system_prompt="System prompt",
+        task_prompt="Do work",
+        context=None,
+        runtime_context={"mode": "backtesting"},
+        memory_state=None,
+        memory_notes=[],
+        bound_tools=[],
+    )
+
+    assert GoogleADKRuntime._model_request_timeout_seconds_for_request(request) == 600.0
+
+
+def test_runtime_model_request_timeout_can_be_configured_on_request():
+    request = RuntimeRequest(
+        agent_name="researcher",
+        model="gemini-3.5-flash",
+        system_prompt="System prompt",
+        task_prompt="Do work",
+        context=None,
+        runtime_context={"mode": "backtesting"},
+        memory_state=None,
+        memory_notes=[],
+        bound_tools=[],
+        model_request_timeout_seconds=42,
+    )
+
+    assert GoogleADKRuntime._model_request_timeout_seconds_for_request(request) == 42.0
+
+
+def test_gemini_generate_content_config_sets_http_timeout_in_milliseconds(monkeypatch):
+    monkeypatch.delenv("LUMIBOT_AGENT_MODEL_REQUEST_TIMEOUT_SECONDS", raising=False)
+    from google.genai import types as genai_types
+
+    request = RuntimeRequest(
+        agent_name="researcher",
+        model="gemini-3.5-flash",
+        system_prompt="System prompt",
+        task_prompt="Do work",
+        context=None,
+        runtime_context={"mode": "backtesting"},
+        memory_state=None,
+        memory_notes=[],
+        bound_tools=[],
+        model_request_timeout_seconds=12.25,
+    )
+
+    config_kwargs = GoogleADKRuntime._generate_content_config_kwargs_for_request(request, genai_types)
+
+    assert config_kwargs["http_options"].timeout == 12250
+    assert genai_types.GenerateContentConfig(**config_kwargs).http_options.timeout == 12250
 
 
 def test_gemini_native_path_uses_plain_model_id_for_implicit_or_adk_context_cache():

--- a/tests/test_agent_tool_permissions.py
+++ b/tests/test_agent_tool_permissions.py
@@ -114,6 +114,18 @@ class _LongSummaryRuntime:
         )
 
 
+class _CaptureRuntime:
+    requests = []
+
+    def run(self, request):
+        type(self).requests.append(request)
+        return AgentRunResult(
+            summary="Captured runtime request.",
+            model=request.model,
+            events=[AgentTraceEvent(kind="text", text="Captured runtime request.")],
+        )
+
+
 def test_agent_allow_trading_false_removes_only_mutating_order_tools(monkeypatch):
     monkeypatch.delenv("FRED_API_KEY", raising=False)
     strategy = _Strategy()
@@ -138,6 +150,37 @@ def test_agent_allow_trading_false_removes_only_mutating_order_tools(monkeypatch
     assert "get_fred_latest" not in tool_names
     assert "get_fred_snapshot" not in tool_names
     assert agent.default_model == "openai/gpt-5.4-mini"
+
+
+def test_agent_timeout_options_forward_to_runtime_request(monkeypatch):
+    monkeypatch.delenv("FRED_API_KEY", raising=False)
+    _CaptureRuntime.requests = []
+    strategy = _Strategy()
+    strategy.vars = _Vars()
+    strategy.is_backtesting = False
+    manager = AgentManager(strategy)
+    manager.create(
+        name="timed",
+        system_prompt="Capture timeouts.",
+        model="gemini-3.5-flash",
+        tools=[],
+        include_builtin_tools=False,
+        _runtime=_CaptureRuntime(),
+        model_request_timeout_seconds=123,
+        run_timeout_seconds=456,
+    )
+
+    manager["timed"].run(task_prompt="Use defaults.")
+    manager["timed"].run(
+        task_prompt="Use overrides.",
+        model_request_timeout_seconds=7,
+        run_timeout_seconds=8,
+    )
+
+    assert _CaptureRuntime.requests[0].model_request_timeout_seconds == 123
+    assert _CaptureRuntime.requests[0].run_timeout_seconds == 456
+    assert _CaptureRuntime.requests[1].model_request_timeout_seconds == 7
+    assert _CaptureRuntime.requests[1].run_timeout_seconds == 8
 
 
 def test_agent_backtest_keeps_fred_tools_when_fred_api_key_is_set(monkeypatch):


### PR DESCRIPTION
## What / Why

This release branch includes the Schwab smoke validation commits already on version/4.5.45 plus a Lumibot AI agent runtime fix for stalled provider/model calls.

The agent runtime change adds provider-level model request timeouts for native Gemini and LiteLLM-backed providers, exposes model_request_timeout_seconds and run_timeout_seconds on self.agents.create(...) and agent.run(...), and logs the effective timeout values plus first ADK event latency.

## Risk

AI agent calls now have a default 600s provider request timeout while the full agent run timeout remains 1800s. A genuinely long single provider request may now fail faster and be handled through the existing transient-error skip/retry path. Normal multi-tool agent runs can still run up to the full run timeout.

## Tests run

- ../bin/safe-timeout 120 python3 -m pytest tests/test_agent_runtime_provider_keys.py tests/test_agent_tool_permissions.py -q
- ../bin/safe-timeout 240 python3 -m pytest tests/test_agent_runtime_errors.py tests/test_agent_runtime_mcp_transports.py tests/test_agent_runtime_remote_mcp.py tests/backtest/test_agent_runtime_backtest.py -q

## Docs

- CHANGELOG.md
- docsrc/agents.rst

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v4.5.45

* **New Features**
  * Added configurable request and run timeouts for AI agents (600s default per request, 1800s per full run).
  * Enhanced agent runtime tracing with timeout settings and first event latency logging.
  * Added live fill-to-hedge smoke test for Schwab trading accounts.

* **Documentation**
  * Added investigation report documenting Titus Schwab strategy validation and optimization.
  * Updated timeout configuration guide with environment variable and override options.

* **Tests**
  * Added timeout behavior verification tests for model requests and full runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->