### PR TITLE
Force broker token refresh for snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.5.52 - Unreleased
+
+### Fixed
+- **BotSpot snapshot runs can force Schwab and Tradier OAuth token refresh.** Schwab rewrites the existing token file on startup when requested, Tradier OAuth writes the existing BotSpot rotation handoff artifact, and Tradier API-token mode remains unchanged.
+
 ## 4.5.50 - Unreleased
 
 ## 4.5.49 - Unreleased

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -33,6 +33,17 @@ from lumibot.trading_builtins import PollingStream
 LUMI_DEFAULT_APP_KEY = "RfUVxotUc8p6CbeCwFmophgNZSat0TLv"
 LUMI_DEFAULT_CALLBACK = "https://api.botspot.trade/broker_oauth/schwab"
 
+
+def _botspot_force_broker_token_refresh() -> bool:
+    return (os.environ.get("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "y",
+        "on",
+    }
+
+
 class Schwab(Broker):
     """
     Broker implementation for Schwab API.
@@ -169,8 +180,7 @@ class Schwab(Broker):
             self.schwab_authorization_error = True
             raise ValueError("Schwab App Key (SCHWAB_APP_KEY) not found in config or environment variables.")
 
-        # Remove all app_secret handling
-        logger.info("[Schwab] SCHWAB_APP_SECRET is no longer used by this Python client.")
+        logger.info("[Schwab] SCHWAB_APP_SECRET is used only for OAuth token refresh when configured.")
 
         schwab_backend_redirect_uri = (
             config.get("SCHWAB_BACKEND_CALLBACK_URL")
@@ -287,9 +297,29 @@ class Schwab(Broker):
             def _update_token(updated_token):
                 """Write refreshed token back to token.json so it persists across restarts."""
                 try:
+                    if not isinstance(updated_token, dict):
+                        raise ValueError("Refreshed Schwab token payload is not a JSON object.")
+                    next_token = dict(token_dict_for_session)
+                    next_token.update(updated_token)
+                    if not next_token.get("refresh_token") and token_dict_for_session.get("refresh_token"):
+                        next_token["refresh_token"] = token_dict_for_session["refresh_token"]
+                    now_ms = int(time.time() * 1000)
+                    next_token.setdefault("issued_at", now_ms)
+                    next_token.setdefault("refresh_token_issued_at", token_dict_for_session.get("refresh_token_issued_at", now_ms))
+                    next_token.setdefault("expires_in", token_dict_for_session.get("expires_in", 1800))
+                    next_token.setdefault(
+                        "refresh_token_expires_in",
+                        token_dict_for_session.get("refresh_token_expires_in", 90 * 24 * 3600),
+                    )
+                    next_token.setdefault("token_type", token_dict_for_session.get("token_type", "Bearer"))
+                    next_token.setdefault("scope", token_dict_for_session.get("scope", "api"))
+                    next_token.pop("id_token", None)
+
+                    token_dict_for_session.clear()
+                    token_dict_for_session.update(next_token)
                     wrapped = {
-                        "creation_timestamp": int(time.time()),
-                        "token": updated_token,
+                        "creation_timestamp": wrapped_token_data.get("creation_timestamp", int(time.time())),
+                        "token": token_dict_for_session,
                     }
                     with open(token_path, "w", encoding="utf-8") as fp:
                         json.dump(wrapped, fp)
@@ -325,6 +355,24 @@ class Schwab(Broker):
 
                 #create refresh hook. This is beacuse oa2session does not perform refreshes with auth headers, only with json bodies. 
                 oauth_session.register_compliance_hook("refresh_token_request", _refresh_token_hook)
+
+            if _botspot_force_broker_token_refresh():
+                refresh_token_value = token_dict_for_session.get("refresh_token")
+                if not refresh_token_value:
+                    raise ConnectionError("[Schwab] Forced token refresh requires a refresh_token.")
+                if not client_secret_env:
+                    raise ConnectionError("[Schwab] Forced token refresh requires SCHWAB_APP_SECRET.")
+                try:
+                    refreshed_token = oauth_session.refresh_token(
+                        oauth_session.auto_refresh_url,
+                        refresh_token=refresh_token_value,
+                        **refresh_kwargs,
+                    )
+                except Exception as e_refresh:
+                    raise ConnectionError("[Schwab] Forced token refresh failed for BotSpot snapshot runtime.") from e_refresh
+                if not isinstance(refreshed_token, dict) or not refreshed_token.get("access_token"):
+                    raise ConnectionError("[Schwab] Forced token refresh response did not include access_token.")
+                _update_token(refreshed_token)
 
             # NOTE: schwab-py >=1.6 removed the app_secret parameter from the Client constructor.
             # Passing it raises: TypeError: BaseClient.__init__() got an unexpected keyword argument 'app_secret'.

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -418,6 +418,7 @@ class Tradier(Broker):
 
         # Install request wrappers before Broker initializes streams/threads.
         self.data_source = data_source
+        self._apply_access_token(self._tradier_access_token)
         self._install_oauth_refresh_hooks()
 
         super().__init__(

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -27,6 +27,16 @@ from lumibot.trading_builtins import PollingStream
 logger = get_logger(__name__)
 
 
+def _botspot_force_broker_token_refresh() -> bool:
+    return (os.environ.get("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "y",
+        "on",
+    }
+
+
 class Tradier(Broker):
     """
     Broker that connects to Tradier API to place orders and retrieve data. Tradier API only supports Order streaming
@@ -385,8 +395,13 @@ class Tradier(Broker):
         self._tradier_paper = paper
         self.polling_interval = polling_interval
 
-        # If this is an OAuth token, refresh before building API clients (best-effort).
-        self._refresh_oauth_token(force=False)
+        # If this is an OAuth token, refresh before building API clients. Snapshot
+        # runtimes can force this so BotSpot receives fresh token material to persist.
+        force_token_refresh = _botspot_force_broker_token_refresh()
+        if self._oauth_enabled():
+            refreshed = self._refresh_oauth_token(force=force_token_refresh)
+            if force_token_refresh and not refreshed:
+                raise RuntimeError("[Tradier] Forced OAuth token refresh failed for BotSpot snapshot runtime.")
 
         # Create the Tradier object
         self.tradier = _Tradier(account_number, self._tradier_access_token, paper)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.51",
+    version="4.5.52",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -1,6 +1,9 @@
 """
 Simple test cases for broker initialization error handling.
 """
+import json
+import time
+
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -72,3 +75,111 @@ class TestBrokerInitializationSimple:
         except Exception as e:
             # Other exceptions are acceptable for this test since we're only testing the broker None case
             pass
+
+
+def test_schwab_force_refresh_on_startup_rewrites_token(monkeypatch, tmp_path):
+    from lumibot.brokers import broker as broker_module
+    from lumibot.brokers import schwab as schwab_module
+    import requests_oauthlib
+
+    token_path = tmp_path / "schwab_token.json"
+    token_path.write_text(
+        json.dumps(
+            {
+                "creation_timestamp": 1,
+                "token": {
+                    "access_token": "old-access",
+                    "refresh_token": "old-refresh",
+                    "issued_at": int(time.time() * 1000),
+                    "expires_in": 1800,
+                    "refresh_token_issued_at": int(time.time() * 1000),
+                    "refresh_token_expires_in": 7776000,
+                    "token_type": "Bearer",
+                    "scope": "api",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class _OAuth2Session:
+        instances = []
+
+        def __init__(
+            self,
+            *,
+            client_id,
+            token,
+            auto_refresh_url,
+            auto_refresh_kwargs,
+            token_updater,
+        ):
+            self.client_id = client_id
+            self.token = token
+            self.auto_refresh_url = auto_refresh_url
+            self.auto_refresh_kwargs = auto_refresh_kwargs
+            self.token_updater = token_updater
+            self.refresh_calls = []
+            self.hooks = []
+            self.instances.append(self)
+
+        def register_compliance_hook(self, hook_type, hook):
+            self.hooks.append((hook_type, hook))
+
+        def refresh_token(self, token_url, *, refresh_token, **kwargs):
+            self.refresh_calls.append(
+                {
+                    "token_url": token_url,
+                    "refresh_token": refresh_token,
+                    "kwargs": kwargs,
+                }
+            )
+            return {
+                "access_token": "new-access",
+                "refresh_token": "new-refresh",
+                "expires_in": 1800,
+                "issued_at": int(time.time() * 1000),
+            }
+
+    class _AccountResponse:
+        status_code = 200
+
+        def json(self):
+            return [{"accountNumber": "12345678", "hashValue": "hash-123"}]
+
+    class _Client:
+        def __init__(self, *, api_key, session):
+            self.api_key = api_key
+            self.session = session
+
+        def get_account_numbers(self):
+            return _AccountResponse()
+
+    monkeypatch.setenv("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH", "true")
+    monkeypatch.setenv("SCHWAB_APP_SECRET", "secret")
+    monkeypatch.setattr(requests_oauthlib, "OAuth2Session", _OAuth2Session)
+    monkeypatch.setattr(schwab_module, "Client", _Client)
+    monkeypatch.setattr(broker_module.Broker, "_start_orders_thread", lambda self: None)
+    monkeypatch.setattr(schwab_module.Schwab, "_finish_initialization", lambda self, *args, **kwargs: None)
+    monkeypatch.setattr(schwab_module.Schwab, "_get_stream_object", lambda self: None)
+
+    broker = schwab_module.Schwab(
+        config={
+            "SCHWAB_ACCOUNT_NUMBER": "5678",
+            "SCHWAB_APP_KEY": "app-key",
+            "SCHWAB_APP_SECRET": "secret",
+            "SCHWAB_TOKEN_PATH": str(token_path),
+        }
+    )
+
+    assert broker.client.session.refresh_calls == [
+        {
+            "token_url": "https://api.schwabapi.com/v1/oauth/token",
+            "refresh_token": "old-refresh",
+            "kwargs": {"client_id": "app-key", "client_secret": "secret"},
+        }
+    ]
+    rewritten = json.loads(token_path.read_text(encoding="utf-8"))
+    assert rewritten["creation_timestamp"] == 1
+    assert rewritten["token"]["access_token"] == "new-access"
+    assert rewritten["token"]["refresh_token"] == "new-refresh"

--- a/tests/test_tradier_force_refresh.py
+++ b/tests/test_tradier_force_refresh.py
@@ -5,6 +5,7 @@ import time
 import pytest
 
 from lumibot.brokers.tradier import Tradier
+from lumibot.data_sources.tradier_data import TradierData
 
 
 def _b64url(payload: dict) -> str:
@@ -86,6 +87,16 @@ def test_oauth_force_refresh_failure_raises(monkeypatch):
     monkeypatch.setenv("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH", "true")
     monkeypatch.setenv("DATADOWNLOADER_BASE_URL", "http://127.0.0.1:1")
     monkeypatch.setenv("DATADOWNLOADER_API_KEY", "test")
+    monkeypatch.delenv("TRADIER_OAUTH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("TRADIER_OAUTH_CLIENT_SECRET", raising=False)
+
+    from lumibot.brokers import tradier as tradier_module
+
+    monkeypatch.setattr(
+        tradier_module.requests,
+        "post",
+        lambda *args, **kwargs: pytest.fail("Forced-refresh failure test must not call network"),
+    )
 
     with pytest.raises(RuntimeError, match="Forced OAuth token refresh failed"):
         Tradier(
@@ -109,3 +120,54 @@ def test_force_refresh_is_noop_for_api_token_mode(monkeypatch):
 
     broker = Tradier(account_number="1234", access_token="api-token", paper=True, connect_stream=False)
     assert broker._tradier_access_token == "api-token"
+
+
+def test_oauth_force_refresh_updates_external_data_source(monkeypatch):
+    token_json = {
+        "access_token": "old-access",
+        "refresh_token": "old-refresh",
+        "expires_in": 86400,
+        "issued_at": int(time.time() * 1000),
+    }
+    monkeypatch.setenv("TRADIER_TOKEN", _b64url(token_json))
+    monkeypatch.setenv("TRADIER_REFRESH_TOKEN", "old-refresh")
+    monkeypatch.setenv("TRADIER_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("TRADIER_OAUTH_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH", "true")
+    monkeypatch.setenv("DATADOWNLOADER_BASE_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("DATADOWNLOADER_API_KEY", "test")
+
+    class _Resp:
+        ok = True
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {
+                "access_token": "forced-access",
+                "refresh_token": "forced-refresh",
+                "expires_in": 86400,
+                "issued_at": int(time.time() * 1000),
+            }
+
+    from lumibot.brokers import tradier as tradier_module
+
+    monkeypatch.setattr(tradier_module.requests, "post", lambda *args, **kwargs: _Resp())
+
+    data_source = TradierData(
+        account_number="1234",
+        access_token="old-access",
+        paper=True,
+        delay=15,
+    )
+
+    broker = Tradier(
+        config={"ACCESS_TOKEN": None, "ACCOUNT_NUMBER": "1234", "PAPER": True},
+        data_source=data_source,
+        connect_stream=False,
+    )
+
+    assert broker.data_source is data_source
+    assert broker._tradier_access_token == "forced-access"
+    assert data_source.api_key == "forced-access"
+    assert data_source.tradier.AUTH_TOKEN == "forced-access"

--- a/tests/test_tradier_force_refresh.py
+++ b/tests/test_tradier_force_refresh.py
@@ -33,6 +33,8 @@ def test_oauth_force_refresh_when_not_expired_writes_botspot_rotation_artifact(m
     monkeypatch.setenv("TRADIER_OAUTH_CLIENT_SECRET", "secret")
     monkeypatch.setenv("BOTSPOT_TRADIER_TOKEN_ROTATION_PATH", str(rotation_path))
     monkeypatch.setenv("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH", "true")
+    monkeypatch.setenv("DATADOWNLOADER_BASE_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("DATADOWNLOADER_API_KEY", "test")
 
     class _Resp:
         ok = True
@@ -82,6 +84,8 @@ def test_oauth_force_refresh_failure_raises(monkeypatch):
     monkeypatch.setenv("TRADIER_TOKEN", _b64url(token_json))
     monkeypatch.setenv("TRADIER_REFRESH_TOKEN", "old-refresh")
     monkeypatch.setenv("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH", "true")
+    monkeypatch.setenv("DATADOWNLOADER_BASE_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("DATADOWNLOADER_API_KEY", "test")
 
     with pytest.raises(RuntimeError, match="Forced OAuth token refresh failed"):
         Tradier(
@@ -94,6 +98,8 @@ def test_force_refresh_is_noop_for_api_token_mode(monkeypatch):
     from lumibot.brokers import tradier as tradier_module
 
     monkeypatch.setenv("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH", "true")
+    monkeypatch.setenv("DATADOWNLOADER_BASE_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("DATADOWNLOADER_API_KEY", "test")
     monkeypatch.delenv("TRADIER_TOKEN", raising=False)
     monkeypatch.setattr(
         tradier_module.requests,

--- a/tests/test_tradier_force_refresh.py
+++ b/tests/test_tradier_force_refresh.py
@@ -1,0 +1,105 @@
+import base64
+import json
+import time
+
+import pytest
+
+from lumibot.brokers.tradier import Tradier
+
+
+def _b64url(payload: dict) -> str:
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _decode_b64url(payload: str) -> dict:
+    missing_padding = len(payload) % 4
+    if missing_padding:
+        payload += "=" * (4 - missing_padding)
+    return json.loads(base64.urlsafe_b64decode(payload.encode("ascii")).decode("utf-8"))
+
+
+def test_oauth_force_refresh_when_not_expired_writes_botspot_rotation_artifact(monkeypatch, tmp_path):
+    token_json = {
+        "access_token": "old-access",
+        "refresh_token": "old-refresh",
+        "expires_in": 86400,
+        "issued_at": int(time.time() * 1000),
+    }
+    rotation_path = tmp_path / "tradier_token_rotation.json"
+    monkeypatch.setenv("TRADIER_TOKEN", _b64url(token_json))
+    monkeypatch.setenv("TRADIER_REFRESH_TOKEN", "old-refresh")
+    monkeypatch.setenv("TRADIER_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("TRADIER_OAUTH_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("BOTSPOT_TRADIER_TOKEN_ROTATION_PATH", str(rotation_path))
+    monkeypatch.setenv("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH", "true")
+
+    class _Resp:
+        ok = True
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {
+                "access_token": "forced-access",
+                "refresh_token": "forced-refresh",
+                "expires_in": 86400,
+                "issued_at": int(time.time() * 1000),
+            }
+
+    from lumibot.brokers import tradier as tradier_module
+
+    refresh_calls = []
+
+    def _fake_post(*args, **kwargs):
+        refresh_calls.append((args, kwargs))
+        return _Resp()
+
+    monkeypatch.setattr(tradier_module.requests, "post", _fake_post)
+
+    broker = Tradier(
+        config={"ACCESS_TOKEN": None, "ACCOUNT_NUMBER": "1234", "PAPER": True},
+        connect_stream=False,
+    )
+
+    assert refresh_calls
+    assert broker._tradier_access_token == "forced-access"
+    artifact = json.loads(rotation_path.read_text(encoding="utf-8"))
+    assert artifact["TRADIER_ACCESS_TOKEN"] == "forced-access"
+    assert artifact["TRADIER_REFRESH_TOKEN"] == "forced-refresh"
+    decoded_token = _decode_b64url(artifact["TRADIER_TOKEN"])
+    assert decoded_token["access_token"] == "forced-access"
+    assert decoded_token["refresh_token"] == "forced-refresh"
+
+
+def test_oauth_force_refresh_failure_raises(monkeypatch):
+    token_json = {
+        "access_token": "old-access",
+        "refresh_token": "old-refresh",
+        "expires_in": 86400,
+        "issued_at": int(time.time() * 1000),
+    }
+    monkeypatch.setenv("TRADIER_TOKEN", _b64url(token_json))
+    monkeypatch.setenv("TRADIER_REFRESH_TOKEN", "old-refresh")
+    monkeypatch.setenv("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH", "true")
+
+    with pytest.raises(RuntimeError, match="Forced OAuth token refresh failed"):
+        Tradier(
+            config={"ACCESS_TOKEN": None, "ACCOUNT_NUMBER": "1234", "PAPER": True},
+            connect_stream=False,
+        )
+
+
+def test_force_refresh_is_noop_for_api_token_mode(monkeypatch):
+    from lumibot.brokers import tradier as tradier_module
+
+    monkeypatch.setenv("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH", "true")
+    monkeypatch.delenv("TRADIER_TOKEN", raising=False)
+    monkeypatch.setattr(
+        tradier_module.requests,
+        "post",
+        lambda *args, **kwargs: pytest.fail("API-token mode must not call OAuth refresh"),
+    )
+
+    broker = Tradier(account_number="1234", access_token="api-token", paper=True, connect_stream=False)
+    assert broker._tradier_access_token == "api-token"


### PR DESCRIPTION
Summary
- Force Schwab OAuth refresh for BotSpot snapshot runtimes and persist through the existing token updater.
- Force Tradier OAuth refresh for snapshot runtimes and write the BotSpot rotation handoff fields.
- Re-apply refreshed Tradier OAuth access tokens to externally supplied TradierData instances before broker startup continues.
- Leave Tradier API-token mode as a no-op for forced refresh.
- Bump package version to 4.5.52.

Review notes
- Security review found no surviving reportable issues in the changed runtime paths.
- Forced Tradier tests were split into a dedicated file to keep the existing test module under the review-size threshold.
- Follow-up review comments were addressed in the forced-refresh tests and Tradier data-source token alignment path.

Tests
- /Users/martin/Documents/LW/lumibot/.venv/bin/python -m pytest tests/test_tradier_force_refresh.py -q
- /Users/martin/Documents/LW/lumibot/.venv/bin/python -m pytest tests/test_tradier.py tests/test_tradier_force_refresh.py tests/test_tradier_oauth_refresh.py tests/test_broker_initialization.py -q
- git diff --check
- gitleaks git . --log-opts origin/dev..HEAD --redact --exit-code 99
