### PR TITLE
fix: fail loudly on Alpaca permission errors

### DIFF
--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -21,9 +21,25 @@ from lumibot.tools.helpers import has_more_than_n_decimal_places
 from lumibot.tools.lumibot_logger import get_logger
 from lumibot.trading_builtins import PollingStream
 
-from .broker import Broker
+from .broker import Broker, LumibotBrokerAPIError
 
 logger = get_logger(__name__)
+
+
+def _is_alpaca_permission_error(error: Exception) -> bool:
+    message = str(error).lower()
+    return any(
+        marker in message
+        for marker in (
+            "40310000",
+            "403",
+            "forbidden",
+            "insufficient permission",
+            "insufficient-permission",
+            "permission denied",
+            "not authorized",
+        )
+    )
 
 
 # Create our own OrderData class to pass to the API because this is easier to work with
@@ -980,6 +996,10 @@ class Alpaca(Broker):
 
         except Exception as e:
             order.set_error(e)
+            try:
+                self._process_trade_event(order, self.ERROR_ORDER, error=e)
+            except Exception:
+                logger.error("Failed to publish Alpaca order rejection event.", exc_info=True)
             message = str(e)
             if "stop price must not be greater than base price / 1.001" in message:
                 logger.error(
@@ -1009,6 +1029,10 @@ class Alpaca(Broker):
                         color="red",
                     )
                 )
+            if _is_alpaca_permission_error(e):
+                raise LumibotBrokerAPIError(
+                    f"Alpaca broker permission failure while submitting {order}: {message}"
+                ) from e
 
         return order
 

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -596,13 +596,23 @@ def _sync_xai_api_key_alias() -> None:
 
 
 def _sync_gemini_api_key_alias() -> None:
-    """Allow product-facing GEMINI_API_KEY with Google SDK internals.
+    """Keep product-facing GEMINI_API_KEY and Google SDK internals aligned.
 
     Google examples and some SDK paths use GOOGLE_API_KEY. LumiBot's public
