### PR TITLE
v4.5.56 - strict Coinbase 5m history boundary fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.56 - Unreleased
+## 4.5.56 - 2026-06-25
+
+Deploy marker: `deploy 4.5.56`
 
 ### Fixed
 - **Strict intraday history checks now understand aggregated minute buckets.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## 4.5.56 - Unreleased
 
+### Fixed
+- **Strict intraday history checks now understand aggregated minute buckets.**
+  A routed Coinbase/CCXT request for `5m` BTC/USDT history can use the last
+  real minute row inside the requested 5-minute bucket instead of treating the
+  normal bucket boundary as stale data, while requests beyond the bucket still
+  fail loudly instead of reusing old prices.
+- **Resampled intraday bars no longer return incomplete current buckets.** When
+  minute/hour data is aggregated into larger intraday bars, LumiBot now drops
+  the partially formed current aggregate bucket so strategies do not trade on
+  incomplete OHLC values.
+
+### Tests
+- **Data entity regressions cover the Greg BTC/USDT 5-minute boundary.** Tests
+  assert strict Coinbase-style minute data can satisfy a `5m` history request at
+  the bucket boundary, does not include the partial current 5-minute candle, and
+  still rejects requests beyond the allowed bucket tolerance.
+
 ## 4.5.55 - 2026-06-25
 
 Deploy marker: `deploy 4.5.55`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.56 - Unreleased
+
 ## 4.5.55 - 2026-06-25
 
 Deploy marker: `deploy 4.5.55`

--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -702,21 +702,39 @@ class Data:
         self._iter_count_last_dt_key = dt_key
         return i
 
-    def _strict_intraday_bar_age_tolerance(self) -> Optional[datetime.timedelta]:
+    def _strict_intraday_bar_age_tolerance(self, request_timestep=None) -> Optional[datetime.timedelta]:
         if not getattr(self, "strict_end_check", False):
             return None
+        source_timestep = request_timestep or getattr(self, "timestep", None)
         try:
-            quantity, unit = parse_timestep_qty_and_unit(getattr(self, "timestep", None))
+            quantity, unit = parse_timestep_qty_and_unit(source_timestep)
             quantity = max(1, int(quantity or 1))
         except Exception:
             quantity = 1
-            unit = getattr(self, "timestep", None)
+            unit = source_timestep
+
+        unit_text = str(unit or "").strip().lower()
+        multiplier = 1 if request_timestep is not None else 3
+        if unit_text == "minute":
+            return datetime.timedelta(minutes=quantity * multiplier)
+        if unit_text == "hour":
+            return datetime.timedelta(hours=quantity * multiplier)
+        return None
+
+    def _strict_end_lag_tolerance(self, request_timestep=None) -> Optional[datetime.timedelta]:
+        if request_timestep is None:
+            return None
+        try:
+            quantity, unit = parse_timestep_qty_and_unit(request_timestep)
+            quantity = max(1, int(quantity or 1))
+        except Exception:
+            return None
 
         unit_text = str(unit or "").strip().lower()
         if unit_text == "minute":
-            return datetime.timedelta(minutes=quantity * 3)
+            return datetime.timedelta(minutes=quantity)
         if unit_text == "hour":
-            return datetime.timedelta(hours=quantity * 3)
+            return datetime.timedelta(hours=quantity)
         return None
 
     def _timestamp_for_iter_count(self, iter_count: int) -> Optional[pd.Timestamp]:
@@ -741,8 +759,9 @@ class Data:
         iter_count: int,
         length,
         timeshift,
+        request_timestep=None,
     ) -> Optional[str]:
-        tolerance = self._strict_intraday_bar_age_tolerance()
+        tolerance = self._strict_intraday_bar_age_tolerance(request_timestep=request_timestep)
         if tolerance is None:
             return None
 
@@ -786,6 +805,7 @@ class Data:
         # Validates if the provided date, length, timeshift, and timestep
         # will return data. Runs function if data, returns None if no data.
         def checker(self, *args, **kwargs):
+            strict_request_timestep = kwargs.pop("_strict_request_timestep", None)
             if type(kwargs.get("length", 1)) not in [int, float]:
                 raise TypeError(f"Length must be an integer. {type(kwargs.get('length', 1))} was provided.")
 
