### PR TITLE
v4.5.48 - Tradier token persistence and IBKR crypto fill safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.48 - Unreleased
+## 4.5.48 - 2026-06-12
+
+Deploy marker: `pending`
 
 ### Fixed
 - **Tradier OAuth token rotations now persist back to the broker config.** When a live Tradier request refreshes an expired access token, the broker updates the in-memory auth config so the next request uses the rotated token instead of repeatedly retrying with the stale token.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Fixed
 - **IBKR crypto quote fills now reject underfilled cache windows.** The fast quote-fill path validates that the simulated timestamp is inside the cached data object's actual coverage before reading bid/ask, preventing market orders from filling against out-of-window BTC quote rows when the downloader only returned later history.
+- **Routed IBKR crypto prices and quotes now reject stale or future intraday frames.** BotSpot Auto crypto routing marks intraday IBKR data as strict, validates full-window coverage before marking crypto/futures series loaded, and prevents `get_last_price()` or `get_quote()` from treating out-of-window cached BTC rows as the current simulation price.
 
 ### Tests
 - **IBKR crypto backtesting coverage now reproduces an underfilled BTC cache window.** The regression test starts a backtest before the first available BTC minute row and asserts the fast quote-fill helper returns no bid/ask instead of fabricating a fill.
+- **Routed IBKR coverage now tests stale-after-end and future-before-start frames.** Direct and routed regressions verify that `get_last_price()` and `get_quote()` return missing data instead of stale/future BTC values when an intraday cache frame does not cover the simulated timestamp.
 
 ## 4.5.47 - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 4.5.48 - Unreleased
 
+### Fixed
+- **IBKR crypto quote fills now reject underfilled cache windows.** The fast quote-fill path validates that the simulated timestamp is inside the cached data object's actual coverage before reading bid/ask, preventing market orders from filling against out-of-window BTC quote rows when the downloader only returned later history.
+
+### Tests
+- **IBKR crypto backtesting coverage now reproduces an underfilled BTC cache window.** The regression test starts a backtest before the first available BTC minute row and asserts the fast quote-fill helper returns no bid/ask instead of fabricating a fill.
+
 ## 4.5.47 - 2026-06-05
 
 Deploy marker: `e51a0478`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.48 - Unreleased
+
 ## 4.5.47 - 2026-06-05
 
 Deploy marker: `e51a0478`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,15 @@
 ## 4.5.48 - Unreleased
 
 ### Fixed
+- **Tradier OAuth token rotations now persist back to the broker config.** When a live Tradier request refreshes an expired access token, the broker updates the in-memory auth config so the next request uses the rotated token instead of repeatedly retrying with the stale token.
 - **IBKR crypto quote fills now reject underfilled cache windows.** The fast quote-fill path validates that the simulated timestamp is inside the cached data object's actual coverage before reading bid/ask, preventing market orders from filling against out-of-window BTC quote rows when the downloader only returned later history.
 - **Routed IBKR crypto prices and quotes now reject stale or future intraday frames.** BotSpot Auto crypto routing marks intraday IBKR data as strict, validates full-window coverage before marking crypto/futures series loaded, and prevents `get_last_price()` or `get_quote()` from treating out-of-window cached BTC rows as the current simulation price.
 
+### Docs
+- **Titus Schwab cancel evidence now records deployment and market-hours retest findings.** The investigation note separates the fixed broker cancel path from the remaining strategy-level Titus risks around fills before cancel, rejected stock hedges, retry behavior, and Schwab option smart-limit support.
+
 ### Tests
+- **Tradier OAuth refresh coverage now asserts rotated tokens are reused.** The regression tests verify refresh state is persisted after retry-layer 401 responses.
 - **IBKR crypto backtesting coverage now reproduces an underfilled BTC cache window.** The regression test starts a backtest before the first available BTC minute row and asserts the fast quote-fill helper returns no bid/ask instead of fabricating a fill.
 - **Routed IBKR coverage now tests stale-after-end and future-before-start frames.** Direct and routed regressions verify that `get_last_price()` and `get_quote()` return missing data instead of stale/future BTC values when an intraday cache frame does not cover the simulated timestamp.
 

--- a/docs/PRODLIKE_LOCAL_BACKTEST_RUNS.md
+++ b/docs/PRODLIKE_LOCAL_BACKTEST_RUNS.md
@@ -13,6 +13,9 @@ This doc standardizes how we run **production-faithful** backtests locally witho
 - If you intentionally allow a local `.env`, set `LUMIBOT_DISABLE_DOTENV_LOCAL=1` when `.env.local` overrides would make the run non-repeatable.
 - Prefer **short windows** (days/weeks/months) for diagnosis; only run full windows once request volume looks sane.
 - Do not delete shared caches. Use `LUMIBOT_CACHE_S3_VERSION=...` to isolate “cold namespace” simulations.
+- Use `--cache-mode readonly` when you want a fresh local cache folder to hydrate
+  from the configured S3 namespace without uploading or mutating shared cache
+  objects.
 - For repeated runs, prevent browser/UI spam (while still writing artifacts) by setting:
   - `LUMIBOT_DISABLE_UI=1`
 

--- a/docs/investigations/2026-06-05_TITUS_SCHWAB_CANCEL_EXACT_PATH.md
+++ b/docs/investigations/2026-06-05_TITUS_SCHWAB_CANCEL_EXACT_PATH.md
@@ -4,7 +4,9 @@ One-line description: Documents the exact-strategy reproduction of Titus's Schwa
 
 Last Updated: 2026-06-05
 
-Status: Active investigation; local broker fix proven, deployment/release still required.
+Status: Broker fix released in LumiBot 4.5.47 and deployed to BotManager
+development and production. Exact Titus strategy still needs a fresh market-hours
+run on the deployed image.
 
 Audience: LumiBot, BotSpot, and support agents debugging live Schwab order execution.
 
@@ -172,6 +174,35 @@ The BotSpot Agent fast-order skill should keep steering new strategy code toward
 `ERROR` as the portable Lumibot status while accepting `REJECTED` as
 compatibility wording.
 
+## Release And Deployment Evidence
+
+LumiBot 4.5.47 contains the Schwab/Tradier broker-adapter direct-call fix and
+the `Order.OrderStatus.REJECTED` compatibility alias.
+
+- LumiBot PR `#1078` merged to `dev` at
+  `d190153ba9aeb4f311279908a6e07831dab3d07e`.
+- LumiBot PR `#1079` merged to `dev` at
+  `7f78e66615c72094e3d7c9b404fe8e5dfffdd3a9`.
+- Git tag `v4.5.47` points to
+  `7f78e66615c72094e3d7c9b404fe8e5dfffdd3a9`.
+- GitHub release workflow `27043071439` completed successfully and published
+  `lumibot==4.5.47`.
+- Direct PyPI install check returned `Version: 4.5.47`.
+
+BotManager was then pointed at LumiBot 4.5.47 with repository variable
+`LUMIBOT_VERSION=4.5.47`.
+
+- BotManager production workflow `27044088862` completed successfully:
+  `https://github.com/Lumiwealth/bot_manager/actions/runs/27044088862`
+- BotManager development workflow `27044060685` completed successfully:
+  `https://github.com/Lumiwealth/bot_manager/actions/runs/27044060685`
+- Both deploy logs showed `LUMIBOT_VERSION: 4.5.47`, installed
+  `lumibot==4.5.47`, and started with `LumiBot v4.5.47 starting`.
+
+This proves the fixed LumiBot package was built into the BotManager dev and
+production deployment images. It does not yet prove Titus's exact strategy has
+passed on the deployed runtime; that requires a new market-hours run.
+
 ## Process Correction
 
 For future customer broker incidents:
@@ -186,3 +217,18 @@ For future customer broker incidents:
    documented as impossible to run.
 6. Keep a private evidence directory with exact logs, code revisions, cleanup
    proof, and a short investigation doc before summarizing status to Rob.
