### PR TITLE
v4.5.47 - Broker cancel state fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,12 +37,11 @@ the customer issue is fixed until the customer strategy path has either
 reproduced and passed, or you have clearly documented why that exact path cannot
 be run.
 
-Specific Schwab lesson from the Titus cancel incident on 2026-06-05:
-strategy code may treat `CANCELLING` as an intermediate "do not block the next
-step forever" state, but the Schwab broker adapter must not treat local
-`CANCELLING` as terminal before it sends the cancel request to Schwab. A broker
-preflight that skips cancel when local status is `CANCELLING` can prevent Schwab
-from ever receiving the cancel call.
+Broker adapters must never treat local `CANCELLING` as terminal before sending
+the broker cancel request. A broker preflight that skips cancel when local status
+is `CANCELLING` can prevent the broker from ever receiving the cancel call. See
+`docs/investigations/2026-06-05_TITUS_SCHWAB_CANCEL_EXACT_PATH.md` for the
+incident that established this rule.
 
 Broker adapter methods that are supposed to contact the broker, especially
 `cancel_order()` and `_modify_order()`, must not silently no-op because of local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,39 @@ These rules are mandatory whenever you work on ThetaData integrations.
 
 Backtesting “accuracy” is measured against live broker behavior when possible (replay a live-traded interval and reproduce fills + PnL within tolerances). Vendor parity (e.g., stored DataBento artifacts) is a regression signal, not absolute truth.
 
+## Customer Broker Bug Reproduction (CRITICAL)
+
+When a customer reports a live broker execution problem, do not accept a nearby
+unit test, smoke script, direct broker call, or simplified order flow as proof
+that the customer issue is understood. First reproduce the exact customer path
+whenever feasible:
+
+- exact saved strategy revision or deployed artifact;
+- same broker and asset class;
+- same order type and lifecycle path;
+- same local strategy/order state transitions;
+- same account selection behavior, with masked account suffix verification;
+- full logs from start through cleanup.
+
+If a simpler smoke test passes, report it only as a smoke test. Do not tell Rob
+the customer issue is fixed until the customer strategy path has either
+reproduced and passed, or you have clearly documented why that exact path cannot
+be run.
+
+Specific Schwab lesson from the Titus cancel incident on 2026-06-05:
+strategy code may treat `CANCELLING` as an intermediate "do not block the next
+step forever" state, but the Schwab broker adapter must not treat local
+`CANCELLING` as terminal before it sends the cancel request to Schwab. A broker
+preflight that skips cancel when local status is `CANCELLING` can prevent Schwab
+from ever receiving the cancel call.
+
+Broker adapter methods that are supposed to contact the broker, especially
+`cancel_order()` and `_modify_order()`, must not silently no-op because of local
+Lumibot status helpers such as `order.is_canceled()`. If the broker request can
+be made, make it and let the broker return success or rejection. Local status can
+be used for strategy workflow decisions, not to suppress an explicit broker API
+call.
+
 ## Multi-Agent Collaboration (CRITICAL)
 This repo is frequently edited by **multiple AI sessions**. To avoid lost work:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 4.5.47 - Unreleased
 
+### Fixed
+- **Explicit broker cancel/modify calls no longer get suppressed by local order state.** Schwab and Tradier now send `cancel_order()` and `_modify_order()` requests to the broker even when Lumibot's local order status is already `CANCELLING`, filled, canceled, expired, or errored, preventing a strategy-side cancel-pending state from blocking the actual broker API call.
+- **Rejected broker-status checks now have a compatibility alias.** `Order.OrderStatus.REJECTED` maps to Lumibot's existing `ERROR` status so generated strategies that check rejected outcomes do not crash while new strategy guidance moves toward `ERROR`.
+
+### Tests
+- **Schwab and Tradier regression tests now cover local terminal/cancel-pending states.** The targeted tests include the exact lifecycle where strategy code marks an order `CANCELLING` before broker cancel and assert the broker API is still called.
+
 ## 4.5.46 - Unreleased
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.47 - Unreleased
+
 ## 4.5.46 - Unreleased
 
 ### Added