@@ -836,9 +856,14 @@ class Data:
             if dt_exceeds_end:
                 strict_end_check = getattr(self, "strict_end_check", False)
                 if strict_end_check:
-                    raise ValueError(
-                        f"The date you are looking for ({dt_key}) for ({self.asset}) is after the available data's end ({self.datetime_end}) with length={length} and timeshift={timeshift}; data refresh required instead of using stale bars."
+                    strict_lag_tolerance = self._strict_end_lag_tolerance(
+                        request_timestep=strict_request_timestep
                     )
+                    gap = dt_key - self.datetime_end
+                    if strict_lag_tolerance is None or gap < datetime.timedelta(0) or gap > strict_lag_tolerance:
+                        raise ValueError(
+                            f"The date you are looking for ({dt_key}) for ({self.asset}) is after the available data's end ({self.datetime_end}) with length={length} and timeshift={timeshift}; data refresh required instead of using stale bars."
+                        )
                 gap = dt_key - self.datetime_end
                 max_gap = datetime.timedelta(days=3)
                 if gap > max_gap:
@@ -866,6 +891,7 @@ class Data:
                 iter_count=i,
                 length=length,
                 timeshift=timeshift,
+                request_timestep=strict_request_timestep,
             )
             if stale_bar_error is not None:
                 raise ValueError(stale_bar_error)
@@ -1443,17 +1469,35 @@ class Data:
             # Convert requested hours to minutes to pull enough base data for resample.
             length = length * 60 * quantity
             unit = "h"
-            data = self._get_bars_dict(dt, length=length, timestep="minute", timeshift=timeshift)
+            data = self._get_bars_dict(
+                dt,
+                length=length,
+                timestep="minute",
+                timeshift=timeshift,
+                _strict_request_timestep=f"{int(quantity)}{timestep}",
+            )
 
         elif timestep == "hour" and self.timestep == "hour":
             unit = "h"
             length = length * quantity
-            data = self._get_bars_dict(dt, length=length, timestep="hour", timeshift=timeshift)
+            data = self._get_bars_dict(
+                dt,
+                length=length,
+                timestep="hour",
+                timeshift=timeshift,
+                _strict_request_timestep=f"{int(quantity)}{timestep}" if int(quantity) > 1 else None,
+            )
 
         else:
             unit = "min"  # Guaranteed to be minute timestep at this point
             length = length * quantity
-            data = self._get_bars_dict(dt, length=length, timestep=timestep, timeshift=timeshift)
+            data = self._get_bars_dict(
+                dt,
+                length=length,
+                timestep=timestep,
+                timeshift=timeshift,
+                _strict_request_timestep=f"{int(quantity)}{timestep}" if int(quantity) > 1 else None,
+            )
 
         if data is None:
             return None
@@ -1465,6 +1509,19 @@ class Data:
 
         # Drop any rows that have NaN values (this can happen if the data is not complete, eg. weekends)
         df_result = df_result.dropna()
+
+        if timestep in {"minute", "hour"} and self.timestep in {"minute", "hour"}:
+            base_delta = datetime.timedelta(minutes=1) if self.timestep == "minute" else datetime.timedelta(hours=1)
+            if timestep == "minute":
+                request_delta = datetime.timedelta(minutes=int(quantity))
+            else:
+                request_delta = datetime.timedelta(hours=int(quantity))
+
+            if request_delta > base_delta and not df.empty:
+                raw_end = df.index.max()
+                if raw_end is not None and not pd.isna(raw_end):
+                    latest_complete_label = raw_end + base_delta - request_delta
+                    df_result = df_result[df_result.index <= latest_complete_label]
 
         # Remove partial day data from the current day, which can happen if the data is in minute timestep.
         if timestep == "day" and self.timestep in {"minute", "hour"}:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.55",
+    version="4.5.56",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_data_entity.py
+++ b/tests/test_data_entity.py
@@ -212,6 +212,62 @@ class TestDataGetLastPriceTradeOnly:
 
         assert data.get_last_price(request_dt) == 70511.75
 
