### PR TITLE
Release 4.5.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-## 4.5.53 - Unreleased
+## 4.5.53 - 2026-06-24
+
+Deploy marker: `deploy 4.5.53`
+
+### Fixed
+- **Coinbase/CCXT same-day downloads no longer request future candles.** Crypto
+  OHLCV cache downloads clamp current-UTC-day requests to the current time and
+  return an empty frame for fully future windows, preventing Coinbase from
+  rejecting active backtests with `start must not be in the future`.
+
+### Tests
+- **CCXT cache regressions now cover current-day and future-only windows.** Unit
+  tests assert current-day downloads are clamped before calling the provider and
+  fully future requests do not hit Coinbase.
 
 ## 4.5.52 - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.53 - Unreleased
+
 ## 4.5.52 - 2026-06-23
 
 Deploy marker: `deploy 4.5.52`

--- a/docs/CRYPTO_BACKTEST_VALIDATION.md
+++ b/docs/CRYPTO_BACKTEST_VALIDATION.md
@@ -2,7 +2,7 @@
 
 One-line description: Controlled validation plan and artifact runner for CCXT/Coinbase crypto backtesting.
 
-Last Updated: 2026-06-22
+Last Updated: 2026-06-24
 
 Status: Active validation workflow
 
@@ -101,6 +101,71 @@ The `buy_hold` case intentionally uses `allocation=1.0` so the strategy line
 should track the same-asset benchmark line. If those lines materially diverge,
 first check the fill price, position quantity, and remaining cash before
 treating the tear sheet as data-provider proof.
+
+### 2026-06-24 Same-Day Coinbase Future-Tail Fix
+
+Greg's production backtest `c6438f71-06a4-473f-871a-1a28f81ceae7`
+failed on `2026-06-24` with:
+
+```text
+ccxt.base.errors.BadRequest: coinbase {"error":"INVALID_ARGUMENT","error_details":"start must not be in the future","message":"start must not be in the future"}
+```
+
+The failed run requested `2026-06-17` through `2026-06-24`. LumiBot correctly
+converted the New York midnight end to `2026-06-24 04:00:00` UTC for the final
+returned rows, but the cache downloader expanded the provider download range to
+the full UTC day: `2026-06-24 23:59:59.999999`. On the current UTC day, that
+lets CCXT pagination advance into a future `since` value, which Coinbase rejects.
+
+Fix:
+
+- Cache windows still expand historical requests to UTC date buckets.
+- If the expanded end is later than the provider's current UTC time, the
+  provider download end is clamped to now.
+- Future-only windows return an empty OHLCV frame without calling the provider.
+- The final dataframe is still filtered to the caller's original requested
+  start/end, so the current-day cache tail does not leak future bars into a
+  shorter backtest window.
+
+Focused proof:
+
+```bash
+/Users/robertgrzesik/bin/safe-timeout 300s python3 -m pytest tests/test_ccxt_store.py -q
+```
+
+Result: `16 passed, 2 skipped`.
+
+Broader crypto regression proof:
+
+```bash
+/Users/robertgrzesik/bin/safe-timeout 1200s python3 -m pytest \
+  tests/test_ccxt_store.py \
+  tests/test_backtesting_ccxt_execution_semantics.py \
+  tests/test_hour_timestep_support.py \
+  tests/test_routed_backtesting_unit.py \
+  tests/test_routed_backtesting_routing_validation.py \
+  tests/test_crypto_backtest_validation_runner.py \
+  tests/test_crypto_backtesting_order_matrix.py -q
+```
+
+Result: `77 passed, 2 skipped`.
+
+Public Coinbase same-day probe:
+
+- Artifact root:
+  `/Users/robertgrzesik/Development/support-artifacts/ccxt-today-edge-20260624`
+- Request shape: `BTC/USDT`, `1m`, `2026-06-17 04:00:00` UTC through
+  `2026-06-24 04:00:00` UTC.
+- Machine now during probe: `2026-06-24 18:16:02` UTC.
+- Provider download range used by LumiBot:
+  `2026-06-17 00:00:00` through `2026-06-24 18:16:02.395109`, not the future
+  end of day.
+- Cache coverage after the probe:
+  `2026-06-17 00:01:00` through `2026-06-24 18:16:00`, `5496` actual candles.
+- No Coinbase `start must not be in the future` error occurred.
+
+No production deploy was performed for this fix during the local validation
+pass.
 
 ### 2026-06-22 Long Coinbase Matrix And Sparse-Page Cache Fix
 

