### PR TITLE
v4.5.55 - Deploy marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.55 - Unreleased
+## 4.5.55 - 2026-06-25
+
+Deploy marker: `deploy 4.5.55`
 
 ### Fixed
 - **Routed Coinbase/CCXT refreshes no longer keep stale legacy data aliases.**


### PR DESCRIPTION
## What
Add the required 4.5.55 release date and deploy-marker changelog entry.

## Why
The 4.5.55 routed CCXT hotfix PR merged with the code fix, but the deployment guide requires the dated changelog marker to be included before tagging the dev merge commit.

## Risk
None; changelog-only release bookkeeping.

## Tests run
- Not run; changelog-only commit.

## Docs
- CHANGELOG.md only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where outdated market aliases and cached data could persist after price data refreshes, helping ensure more accurate historical prices.
* **Tests**
  * Added regression coverage for refreshed BTC/USDT historical price retrieval after data updates.
* **Documentation**
  * Updated the release notes to mark version 4.5.55 as dated and ready for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->