### PR TITLE
v4.5.55 - Routed CCXT cache refresh fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.55 - Unreleased
+
 ## 4.5.54 - 2026-06-24
 
 Deploy marker: `deploy 4.5.54`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 4.5.55 - Unreleased
 
+### Fixed
+- **Routed Coinbase/CCXT refreshes no longer keep stale legacy data aliases.**
+  When a crypto dataset is refreshed during a routed backtest, LumiBot now
+  updates the legacy `(asset, quote)` lookup alias and clears the PandasData
+  lookup cache so later strategy history requests use the refreshed bars instead
+  of a pre-refresh `Data` object that ended days earlier.
+
+### Tests
+- **Routed CCXT regression now covers stale in-memory BTC/USDT aliases.** The
+  regression seeds a June 16 BTC/USDT dataset, refreshes June 23 data through
+  the routed Coinbase path, and asserts `get_historical_prices()` returns the
+  refreshed June 23 bar instead of the stale June 16 bar.
+
 ## 4.5.54 - 2026-06-24
 
 Deploy marker: `deploy 4.5.54`

--- a/lumibot/backtesting/routed_backtesting.py
+++ b/lumibot/backtesting/routed_backtesting.py
@@ -327,8 +327,13 @@ class _DataFrameRoutingAdapter(_RoutingAdapter):
         data = Data(original_asset, merged, timestep=ts_unit, quote=original_quote_asset)
         data.strict_end_check = ts_unit != "day"
         self._router._data_store[canonical_key] = data
-        if legacy_key not in self._router._data_store:
+        legacy_data = self._router._data_store.get(legacy_key)
+        if legacy_data is None or legacy_data is existing or getattr(legacy_data, "timestep", None) == ts_unit:
             self._router._data_store[legacy_key] = data