--- a/lumibot/tools/ccxt_data_store.py
+++ b/lumibot/tools/ccxt_data_store.py
@@ -92,6 +92,28 @@ class CcxtCacheDB:
             return value.replace(tzinfo=None)
         return value.astimezone(timezone.utc).replace(tzinfo=None)
 
+    def _current_utc_naive(self) -> datetime:
+        return datetime.utcnow().replace(tzinfo=None)
+
+    def _normalize_download_window(self, start: datetime, end: datetime | None) -> tuple[datetime, datetime]:
+        """Expand cache windows by UTC date without requesting future provider bars."""
+        now_dt = self._current_utc_naive()
+        if end is None:
+            end = now_dt
+
+        start_dt = self._to_utc_naive(start)
+        end_dt = self._to_utc_naive(end)
+
+        # Cache coverage is tracked by UTC date buckets, but same-day requests
+        # must stop at the provider's current time. Coinbase rejects OHLCV calls
+        # whose paginated ``since`` value drifts into the future.
+        start_dt = start_dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        end_dt = end_dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+        if end_dt > now_dt:
+            end_dt = now_dt
+
+        return start_dt, end_dt
+
 
     def get_cache_file_name(self, symbol:str, timeframe:str)->str:
         """Returns the cache file name. If the cache folder does not exist, it is created.
@@ -186,25 +208,27 @@ class CcxtCacheDB:
                        Use datetime as the index.
                        datetime, open, high, low, close, volume, missing columns.
         """
-        if end is None:
-            end = datetime.utcnow()
-
         if limit is None:
             limit = self.max_download_limit
 
-        start_dt = self._to_utc_naive(start)
-        end_dt = self._to_utc_naive(end)
+        if timeframe not in _TIMEFRAME_SECONDS:
+            raise ValueError(f"Unsupported CCXT timeframe {timeframe!r}; expected one of {sorted(_TIMEFRAME_SECONDS)}")
 
-        # set start_dt to 00:00:00 and end_dt to 23:59:59
-        start_dt = start_dt.replace(hour=0, minute=0, second=0, microsecond=0)
-        end_dt = end_dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+        start_dt, end_dt = self._normalize_download_window(start, end)
+        if start_dt > end_dt:
+            self.logger.warning(
+                "Requested CCXT range starts after the provider's current time; "
+                "no historical bars are available yet for %s %s.",
+                symbol,
+                timeframe,
+            )
+            empty = self._empty_ohlcv_frame()
+            empty.set_index("datetime", inplace=True)
+            return empty
 
         download_ranges,overap_range_ids,cache_range = self._calc_download_ranges(symbol, timeframe,start_dt, end_dt)
 
         self.logger.info(f"download ranges :\n{self._table_str(download_ranges,headers=['from','to'])}")
-
-        if timeframe not in _TIMEFRAME_SECONDS:
-            raise ValueError(f"Unsupported CCXT timeframe {timeframe!r}; expected one of {sorted(_TIMEFRAME_SECONDS)}")
 
         for download_start,download_end in download_ranges:
             range_cnt = self._count_timeframe_units(download_start, download_end, timeframe)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.52",
