### PR TITLE
v4.5.54 - CCXT cache coverage fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
-## 4.5.54 - Unreleased
+## 4.5.54 - 2026-06-24
+
+Deploy marker: `deploy 4.5.54`
+
+### Fixed
+- **Coinbase/CCXT cache ranges now track actual returned candle coverage.**
+  Partial provider responses no longer mark the full requested window as cached,
+  so a BTC/USDT request that only receives bars through June 16 cannot hide a
+  missing June 17 tail from later backtest reads.
+- **Empty Coinbase/CCXT responses no longer create fake cache coverage.** Empty
+  provider responses leave no executable rows and no coverage metadata, forcing
+  future attempts to ask the provider again instead of trusting a phantom range.
+
+### Docs
+- **Crypto validation docs now record the post-deploy partial-coverage failure.**
+  The runbook explains why cache metadata must be derived from real candles and
+  cites the Greg production validation backtest that exposed the issue.
+
+### Tests
+- **CCXT cache regressions now cover partial underfills.** Tests assert a
+  partial June 16 response for a June 16-17 request does not certify June 17,
+  and that a later June 17 read refetches and stores the missing tail.
 
 ## 4.5.53 - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.54 - Unreleased
+
 ## 4.5.53 - 2026-06-24
 
 Deploy marker: `deploy 4.5.53`

--- a/docs/CRYPTO_BACKTEST_VALIDATION.md
+++ b/docs/CRYPTO_BACKTEST_VALIDATION.md
@@ -167,6 +167,48 @@ Public Coinbase same-day probe:
 No production deploy was performed for this fix during the local validation
 pass.
 
+### 2026-06-24 Partial Provider Coverage Must Not Certify The Requested Window
+
+The first production validation after the same-day Coinbase fix no longer hit
+Coinbase's future-window `BadRequest`, but Greg's unchanged BTC/USDT strategy
+still could not load `5m` bars. The production log for backtest
+`2eef9de5-6e6b-411c-85de-a1139b7efbfe` repeatedly reported that the strategy
+requested `2026-06-17 00:00:00-04:00`, while available data ended at
+`2026-06-16 23:59:00-04:00`.
+
+Root cause:
+
+- The downloader requested a wider cache window such as `2026-06-16` through
+  `2026-06-17`.
+- Coinbase/CCXT returned real candles only through `2026-06-16 23:59`.
+- `cache_dt_ranges` still marked the entire requested window as cached.
+- Warm reads then trusted the metadata and did not refetch the missing
+  `2026-06-17` tail, exposing stale cache coverage to the backtester.
+
+Fix:
+
+- Cache range metadata is now derived from actual executable rows written to
+  `candles`, not from the requested provider window.
+- The metadata end is the end of the last real candle interval. For example, a
+  final `1m` candle at `23:59:00` certifies coverage through
+  `23:59:59.999999`, not through a later requested day.
+- Empty provider responses create no fake coverage metadata. They may still
+  leave an empty cache file, but they do not hide missing bars from future
+  attempts.
+- Existing overlapping ranges are preserved and merged only with newly proven
+  real-row coverage.
+
+Focused proof:
+
+```bash
+/Users/robertgrzesik/Development/lumibot/.venv/bin/python -m pytest \
+  tests/test_ccxt_store.py \
+  tests/test_backtesting_ccxt_execution_semantics.py \
+  tests/test_crypto_backtesting_order_matrix.py -q
+```
+
+Result: `45 passed, 2 skipped`.
+
 ### 2026-06-22 Long Coinbase Matrix And Sparse-Page Cache Fix
 
 Root cause found during long BTC/USDT validation:

--- a/lumibot/tools/ccxt_data_store.py
+++ b/lumibot/tools/ccxt_data_store.py
@@ -3,7 +3,7 @@ import duckdb
 import os
 import uuid
 import ccxt
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from tabulate import tabulate
 import pandas as pd
 from pandas import DataFrame
@@ -230,6 +230,8 @@ class CcxtCacheDB:
 
         self.logger.info(f"download ranges :\n{self._table_str(download_ranges,headers=['from','to'])}")
 