+
+## Remaining Work
+
+1. Run Titus's exact strategy path again during market hours using the deployed
+   BotManager image with LumiBot 4.5.47.
+2. Compare the deployed run timeline against local proof: order placement,
+   cancel request, Schwab HTTP response, direct broker status, and any cleanup
+   order.
+3. Use the support log export work to capture complete deployment logs instead
+   of relying on partial console evidence.
+4. Decide whether to deploy the BotSpot Agent fast-order skill update after
+   isolating it from unrelated dirty files in `botspot_agent`.
+5. Audit the broader explicit broker action contract across adapters, especially
+   cancel and modify behavior, so no adapter silently skips a requested broker
+   action based only on local cached status.

--- a/docs/investigations/2026-06-05_TITUS_SCHWAB_CANCEL_EXACT_PATH.md
+++ b/docs/investigations/2026-06-05_TITUS_SCHWAB_CANCEL_EXACT_PATH.md
@@ -203,6 +203,71 @@ This proves the fixed LumiBot package was built into the BotManager dev and
 production deployment images. It does not yet prove Titus's exact strategy has
 passed on the deployed runtime; that requires a new market-hours run.
 
+## 2026-06-08 Market-Hours Local Schwab Retest
+
+All tests below used the local Schwab token path and verified the intended
+account by masked suffix in private artifacts. Raw artifacts are in:
+
+- `logs/titus_private/imported_cancel_methods_20260608_20260608_145618.log`
+- `logs/titus_private/imported_cancel_methods_20260608_20260608_145618.json`
+- `logs/titus_private/exact_v85_full_live_20260608_20260608_150135.log`
+- `logs/titus_private/reconcile_exact_v85_full_live_20260608_1501.json`
+
+### Exact v85 cancel methods
+
+The imported-method harness loaded the exact saved v85 revision:
+
+`logs/titus_private/revision_v85_ffe083f0-13cc-42b8-b9bc-4ac451a61d41.py`
+
+It submitted two deliberately low-priced LW option limit orders and invoked the
+revision's original cancel paths:
+
+1. `_cancel_and_confirm`
+2. `_manage_pending_buy`
+
+Both orders were `WORKING` before cancel. Both Schwab cancel API calls returned
+HTTP 200. Direct Schwab order reads immediately after cancel showed `CANCELED`.
+Measured method elapsed times were about 1.5-1.7 seconds.
+
+### Exact v85 full strategy class
+
+A run-only wrapper was created at:
+
+`logs/titus_private/run_exact_v85_full_live_20260608.py`
+
+The wrapper imports the exact saved v85 file without editing it, injects the live
+Schwab broker, runs the strategy for a bounded window, then reconciles/cancels
+orders. The first full run proved:
+
+- The exact strategy submitted LW option buy orders.
+- Two pending buy orders hit the strategy's cancel path.
+- Schwab returned HTTP 200 for both cancels.
+- Direct Schwab reads showed `CANCELED`.
+- The cancel requests were sent even when the local order status was already
+  `cancelling`, which proves the fixed broker adapter is no longer skipping the
+  broker call because of local status.
+
+The run also exposed separate strategy/broker behavior that is not the original
+cancel-skip bug:
+
+- One LW option buy filled before cancellation.
+- The strategy then attempted a stock hedge fallback using repeated `SELL_SHORT`
+  market orders for 100 LW shares. Schwab rejected each stock short hedge
+  attempt.
+- After the hedge rejection loop, the strategy resumed scanning and submitted
+  more buy candidates.
+- One later open LW option order was canceled during reconciliation.
+- One filled LW option position remained after the test:
+  `LW 2026-06-12 39 CALL`, quantity `1`.
+- During forced stop, Schwab option smart-limit modification logged:
+  `Order type smart_limit not supported for options with Schwab templates.`
+
+Current conclusion: the direct Schwab cancel bug is fixed locally in this exact
+strategy path. The remaining Titus risk is likely not "cancel_order never reaches
+Schwab" anymore; it is now the strategy's broader flow: fills before cancel,
+rejected stock hedge fallback, repeated retry behavior, and Schwab option
+smart-limit modification support.
+
 ## Process Correction
 
 For future customer broker incidents:

