### PR TITLE
Release 4.5.49 stale IBKR cache protections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 4.5.49 - Unreleased
 
+### Fixed
+- **Strict intraday data reads now reject stale bars inside sparse cache frames.** When strict end checking is enabled, minute/hour data must resolve to a recent bar near the simulated timestamp instead of walking back days or weeks to the previous real BTC row inside a broader cache object.
+- **Malformed rebuilt IBKR history windows are terminal no-data windows.** If the Data Downloader exhausts the rebuild path and still returns a malformed IBKR history payload, LumiBot records the requested range as missing instead of repeatedly refetching the same invalid minute window.
+
+### Docs
+- **Greg BTC stale-fill investigation now documents the S3 cache and Data Downloader root cause.** The note records the bad production BTC cache object, the queued downloader proof that stale crypto tails were marked complete/cacheable, and the required cache quarantine path.
+
+### Tests
+- **Data entity tests now reproduce stale BTC bars inside sparse intraday frames.** Regression coverage asserts strict minute reads reject March BTC data when an April simulation timestamp is requested, while allowing recent bars inside the configured tolerance.
+
 ## 4.5.48 - 2026-06-12
 
 Deploy marker: `pending`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.49 - Unreleased
+
 ## 4.5.48 - 2026-06-12
 
 Deploy marker: `pending`

--- a/docs/investigations/2026-06-11_GREG_BTC_ROUTED_QUOTE_FILL.md
+++ b/docs/investigations/2026-06-11_GREG_BTC_ROUTED_QUOTE_FILL.md
@@ -2,7 +2,7 @@
 
 One-line description: Production artifact diagnosis and LumiBot fix for Greg's BTC backtest drop caused by out-of-window IBKR crypto prices.
 Last Updated: 2026-06-12
-Status: Fix implemented on `version/4.5.48`; production artifacts parsed; full local replay remains Data Downloader-bound
+Status: Fixed in `v4.5.48`; production Bot Manager rerun of the April 15-19 window completed with no stale fills
 Audience: LumiBot, BotSpot Node, and BotSpot support engineers
 
 ## Overview
@@ -220,20 +220,43 @@ Result on 2026-06-12:
 - `24 passed`
 - one third-party `websockets.legacy` deprecation warning
 
+Production release and runtime validation:
+
+- LumiBot `v4.5.48` was published and installed by Bot Manager production and
+  development image builds. Production GitHub Actions run `27403208749` and
+  development run `27403207949` both logged `LUMIBOT_VERSION=4.5.48` and
+  `lumibot==4.5.48` in the dependency/backtest image builds.
+- A production BotSpot/Bot Manager rerun used Greg's same revision
+  `9c8e12ce-7ffd-438e-907d-57a13660a1f8` for `2026-04-15` through
+  `2026-04-18 23:59` with budget `1300`. New manager bot/backtest id:
+  `4aca383a-3688-4ca7-a058-cfd98586c7e7`.
+- The completed rerun `settings.json` reported `lumibot_version: 4.5.48`,
+  Data Downloader base URL `http://data-downloader.lumiwealth.com:8080`, and
+  remote cache `backend=s3`, `mode=readwrite`, `bucket=lumibot-cache-prod`,
+  `prefix=prod/cache`, `version=v1`.
+- The completed rerun still logged underfilled IBKR BTC hourly data and explicit
+  "data refresh required instead of using stale bars" messages, but those
+  missing-data conditions no longer produced out-of-window fills.
+- `trades.parquet` and `trade_events.parquet` each had 12 lifecycle rows:
+  6 `new` BTC buy orders and 6 `canceled` BTC buy orders. They had
+  0 priced rows, 0 filled-quantity rows, and 0 rows at stale price `70511.75`.
+- `stats.parquet` had 1,154 rows with `portfolio_value` min/max exactly
+  `1300`, `cash` min/max exactly `1300`, `return` min/max `0`, and
+  0 rows with positions.
+
 ## Required Follow-Up
 
-Before telling a customer that a rerun will exactly match a new expected
-full-window result, run a completed post-fix backtest in BotSpot/Bot Manager and
-compare its final stats. The current code-level fix is regression-tested, but
-the same-turn local full-window replay was downloader-bound.
+The April 15-19 production rerun proves the stale-fill failure no longer occurs
+in the reported April drop window. Before promising an exact new result for the
+entire March 9-June 5 customer backtest, run the full original window again and
+compare final stats.
 