--- a/docs/investigations/2026-06-05_TITUS_SCHWAB_CANCEL_EXACT_PATH.md
+++ b/docs/investigations/2026-06-05_TITUS_SCHWAB_CANCEL_EXACT_PATH.md
@@ -1,0 +1,187 @@
+# Titus Schwab Cancel Exact Path Investigation
+
+One-line description: Documents the exact-strategy reproduction of Titus's Schwab cancel issue, the local Lumibot fix, and the remaining generated-strategy bug.
+
+Last Updated: 2026-06-05
+
+Status: Active investigation; local broker fix proven, deployment/release still required.
+
+Audience: LumiBot, BotSpot, and support agents debugging live Schwab order execution.
+
+## Overview
+
+Titus repeatedly reported that his live Schwab option orders would not cancel.
+Earlier simplified Schwab cancel tests proved only that a normal direct Schwab
+cancel could work. They did not reproduce the exact customer path. The issue was
+only found after running Titus's actual saved strategy revision locally against
+Rob's Schwab account.
+
+This was a process failure. For live broker support issues, a passing nearby
+smoke test is not enough. The exact customer strategy, same broker, same order
+state, same asset class, and same lifecycle path must be run whenever feasible.
+
+## Artifacts
+
+Private customer artifacts are stored under `logs/titus_private/` and are
+gitignored/private. Do not expose raw account numbers, tokens, or customer
+strategy code outside approved support channels.
+
+- Exact saved revision used for the live reproduction:
+  `logs/titus_private/revision_v85_ffe083f0-13cc-42b8-b9bc-4ac451a61d41.py`
+- Pre-fix exact strategy run:
+  `logs/titus_private/run_exact_v85_imported_correct_account_20260605_151804.log`
+- Local patched method-level proof:
+  `logs/titus_private/imported_cancel_methods_local_patch_20260605_154044.log`
+  and `logs/titus_private/imported_cancel_methods_local_patch_20260605_154044.json`
+- Local patched full strategy proof with close-window override:
+  `logs/titus_private/run_v85_no_close_block_live_20260605_154748.log`
+- Run-only close-window override copy:
+  `logs/titus_private/revision_v85_live_no_close_block_20260605_154715.py`
+
+## What Was Proven
+
+1. The exact Titus v85 strategy reproduced the cancel failure before the broker
+   patch.
+
+   Evidence from `run_exact_v85_imported_correct_account_20260605_151804.log`:
+
+   - It submitted a real LW option buy order:
+     `Submitted BUY LW 2026-06-05 41.0 CALL limit 1.0700 as buy_to_open`
+   - It reached the strategy cancel path:
+     `BUY not filled after 8.9s; canceling and resuming scan.`
+   - Schwab cancel was skipped before the API call because local status was
+     already `cancelling`:
+     `[SchwabCancelTelemetry] skip_terminal order_id=1006639759692 symbol=LW local_status=cancelling`
+
+2. The local Schwab broker fix made the same cancellation path send the cancel
+   request to Schwab and receive broker confirmation.
+
+   Evidence from `imported_cancel_methods_local_patch_20260605_154044.log`:
+
+   - Order ending `40519875`: Schwab cancel request sent, HTTP `200`, direct
+     read `broker_status=CANCELED`.
+   - Order ending `40519890`: Schwab cancel request sent, HTTP `200`, direct
+     read `broker_status=CANCELED`.
+
+3. The full Titus v85 strategy, with only the final-five-minute buy block
+   disabled for the live test, placed and canceled a real LW option order after
+   the broker patch.
+
+   Evidence from `run_v85_no_close_block_live_20260605_154748.log`:
+
+   - It submitted order ending `41456881`:
+     `Submitted BUY LW 2026-06-05 40.0 CALL limit 2.0300 as buy_to_open`
+   - It sent the Schwab cancel request even though local status was
+     `cancelling`:
+     `[SchwabCancelTelemetry] request order_id=1006641456881 ... local_status=cancelling`
+   - Schwab accepted the cancel:
+     `[SchwabCancelTelemetry] response order_id=1006641456881 http_status=200`
+   - Direct Schwab read confirmed cancellation:
+     `broker_status=CANCELED ... close_time=2026-06-05T19:50:32+0000`
+
+4. The full strategy then exposed a separate generated-strategy bug in the
+   hedge fallback path.
+
+   Evidence from `run_v85_no_close_block_live_20260605_154748.log`:
+
+   - It submitted and filled order ending `41456908`, LW 2026-06-05 40.5C.
+   - It tried a stock hedge fallback: `sell_short 100 shares of LW`.
+   - Schwab returned that hedge order as `error`.
+   - The strategy crashed because it referenced a non-existent enum:
+     `Order.OrderStatus.REJECTED`
+   - Python raised `AttributeError: REJECTED`.
+
+5. Cleanup was performed after the live test.
+
+   - The filled LW 40.5C position was closed with a sell-to-close order ending
+     `41457123`, status `FILLED`.
+   - A direct Schwab account check after cleanup showed no open LW orders and no
+     LW positions on the tested account.
+
+## Cancel vs Cancelling: The Important Distinction
+
+There are two different layers, and confusing them caused the earlier reasoning
+mistake.
+
+1. Strategy-level behavior:
+
+   It can be reasonable for a strategy to treat `CANCELLING` as an intermediate
+   state for workflow purposes. For example, after asking the broker to cancel,
+   the strategy should not block forever just because Schwab has not yet
+   returned final `CANCELED`.
+
+2. Broker adapter behavior:
+
+   The Schwab broker adapter must not treat local `CANCELLING` as terminal
+   before it sends the cancel API call. If `cancel_order()` checks
+   `order.is_canceled()` and `is_canceled()` returns true for `CANCELLING`, the
+   broker can skip sending the actual Schwab cancel request.
+
+The broken path was the broker adapter preflight, not the idea that strategy code
+may observe `CANCELLING` as a non-blocking intermediate state after a cancel has
+actually been requested.
+
+## Local Lumibot Fix
+
+The local change in `lumibot/brokers/schwab.py` does two things:
+
+1. Schwab account selection now supports a unique account-number suffix and no
+   longer silently falls back to the first returned account when a suffix like
+   `364` is provided.
+
+2. `Schwab.cancel_order()` no longer skips the cancel call based on local order
+   status. If there is an order identifier and the Schwab client/account hash is
+   available, it attempts the Schwab cancel request and lets Schwab answer.
+
+3. The same local-state no-op pattern was also removed from Schwab modify,
+   Tradier cancel, and Tradier modify. A repo-wide broker check found no
+   remaining broker-adapter `order.is_canceled()` preflight guards after this
+   change.
+
+## Remaining Strategy Fix
+
+Titus v85 contains generated code that checks:
+
+```python
+refreshed.status == Order.OrderStatus.REJECTED
+```
+
+That enum does not exist. Schwab rejected/error orders are represented in the
+observed Lumibot path as:
+
+```python
+Order.OrderStatus.ERROR
+```
+
+Generated fast-trading strategies should handle rejected broker outcomes by
+checking `ERROR` and other terminal non-filled states, for example:
+
+```python
+if refreshed and refreshed.status in {
+    Order.OrderStatus.ERROR,
+    Order.OrderStatus.CANCELED,
+    Order.OrderStatus.EXPIRED,
+}:
+    retries += 1
+    self.log_message(f"Stock hedge did not complete ({refreshed.status}); retrying.", color="yellow")
+    continue
+```
+
+This is a strategy-generation/skill prompt issue, and LumiBot now also provides
+`Order.OrderStatus.REJECTED` as a compatibility alias for `ERROR` so generated
+strategies that use the broker-style word do not crash.
+
+## Process Correction
+
+For future customer broker incidents:
+
+1. Pull the exact deployed strategy revision and exact deployment logs first.
+2. Run the exact strategy path locally when feasible, with only minimal
+   explicitly documented test overrides.
+3. If a run-only override is needed, save it as a separate clearly named file and
+   state exactly what changed.
+4. Treat direct broker smoke tests only as smoke tests.
+5. Do not report the customer bug fixed until the exact path either passes or is
+   documented as impossible to run.
+6. Keep a private evidence directory with exact logs, code revisions, cleanup
+   proof, and a short investigation doc before summarizing status to Rob.