+        downloaded_coverage_ranges = []
+
         for download_start,download_end in download_ranges:
             range_cnt = self._count_timeframe_units(download_start, download_end, timeframe)
 
@@ -240,29 +242,33 @@ class CcxtCacheDB:
                                            range_cnt, download_start, download_end)
             df = self._fill_missing_data(df, timeframe)
             self._cache_ohlcv(symbol, df, timeframe)
+            coverage_range = self._coverage_range_from_rows(df, download_start, download_end, timeframe)
+            if coverage_range is not None:
+                downloaded_coverage_ranges.append(coverage_range)
 
         cache_file = self.get_cache_file_name(symbol, timeframe)
 
-        if download_ranges:
-            if len(overap_range_ids) > 0:
-                start_dt = cache_range[0]
-                end_dt = cache_range[1]
-            else:
-                # Cache ranges are coverage metadata, not proof that every bar inside the
-                # range exists. Empty/no-tick responses still satisfy "we asked the
-                # provider for this window" so warm-cache reads do not keep retrying and
-                # never synthesize executable bars.
-                start_dt = cache_range[0]
-                end_dt = cache_range[1]
-
+        if downloaded_coverage_ranges:
             with duckdb.connect(cache_file) as con:
-                # insert new cache data range
-                con.execute("""INSERT INTO cache_dt_ranges VALUES (?, ?, ?)""",
-                            (str(uuid.uuid4().hex),start_dt,end_dt))
-                # delete overlapping ranges
+                coverage_ranges = downloaded_coverage_ranges
                 if len(overap_range_ids) > 0:
+                    old_ranges = []
+                    for range_id in overap_range_ids:
+                        old_ranges.extend(
+                            con.execute(
+                                """SELECT start_dt, end_dt FROM cache_dt_ranges WHERE id = ?""",
+                                (range_id,),
+                            ).fetchall()
+                        )
+                    coverage_ranges = old_ranges + coverage_ranges
                     params = [(id,) for id in overap_range_ids]
-                    con.executemany("""DELETE FROM  cache_dt_ranges WHERE id = ?""", params)
+                    con.executemany("""DELETE FROM cache_dt_ranges WHERE id = ?""", params)
+
+                for start_dt, end_dt in self._merge_coverage_ranges(coverage_ranges):
+                    con.execute(
+                        """INSERT INTO cache_dt_ranges VALUES (?, ?, ?)""",
+                        (str(uuid.uuid4().hex), start_dt, end_dt),
+                    )
 
         with duckdb.connect(cache_file) as con:
             df = con.execute("""select * from cache_dt_ranges""").fetch_df()
@@ -295,6 +301,52 @@ class CcxtCacheDB:
             # insert df to cache db
             if df is not None and not df.empty:
                 con.execute("""INSERT INTO candles SELECT *  from df""")