-1. Build and publish LumiBot `4.5.48`.
-2. Trigger a new Greg-window BotSpot backtest from the executed revision or a
-   support clone.
-3. Confirm the rerun no longer has the stale `70511.75` repeated fills and that
-   fills fall inside or near the relevant BTC quote/OHLC frame.
-4. Separately investigate why fresh local replay needs to hydrate many BTC
-   minute chunks despite production S3 cache configuration; that is a
-   performance/cache-coverage issue, not the root data-integrity bug fixed here.
+Remaining follow-up:
+
+1. Run the full `2026-03-09` to `2026-06-05` window after `v4.5.48` if Greg or
+   support needs exact replacement metrics for the full reported run.
+2. Investigate why fresh local replay needs to hydrate many BTC minute chunks
+   despite production S3 cache configuration; that is a performance/cache
+   coverage issue, not the root data-integrity bug fixed here.
 
 Do not add fake trades, synthetic bars, carry-forward bid/ask rows, or strategy-specific patches to make this backtest look better. Missing data must stay missing.

--- a/docs/investigations/2026-06-11_GREG_BTC_ROUTED_QUOTE_FILL.md
+++ b/docs/investigations/2026-06-11_GREG_BTC_ROUTED_QUOTE_FILL.md
@@ -260,3 +260,64 @@ Remaining follow-up:
    coverage issue, not the root data-integrity bug fixed here.
 
 Do not add fake trades, synthetic bars, carry-forward bid/ask rows, or strategy-specific patches to make this backtest look better. Missing data must stay missing.
+
+## 2026-06-12 Deeper Cache And Downloader Audit
+
+Follow-up audit found that the `70511.75` stale fill was not random. A read-only
+copy of the production S3 object
+`s3://lumibot-cache-prod/prod/cache/v1/ibkr/crypto/minute/bars/crypto_BTC_USD_minute_ZEROHASH_TRADES_AHR.parquet`
+showed:
+
+- 72,806 total rows, timestamp range `2025-04-21 04:00 UTC` to
+  `2026-06-05 03:57 UTC`;
+- 0 rows for `2026-04-01` through `2026-04-08`;
+- only 2 rows for `2026-04-15` through `2026-04-19`, both placeholder rows with
+  `missing=True` and all OHLC/volume values `NaN`;
+- the last real BTC minute before that gap was `2026-03-24 03:58 UTC`, close
+  `70511.75`, followed by placeholder rows at `2026-03-24 04:00 UTC`,
+  `2026-04-15 04:00 UTC`, and `2026-04-18 04:00 UTC`.
+
+That explains the observed April stale fills: older LumiBot paths could ask for
+an April timestamp, skip over placeholder rows, and reuse the last real minute
+from March 24.
+
+A bounded production Data Downloader probe against the queued IBKR path also
+showed a downloader validation issue. Request:
+
+```text
+symbol=BTC, conid=541686651, source=Trades, bar=1min, period=1w,
+startTime=20260419-00:00:00, outsideRth=true
+```
+
+The queued response returned 7,960 rows from `2026-04-12 07:00 UTC` through
+`2026-04-17 19:59 UTC` and annotated the payload as
+`classification=complete`, `cache_write_policy=allow`, `requested_end=2026-04-19
+00:00 UTC`. That should not be cacheable as complete for 24/7 crypto data.
+
+The likely downloader bug is in
+`botspot_data_downloader/src/botspot_data_downloader/queue_worker.py`:
+`_ibkr_history_tail_coverage_error()` only checks intraday tail coverage when
+`requested_end` falls during US regular trading hours. That exception makes
+sense for US stock/index history after market close, but it lets BTC/crypto
+weekend or overnight tail gaps bypass stale-tail detection.
+
+The Greg rerun task definition also did not include `LUMIBOT_CACHE_BACKEND`,
+`LUMIBOT_CACHE_S3_BUCKET`, `LUMIBOT_CACHE_S3_PREFIX`,
+`LUMIBOT_CACHE_S3_REGION`, or `LUMIBOT_CACHE_S3_VERSION` as task-definition
+environment variables. Those values may have been passed as ECS run-task
+overrides or loaded from another runtime source, but `describe-task-definition`
+alone is insufficient proof. The observed artifact reported cache version `v1`,
+which matches LumiBot's default when `LUMIBOT_CACHE_S3_VERSION` is not injected.
+
+Next fix should be root-cause oriented:
+
+1. Fix Data Downloader crypto/24-7 tail coverage so stale tails become
+   `partial`/non-cacheable instead of `complete`/`allow`.
+2. Add LumiBot gap/staleness guards for intraday price/quote/fill reads so a
+   sparse in-window object cannot walk back days or weeks to the previous real
+   bar.
+3. Trace the BotSpot Node -> Bot Manager -> ECS run-task environment to explain
+   why the Greg production backtest used cache `v1` despite Node source
+   defaulting BotSpot Auto cache version to `v44`.
+4. After code fixes, surgically invalidate only the affected production BTC
+   cache objects proven bad. Do not bump the global production cache version.