+        try:
+            self._router._find_asset_in_data_store_cache.clear()
+        except Exception:
+            pass
         return None
 
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.54",
+    version="4.5.55",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_hour_timestep_support.py
+++ b/tests/test_hour_timestep_support.py
@@ -396,3 +396,97 @@ def test_routed_ccxt_crypto_quote_stays_minute_even_when_day_mode_is_inferred(mo
     assert calls[0]["exchange_id"] == "coinbase"
     assert calls[0]["symbol"] == "BTC/USDT"
     assert calls[0]["timeframe"] == "1m"
+
+
+def test_routed_ccxt_refresh_replaces_stale_legacy_alias_and_lookup_cache(monkeypatch):
+    import lumibot.tools.ccxt_data_store as ccxt_data_store
+    import lumibot.tools.thetadata_helper as thetadata_helper
+
+    monkeypatch.setattr(ThetaDataBacktestingPandas, "kill_processes_by_name", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(thetadata_helper, "reset_theta_terminal_tracking", lambda *_args, **_kwargs: None)
+
+    calls = []
+
+    class _FakeCcxtCache:
+        def __init__(self, exchange_id):
+            self.exchange_id = exchange_id
+
+        def download_ohlcv(self, symbol, timeframe, start_datetime, end_dt):
+            calls.append(
+                {
+                    "exchange_id": self.exchange_id,
+                    "symbol": symbol,
+                    "timeframe": timeframe,
+                    "start_datetime": start_datetime,
+                    "end_dt": end_dt,
+                }
+            )
+            return pd.DataFrame(
+                {
+                    "open": [200.0, 201.0],
+                    "high": [201.0, 202.0],
+                    "low": [199.0, 200.0],
+                    "close": [200.5, 201.5],
+                    "volume": [20.0, 21.0],
+                },
+                index=pd.DatetimeIndex([datetime(2026, 6, 23, 19, 58), datetime(2026, 6, 23, 19, 59)]),
+            )
+
+    monkeypatch.setattr(ccxt_data_store, "CcxtCacheDB", _FakeCcxtCache)
+
+    ds = RoutedBacktestingPandas(
+        datetime_start=datetime(2026, 6, 17, tzinfo=timezone.utc),
+        datetime_end=datetime(2026, 6, 24, tzinfo=timezone.utc),
+        config={"backtesting_data_routing": {"crypto": "coinbase", "default": "thetadata"}},
+        username="dev",
+        password="dev",
+        use_quote_data=False,
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+
+    asset = Asset(symbol="BTC", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset(symbol="USDT", asset_type=Asset.AssetType.CRYPTO)
+    canonical_key, legacy_key = ds._build_dataset_keys(asset, quote, "minute")
+
+    old_index = pd.DatetimeIndex([datetime(2026, 6, 16, 23, 59, tzinfo=timezone.utc)]).tz_convert(
+        "America/New_York"
+    )
+    old_data = Data(
+        asset,
+        pd.DataFrame(
+            {
+                "open": [100.0],
+                "high": [101.0],
+                "low": [99.0],
+                "close": [100.5],
+                "volume": [10.0],
+            },
+            index=old_index,
+        ),
+        timestep="minute",
+        quote=quote,
+    )
+    old_data.strict_end_check = True
+    ds._data_store[canonical_key] = old_data
+    ds._data_store[legacy_key] = old_data
+    ds._find_asset_in_data_store_cache[(asset, quote, "minute")] = legacy_key
+
+    ds._update_pandas_data(
+        asset,
+        quote,
+        length=1300,
+        timestep="minute",
+        start_dt=datetime(2026, 6, 23, 20, 0, tzinfo=timezone.utc),
+    )
+
+    assert calls
+    assert ds._data_store[legacy_key] is ds._data_store[canonical_key]
+    assert ds._find_asset_in_data_store_cache == {}
+
+    ds._datetime = datetime(2026, 6, 23, 20, 0, tzinfo=timezone.utc)
+    bars = ds.get_historical_prices(asset, length=1, timestep="minute", quote=quote)
+
+    assert bars is not None
+    assert bars.df["close"].iloc[-1] == 200.5
+    assert bars.df.index[-1].tz_convert("UTC") == pd.Timestamp("2026-06-23 19:58:00+00:00")


### PR DESCRIPTION
## What
Release 4.5.55 fixes routed Coinbase/CCXT backtests that refreshed cache coverage but continued serving a stale legacy asset/quote data alias from the in-memory PandasData lookup cache.

## Why
Production validation of Gregs exact BTC/USDT strategy on 4.5.54 no longer hit Coinbases future-start error, but still failed because strategy history calls could reuse a pre-refresh BTC/USDT Data object ending on June 16 after the routed provider had already loaded June 17-24 bars under the canonical timestep key.

## Risk
Low and scoped to routed backtesting refresh bookkeeping. The change only updates the legacy alias when it is absent, points to the same stale object, or has the same timestep, and clears the lookup cache after a refresh. If this regresses, routed crypto backtests may fail to reuse cached bars or may report missing data again.

## Tests run
- /Users/robertgrzesik/Development/bin/safe-timeout 240s /Users/robertgrzesik/Development/lumibot/.venv/bin/python -m pytest /Users/robertgrzesik/Development/lumibot/tests/test_ccxt_store.py /Users/robertgrzesik/Development/lumibot/tests/test_backtesting_ccxt_execution_semantics.py /Users/robertgrzesik/Development/lumibot/tests/test_crypto_backtesting_order_matrix.py /Users/robertgrzesik/Development/lumibot/tests/test_hour_timestep_support.py -q -> 54 passed, 2 skipped

## Docs
- CHANGELOG.md documents the 4.5.55 fix and regression coverage.
- No public docs or visuals needed; this is an internal data refresh correctness fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed refreshed Coinbase/CCXT market data so historical requests no longer return stale cached bars after an update.
  * Improved handling of legacy lookup entries so updated data is consistently used across subsequent price queries.

* **Tests**
  * Added regression coverage to verify refreshed minute-level data is returned correctly after a cache update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->