+    version="4.5.53",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_ccxt_store.py
+++ b/tests/test_ccxt_store.py
@@ -122,6 +122,68 @@ def test_ccxt_cache_converts_aware_request_bounds_to_utc_before_query(tmp_path, 
     assert list(df.index) == [pd.Timestamp("2026-03-15 04:00:00")]
 
 
+def test_ccxt_cache_clamps_current_utc_day_download_end_to_now(tmp_path, monkeypatch):
+    cache = _cache_without_live_exchange(tmp_path, monkeypatch)
+    ny = pytz.timezone("America/New_York")
+    now = datetime(2026, 6, 24, 18, 15, 0, 123456)
+    requested_end_utc = datetime(2026, 6, 24, 4, 0)
+    calls = []
+
+    monkeypatch.setattr(cache, "_current_utc_naive", lambda: now)
+
+    def fake_get_barset(symbol, timeframe, limit, start, end):
+        calls.append({"symbol": symbol, "timeframe": timeframe, "start": start, "end": end})
+        return _bars(
+            (requested_end_utc, 100.0, 101.0, 99.0, 100.5, 10.0),
+            (now.replace(microsecond=0), 110.0, 111.0, 109.0, 110.5, 11.0),
+        )
+
+    monkeypatch.setattr(cache, "_get_barset_from_api", fake_get_barset)
+
+    df = cache.download_ohlcv(
+        "BTC/USDT",
+        "1m",
+        ny.localize(datetime(2026, 6, 17, 0, 0)),
+        ny.localize(datetime(2026, 6, 24, 0, 0)),
+    )
+
+    assert calls
+    assert calls[0]["start"] == datetime(2026, 6, 17, 0, 0)
+    assert calls[0]["end"] == now
+    assert pd.Timestamp("2026-06-24 04:00:00") in df.index
+    assert pd.Timestamp(now.replace(microsecond=0)) not in df.index
+
+    with duckdb.connect(cache.get_cache_file_name("BTC/USDT", "1m")) as con:
+        ranges = con.execute("select start_dt, end_dt from cache_dt_ranges").fetch_df()
+    assert ranges.iloc[0].start_dt == datetime(2026, 6, 17, 0, 0)
+    assert ranges.iloc[0].end_dt == now
+
+
+def test_ccxt_cache_future_only_window_returns_empty_without_provider_call(tmp_path, monkeypatch):
+    cache = _cache_without_live_exchange(tmp_path, monkeypatch)
+    now = datetime(2026, 6, 24, 18, 15, 0)
+    calls = {"count": 0}
+
+    monkeypatch.setattr(cache, "_current_utc_naive", lambda: now)
+
+    def fake_get_barset(symbol, timeframe, limit, start, end):
+        calls["count"] += 1
+        raise AssertionError("future-only requests must not reach the provider")
+
+    monkeypatch.setattr(cache, "_get_barset_from_api", fake_get_barset)
+
+    df = cache.download_ohlcv(
+        "BTC/USDT",
+        "1m",
+        datetime(2026, 6, 25, 0, 0),
+        datetime(2026, 6, 25, 1, 0),
+    )
+
+    assert df.empty
+    assert calls["count"] == 0
+    assert not os.path.exists(cache.get_cache_file_name("BTC/USDT", "1m"))
+
+
 def test_ccxt_cache_uses_native_day_timeframe_without_synthesizing_missing_days(tmp_path, monkeypatch):
     cache = _cache_without_live_exchange(tmp_path, monkeypatch)
     calls = []


### PR DESCRIPTION
## Scope
- Clamp Coinbase/CCXT current-day OHLCV downloads to the current UTC time so active same-day crypto backtests do not request future candles.
- Add regression tests for current-day clamp and future-only windows.
- Update 4.5.53 changelog.

## Validation
- .venv/bin/python -m pytest tests/test_ccxt_store.py -q
- .venv/bin/python -m pytest tests/test_backtesting_ccxt_execution_semantics.py tests/test_crypto_backtesting_order_matrix.py -q
- Production pre-deploy Greg revision reproduction failed with Coinbase: start must not be in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed same-day crypto download requests so future candles are no longer requested, preventing provider rejections during active backtests.
  * Future-only time windows now return an empty result instead of triggering a failed download.

* **Tests**
  * Added regression coverage for current-day clamping and future-only request handling.

* **Documentation**
  * Updated the validation guide and added a new release entry for 4.5.53.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->