--- a/docs/investigations/2026-06-11_GREG_BTC_ROUTED_QUOTE_FILL.md
+++ b/docs/investigations/2026-06-11_GREG_BTC_ROUTED_QUOTE_FILL.md
@@ -1,0 +1,97 @@
+# Greg BTC Routed Quote Fill Investigation
+
+One-line description: Local reproduction of Greg's BTC backtest drop traced to IBKR crypto quote-fill coverage validation.
+Last Updated: 2026-06-11
+Status: Fix implemented locally with focused regression coverage
+Audience: LumiBot, BotSpot Node, and BotSpot support engineers
+
+## Overview
+
+Greg reported a large backtest result drop in a BotSpot email thread with subject `april 17`. The production backtest was:
+
+- Backtest: `64d6495f-bfaf-46e8-b150-0110ed773b4a`
+- Strategy: `72953aee-a7d0-45f3-b65c-877f1c3694ad`
+- Revision: `9c8e12ce-7ffd-438e-907d-57a13660a1f8`
+- AI strategy: `1e3d4506-3ebd-49a8-9d14-496c4e42ca66`
+- Period: 2026-03-09 to 2026-06-05
+- Production summary: total return about `-8.55%`, CAGR about `-30.99%`, max drawdown about `-64.18%`
+
+The exact saved revision files were exported from the production database through the read-only support path into:
+
+- `/Users/robertgrzesik/Development/support-artifacts/greg-backtest-april17-20260611/revision-9c8e12ce/main.py`
+- `/Users/robertgrzesik/Development/support-artifacts/greg-backtest-april17-20260611/revision-9c8e12ce/requirements.txt`
+- `/Users/robertgrzesik/Development/support-artifacts/greg-backtest-april17-20260611/revision-9c8e12ce/manifest.json`
+
+No broker deployment secrets or account credentials were copied.
+
+## Reproduction
+
+The copied strategy is `MultiMineralBot`, trading spot `BTC/USDT` in BotSpot while the local backtest harness maps it to BTC/USD quote data. It uses:
+
+- `set_market("24/7")`
+- `check_interval: "5M"`
+- `timestep: "1h"`
+- budget `1300`
+- leverage `10`
+- routed BotSpot Auto data provider config with crypto routed to IBKR
+
+The local production-like replay used the copied revision and the same 2026-03-09 to 2026-06-05 window. Logs are under:
+
+- `/Users/robertgrzesik/Development/support-artifacts/greg-backtest-april17-20260611/local-run-v100-prodlike-remote-dd/subprocess_greg-v100-prodlike-remote-dd.log`
+
+The run was intentionally stopped after it had already reproduced the incorrect early fill path. It did not need to finish the full multi-month backtest to prove the failing invariant.
+
+## Finding
+
+The replay showed IBKR crypto history was underfilled for the early simulation window:
+
+- Available BTC minute data started around 2026-03-22.
+- The simulation was evaluating and submitting orders on 2026-03-12.
+- LumiBot logged that requested BTC dates were outside the available data range.
+- Despite that, market orders could still fill from quote/bid-ask data before the cached data object actually covered the simulated timestamp.
+
+The narrow code path was `BacktestingBroker._fast_get_bid_ask_for_fill()` in `lumibot/backtesting/backtesting_broker.py`.
+
+That helper is an IBKR REST backtesting speed path. It reads bid/ask directly from the cached `Data` object's datalines and bypasses the normal guarded `Data.get_quote()` wrapper. Before the fix, it called `data_obj.get_iter_count(now)` directly. For timestamps before the first cached row, that can produce an invalid positional lookup instead of surfacing missing data.
+
+This is a backtest engine bug, not a Greg strategy logic bug. The strategy submitted an order during a period where the data source did not cover the simulated timestamp; the engine should not fill that order from an out-of-window bid/ask row.
+
+## Fix
+
+`BacktestingBroker._fast_get_bid_ask_for_fill()` now validates that the simulated timestamp is inside the cached data object's actual `datetime_start` and `datetime_end` before reading bid/ask datalines. It also rejects negative `get_iter_count()` results.
+
+If coverage is missing, the helper returns `(None, None)`. Existing missing-data handling can then cancel, skip, or fall back through the honest non-quote path without fabricating a fill.
+
+Regression coverage was added in:
+
+- `tests/test_ibkr_crypto_backtesting_smoke_stubbed.py::test_ibkr_rest_fast_crypto_quote_fill_rejects_underfilled_cache_before_start`
+
+The regression recreates the customer shape:
+
+- backtest starts 2026-03-09;
+- first real BTC minute row starts 2026-03-22;
+- broker evaluates a March 12 quote-fill attempt;
+- expected result is no bid/ask fill.
+
+## Validation
+
+Focused suite:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 1200 python3 -m pytest tests/test_ibkr_crypto_backtesting_smoke_stubbed.py -q
+```
+
+Result on 2026-06-11:
+
+- `7 passed`
+- one third-party `websockets.legacy` deprecation warning
+
+## Follow-Up
+
+Before telling a customer that the historical result is corrected in production, deploy the LumiBot version containing this fix through the normal version branch and BotManager release path. Then rerun Greg's copied revision for the same 2026-03-09 to 2026-06-05 window and compare:
+
+- whether March 12-21 no longer creates quote fills from uncovered BTC data;
+- portfolio value and drawdown around April 17;
+- trades and trade events around the reported drop.
+
+Do not add fake trades, synthetic bars, carry-forward bid/ask rows, or strategy-specific patches to make this backtest look better. Missing data must stay missing.

--- a/docs/investigations/2026-06-11_GREG_BTC_ROUTED_QUOTE_FILL.md
+++ b/docs/investigations/2026-06-11_GREG_BTC_ROUTED_QUOTE_FILL.md
@@ -1,8 +1,8 @@
 # Greg BTC Routed Quote Fill Investigation
 
-One-line description: Local reproduction of Greg's BTC backtest drop traced to IBKR crypto quote-fill coverage validation.
-Last Updated: 2026-06-11
-Status: Fix implemented locally with focused regression coverage
+One-line description: Production artifact diagnosis and LumiBot fix for Greg's BTC backtest drop caused by out-of-window IBKR crypto prices.
+Last Updated: 2026-06-12
+Status: Fix implemented on `version/4.5.48`; production artifacts parsed; full local replay remains Data Downloader-bound
 Audience: LumiBot, BotSpot Node, and BotSpot support engineers
 
 ## Overview
@@ -16,13 +16,41 @@ Greg reported a large backtest result drop in a BotSpot email thread with subjec
 - Period: 2026-03-09 to 2026-06-05
 - Production summary: total return about `-8.55%`, CAGR about `-30.99%`, max drawdown about `-64.18%`
 
-The exact saved revision files were exported from the production database through the read-only support path into:
+An initial support copy of the saved revision files was exported from the
+production database through the read-only support path into:
 
 - `/Users/robertgrzesik/Development/support-artifacts/greg-backtest-april17-20260611/revision-9c8e12ce/main.py`
 - `/Users/robertgrzesik/Development/support-artifacts/greg-backtest-april17-20260611/revision-9c8e12ce/requirements.txt`
 - `/Users/robertgrzesik/Development/support-artifacts/greg-backtest-april17-20260611/revision-9c8e12ce/manifest.json`
 
 No broker deployment secrets or account credentials were copied.
+
+Important correction from the 2026-06-12 audit: the executed production
+`code.zip` pulled from the backtest runner artifact path is not byte-identical
+to the older database-exported `main.py` in the 2026-06-11 support folder.
+All future reproduction for this incident must use the executed code zip:
+
+- `/Users/robertgrzesik/Development/support-artifacts/greg-backtest-april17-20260612/prod-artifacts/code.zip`
+- `/Users/robertgrzesik/Development/support-artifacts/greg-backtest-april17-20260612/prod-artifacts/executed-code/main.py`
+
+The executed `main.py` SHA-256 is
+`91473f8fa813cd5fa818bdad6201053b936c999f3a2f725586c25d9e567e8b40`.
+
+Production result artifacts were exported through the supported Bot Manager API
+and CloudWatch, then parsed into:
+
+- `/Users/robertgrzesik/Development/support-artifacts/greg-backtest-april17-20260612/analysis/production_artifact_summary.md`
+- `/Users/robertgrzesik/Development/support-artifacts/greg-backtest-april17-20260612/prod-artifacts/api-artifacts/trades.csv`
+- `/Users/robertgrzesik/Development/support-artifacts/greg-backtest-april17-20260612/prod-artifacts/api-artifacts/indicators.csv`
+
+The production artifacts prove the April drop was not just a visual/chart issue:
+
+- 76 filled trades were present.
+- 63 of 76 fills were outside the same-hour BTC OHLC candle.
+- The stale price `70511.75` was reused across many fills.
+- April 15-17 contained five fills at `70511.75`.
+- The largest one-row portfolio drop was `-56.25%` at
+  `2026-04-17 10:05:00-04:00`, immediately after a sell fill at `70511.75`.
 
 ## Reproduction
 
@@ -41,7 +69,73 @@ The local production-like replay used the copied revision and the same 2026-03-0
 
 The run was intentionally stopped after it had already reproduced the incorrect early fill path. It did not need to finish the full multi-month backtest to prove the failing invariant.
 
-## Finding
+## 2026-06-12 Audit Result
+
+Rob correctly challenged the first pass as too narrow. The first draft only
+guarded the direct IBKR REST quote-fill speed path. Greg's production backtest
+used the BotSpot Auto JSON router:
+
+```json
+{"default":"ibkr","stock":"ibkr","index":"ibkr","option":"thetadata","crypto":"ibkr","crypto_future":"ibkr","future":"ibkr","cont_future":"ibkr"}
+```
+
+That routes BTC through `RoutedBacktestingPandas`, so the real fix needed to
+cover routed IBKR crypto price and quote lookups, not only direct fill speed
+helpers.
+
+Correct production model for this audit:
+
+- BotSpot Node starts the backtest from the saved revision and server-side data
+  provider config. User-supplied raw env vars are blocked.
+- BotSpot Auto routes crypto to IBKR. This is not a ThetaData investigation
+  unless evidence later shows a non-crypto asset or routing bug.
+- Bot Manager runs the backtest in an ephemeral ECS/container environment. The
+  local disk starts effectively cold, so Rob's existing workstation cache is
+  not production-equivalent.
+- Bot Manager's `BACKTEST_CACHE_*` object-cache warm path is separate from
+  LumiBot's `LUMIBOT_CACHE_*` market-data parquet cache.
+- LumiBot's S3 cache key is based on the path relative to
+  `LUMIBOT_CACHE_FOLDER`, and the cache env is read at import time. Local
+  reproduction must set these variables before importing LumiBot.
+- Data Downloader classifies IBKR history responses and has a write policy that
+  should deny partial responses. If an underfilled parquet is present, the
+  audit must identify whether it came from a stale S3 object, a too-narrow
+  LumiBot request, a routed-data coverage bug, or a downloader classification
+  bug.
+- `LUMIBOT_BACKTEST_AUDIT=1` adds useful trade-event telemetry, but it can
+  bypass the direct fast fill path. The replay matrix must include both audited
+  and non-audited runs.
+
+Do not bump the production cache version or delete production cache objects for
+this incident. The bug is in LumiBot's acceptance of an out-of-window intraday
+frame as a current price/quote. Missing or partial data must stay missing; it
+must not be hidden by synthetic bars or cache deletion.
+
+Additional verified facts from the 2026-06-12 audit:
+
+- The production backtest row still points to revision
+  `9c8e12ce-7ffd-438e-907d-57a13660a1f8`, version `100`, crypto data
+  requirements, and a completed summary of about `-8.55%` total return and
+  `-64.18%` max drawdown.
+- The result manifest lists settings, logs, trades, trade events, indicators,
+  and parquet artifacts for backtest
+  `64d6495f-bfaf-46e8-b150-0110ed773b4a`. Settings, trades, stats, tearsheet,
+  completion, and indicators were exported through the product-supported API.
+  Direct S3 reads for some result objects failed KMS decrypt from the local CLI,
+  so CloudWatch plus API artifacts were used for evidence.
+- The owner-scoped production MCP artifact tools correctly rejected cross-user
+  access to Greg's result artifacts from this session. That means exact
+  production fill proof must come from a support/admin artifact export path, not
+  from bypassing ownership checks.
+- A fresh local replay from the executed code zip with production Data
+  Downloader reached the early March 12 signal region and showed the corrected
+  current price path (`71421.5000`, not `70511.75`). Full-window replay did not
+  finish in-turn because a fresh local task had to hydrate many IBKR `1min`
+  `Trades`, `Bid_Ask`, and `Midpoint` chunks through the downloader. Partial
+  replay logs are preserved under
+  `/Users/robertgrzesik/Development/support-artifacts/greg-backtest-april17-20260612/local-runs/`.
+
+## Finding From First Pass
 
 The replay showed IBKR crypto history was underfilled for the early simulation window:
 
@@ -50,48 +144,96 @@ The replay showed IBKR crypto history was underfilled for the early simulation w
 - LumiBot logged that requested BTC dates were outside the available data range.
 - Despite that, market orders could still fill from quote/bid-ask data before the cached data object actually covered the simulated timestamp.
 
-The narrow code path was `BacktestingBroker._fast_get_bid_ask_for_fill()` in `lumibot/backtesting/backtesting_broker.py`.
+The clearest first-pass local evidence was around simulated
+`2026-03-12 08:00:00-04:00`:
+
+- the strategy submitted a BTC/USD market buy;
+- the log repeatedly warned that `BTC/USD` minute `Trades` history remained
+  underfilled and was returning available real bars;
+- the order filled at `$62,718.00`;
+- the same heartbeat region reported strategy price values around `$70,445.50`.
+
+That was enough to justify the deeper fill-provenance audit. Later production
+artifacts above confirmed the same class of problem in Greg's actual completed
+backtest, especially the repeated `70511.75` fills around April 15-17.
+
+The direct code path reproduced in the first pass was
+`BacktestingBroker._fast_get_bid_ask_for_fill()` in
+`lumibot/backtesting/backtesting_broker.py`.
 
 That helper is an IBKR REST backtesting speed path. It reads bid/ask directly from the cached `Data` object's datalines and bypasses the normal guarded `Data.get_quote()` wrapper. Before the fix, it called `data_obj.get_iter_count(now)` directly. For timestamps before the first cached row, that can produce an invalid positional lookup instead of surfacing missing data.
 
 This is a backtest engine bug, not a Greg strategy logic bug. The strategy submitted an order during a period where the data source did not cover the simulated timestamp; the engine should not fill that order from an out-of-window bid/ask row.
 
-## Fix
+The reopened audit also found a separate routed-path hazard to verify. In
+`lumibot/backtesting/routed_backtesting.py`, `_IbkrRoutingAdapter._fetch_df()`
+can mark crypto/futures series as fully loaded after any non-empty prefetch in
+some paths. Other routed prefetch paths already call
+`ibkr_helper.frame_covers_requested_window()` before marking the series loaded.
+If Greg's backtest received a partial non-empty routed IBKR frame, that
+fully-loaded marker could prevent a later repair fetch. The fix now applies the
+same `frame_covers_requested_window()` gate to those paths.
 
-`BacktestingBroker._fast_get_bid_ask_for_fill()` now validates that the simulated timestamp is inside the cached data object's actual `datetime_start` and `datetime_end` before reading bid/ask datalines. It also rejects negative `get_iter_count()` results.
+## Implemented Fix
 
-If coverage is missing, the helper returns `(None, None)`. Existing missing-data handling can then cancel, skip, or fall back through the honest non-quote path without fabricating a fill.
+The fix on `version/4.5.48` now covers all three unsafe surfaces found during
+the audit:
 
-Regression coverage was added in:
+- `BacktestingBroker._fast_get_bid_ask_for_fill()` rejects direct IBKR fast-fill
+  data when the simulated timestamp is outside the cached object's
+  `datetime_start`/`datetime_end`.
+- `RoutedBacktestingPandas` and `InteractiveBrokersRESTBacktesting` mark
+  intraday IBKR-backed `Data` objects with `strict_end_check=True`.
+- `ThetaDataBacktestingPandas.get_last_price()` now respects strict intraday
+  frame bounds before using its direct `get_iter_count()` last-trade path.
+- `ThetaDataBacktestingPandas.get_quote()` now requires `frame_start <= dt <=
+  frame_end` before taking its quote fast path, so a future-only frame cannot
+  produce a current quote.
+- `_IbkrRoutingAdapter._fetch_df()` no longer marks crypto/futures full-window
+  prefetches as fully loaded unless `ibkr_helper.frame_covers_requested_window()`
+  confirms coverage.
+- `scripts/run_backtest_prodlike.py` has a `--cache-mode` flag so future
+  replays can explicitly run production S3 cache in `readonly` mode.
 
-- `tests/test_ibkr_crypto_backtesting_smoke_stubbed.py::test_ibkr_rest_fast_crypto_quote_fill_rejects_underfilled_cache_before_start`
+If coverage is missing, LumiBot now returns `None`/empty `Quote` for the price
+surface instead of carrying a stale or future intraday row into strategy sizing,
+markers, or fills.
 
-The regression recreates the customer shape:
+Regression coverage was added for direct and routed paths:
 
-- backtest starts 2026-03-09;
-- first real BTC minute row starts 2026-03-22;
-- broker evaluates a March 12 quote-fill attempt;
-- expected result is no bid/ask fill.
+- direct fast-fill rejects a future BTC minute frame for a March 12 fill attempt;
+- direct IBKR `get_last_price()` rejects both stale-after-end and
+  future-before-start intraday frames;
+- routed IBKR `get_last_price()` and `get_quote()` reject both stale-after-end
+  and future-before-start intraday frames.
 
 ## Validation
 
 Focused suite:
 
 ```bash