+    def test_strict_intraday_allows_multi_minute_history_at_bucket_boundary(self):
+        asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+        quote = Asset("USDT", asset_type=Asset.AssetType.CRYPTO)
+        tz = pytz.timezone("America/New_York")
+        base_dt = tz.localize(datetime(2026, 6, 23, 23, 0))
+        dates = [base_dt + timedelta(minutes=i) for i in range(14)]
+        df = (
+            pd.DataFrame(
+                {
+                    "datetime": dates,
+                    "open": [100.0 + i for i in range(14)],
+                    "high": [101.0 + i for i in range(14)],
+                    "low": [99.0 + i for i in range(14)],
+                    "close": [100.5 + i for i in range(14)],
+                    "volume": [1.0] * 14,
+                }
+            )
+            .set_index("datetime")
+        )
+
+        data = Data(asset, df, timestep="minute", quote=quote)
+        data.strict_end_check = True
+
+        bars = data.get_bars(base_dt + timedelta(minutes=15), length=3, timestep="5m")
+
+        assert bars is not None
+        assert list(bars.index) == [base_dt, base_dt + timedelta(minutes=5)]
+        assert bars.iloc[-1]["close"] == 109.5
+        assert base_dt + timedelta(minutes=10) not in bars.index
+
+    def test_strict_intraday_rejects_multi_minute_history_past_bucket_tolerance(self):
+        asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+        quote = Asset("USDT", asset_type=Asset.AssetType.CRYPTO)
+        tz = pytz.timezone("America/New_York")
+        base_dt = tz.localize(datetime(2026, 6, 23, 23, 0))
+        dates = [base_dt + timedelta(minutes=i) for i in range(14)]
+        df = (
+            pd.DataFrame(
+                {
+                    "datetime": dates,
+                    "open": [100.0 + i for i in range(14)],
+                    "high": [101.0 + i for i in range(14)],
+                    "low": [99.0 + i for i in range(14)],
+                    "close": [100.5 + i for i in range(14)],
+                    "volume": [1.0] * 14,
+                }
+            )
+            .set_index("datetime")
+        )
+
+        data = Data(asset, df, timestep="minute", quote=quote)
+        data.strict_end_check = True
+
+        with pytest.raises(ValueError, match="after the available data's end"):
+            data.get_bars(base_dt + timedelta(minutes=20), length=3, timestep="5m")
+
     def test_get_quote_includes_source_bar_provenance(self):
         asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
         tz = pytz.timezone("America/New_York")


### PR DESCRIPTION
What / Why

This hotfix addresses the remaining Greg BTC/USDT production validation failure after 4.5.55. Routed Coinbase/CCXT refreshes now reach the current day, but strict intraday history checks were still rejecting normal 5-minute history requests when the requested simulation time was just past the cached minute-data end inside the same 5-minute bucket. The fix lets aggregated minute/hour history use a bounded requested-bucket tolerance while still rejecting requests beyond the bucket and wrong-day stale data. It also drops incomplete current aggregate buckets so we do not replace an error with partial OHLC bars.

Risk

Medium: this touches Data.get_bars resampling behavior for intraday multi-minute/hour bars. The intended behavior is stricter correctness: no incomplete aggregate buckets, no stale wrong-day prices, and no tolerance for native 1-minute execution fills.

Tests run

/Users/robertgrzesik/Development/bin/safe-timeout 240s /Users/robertgrzesik/Development/lumibot/.venv/bin/python -m pytest /Users/robertgrzesik/Development/lumibot/tests/test_data_entity.py /Users/robertgrzesik/Development/lumibot/tests/test_ccxt_store.py /Users/robertgrzesik/Development/lumibot/tests/test_backtesting_ccxt_execution_semantics.py /Users/robertgrzesik/Development/lumibot/tests/test_crypto_backtesting_order_matrix.py /Users/robertgrzesik/Development/lumibot/tests/test_hour_timestep_support.py -q

Result: 64 passed, 2 skipped.

Docs

CHANGELOG.md updated for 4.5.56. No user-facing docs or visuals needed; this is a runtime correctness hotfix for backtest data retrieval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved strict intraday history handling for minute-based and resampled bars.
  * Fixed 5-minute boundary behavior so returned history no longer includes partial or stale latest buckets.
  * Requests made too far beyond available data now correctly raise an error instead of returning incomplete results.

* **Tests**
  * Added coverage for 5-minute bucket boundary behavior and end-of-data validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->