+
+    def _coverage_range_from_rows(
+        self,
+        df: DataFrame,
+        requested_start: datetime,
+        requested_end: datetime,
+        timeframe: str,
+    ) -> tuple[datetime, datetime] | None:
+        """Return the actual cache coverage represented by provider bars.
+
+        Cache metadata must describe real executable rows, not the requested
+        window. Coinbase can return a partial page without raising; marking the
+        entire requested window as cached would make later reads trust missing
+        bars and fail with stale data.
+        """
+        df = self._filter_executable_rows(df)
+        if df.empty:
+            return None
+
+        first_bar = pd.Timestamp(df["datetime"].min()).to_pydatetime().replace(tzinfo=None)
+        last_bar = pd.Timestamp(df["datetime"].max()).to_pydatetime().replace(tzinfo=None)
+        bar_end = last_bar + timedelta(seconds=_TIMEFRAME_SECONDS[timeframe]) - timedelta(microseconds=1)
+
+        coverage_start = max(first_bar, requested_start)
+        coverage_end = min(bar_end, requested_end)
+        if coverage_end < coverage_start:
+            return None
+
+        return coverage_start, coverage_end
+
+    def _merge_coverage_ranges(
+        self,
+        ranges: list[tuple[datetime, datetime]],
+    ) -> list[tuple[datetime, datetime]]:
+        normalized = sorted((start, end) for start, end in ranges if start <= end)
+        if not normalized:
+            return []
+
+        merged = [normalized[0]]
+        for start, end in normalized[1:]:
+            last_start, last_end = merged[-1]
+            if start <= last_end + timedelta(microseconds=1):
+                merged[-1] = (last_start, max(last_end, end))
+            else:
+                merged.append((start, end))
+        return merged
 
 
     def _calc_download_ranges(self,symbol:str,timeframe:str,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.53",
+    version="4.5.54",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_ccxt_store.py
+++ b/tests/test_ccxt_store.py
@@ -134,6 +134,7 @@ def test_ccxt_cache_clamps_current_utc_day_download_end_to_now(tmp_path, monkeyp
     def fake_get_barset(symbol, timeframe, limit, start, end):
         calls.append({"symbol": symbol, "timeframe": timeframe, "start": start, "end": end})
         return _bars(
+            (datetime(2026, 6, 17, 0, 0), 99.0, 100.0, 98.0, 99.5, 9.0),
             (requested_end_utc, 100.0, 101.0, 99.0, 100.5, 10.0),
             (now.replace(microsecond=0), 110.0, 111.0, 109.0, 110.5, 11.0),
         )
@@ -209,7 +210,7 @@ def test_ccxt_cache_uses_native_day_timeframe_without_synthesizing_missing_days(
     assert pd.Timestamp("2026-01-02 00:00:00") not in df.index
 
 
-def test_ccxt_cache_empty_response_records_coverage_without_fake_rows(tmp_path, monkeypatch):
+def test_ccxt_cache_empty_response_does_not_record_fake_coverage(tmp_path, monkeypatch):
     cache = _cache_without_live_exchange(tmp_path, monkeypatch)
     calls = {"count": 0}
 
@@ -227,11 +228,55 @@ def test_ccxt_cache_empty_response_records_coverage_without_fake_rows(tmp_path, 
 
     assert first.empty
     assert second.empty
-    assert calls["count"] == first_call_count
+    assert calls["count"] > first_call_count
 
     with duckdb.connect(cache.get_cache_file_name("BTC/USDT", "1m")) as con:
         ranges = con.execute("select * from cache_dt_ranges").fetch_df()
+    assert ranges.empty
+
+
+def test_ccxt_cache_partial_underfill_does_not_mark_missing_tail_cached(tmp_path, monkeypatch):
+    cache = _cache_without_live_exchange(tmp_path, monkeypatch)
+    calls = []
+
+    def fake_get_barset(symbol, timeframe, limit, start, end):
+        calls.append({"start": start, "end": end})
+        if len(calls) == 1:
+            return _bars(
+                (datetime(2026, 6, 16, 0, 0), 100.0, 101.0, 99.0, 100.5, 10.0),
+                (datetime(2026, 6, 16, 23, 59), 110.0, 111.0, 109.0, 110.5, 11.0),
+            )
+        return _bars(
+            (datetime(2026, 6, 17, 0, 0), 111.0, 112.0, 110.0, 111.5, 12.0),
+            (datetime(2026, 6, 17, 23, 59), 120.0, 121.0, 119.0, 120.5, 13.0),
+        )
+
+    monkeypatch.setattr(cache, "_get_barset_from_api", fake_get_barset)
+
+    first = cache.download_ohlcv("BTC/USDT", "1m", datetime(2026, 6, 16), datetime(2026, 6, 17))
+
+    assert pd.Timestamp("2026-06-16 23:59:00") in first.index
+    assert pd.Timestamp("2026-06-17 00:00:00") not in first.index
+
+    with duckdb.connect(cache.get_cache_file_name("BTC/USDT", "1m")) as con:
+        ranges = con.execute("select start_dt, end_dt from cache_dt_ranges").fetch_df()
     assert len(ranges) == 1
+    assert ranges.iloc[0].start_dt == datetime(2026, 6, 16, 0, 0)
+    assert ranges.iloc[0].end_dt == datetime(2026, 6, 16, 23, 59, 59, 999999)
+
+    second = cache.download_ohlcv("BTC/USDT", "1m", datetime(2026, 6, 17), datetime(2026, 6, 17))
+
+    assert len(calls) == 2
+    assert calls[1]["start"] > datetime(2026, 6, 16, 23, 59)
+    assert pd.Timestamp("2026-06-17 00:00:00") in second.index
+
+    with duckdb.connect(cache.get_cache_file_name("BTC/USDT", "1m")) as con:
+        ranges = con.execute("select start_dt, end_dt from cache_dt_ranges order by start_dt").fetch_df()
+    assert len(ranges) == 2
+    assert ranges.iloc[0].start_dt == datetime(2026, 6, 16, 0, 0)
+    assert ranges.iloc[0].end_dt == datetime(2026, 6, 16, 23, 59, 59, 999999)
+    assert ranges.iloc[1].start_dt == datetime(2026, 6, 17, 0, 0)
+    assert ranges.iloc[1].end_dt == datetime(2026, 6, 17, 23, 59, 59, 999999)
 
 
 def test_ccxt_api_pagination_advances_across_empty_sparse_pages(tmp_path, monkeypatch):
@@ -364,10 +409,15 @@ def test_ccxt_cache_warm_reads_do_not_refetch_supported_timeframes(
                 "end": end,
             }
         )
-        return _bars(
+        rows = [
             (datetime(2026, 1, 1), 100.0, 101.0, 99.0, 100.5, 10.0),
             (datetime(2026, 1, 1) + expected_step, 101.0, 102.0, 100.0, 101.5, 11.0),
-        )
+        ]
+        if requested_timeframe == "1m":
+            rows.append((datetime(2026, 1, 1, 23, 59), 199.0, 200.0, 198.0, 199.5, 19.0))
+        elif requested_timeframe == "1h":
+            rows.append((datetime(2026, 1, 1, 23, 0), 199.0, 200.0, 198.0, 199.5, 19.0))
+        return _bars(*rows)
 
     monkeypatch.setattr(cache, "_get_barset_from_api", fake_get_barset)
 


### PR DESCRIPTION
## What
Release 4.5.54 with a focused CCXT/Coinbase cache metadata fix.

- Cache range metadata now reflects actual executable candles returned by CCXT, not the requested provider window.
- Empty CCXT responses no longer create fake cached coverage.
- Existing overlapping cache ranges are preserved and merged only with newly proven real-row coverage.

## Why
Greg's production BTC/USDT backtest no longer hit Coinbase's same-day future-window error after 4.5.53, but the next validation exposed a second cache bug: a partial Coinbase response ending on June 16 could still mark June 17 as cached. Later warm reads trusted that metadata and failed to fetch the missing BTC bars.

## Risk
Low and scoped to CCXT OHLCV cache metadata. The main behavior change is intentionally stricter: missing provider rows remain uncached instead of being hidden behind requested-window metadata. This can cause retries for genuinely empty windows, but it prevents stale or missing bars from being treated as available.

## Tests run
```bash
/Users/robertgrzesik/Development/lumibot/.venv/bin/python -m pytest \
  /Users/robertgrzesik/Development/lumibot/tests/test_ccxt_store.py \
  /Users/robertgrzesik/Development/lumibot/tests/test_backtesting_ccxt_execution_semantics.py \
  /Users/robertgrzesik/Development/lumibot/tests/test_crypto_backtesting_order_matrix.py -q
```

Result: `45 passed, 2 skipped`.

## Docs
Updated `/Users/robertgrzesik/Development/lumibot/docs/CRYPTO_BACKTEST_VALIDATION.md` with the 2026-06-24 partial-provider-coverage finding and the invariant that cache metadata must be derived from real returned candles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache coverage tracking so partial or empty market data responses no longer create false cached ranges.
  * Warm reads now refetch missing candle data instead of incorrectly treating incomplete coverage as complete.

* **Tests**
  * Added regression coverage for empty responses, partial underfills, and day-boundary warm reads.

* **Documentation**
  * Updated release notes and crypto validation guidance to reflect the new cache-coverage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->