-    docs use GEMINI_API_KEY, so mirror it when the Google name is absent.
+    docs and BotSpot saved-env contract use GEMINI_API_KEY. Treat GEMINI_API_KEY
+    as canonical when both names are present so deployments do not silently use a
+    different Google key than the one selected for the strategy.
     """
-    if not os.environ.get("GOOGLE_API_KEY") and os.environ.get("GEMINI_API_KEY"):
-        os.environ["GOOGLE_API_KEY"] = os.environ["GEMINI_API_KEY"]
+    gemini_key = os.environ.get("GEMINI_API_KEY")
+    google_key = os.environ.get("GOOGLE_API_KEY")
+    if gemini_key:
+        if google_key and google_key != gemini_key:
+            logging.getLogger(__name__).warning(
+                "Both GEMINI_API_KEY and GOOGLE_API_KEY are set; using GEMINI_API_KEY for Gemini runtime requests."
+            )
+        os.environ["GOOGLE_API_KEY"] = gemini_key
+    elif google_key:
+        os.environ["GEMINI_API_KEY"] = google_key
 
 
 def _sync_together_api_key_alias() -> None:
@@ -646,18 +656,34 @@ def _provider_prompt_cache_key(request: RuntimeRequest) -> str:
 def _model_context_limit_tokens(model: Any) -> int | None:
     if not isinstance(model, str):
         return None
+    raw_limit = os.environ.get("LUMIBOT_AGENT_CONTEXT_LIMIT_TOKENS")
+    if raw_limit:
+        try:
+            return max(int(raw_limit), 1_000)
+        except Exception:
+            pass
     lower = model.strip().lower()
     if lower.startswith("deepseek/deepseek-v4-"):
         return 1_048_576
+    if lower.startswith("gemini-") or lower.startswith("google/gemini") or lower.startswith("google_ai/gemini"):
+        return 1_000_000
     return None
 
 
 def _model_context_string_limit_chars(model: Any) -> int | None:
     if not isinstance(model, str):
         return None
+    raw_limit = os.environ.get("LUMIBOT_AGENT_CONTEXT_STRING_MAX_CHARS")
+    if raw_limit:
+        try:
+            return max(int(raw_limit), 1_000)
+        except Exception:
+            pass
     lower = model.strip().lower()
     if lower.startswith("deepseek/deepseek-v4-"):
         return 20_000
+    if lower.startswith("gemini-") or lower.startswith("google/gemini") or lower.startswith("google_ai/gemini"):
+        return 50_000
     return None
 
 
@@ -762,7 +788,7 @@ def _prune_tool_response_for_context_window(tool_response: Any, *, tool_name: st
         "original_chars": response_chars,
         "excerpt": _truncate_preserving_edges(serialized, max_chars, label=f"tool_response.{tool_name or 'unknown'}"),
         "message": (
-            "Tool response was shortened by Lumibot before sending it back to this DeepSeek model "
+            "Tool response was shortened by Lumibot before sending it back to this model "
             "because the provider context window would otherwise be exceeded. Call a targeted tool "
             "again if more detail is required."
         ),

--- a/tests/test_agent_runtime_provider_keys.py
+++ b/tests/test_agent_runtime_provider_keys.py
@@ -11,6 +11,8 @@ from lumibot.components.agents.runtime import (
     RuntimeRequest,
     _aggregate_usage_metadata,
     _resolve_model_for_adk,
+    _model_context_limit_tokens,
+    _model_context_string_limit_chars,
     _strip_thought_parts_from_litellm_request,
     _supports_explicit_temperature_for_adk_model,
     _sync_gemini_api_key_alias,
@@ -49,13 +51,32 @@ def test_gemini_api_key_alias_populates_google_api_key(monkeypatch):
     assert os.environ["GOOGLE_API_KEY"] == "gemini-test-key"
 
 
-def test_google_api_key_wins_over_gemini_alias(monkeypatch):
+def test_gemini_api_key_wins_over_google_alias(monkeypatch):
     monkeypatch.setenv("GOOGLE_API_KEY", "google-test-key")
     monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
 
     _sync_gemini_api_key_alias()
 
+    assert os.environ["GOOGLE_API_KEY"] == "gemini-test-key"
+    assert os.environ["GEMINI_API_KEY"] == "gemini-test-key"
+
+
+def test_google_api_key_populates_gemini_alias(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-test-key")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    _sync_gemini_api_key_alias()
+
     assert os.environ["GOOGLE_API_KEY"] == "google-test-key"
+    assert os.environ["GEMINI_API_KEY"] == "google-test-key"
+
+
+def test_gemini_models_have_runtime_context_budget(monkeypatch):
+    monkeypatch.delenv("LUMIBOT_AGENT_CONTEXT_LIMIT_TOKENS", raising=False)
+    monkeypatch.delenv("LUMIBOT_AGENT_CONTEXT_STRING_MAX_CHARS", raising=False)
+
+    assert _model_context_limit_tokens("gemini-3.1-pro") == 1_000_000
+    assert _model_context_string_limit_chars("gemini-3.1-pro") == 50_000
 
 
 def test_together_api_key_alias_populates_litellm_key(monkeypatch):

--- a/tests/test_alpaca.py
+++ b/tests/test_alpaca.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 from lumibot.entities import Asset, Order
 from lumibot.brokers.alpaca import Alpaca
+from lumibot.brokers.broker import LumibotBrokerAPIError
 from lumibot.data_sources.alpaca_data import AlpacaData
 from lumibot.example_strategies.stock_buy_and_hold import BuyAndHold
 from lumibot.credentials import ALPACA_TEST_CONFIG
@@ -54,6 +55,22 @@ class TestAlpacaBroker:
         order = Order(asset=Asset("SPY"), quantity=10, side=Order.OrderSide.BUY, strategy='abc')
         broker.submit_order(order=order)
         broker._conform_order.assert_called_once()
+
+    def test_alpaca_permission_rejection_publishes_error_event_and_fails_loudly(self):
+        broker = Alpaca(ALPACA_UNIT_CONFIG, connect_stream=False)
+        broker.api.submit_order = MagicMock(side_effect=Exception("40310000 insufficient permission to trade"))
+        broker._process_trade_event = MagicMock()
+        order = Order(asset=Asset("SPY"), quantity=10, side=Order.OrderSide.BUY, strategy='abc')
+
+        with pytest.raises(LumibotBrokerAPIError, match="Alpaca broker permission failure"):
+            broker._submit_order(order)
+
+        assert order.status == "error"
+        assert "insufficient permission" in order.error_message
+        broker._process_trade_event.assert_called_once()
+        args, kwargs = broker._process_trade_event.call_args
+        assert args[:2] == (order, broker.ERROR_ORDER)
+        assert "insufficient permission" in str(kwargs["error"])
 
     def test_limit_order_conforms_when_limit_price_gte_one_dollar(self):
         broker = Alpaca(ALPACA_UNIT_CONFIG, connect_stream=False)


### PR DESCRIPTION
## Summary\n- publish Alpaca order rejection events when submit_order raises\n- raise LumibotBrokerAPIError for Alpaca permission/auth rejections like 40310000 insufficient permission\n- make GEMINI_API_KEY canonical over GOOGLE_API_KEY and add Gemini context budgets\n\n## Validation\n- pytest -q tests/test_alpaca.py tests/test_agent_runtime_provider_keys.py -m 'not apitest'\n\nNote: full targeted run including apitest failed on existing live Alpaca test credentials with 401 Unauthorized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gemini and Google API keys now sync more predictably, with Gemini treated as the primary key when both are present.
  * Agent context limits can now be adjusted through environment settings for finer control.

* **Bug Fixes**
  * Order submission now reports permission-related broker failures more clearly.
  * Failed order submissions now consistently emit an error event and mark the order as errored.
  * Context-pruning messages were simplified to be more provider-neutral.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->