### PR TITLE
deploy 4.5.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.5.47 - 2026-06-05
 
-Deploy marker: `pending`
+Deploy marker: `e51a0478`
 
 ### Fixed
 - **Explicit broker cancel/modify calls no longer get suppressed by local order state.** Schwab and Tradier now send `cancel_order()` and `_modify_order()` requests to the broker even when Lumibot's local order status is already `CANCELLING`, filled, canceled, expired, or errored, preventing a strategy-side cancel-pending state from blocking the actual broker API call.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.47 - Unreleased
+## 4.5.47 - 2026-06-05
+
+Deploy marker: `pending`
 
 ### Fixed
 - **Explicit broker cancel/modify calls no longer get suppressed by local order state.** Schwab and Tradier now send `cancel_order()` and `_modify_order()` requests to the broker even when Lumibot's local order status is already `CANCELLING`, filled, canceled, expired, or errored, preventing a strategy-side cancel-pending state from blocking the actual broker API call.


### PR DESCRIPTION
What / Why

Adds the required 4.5.47 release marker bookkeeping after the broker cancel-state fix was merged. This dates the changelog entry and records the deploy marker commit.

Risk

Docs/changelog only.

Tests run

- Broker fix tests were run before the prior merge: python3 -m pytest tests/test_order.py tests/test_schwab_positions_unit.py tests/test_tradier.py -q
- GitHub build will run on this PR.

Docs

- CHANGELOG.md release marker for 4.5.47.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Finalized version 4.5.47 release in the changelog with an official release date and deploy marker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->