--- a/docs/investigations/2026-06-05_TITUS_SCHWAB_CANCEL_EXACT_PATH.md
+++ b/docs/investigations/2026-06-05_TITUS_SCHWAB_CANCEL_EXACT_PATH.md
@@ -138,7 +138,7 @@ The local change in `lumibot/brokers/schwab.py` does two things:
    remaining broker-adapter `order.is_canceled()` preflight guards after this
    change.
 
-## Remaining Strategy Fix
+## Strategy Guidance
 
 Titus v85 contains generated code that checks:
 
@@ -146,15 +146,16 @@ Titus v85 contains generated code that checks:
 refreshed.status == Order.OrderStatus.REJECTED
 ```
 
-That enum does not exist. Schwab rejected/error orders are represented in the
-observed Lumibot path as:
+Schwab rejected/error orders are represented in the observed Lumibot path as:
 
 ```python
 Order.OrderStatus.ERROR
 ```
 
-Generated fast-trading strategies should handle rejected broker outcomes by
-checking `ERROR` and other terminal non-filled states, for example:
+LumiBot now also provides `Order.OrderStatus.REJECTED` as a compatibility alias
+for `ERROR` so generated strategies that use the broker-style word do not crash.
+New generated fast-trading strategies should still prefer `ERROR` and other
+terminal non-filled states, for example:
 
 ```python
 if refreshed and refreshed.status in {
@@ -167,9 +168,9 @@ if refreshed and refreshed.status in {
     continue
 ```
 
-This is a strategy-generation/skill prompt issue, and LumiBot now also provides
-`Order.OrderStatus.REJECTED` as a compatibility alias for `ERROR` so generated
-strategies that use the broker-style word do not crash.
+The BotSpot Agent fast-order skill should keep steering new strategy code toward
+`ERROR` as the portable Lumibot status while accepting `REJECTED` as
+compatibility wording.
 
 ## Process Correction
 

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -358,18 +358,36 @@ class Schwab(Broker):
             resp_accounts = self.client.get_account_numbers()
             if hasattr(resp_accounts, 'status_code') and resp_accounts.status_code == 200:
                 accounts_json = resp_accounts.json()
-                # Find entry matching our account number; fall back to first
+                # Find entry matching our account number. BotSpot often passes
+                # the last 3-4 account digits, so allow a unique suffix match.
                 target_acc = None
                 for acc in accounts_json:
                     if str(acc.get('accountNumber')) == str(self.account_number):
                         target_acc = acc
                         break
                 if not target_acc and accounts_json:
-                    target_acc = accounts_json[0]
-                    logger.warning(
-                        "[Schwab] Could not match account number %s; using first account hash from API response.",
-                        self._mask_account_number(self.account_number),
-                    )
+                    suffix_matches = [
+                        acc for acc in accounts_json
+                        if str(acc.get('accountNumber', '')).endswith(str(self.account_number))
+                    ]
+                    if len(suffix_matches) == 1:
+                        target_acc = suffix_matches[0]
+                        self.account_number = str(target_acc.get('accountNumber'))
+                        logger.info(
+                            "[Schwab] Matched account suffix %s to account %s.",
+                            self._mask_account_number(str(self.account_number)[-4:]),
+                            self._mask_account_number(self.account_number),
+                        )
+                    elif len(suffix_matches) > 1:
+                        raise ValueError(
+                            f"Schwab account suffix {self._mask_account_number(self.account_number)} "
+                            "matched multiple accounts. Provide the full account number."
+                        )
+                    else:
+                        raise ValueError(
+                            f"Could not match Schwab account {self._mask_account_number(self.account_number)} "
+                            "to any account returned by Schwab."
+                        )
 
                 if target_acc and 'hashValue' in target_acc:
                     hash_value = target_acc['hashValue']
@@ -2134,10 +2152,6 @@ class Schwab(Broker):
             logger.error(colored(f"Schwab client or account hash not initialized. Cannot modify order {order.identifier}.", "red"))
             return # Return early
 
-        # Check if the order is already cancelled or filled
-        if order.is_filled() or order.is_canceled():
-            return
-
         if not order.identifier:
             logger.error(colored("Order identifier is not set, unable to modify order. Did you remember to submit it?", "red"))
             return
@@ -2259,15 +2273,6 @@ class Schwab(Broker):
         -------
         None
         """
-        if order.is_filled() or order.is_canceled():
-            logger.info(
-                "[SchwabCancelTelemetry] skip_terminal "
-                f"order_id={order.identifier or '<missing>'} "
-                f"symbol={getattr(getattr(order, 'asset', None), 'symbol', '<missing>')} "
-                f"local_status={getattr(order, 'status', '<missing>')}"
-            )
-            return
-
         if not order.identifier:
             logger.error(
                 "[SchwabCancelTelemetry] missing_identifier "

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -366,10 +366,14 @@ class Schwab(Broker):
                         target_acc = acc
                         break
                 if not target_acc and accounts_json:
-                    suffix_matches = [
-                        acc for acc in accounts_json
-                        if str(acc.get('accountNumber', '')).endswith(str(self.account_number))
-                    ]
+                    account_lookup = str(self.account_number)
+                    min_suffix_length = 3
+                    suffix_matches = []
+                    if len(account_lookup) >= min_suffix_length:
+                        suffix_matches = [
+                            acc for acc in accounts_json
+                            if str(acc.get('accountNumber', '')).endswith(account_lookup)
+                        ]
                     if len(suffix_matches) == 1:
                         target_acc = suffix_matches[0]
                         self.account_number = str(target_acc.get('accountNumber'))
@@ -2129,9 +2133,11 @@ class Schwab(Broker):
     def _modify_order(self, order: Order, limit_price: Union[float, None] = None,
                       stop_price: Union[float, None] = None):
         """
-        Modify an order at the broker. Nothing will be done for orders that are already cancelled or filled. You are
-        only allowed to change the limit price and/or stop price. If you want to change the quantity,
-        you must cancel the order and submit a new one.
+        Modify an order at the broker by sending an explicit replace request to
+        Schwab. The broker response is the source of truth even if local status
+        appears terminal. Only limit and/or stop price can be changed. If you
+        want to change the quantity, you must cancel the order and submit a new
+        one.
         
         Parameters
         ----------
@@ -2262,7 +2268,9 @@ class Schwab(Broker):
 
     def cancel_order(self, order: Order) -> None:
         """
-        Cancel an order at the broker. Nothing will be done for orders that are already cancelled or filled.
+        Cancel an order at the broker by sending an explicit cancel request to
+        Schwab. The broker response is the source of truth even if local status
+        appears terminal.
         
         Parameters
         ----------

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -397,13 +397,15 @@ class Tradier(Broker):
             return
 
     def cancel_order(self, order: Order):
-        """Cancels an order at the broker."""
+        """Cancel an order at the broker with an explicit broker request."""
 
         if not order.identifier:
             raise ValueError("Order identifier is not set, unable to cancel order. Did you remember to submit it?")
 
-        # Cancel the order
-        self.tradier.orders.cancel(order.identifier)
+        try:
+            self.tradier.orders.cancel(order.identifier)
+        except TradierApiError as e:
+            raise LumibotBrokerAPIError(f"Unable to cancel order at broker. {e}") from e
 
     def _modify_order(self, order: Order,
                       limit_price: Union[float, None] = None,

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -397,10 +397,7 @@ class Tradier(Broker):
             return
 
     def cancel_order(self, order: Order):
-        """Cancels an order at the broker. Nothing will be done for orders that are already cancelled or filled."""
-        # Check if the order is already cancelled or filled
-        if order.is_filled() or order.is_canceled():
-            return
+        """Cancels an order at the broker."""
 
         if not order.identifier:
             raise ValueError("Order identifier is not set, unable to cancel order. Did you remember to submit it?")
@@ -412,14 +409,10 @@ class Tradier(Broker):
                       limit_price: Union[float, None] = None,
                       stop_price: Union[float, None] = None):
         """
-        Modify an order at the broker. Nothing will be done for orders that are already cancelled or filled. You are
-        only allowed to change the limit price and/or stop price. If you want to change the quantity,
-        you must cancel the order and submit a new one (Tradier limitation).
+        Modify an order at the broker. You are only allowed to change the limit
+        price and/or stop price. If you want to change the quantity, you must
+        cancel the order and submit a new one (Tradier limitation).
         """
-        # Check if the order is already cancelled or filled
-        if order.is_filled() or order.is_canceled():
-            return
-
         if not order.identifier:
             raise ValueError("Order identifier is not set, unable to modify order. Did you remember to submit it?")
 

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -194,6 +194,7 @@ class Order:
         ASSIGNED = "assigned"
         EXERCISED = "exercised"
         ERROR = "error"
+        REJECTED = "error"
         EXPIRED = "expired"
         UNKNOWN = "unknown"
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.46",
+    version="4.5.47",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -6,6 +6,10 @@ from lumibot.entities import Asset, Order
 
 
 class TestOrderBasics:
+    def test_rejected_status_aliases_error_for_broker_rejection_compatibility(self):
+        assert Order.OrderStatus.REJECTED == Order.OrderStatus.ERROR
+        assert Order.OrderStatus.REJECTED.value == "error"
+
     def test_side_must_be_one_of(self):
         assert Order(asset=Asset("SPY"), quantity=10, side="buy", strategy='abc').side == 'buy'
         assert Order(asset=Asset("SPY"), quantity=10, side="sell", strategy='abc').side == 'sell'

--- a/tests/test_schwab_positions_unit.py
+++ b/tests/test_schwab_positions_unit.py
@@ -901,6 +901,19 @@ def test_schwab_cancel_order_calls_client_with_order_id_then_account_hash():
     ]
 
 
+def test_schwab_cancel_order_calls_client_even_when_local_status_is_cancelling():
+    client = _CancelClient()
+    broker = _broker_for_cancel(client=client)
+    order = _order(status=Order.OrderStatus.SUBMITTED)
+
+    # Strategy.cancel_order sets local status to CANCELLING before calling the
+    # broker. Schwab must still receive the cancel request in that exact path.
+    order.status = Order.OrderStatus.CANCELLING
+    broker.cancel_order(order)
+
+    assert client.cancel_calls == [("order-123", "account-hash")]
+
+
 def test_schwab_pull_broker_order_calls_client_with_order_id_then_account_hash():
     client = _OrderClient()
     broker = _broker_for_order_pull(client=client)
@@ -949,14 +962,47 @@ def test_schwab_cancel_order_marks_advanced_order_children_canceled():
     assert not order.is_active()
 
 
-def test_schwab_cancel_order_noops_for_terminal_orders():
+@pytest.mark.parametrize(
+    "status",
+    [
+        Order.OrderStatus.CANCELED,
+        Order.OrderStatus.FILLED,
+        Order.OrderStatus.ERROR,
+        Order.OrderStatus.EXPIRED,
+    ],
+)
+def test_schwab_cancel_order_still_calls_broker_for_local_terminal_statuses(status):
     client = _CancelClient()
     broker = _broker_for_cancel(client=client)
 
-    broker.cancel_order(_order(status=Order.OrderStatus.FILLED))
-    broker.cancel_order(_order(status=Order.OrderStatus.CANCELED))
+    broker.cancel_order(_order(status=status))
 
-    assert client.cancel_calls == []
+    assert client.cancel_calls == [("order-123", "account-hash")]
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        Order.OrderStatus.CANCELLING,
+        Order.OrderStatus.CANCELED,
+        Order.OrderStatus.FILLED,
+        Order.OrderStatus.ERROR,
+        Order.OrderStatus.EXPIRED,
+    ],
+)
+def test_schwab_modify_order_still_calls_broker_for_local_statuses(status):
+    client = _ReplaceClient()
+    broker = Schwab.__new__(Schwab)
+    broker.schwab_authorization_error = False
+    broker.client = client
+    broker.hash_value = "account-hash"
+    order = _option_order()
+    order.status = status
+
+    broker._modify_order(order, limit_price=4.75)
+
+    assert client.get_order_calls == [("order-123", "account-hash")]
+    assert len(client.replace_calls) == 1
 
 
 def test_schwab_cancel_order_requires_identifier():

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -157,11 +157,54 @@ class TestTradierBroker:
         broker._modify_order(order, limit_price=100.0)
         assert mock_modify.called
 
-        # Filled or cancelled orders are not touched
+        # Explicit broker modify requests should still be sent even if local
+        # status looks terminal. The broker is the source of truth.
         mock_modify.reset_mock()
         order.status = order.OrderStatus.FILLED
         broker._modify_order(order, limit_price=100.0)
-        assert not mock_modify.called
+        assert mock_modify.called
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            Order.OrderStatus.CANCELLING,
+            Order.OrderStatus.CANCELED,
+            Order.OrderStatus.FILLED,
+            Order.OrderStatus.ERROR,
+            Order.OrderStatus.EXPIRED,
+        ],
+    )
+    def test_cancel_order_calls_broker_api_even_when_local_status_is_terminal(self, mocker, status):
+        broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True, connect_stream=False)
+        mock_cancel = mocker.patch.object(broker.tradier.orders, "cancel")
+        order = Order("my_strat", Asset("SPY"), 10, Order.OrderSide.SELL, order_type="limit")
+        order.identifier = "123456"
+        order.status = status
+
+        broker.cancel_order(order)
+
+        mock_cancel.assert_called_once_with("123456")
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            Order.OrderStatus.CANCELLING,
+            Order.OrderStatus.CANCELED,
+            Order.OrderStatus.FILLED,
+            Order.OrderStatus.ERROR,
+            Order.OrderStatus.EXPIRED,
+        ],
+    )
+    def test_modify_order_calls_broker_api_even_when_local_status_is_terminal(self, mocker, status):
+        broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True, connect_stream=False)
+        mock_modify = mocker.patch.object(broker.tradier.orders, "modify")
+        order = Order("my_strat", Asset("SPY"), 10, Order.OrderSide.SELL, order_type="limit")
+        order.identifier = "123456"
+        order.status = status
+
+        broker._modify_order(order, limit_price=100.0)
+
+        assert mock_modify.called
 
     def test_tradier_side2lumi(self):
         broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True, connect_stream=False)

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -155,14 +155,14 @@ class TestTradierBroker:
         # Modify sent to API
         order.identifier = "123456"
         broker._modify_order(order, limit_price=100.0)
-        assert mock_modify.called
+        mock_modify.assert_called_once_with("123456", limit_price=100.0, stop_price=None)
 
         # Explicit broker modify requests should still be sent even if local
         # status looks terminal. The broker is the source of truth.
         mock_modify.reset_mock()
         order.status = order.OrderStatus.FILLED
         broker._modify_order(order, limit_price=100.0)
-        assert mock_modify.called
+        mock_modify.assert_called_once_with("123456", limit_price=100.0, stop_price=None)
 
     @pytest.mark.parametrize(
         "status",
@@ -204,7 +204,7 @@ class TestTradierBroker:
 
         broker._modify_order(order, limit_price=100.0)
 
-        assert mock_modify.called
+        mock_modify.assert_called_once_with("123456", limit_price=100.0, stop_price=None)
 
     def test_tradier_side2lumi(self):
         broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True, connect_stream=False)


### PR DESCRIPTION
What / Why

Fixes a live Schwab cancel path reproduced from Titus's strategy: local strategy code can mark an order CANCELLING before the broker adapter sends the cancel request. Schwab and Tradier broker adapters now send explicit cancel and modify requests to the broker even when local Lumibot status already appears canceling or terminal. The broker remains the source of truth.

Risk

Low to medium. This changes broker adapter behavior for explicit cancel_order and modify_order calls. A broker may now receive cancel or replace requests it would previously have skipped locally, including for filled/canceled/error local states. That is intentional; the broker should return the authoritative success or rejection. Watch live order logs for broker-side rejected cancel/replace responses.

Tests run

- python3 -m pytest tests/test_order.py tests/test_schwab_positions_unit.py tests/test_tradier.py -q: 81 passed, 1 skipped.
- python3 -m pytest -m "not apitest and not downloader" --tb=short -q --durations=30: timed out with exit code 124 after several slow acceptance/backtest tests and no failure output. Per docs/DEPLOYMENT.md, release should gate on GitHub CI for the same marker expression.

Docs / Prompts

- CHANGELOG.md updated for 4.5.47.
- AGENTS.md updated with the exact-customer-path reproduction rule and the broker adapter direct-call rule.
- docs/investigations/2026-06-05_TITUS_SCHWAB_CANCEL_EXACT_PATH.md documents the Titus cancel path, evidence, and remaining verification work.
- BotSpot Agent fast-order skill guidance was updated locally in botspot_agent to avoid teaching strategies to skip broker cancel on local CANCELLING state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cancellations and modifications now always send broker requests even when local order state appears terminal.
  * Added REJECTED order status alias for broker compatibility.

* **Behavior**
  * Schwab account lookup now supports unique trailing-suffix matching for account selection.

* **Documentation**
  * Added investigation and process guidance documenting exact reproduction requirements and resolution checklist.

* **Tests**
  * New regression tests covering Schwab and Tradier cancel/modify behaviors across order states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->