--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -702,6 +702,86 @@ class Data:
         self._iter_count_last_dt_key = dt_key
         return i
 
+    def _strict_intraday_bar_age_tolerance(self) -> Optional[datetime.timedelta]:
+        if not getattr(self, "strict_end_check", False):
+            return None
+        try:
+            quantity, unit = parse_timestep_qty_and_unit(getattr(self, "timestep", None))
+            quantity = max(1, int(quantity or 1))
+        except Exception:
+            quantity = 1
+            unit = getattr(self, "timestep", None)
+
+        unit_text = str(unit or "").strip().lower()
+        if unit_text == "minute":
+            return datetime.timedelta(minutes=quantity * 3)
+        if unit_text == "hour":
+            return datetime.timedelta(hours=quantity * 3)
+        return None
+
+    def _timestamp_for_iter_count(self, iter_count: int) -> Optional[pd.Timestamp]:
+        try:
+            if iter_count < 0:
+                return None
+            raw_timestamp = self.datalines["datetime"].dataline[iter_count]
+        except Exception:
+            return None
+        try:
+            timestamp = pd.Timestamp(raw_timestamp)
+        except Exception:
+            return None
+        if pd.isna(timestamp):
+            return None
+        return timestamp
+
+    def _strict_intraday_stale_bar_error(
+        self,
+        *,
+        dt_key,
+        iter_count: int,
+        length,
+        timeshift,
+    ) -> Optional[str]:
+        tolerance = self._strict_intraday_bar_age_tolerance()
+        if tolerance is None:
+            return None
+
+        bar_ts = self._timestamp_for_iter_count(iter_count)
+        if bar_ts is None:
+            return None
+        try:
+            dt_ts = pd.Timestamp(dt_key)
+        except Exception:
+            return None
+        if pd.isna(dt_ts):
+            return None
+
+        try:
+            if bar_ts.tzinfo is not None and dt_ts.tzinfo is not None:
+                dt_cmp = dt_ts.tz_convert(bar_ts.tzinfo)
+                bar_cmp = bar_ts
+            elif bar_ts.tzinfo is not None:
+                dt_cmp = dt_ts.tz_localize(bar_ts.tzinfo)
+                bar_cmp = bar_ts
+            elif dt_ts.tzinfo is not None:
+                dt_cmp = dt_ts
+                bar_cmp = bar_ts.tz_localize(dt_ts.tzinfo)
+            else:
+                dt_cmp = dt_ts
+                bar_cmp = bar_ts
+        except Exception:
+            return None
+
+        gap = dt_cmp - bar_cmp
+        if gap <= tolerance:
+            return None
+
+        return (
+            f"The date you are looking for ({dt_key}) for ({self.asset}) resolved to stale "
+            f"{getattr(self, 'timestep', None)} data at {bar_ts} with gap={gap}, "
+            f"length={length}, and timeshift={timeshift}; data refresh required instead of using stale bars."
+        )
+
     def check_data(func):
         # Validates if the provided date, length, timeshift, and timestep
         # will return data. Runs function if data, returns None if no data.
@@ -780,6 +860,15 @@ class Data:
 
             # Use the optimized iter-count implementation (dict hit, cursor, or searchsorted fallback).
             i = self.get_iter_count(dt_key)