-/Users/robertgrzesik/Development/bin/safe-timeout 1200 python3 -m pytest tests/test_ibkr_crypto_backtesting_smoke_stubbed.py -q
+/Users/robertgrzesik/Development/bin/safe-timeout 240 python3 -m pytest tests/test_interactive_brokers_rest_backtesting_unit.py tests/test_routed_backtesting_ibkr_daily_prefetch.py tests/test_ibkr_crypto_backtesting_smoke_stubbed.py -q
 ```
 
-Result on 2026-06-11:
+Result on 2026-06-12:
 
-- `7 passed`
+- `24 passed`
 - one third-party `websockets.legacy` deprecation warning
 
-## Follow-Up
+## Required Follow-Up
 
-Before telling a customer that the historical result is corrected in production, deploy the LumiBot version containing this fix through the normal version branch and BotManager release path. Then rerun Greg's copied revision for the same 2026-03-09 to 2026-06-05 window and compare:
+Before telling a customer that a rerun will exactly match a new expected
+full-window result, run a completed post-fix backtest in BotSpot/Bot Manager and
+compare its final stats. The current code-level fix is regression-tested, but
+the same-turn local full-window replay was downloader-bound.
 
-- whether March 12-21 no longer creates quote fills from uncovered BTC data;
-- portfolio value and drawdown around April 17;
-- trades and trade events around the reported drop.
+1. Build and publish LumiBot `4.5.48`.
+2. Trigger a new Greg-window BotSpot backtest from the executed revision or a
+   support clone.
+3. Confirm the rerun no longer has the stale `70511.75` repeated fills and that
+   fills fall inside or near the relevant BTC quote/OHLC frame.
+4. Separately investigate why fresh local replay needs to hydrate many BTC
+   minute chunks despite production S3 cache configuration; that is a
+   performance/cache-coverage issue, not the root data-integrity bug fixed here.
 
 Do not add fake trades, synthetic bars, carry-forward bid/ask rows, or strategy-specific patches to make this backtest look better. Missing data must stay missing.

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -3283,7 +3283,36 @@ class BacktestingBroker(Broker):
             return None, None
 
         try:
+            now_ts = pd.Timestamp(now)
+            start_ts = pd.Timestamp(getattr(data_obj, "datetime_start", None))
+            end_ts = pd.Timestamp(getattr(data_obj, "datetime_end", None))
+
+            if pd.isna(now_ts) or pd.isna(start_ts) or pd.isna(end_ts):
+                return None, None
+
+            if now_ts.tzinfo is not None and start_ts.tzinfo is not None:
+                now_for_start = now_ts.tz_convert(start_ts.tzinfo)
+                start_cmp = start_ts
+            else:
+                now_for_start = now_ts.tz_localize(None) if now_ts.tzinfo is not None else now_ts
+                start_cmp = start_ts.tz_localize(None) if start_ts.tzinfo is not None else start_ts
+
+            if now_ts.tzinfo is not None and end_ts.tzinfo is not None:
+                now_for_end = now_ts.tz_convert(end_ts.tzinfo)
+                end_cmp = end_ts
+            else:
+                now_for_end = now_ts.tz_localize(None) if now_ts.tzinfo is not None else now_ts
+                end_cmp = end_ts.tz_localize(None) if end_ts.tzinfo is not None else end_ts
+
+            if now_for_start < start_cmp or now_for_end > end_cmp:
+                return None, None
+        except Exception:
+            return None, None
+
+        try:
             i = data_obj.get_iter_count(now)
+            if i < 0:
+                return None, None
             bid = bid_line.dataline[i]
             ask = ask_line.dataline[i]
         except Exception:

--- a/lumibot/backtesting/interactive_brokers_rest_backtesting.py
+++ b/lumibot/backtesting/interactive_brokers_rest_backtesting.py
@@ -574,6 +574,7 @@ class InteractiveBrokersRESTBacktesting(PandasData):
         unit = str(unit)
         data_timestep = unit if unit in {"minute", "day"} else "minute"
         data = Data(asset, merged, timestep=data_timestep, quote=quote)
+        data.strict_end_check = data_timestep != "day"
         data._native_timestep_quantity = int(qty)  # type: ignore[attr-defined]
         data._native_timestep_unit = unit  # type: ignore[attr-defined]
         # CRITICAL: Pandas backtesting expects each Data object to have `iter_index`/datalines

--- a/lumibot/backtesting/routed_backtesting.py
+++ b/lumibot/backtesting/routed_backtesting.py
@@ -325,6 +325,7 @@ class _DataFrameRoutingAdapter(_RoutingAdapter):
             merged = df
 
         data = Data(original_asset, merged, timestep=ts_unit, quote=original_quote_asset)
+        data.strict_end_check = ts_unit != "day"
         self._router._data_store[canonical_key] = data
         if legacy_key not in self._router._data_store:
             self._router._data_store[legacy_key] = data
@@ -626,6 +627,7 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
         # slice directly without resampling each iteration.
         data_timestep = unit if unit in {"minute", "hour", "day"} else "minute"
         data = Data(original_asset, merged, timestep=data_timestep, quote=original_quote_asset)
+        data.strict_end_check = data_timestep != "day"
         data._native_timestep_quantity = int(qty)  # type: ignore[attr-defined]
         data._native_timestep_unit = unit  # type: ignore[attr-defined]
         try:
@@ -696,7 +698,14 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
             )
             if df is None or df.empty:
                 return None
-            self._fully_loaded_series.add(canonical_key)
+            if ibkr_helper.frame_covers_requested_window(
+                df,
+                asset=asset,
+                timestep=ts_unit,
+                start_dt=prefetch_start,
+                end_dt=prefetch_end,
+            ):
+                self._fully_loaded_series.add(canonical_key)
             return df
 
         if asset_type == "crypto" and ts_unit in {"minute", "hour"} and canonical_key not in self._fully_loaded_series:
@@ -717,7 +726,14 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
             )
             if df is None or df.empty:
                 return None
-            self._fully_loaded_series.add(canonical_key)
+            if ibkr_helper.frame_covers_requested_window(
+                df,
+                asset=asset,
+                timestep=ts_unit,
+                start_dt=prefetch_start,
+                end_dt=prefetch_end,
+            ):
+                self._fully_loaded_series.add(canonical_key)
             return df
 
         if asset_type == "crypto" and ts_unit == "day" and canonical_key not in self._fully_loaded_series:
@@ -739,7 +755,14 @@ class _IbkrRoutingAdapter(_DataFrameRoutingAdapter):
             )
             if df is None or df.empty:
                 return None
-            self._fully_loaded_series.add(canonical_key)
+            if ibkr_helper.frame_covers_requested_window(
+                df,
+                asset=asset,
+                timestep=ts_unit,
+                start_dt=prefetch_start,
+                end_dt=prefetch_end,
+            ):
+                self._fully_loaded_series.add(canonical_key)
             return df
 
         return ibkr_helper.get_price_data(

--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -2847,6 +2847,34 @@ class ThetaDataBacktestingPandas(PandasData):
                 data_obj = self.pandas_data.get((key[0], key[1]))
             if data_obj is None or not hasattr(data_obj, "df") or data_obj.df is None:
                 return None
+            if bool(getattr(data_obj, "strict_end_check", False)):
+                try:
+                    normalized_dt = self._normalize_default_timezone(dt) if dt is not None else None
+                    normalized_start = self._normalize_default_timezone(getattr(data_obj, "datetime_start", None))
+                    normalized_end = self._normalize_default_timezone(getattr(data_obj, "datetime_end", None))
+                    if (
+                        normalized_dt is not None
+                        and normalized_start is not None
+                        and normalized_dt < normalized_start
+                    ):
+                        logger.info(
+                            "[THETA][DEBUG][LAST_PRICE] strict start check rejected future frame for %s at dt=%s frame_start=%s",
+                            key,
+                            normalized_dt,
+                            normalized_start,
+                        )
+                        return None
+                    if normalized_dt is not None and normalized_end is not None and normalized_dt > normalized_end:
+                        logger.info(
+                            "[THETA][DEBUG][LAST_PRICE] strict end check rejected stale frame for %s at dt=%s frame_end=%s",
+                            key,
+                            normalized_dt,
+                            normalized_end,
+                        )
+                        return None
+                except Exception:
+                    logger.debug("[THETA][DEBUG][LAST_PRICE] strict end check failed", exc_info=True)
+                    return None
 
             df = data_obj.df
             close_series = df.get("close")
@@ -3724,9 +3752,16 @@ class ThetaDataBacktestingPandas(PandasData):
                     candidate_df = getattr(candidate_data, "df", None)
                     if candidate_df is not None and not candidate_df.empty and self._frame_has_quote_columns(candidate_df):
                         data_end = getattr(candidate_data, "datetime_end", None)
+                        data_start = getattr(candidate_data, "datetime_start", None)
                         normalized_dt = self._normalize_default_timezone(dt) if dt is not None else None
+                        normalized_start = self._normalize_default_timezone(data_start) if data_start is not None else None
                         normalized_end = self._normalize_default_timezone(data_end) if data_end is not None else None
-                        if normalized_dt is not None and normalized_end is not None and normalized_dt <= normalized_end:
+                        if (
+                            normalized_dt is not None
+                            and normalized_start is not None
+                            and normalized_end is not None
+                            and normalized_start <= normalized_dt <= normalized_end
+                        ):
                             should_refresh = False
                             fast_data = candidate_data
         except Exception:

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -69,6 +69,12 @@ class Tradier(Broker):
         return json.loads(decoded_bytes.decode("utf-8"))
 
     @staticmethod
+    def _encode_base64url_json(payload: dict) -> str:
+        """Encode a JSON payload as unpadded base64url."""
+        raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    @staticmethod
     def _is_auth_error(err: Exception) -> bool:
         msg = str(err or "")
         lower_msg = msg.lower()
@@ -126,6 +132,46 @@ class Tradier(Broker):
             except Exception:
                 pass
             _update_client(getattr(ds, "tradier", None))
+
+    def _persist_oauth_rotation(self, token_json: dict, new_access_token: str, new_refresh_token: str | None) -> None:
+        """Write rotated BotSpot Tradier OAuth tokens for Bot Manager persistence."""
+        rotation_path = os.environ.get("BOTSPOT_TRADIER_TOKEN_ROTATION_PATH")
+        if not rotation_path:
+            return
+
+        refresh_token = new_refresh_token or getattr(self, "_oauth_refresh_token", None)
+        payload = dict(token_json)
+        payload["access_token"] = new_access_token
+        if refresh_token:
+            payload["refresh_token"] = refresh_token
+
+        rotated_values = {
+            "TRADIER_ACCESS_TOKEN": new_access_token,
+            "TRADIER_TOKEN": self._encode_base64url_json(payload),
+        }
+        if refresh_token:
+            rotated_values["TRADIER_REFRESH_TOKEN"] = refresh_token
+
+        tmp_path = f"{rotation_path}.tmp.{os.getpid()}.{threading.get_ident()}"
+        try:
+            rotation_dir = os.path.dirname(rotation_path)
+            if rotation_dir:
+                os.makedirs(rotation_dir, mode=0o700, exist_ok=True)
+            with open(tmp_path, "w", encoding="utf-8") as handle:
+                json.dump(rotated_values, handle, separators=(",", ":"))
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, rotation_path)
+            try:
+                os.chmod(rotation_path, 0o600)
+            except OSError:
+                pass
+        except Exception as e:
+            try:
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+            except OSError:
+                pass
+            logger.warning(f"[Tradier] Failed to persist OAuth token rotation artifact: {e}")
 
     def _refresh_oauth_token(self, *, force: bool = False) -> bool:
         """Refresh Tradier OAuth token if possible. Returns True on successful refresh."""
@@ -185,10 +231,8 @@ class Tradier(Broker):
                 logger.warning("[Tradier] OAuth refresh response missing access_token.")
                 return False
 
-            # Refresh token is typically stable for Tradier partner apps, but handle the case where it changes.
             new_refresh_token = token_json.get("refresh_token")
-            if new_refresh_token and new_refresh_token != refresh_token:
-                logger.warning("[Tradier] OAuth refresh rotated refresh_token; rotation is not persisted in env vars and may require re-linking later.")
+            if new_refresh_token:
                 self._oauth_refresh_token = new_refresh_token
 
             expires_in = token_json.get("expires_in")
@@ -202,6 +246,7 @@ class Tradier(Broker):
                 pass
 
             self._apply_access_token(new_access_token)
+            self._persist_oauth_rotation(token_json, new_access_token, new_refresh_token)
             return True
 
     def _install_oauth_refresh_hooks(self) -> None:

--- a/scripts/run_backtest_prodlike.py
+++ b/scripts/run_backtest_prodlike.py
@@ -177,6 +177,12 @@ def main() -> int:
         help="Override LUMIBOT_CACHE_S3_PREFIX (alternative to cache-version)",
     )
     parser.add_argument(
+        "--cache-mode",
+        default=None,
+        choices=["disabled", "readonly", "readwrite"],
+        help="Override LUMIBOT_CACHE_MODE without editing the dotenv file.",
+    )
+    parser.add_argument(
         "--use-dotenv-s3-keys",
         action="store_true",
         help="Use LUMIBOT_CACHE_S3_ACCESS_KEY_ID/SECRET from the dotenv file instead of the host AWS credential chain.",
@@ -313,6 +319,9 @@ def main() -> int:
         env["LUMIBOT_CACHE_FOLDER"] = args.cache_folder
         Path(args.cache_folder).mkdir(parents=True, exist_ok=True)
 
+    if args.cache_mode:
+        env["LUMIBOT_CACHE_MODE"] = args.cache_mode
+
     if args.cache_version:
         env["LUMIBOT_CACHE_S3_VERSION"] = args.cache_version
 
@@ -326,6 +335,7 @@ def main() -> int:
     print(f"[run] window={args.start} -> {args.end}")
     print(f"[run] workdir={workdir}")
     print(f"[run] cache_folder={env.get('LUMIBOT_CACHE_FOLDER')}")
+    print(f"[run] cache_mode={env.get('LUMIBOT_CACHE_MODE')}")
     print(f"[run] cache_s3_bucket={env.get('LUMIBOT_CACHE_S3_BUCKET')}")
     print(f"[run] cache_s3_prefix={env.get('LUMIBOT_CACHE_S3_PREFIX')}")
     print(f"[run] cache_s3_version={env.get('LUMIBOT_CACHE_S3_VERSION')}")
@@ -415,6 +425,7 @@ def main() -> int:
             "metrics": subprocess_metrics,
             "cache": {
                 "folder": env.get("LUMIBOT_CACHE_FOLDER"),
+                "mode": env.get("LUMIBOT_CACHE_MODE"),
                 "s3_bucket": env.get("LUMIBOT_CACHE_S3_BUCKET"),
                 "s3_prefix": env.get("LUMIBOT_CACHE_S3_PREFIX"),
                 "s3_version": env.get("LUMIBOT_CACHE_S3_VERSION"),

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.47",
+    version="4.5.48",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_ibkr_crypto_backtesting_smoke_stubbed.py
+++ b/tests/test_ibkr_crypto_backtesting_smoke_stubbed.py
@@ -122,6 +122,59 @@ def test_ibkr_rest_backtesting_crypto_market_orders_fill_at_ask_and_bid(monkeypa
     assert sell.get_fill_price() == pytest.approx(expected_bid_1, rel=1e-12)
 
 
+def test_ibkr_rest_fast_crypto_quote_fill_rejects_underfilled_cache_before_start(monkeypatch):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    backtest_start = pd.Timestamp("2026-03-09 00:00", tz="America/New_York")
+    first_real_bar = pd.Timestamp("2026-03-22 03:00", tz="America/New_York")
+    idx = pd.date_range(first_real_bar, periods=3, freq="1min", tz="America/New_York")
+    df = pd.DataFrame(
+        {
+            "open": [62_700.0, 62_710.0, 62_720.0],
+            "high": [62_750.0, 62_760.0, 62_770.0],
+            "low": [62_650.0, 62_660.0, 62_670.0],
+            "close": [62_718.0, 62_728.0, 62_738.0],
+            "bid": [62_717.0, 62_727.0, 62_737.0],
+            "ask": [62_719.0, 62_729.0, 62_739.0],
+            "volume": [1_000, 1_000, 1_000],
+        },
+        index=idx,
+    )
+
+    def fake_get_price_data(*, asset, quote, timestep, start_dt, end_dt, exchange=None, include_after_hours=True, source=None):
+        return df
+
+    monkeypatch.setattr(ibkr_helper, "get_price_data", fake_get_price_data)
+
+    data_source = InteractiveBrokersRESTBacktesting(
+        datetime_start=backtest_start.to_pydatetime(),
+        datetime_end=(idx[-1] + pd.Timedelta(minutes=1)).to_pydatetime(),
+        market="24/7",
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    data_source.load_data()
+
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+
+    base = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+    data_source.get_historical_prices_between_dates(
+        (base, quote),
+        timestep="minute",
+        quote=quote,
+        start_date=backtest_start.to_pydatetime(),
+        end_date=idx[-1].to_pydatetime(),
+    )
+
+    broker._update_datetime(pd.Timestamp("2026-03-12 08:00", tz="America/New_York").to_pydatetime())
+
+    assert broker._fast_get_bid_ask_for_fill(base, quote) == (None, None)
+
+
 def test_ibkr_rest_backtesting_crypto_limit_orders_fill_against_quotes(monkeypatch):
     import lumibot.tools.ibkr_helper as ibkr_helper
 

--- a/tests/test_interactive_brokers_rest_backtesting_unit.py
+++ b/tests/test_interactive_brokers_rest_backtesting_unit.py
@@ -166,6 +166,96 @@ def test_ibkr_rest_crypto_minute_prefetch_stays_unloaded_when_coverage_fails(mon
     assert (asset, quote, "minute", "AUTO") not in ds._fully_loaded_series
 
 
+def test_ibkr_rest_crypto_last_price_rejects_stale_underfilled_intraday_frame(monkeypatch):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    ny = ZoneInfo("America/New_York")
+    stale_dt = datetime(2026, 3, 24, 0, 0, tzinfo=ny)
+    sim_dt = datetime(2026, 4, 17, 10, 0, tzinfo=ny)
+
+    def fake_get_price_data(*, asset, quote, timestep, start_dt, end_dt, exchange=None, include_after_hours=True, source=None):
+        idx = pd.DatetimeIndex([stale_dt])
+        return pd.DataFrame(
+            {
+                "open": [70511.75],
+                "high": [70511.75],
+                "low": [70511.75],
+                "close": [70511.75],
+                "bid": [70510.75],
+                "ask": [70512.75],
+                "volume": [1.0],
+            },
+            index=idx,
+        )
+
+    monkeypatch.setattr(ibkr_helper, "get_price_data", fake_get_price_data)
+    monkeypatch.setattr(ibkr_helper, "frame_covers_requested_window", lambda *args, **kwargs: False)
+
+    ds = InteractiveBrokersRESTBacktesting(
+        datetime_start=datetime(2026, 3, 9, tzinfo=ny),
+        datetime_end=datetime(2026, 6, 5, tzinfo=ny),
+        market="24/7",
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    ds._update_datetime(sim_dt)
+
+    asset = Asset(symbol="BTC", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset(symbol="USD", asset_type=Asset.AssetType.FOREX)
+
+    assert ds.get_last_price(asset, quote=quote) is None
+
+    key = (asset, quote, "minute", "AUTO")
+    data = ds._data_store[key]
+    assert data.strict_end_check is True
+    assert float(data.df["close"].iloc[-1]) == 70511.75
+
+
+def test_ibkr_rest_crypto_last_price_rejects_future_underfilled_intraday_frame(monkeypatch):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    ny = ZoneInfo("America/New_York")
+    future_dt = datetime(2026, 3, 24, 0, 0, tzinfo=ny)
+    sim_dt = datetime(2026, 3, 12, 7, 0, tzinfo=ny)
+
+    def fake_get_price_data(*, asset, quote, timestep, start_dt, end_dt, exchange=None, include_after_hours=True, source=None):
+        idx = pd.DatetimeIndex([future_dt])
+        return pd.DataFrame(
+            {
+                "open": [70511.75],
+                "high": [70511.75],
+                "low": [70511.75],
+                "close": [70511.75],
+                "bid": [70510.75],
+                "ask": [70512.75],
+                "volume": [1.0],
+            },
+            index=idx,
+        )
+
+    monkeypatch.setattr(ibkr_helper, "get_price_data", fake_get_price_data)
+    monkeypatch.setattr(ibkr_helper, "frame_covers_requested_window", lambda *args, **kwargs: False)
+
+    ds = InteractiveBrokersRESTBacktesting(
+        datetime_start=datetime(2026, 3, 9, tzinfo=ny),
+        datetime_end=datetime(2026, 6, 5, tzinfo=ny),
+        market="24/7",
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    ds._update_datetime(sim_dt)
+
+    asset = Asset(symbol="BTC", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset(symbol="USD", asset_type=Asset.AssetType.FOREX)
+
+    assert ds.get_last_price(asset, quote=quote) is None
+
+    key = (asset, quote, "minute", "AUTO")
+    data = ds._data_store[key]
+    assert data.strict_end_check is True
+    assert float(data.df["close"].iloc[0]) == 70511.75
+
+
 def test_ibkr_rest_futures_minute_prefetch_stays_unloaded_when_coverage_fails(monkeypatch):
     import lumibot.tools.ibkr_helper as ibkr_helper
 

--- a/tests/test_routed_backtesting_ibkr_daily_prefetch.py
+++ b/tests/test_routed_backtesting_ibkr_daily_prefetch.py
@@ -120,6 +120,118 @@ def test_routed_backtesting_crypto_daily_tuple_lookup_uses_prefetched_canonical_
     assert not bars.df.empty
 
 
+def test_routed_ibkr_crypto_intraday_rejects_stale_underfilled_last_price_and_quote(monkeypatch):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    ny = "America/New_York"
+    stale_ts = pd.Timestamp("2026-03-24 00:00", tz=ny)
+    sim_ts = pd.Timestamp("2026-04-17 10:00", tz=ny)
+    calls: list[tuple[datetime, datetime, str]] = []
+
+    def _fake_get_price_data(*, asset, quote, timestep, start_dt, end_dt, exchange=None, include_after_hours=True, source=None):
+        calls.append((start_dt, end_dt, str(timestep)))
+        df = pd.DataFrame(
+            {
+                "open": [70511.75],
+                "high": [70511.75],
+                "low": [70511.75],
+                "close": [70511.75],
+                "bid": [70510.75],
+                "ask": [70512.75],
+                "volume": [1.0],
+            },
+            index=pd.DatetimeIndex([stale_ts]),
+        )
+        df.index.name = "timestamp"
+        return df
+
+    monkeypatch.setattr(ibkr_helper, "get_price_data", _fake_get_price_data)
+    monkeypatch.setattr(ibkr_helper, "frame_covers_requested_window", lambda *args, **kwargs: False)
+
+    source = RoutedBacktestingPandas(
+        datetime_start=pd.Timestamp("2026-03-09 00:00", tz=ny).to_pydatetime(),
+        datetime_end=pd.Timestamp("2026-06-05 00:00", tz=ny).to_pydatetime(),
+        market="24/7",
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    source.load_data()
+    source._update_datetime(sim_ts.to_pydatetime())
+
+    base = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+    assert source.get_last_price(base, timestep="minute", quote=quote) is None
+
+    quote_obj = source.get_quote(base, quote=quote, timestep="minute")
+    assert quote_obj.price is None
+    assert quote_obj.bid is None
+    assert quote_obj.ask is None
+
+    key = source.find_asset_in_data_store(base, quote, "minute")
+    assert key is not None
+    data = source._data_store[key]
+    assert data.strict_end_check is True
+    assert float(data.df["close"].iloc[-1]) == 70511.75
+    assert calls
+
+
+def test_routed_ibkr_crypto_intraday_rejects_future_underfilled_last_price_and_quote(monkeypatch):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    ny = "America/New_York"
+    future_ts = pd.Timestamp("2026-03-24 00:00", tz=ny)
+    sim_ts = pd.Timestamp("2026-03-12 07:00", tz=ny)
+    calls: list[tuple[datetime, datetime, str]] = []
+
+    def _fake_get_price_data(*, asset, quote, timestep, start_dt, end_dt, exchange=None, include_after_hours=True, source=None):
+        calls.append((start_dt, end_dt, str(timestep)))
+        df = pd.DataFrame(
+            {
+                "open": [70511.75],
+                "high": [70511.75],
+                "low": [70511.75],
+                "close": [70511.75],
+                "bid": [70510.75],
+                "ask": [70512.75],
+                "volume": [1.0],
+            },
+            index=pd.DatetimeIndex([future_ts]),
+        )
+        df.index.name = "timestamp"
+        return df
+
+    monkeypatch.setattr(ibkr_helper, "get_price_data", _fake_get_price_data)
+    monkeypatch.setattr(ibkr_helper, "frame_covers_requested_window", lambda *args, **kwargs: False)
+
+    source = RoutedBacktestingPandas(
+        datetime_start=pd.Timestamp("2026-03-09 00:00", tz=ny).to_pydatetime(),
+        datetime_end=pd.Timestamp("2026-06-05 00:00", tz=ny).to_pydatetime(),
+        market="24/7",
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    source.load_data()
+    source._update_datetime(sim_ts.to_pydatetime())
+
+    base = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+    assert source.get_last_price(base, timestep="minute", quote=quote) is None
+
+    quote_obj = source.get_quote(base, quote=quote, timestep="minute")
+    assert quote_obj.price is None
+    assert quote_obj.bid is None
+    assert quote_obj.ask is None
+
+    key = source.find_asset_in_data_store(base, quote, "minute")
+    assert key is not None
+    data = source._data_store[key]
+    assert data.strict_end_check is True
+    assert float(data.df["close"].iloc[0]) == 70511.75
+    assert calls
+
+
 def test_routed_backtesting_prefetches_ibkr_stock_daily_with_full_lookback(monkeypatch):
     calls: list[tuple[datetime, datetime, str]] = []
 

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -139,6 +139,55 @@ class TestTradierBroker:
 
         assert broker._tradier_access_token == "new-access"
 
+    def test_oauth_refresh_writes_botspot_rotation_artifact(self, monkeypatch, tmp_path):
+        token_json = {
+            "access_token": "old-access",
+            "refresh_token": "old-refresh",
+            "expires_in": 1,
+            "issued_at": int((time.time() - 3600) * 1000),
+        }
+        rotation_path = tmp_path / "tradier_token_rotation.json"
+        monkeypatch.setenv("TRADIER_TOKEN", self._b64url(token_json))
+        monkeypatch.setenv("TRADIER_REFRESH_TOKEN", "old-refresh")
+        monkeypatch.setenv("TRADIER_OAUTH_CLIENT_ID", "cid")
+        monkeypatch.setenv("TRADIER_OAUTH_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("BOTSPOT_TRADIER_TOKEN_ROTATION_PATH", str(rotation_path))
+
+        class _Resp:
+            ok = True
+            status_code = 200
+            text = ""
+
+            def json(self):
+                return {
+                    "access_token": "new-access",
+                    "refresh_token": "new-refresh",
+                    "expires_in": 86400,
+                    "issued_at": int(time.time() * 1000),
+                }
+
+        from lumibot.brokers import tradier as tradier_module
+
+        monkeypatch.setattr(tradier_module.requests, "post", lambda *args, **kwargs: _Resp())
+
+        Tradier(
+            config={"ACCESS_TOKEN": None, "ACCOUNT_NUMBER": "1234", "PAPER": True},
+            connect_stream=False,
+        )
+
+        artifact = json.loads(rotation_path.read_text(encoding="utf-8"))
+        assert artifact["TRADIER_ACCESS_TOKEN"] == "new-access"
+        assert artifact["TRADIER_REFRESH_TOKEN"] == "new-refresh"
+        decoded_token = self._decode_b64url(artifact["TRADIER_TOKEN"])
+        assert decoded_token["access_token"] == "new-access"
+        assert decoded_token["refresh_token"] == "new-refresh"
+
+    def _decode_b64url(self, payload: str) -> dict:
+        missing_padding = len(payload) % 4
+        if missing_padding:
+            payload += "=" * (4 - missing_padding)
+        return json.loads(base64.urlsafe_b64decode(payload).decode("utf-8"))
+
     def test_modify_order(self, mocker):
         broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True, connect_stream=False)
         mock_modify = mocker.patch.object(broker.tradier.orders, "modify")


### PR DESCRIPTION
## What

Release branch for v4.5.48. Includes Tradier token rotation persistence, the Greg BTC IBKR routed backtesting safety fix, production-like replay/cache documentation, and Titus Schwab cancel evidence docs.

## Why

Greg production BTC backtest had a real data-integrity failure, not just a chart issue. Production artifacts showed 76 fills, 63 outside the same-hour BTC OHLC candle, with the stale price `70511.75` reused across March and April and five April 15-17 fills at that same value.

The first draft only guarded the direct IBKR fast quote-fill path. The deeper audit showed BotSpot Auto crypto uses `RoutedBacktestingPandas`, so the fix also protects routed IBKR `get_last_price()` and `get_quote()` paths.

## Fix

- Direct IBKR fast quote fills now reject data when the simulated timestamp is outside the cached frame.
- Routed and direct IBKR intraday `Data` objects are marked strict.
- `ThetaDataBacktestingPandas.get_last_price()` rejects strict intraday frames that are stale after the simulation timestamp or future before it.
- `ThetaDataBacktestingPandas.get_quote()` no longer uses its quote fast path unless `frame_start <= dt <= frame_end`.
- Routed IBKR crypto/futures prefetches only mark a series fully loaded after `frame_covers_requested_window()` passes.
- `scripts/run_backtest_prodlike.py` now supports `--cache-mode readonly` for production-faithful S3 hydration tests.
- Tradier OAuth refreshes persist rotated token state back to the broker config.

## Risk

- Some IBKR crypto/futures backtests may now return missing price/quote data where they previously carried a stale or future intraday row. That is intended; missing data must stay missing.
- Full Greg-window local replay did not complete in-turn because fresh local runs had to hydrate many IBKR minute `Trades`, `Bid_Ask`, and `Midpoint` chunks through the production Data Downloader. The deterministic regressions cover the data-integrity bug directly.

## Tests run

- `/Users/robertgrzesik/Development/bin/safe-timeout 240 python3 -m pytest tests/test_interactive_brokers_rest_backtesting_unit.py tests/test_routed_backtesting_ibkr_daily_prefetch.py tests/test_ibkr_crypto_backtesting_smoke_stubbed.py -q` -> 24 passed.
- `git diff --check` -> passed.
- GitHub docs build on current head `585fa215` -> pending at last edit.
- Full LumiBot CI/CD run `27400948881` -> lint, all unit shards, all backtest shards, and `LintAndTest` passed.

## Docs / Prompts

- `docs/investigations/2026-06-11_GREG_BTC_ROUTED_QUOTE_FILL.md`
- `docs/PRODLIKE_LOCAL_BACKTEST_RUNS.md`
- `docs/investigations/2026-06-05_TITUS_SCHWAB_CANCEL_EXACT_PATH.md`
- `CHANGELOG.md`
- No BotSpot agent prompt change needed; this is a LumiBot runtime data-integrity fix, not a generated-strategy behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: v4.5.48

* **Bug Fixes**
  * Tradier OAuth token rotation now persists to the filesystem
  * Improved validation of cached crypto quote data to reject stale or underfilled frames
  * Enhanced boundary checking for routed intraday trading data

* **New Features**
  * Added `--cache-mode` flag for controlling backtest cache behavior (disabled|readonly|readwrite)

* **Documentation**
  * Updated investigation reports with deployment evidence and testing outcomes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->