+
+            stale_bar_error = self._strict_intraday_stale_bar_error(
+                dt_key=dt_key,
+                iter_count=i,
+                length=length,
+                timeshift=timeshift,
+            )
+            if stale_bar_error is not None:
+                raise ValueError(stale_bar_error)
 
             data_index = i + 1 - length - timeshift
             is_data = data_index >= 0

--- a/lumibot/tools/ibkr_helper.py
+++ b/lumibot/tools/ibkr_helper.py
@@ -2668,6 +2668,12 @@ def _is_not_found_error(cache_manager, exc: Exception) -> bool:
 
 def _is_terminal_no_data_error(exc: Exception) -> bool:
     msg = str(exc).lower()
+    # Data Downloader only emits this after the IBKR history response failed validation, was
+    # rebuilt from smaller windows, and still could not produce a cacheable payload. Treat the
+    # known malformed-payload variant as terminal for the requested window so backtests do not
+    # repeatedly resubmit the same dead 1-minute range.
+    if "ibkr history remained invalid after rebuild" in msg and "malformed_history_payload" in msg:
+        return True
     return any(
         token in msg
         for token in (

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.48",
+    version="4.5.49",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_data_entity.py
+++ b/tests/test_data_entity.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta
 import numpy as np
 import pandas as pd
 import pytz
+import pytest
 
 from lumibot.entities import Asset
 from lumibot.entities.data import Data
@@ -159,3 +160,54 @@ class TestDataGetLastPriceTradeOnly:
         tz = pytz.timezone("America/New_York")
         dt = tz.localize(datetime(2024, 1, 3, 9, 30))
         assert data.get_last_price(dt) == 5.0
+
+    def test_strict_intraday_rejects_stale_bar_inside_sparse_frame(self):
+        asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+        tz = pytz.timezone("America/New_York")
+        stale_dt = tz.localize(datetime(2026, 3, 23, 23, 58))
+        future_dt = tz.localize(datetime(2026, 4, 20, 0, 0))
+        request_dt = tz.localize(datetime(2026, 4, 15, 0, 0))
+        df = (
+            pd.DataFrame(
+                {
+                    "datetime": [stale_dt, future_dt],
+                    "open": [70511.75, 73830.25],
+                    "high": [70521.50, 73847.50],
+                    "low": [70505.75, 73771.75],
+                    "close": [70511.75, 73835.75],
+                    "volume": [0.01964, 0.577128],
+                }
+            )
+            .set_index("datetime")
+        )
+
+        data = Data(asset, df, timestep="minute", quote=Asset("USD", asset_type=Asset.AssetType.FOREX))
+        data.strict_end_check = True
+
+        with pytest.raises(ValueError, match="resolved to stale .*data refresh required"):
+            data.get_last_price(request_dt)
+
+    def test_strict_intraday_allows_recent_bar_within_tolerance(self):
+        asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+        tz = pytz.timezone("America/New_York")
+        bar_dt = tz.localize(datetime(2026, 4, 15, 0, 0))
+        request_dt = bar_dt + timedelta(minutes=2)
+        future_dt = bar_dt + timedelta(minutes=5)
+        df = (
+            pd.DataFrame(
+                {
+                    "datetime": [bar_dt, future_dt],
+                    "open": [70500.0, 70520.0],
+                    "high": [70525.0, 70535.0],
+                    "low": [70490.0, 70510.0],
+                    "close": [70511.75, 70530.0],
+                    "volume": [1.0, 1.0],
+                }
+            )
+            .set_index("datetime")
+        )
+
+        data = Data(asset, df, timestep="minute", quote=Asset("USD", asset_type=Asset.AssetType.FOREX))
+        data.strict_end_check = True
+
+        assert data.get_last_price(request_dt) == 70511.75

--- a/tests/test_ibkr_helper_unit.py
+++ b/tests/test_ibkr_helper_unit.py
@@ -400,6 +400,92 @@ def test_unresolvable_stock_conid_is_terminal_no_data():
     assert ibkr_helper._is_terminal_no_data_error(RuntimeError("IBKR conid lookup is negatively cached for ARCH-DEFUNCT-2838"))
 
 
+def test_ibkr_malformed_rebuild_failure_is_terminal_no_data():
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    assert ibkr_helper._is_terminal_no_data_error(
+        RuntimeError(
+            "Request abc permanently failed: IBKR history remained invalid after rebuild "
+            "(conid=72539702 period=1000min bar=1min reason=mid:malformed_history_payload)"
+        )
+    )
+    assert ibkr_helper._is_terminal_no_data_error(
+        RuntimeError(
+            "IBKR history remained invalid after rebuild "
+            "(conid=72539702 period=1000min bar=1min reason=tail:malformed_history_payload)"
+        )
+    )
+    assert not ibkr_helper._is_terminal_no_data_error(
+        RuntimeError(
+            "IBKR history remained invalid after rebuild "
+            "(conid=72539702 period=1000min bar=1min reason=mid:overlap_bar_mismatch:1775834580000)"
+        )
+    )
+    assert not ibkr_helper._is_terminal_no_data_error(RuntimeError("Timed out waiting for downloader queue"))
+
+
+def test_ibkr_malformed_rebuild_failure_records_missing_window_and_suppresses_refetch(monkeypatch, tmp_path):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    monkeypatch.setattr(ibkr_helper, "LUMIBOT_CACHE_FOLDER", tmp_path.as_posix())
+    ibkr_helper._RUNTIME_HISTORY_NO_DATA_WINDOWS.clear()
+
+    asset = Asset(symbol="TQQQ", asset_type=Asset.AssetType.STOCK)
+    quote = Asset(symbol="USD", asset_type=Asset.AssetType.FOREX)
+    start = datetime(2015, 12, 30, 3, 43, tzinfo=timezone.utc)
+    end = datetime(2015, 12, 30, 20, 23, tzinfo=timezone.utc)
+    calls = {"fetch": 0}
+
+    def _raise_permanent_malformed_history(**kwargs):
+        calls["fetch"] += 1
+        raise RuntimeError(
+            "Request 01baaf8d permanently failed: IBKR history remained invalid after rebuild "
+            "(conid=72539702 period=1000min bar=1min reason=mid:malformed_history_payload)"
+        )
+
+    monkeypatch.setattr(ibkr_helper, "_fetch_history_between_dates", _raise_permanent_malformed_history)
+
+    first = ibkr_helper.get_price_data(
+        asset=asset,
+        quote=quote,
+        timestep="minute",
+        start_dt=start,
+        end_dt=end,
+        exchange=None,
+        include_after_hours=True,
+        source="Trades",
+    )
+
+    assert first.empty
+    assert calls["fetch"] == 1
+
+    cache_file = ibkr_helper._cache_file_for(
+        asset=asset,
+        quote=quote,
+        timestep="minute",
+        exchange=None,
+        source="Trades",
+        include_after_hours=True,
+    )
+    cached = pd.read_parquet(cache_file)
+    assert len(cached) == 2
+    assert cached["missing"].fillna(False).astype(bool).all()
+
+    second = ibkr_helper.get_price_data(
+        asset=asset,
+        quote=quote,
+        timestep="minute",
+        start_dt=start + timedelta(minutes=5),
+        end_dt=end - timedelta(minutes=5),
+        exchange=None,
+        include_after_hours=True,
+        source="Trades",
+    )
+
+    assert second.empty
+    assert calls["fetch"] == 1
+
+
 def test_unresolvable_stock_conid_uses_negative_cache(monkeypatch, tmp_path):
     import lumibot.tools.ibkr_helper as ibkr_helper
 


### PR DESCRIPTION
## Summary
- reject stale strict intraday bars inside sparse cache frames
- treat malformed rebuilt IBKR history windows as terminal no-data windows
- document Greg BTC stale-fill cache/downloader proof

## Tests
- /Users/robertgrzesik/Development/bin/safe-timeout 240 python3 -m pytest tests/test_ibkr_helper_unit.py tests/test_data_entity.py tests/test_interactive_brokers_rest_backtesting_unit.py tests/test_routed_backtesting_ibkr_daily_prefetch.py tests/test_ibkr_crypto_backtesting_smoke_stubbed.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict intraday bar staleness detection to prevent using stale market data.

* **Bug Fixes**
  * Fixed stale fills in sparse intraday cache frames.
  * Eliminated repeated refetch attempts for malformed broker history responses.
  * Improved malformed history response handling to treat certain failures as terminal.

* **Documentation**
  * Updated investigation documentation with production validation results and cache audit findings.

* **Tests**
  * Added tests for bar staleness detection and malformed history response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->