### PR TITLE
v4.5.57 - Coinbase crypto full-window prefetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.57 - Unreleased
+
 ## 4.5.56 - 2026-06-25
 
 Deploy marker: `deploy 4.5.56`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## 4.5.57 - Unreleased
 
+### Fixed
+- **Routed Coinbase/CCXT crypto history now preloads the full backtest window.**
+  BTC/USDT, BTC/USD, and other exact crypto quote pairs are loaded once for the
+  requested minute, hour, or day backtest window instead of refetching a moving
+  slice at each simulated timestamp. This avoids the repeated current-edge
+  `data unavailable` loop seen in production Greg BTC/USDT validation while
+  keeping strategy access time-bounded through `Data.get_bars(dt)`.
+- **Full-window routed data loads now stop redundant retries.** Shared routed
+  dataframe adapters honor full-window and empty-window markers before fetching
+  again, so known-loaded or known-empty Coinbase windows do not hammer the
+  provider every strategy step.
+
+### Tests
+- **Routed Coinbase/CCXT regressions cover exact-pair full-window loading.**
+  Tests assert BTC/USDT routes to Coinbase as `BTC/USDT` with no USD fallback,
+  preloads minute/hour/day windows through the full backtest end, and does not
+  refetch the same full or empty window on the next simulated step.
+
 ## 4.5.56 - 2026-06-25
 
 Deploy marker: `deploy 4.5.56`

--- a/docs/investigations/2026-06-11_GREG_BTC_ROUTED_QUOTE_FILL.md
+++ b/docs/investigations/2026-06-11_GREG_BTC_ROUTED_QUOTE_FILL.md
@@ -996,3 +996,53 @@ it can prove the final customer backtest result end-to-end. The next production-
 like proof should either use a verified complete BTC cache prefix for the full
 window or run a narrower Greg window that reaches the previously bad April 15-17
 fill region without spending the entire timeout on cold BTC hydration.
+
+## 2026-06-25 Production Coinbase Follow-Up
+
+Production validation after the Coinbase switch showed two separate outcomes:
+
+- LumiBot `4.5.56` completed Greg's copied BTC/USDT strategy revision in
+  production BotSpot with `settings.json.lumibot_version == "4.5.56"`.
+- The original hard failure (`ccxt.base.errors.BadRequest`, Coinbase
+  `INVALID_ARGUMENT`, and `start must not be in the future`) did not appear in
+  the production backtest logs.
+- The same run still emitted many current-edge history messages such as
+  `Error getting bars`, `5m data unavailable`, and `after the available data's
+  end`. The backtest completed with fills, so this was no longer the original
+  hard failure, but it meant the routed Coinbase data source was still loading
+  history incrementally instead of giving the in-memory Data object the full
+  requested backtest window.
+
+The `4.5.57` follow-up keeps the strategy code and pair selection unchanged. It
+changes only the routed Coinbase/CCXT history load path:
+
+- For crypto minute/hour/day series, the first routed CCXT load requests the
+  full backtest window (plus the computed lookback/warmup start), not only the
+  current simulated slice.
+- The shared dataframe adapter now honors full-window and empty-window markers
+  before calling the provider again.
+- Exact pair semantics are preserved: a request for `BTC/USDT` asks Coinbase
+  for `BTC/USDT`; there is no hidden `BTC/USD` fallback.
+- Future bars in the in-memory Data object remain inaccessible to strategy
+  logic because `Data.get_bars(dt)` slices by the current simulated timestamp.
+
+Focused local verification before release:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 240s \
+  /Users/robertgrzesik/Development/lumibot/.venv/bin/python -m pytest \
+  /Users/robertgrzesik/Development/lumibot/tests/test_routed_backtesting_ibkr_daily_prefetch.py \
+  /Users/robertgrzesik/Development/lumibot/tests/test_ccxt_store.py \
+  /Users/robertgrzesik/Development/lumibot/tests/test_backtesting_ccxt_execution_semantics.py \
+  /Users/robertgrzesik/Development/lumibot/tests/test_data_entity.py -q
+```
+
+Result: `53 passed, 2 skipped`.
+
+Production sign-off for this follow-up still requires a new BotSpot production
+backtest after Bot Manager installs `lumibot==4.5.57`, with checks for:
+
+- `settings.json.lumibot_version == "4.5.57"`
+- no Coinbase `INVALID_ARGUMENT` / future-start error
+- sharply reduced or absent current-edge `5m data unavailable` log loop
+- trade events and chart artifacts available on the production AI Agent page

--- a/lumibot/backtesting/routed_backtesting.py
+++ b/lumibot/backtesting/routed_backtesting.py
@@ -285,6 +285,11 @@ class _DataFrameRoutingAdapter(_RoutingAdapter):
                 pass
 
         canonical_key, legacy_key = self._router._build_dataset_keys(original_asset, original_quote_asset, ts_unit)
+        if canonical_key in self._fully_loaded_series and canonical_key in self._router._data_store:
+            return None
+        if canonical_key in self._empty_prefetch_series:
+            return None
+
         existing = self._router._data_store.get(canonical_key)
         existing_df = getattr(existing, "df", None) if existing is not None else None
 
@@ -952,7 +957,36 @@ class _CcxtRoutingAdapter(_DataFrameRoutingAdapter):
             raise RoutingProviderError(f"CCXT routing only supports minute/hour/day timesteps, got {ts_unit!r}.")
 
         symbol = f"{asset.symbol.upper()}/{quote_asset.symbol.upper()}"
-        df = cache_db.download_ohlcv(symbol, timeframe, start_datetime, end_dt)
+        if ts_unit in {"minute", "hour"} and canonical_key not in self._fully_loaded_series:
+            try:
+                prefetch_start = min(start_datetime, self._router.datetime_start)
+            except Exception:
+                prefetch_start = start_datetime
+            prefetch_end = self._router.datetime_end or end_dt
+            df = cache_db.download_ohlcv(symbol, timeframe, prefetch_start, prefetch_end)
+            if df is None or df.empty:
+                self._empty_prefetch_series.add(canonical_key)
+                return None
+            # The data store may contain the full run window; Data.get_bars(dt) still slices by
+            # simulation time, so future rows are not visible to strategy logic at earlier steps.
+            self._fully_loaded_series.add(canonical_key)
+        elif ts_unit == "day" and canonical_key not in self._fully_loaded_series:
+            try:
+                lookback_days = max(7, int(length) + 5)
+            except Exception:
+                lookback_days = 7
+            try:
+                prefetch_start = min(start_datetime, self._router.datetime_start - timedelta(days=lookback_days))
+            except Exception:
+                prefetch_start = start_datetime
+            prefetch_end = self._router.datetime_end or end_dt
+            df = cache_db.download_ohlcv(symbol, timeframe, prefetch_start, prefetch_end)
+            if df is None or df.empty:
+                self._empty_prefetch_series.add(canonical_key)
+                return None
+            self._fully_loaded_series.add(canonical_key)
+        else:
+            df = cache_db.download_ohlcv(symbol, timeframe, start_datetime, end_dt)
         if df is None or df.empty:
             return None
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.56",
+    version="4.5.57",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_routed_backtesting_ibkr_daily_prefetch.py
+++ b/tests/test_routed_backtesting_ibkr_daily_prefetch.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from types import MethodType
 
 import pandas as pd
+import pytest
 
 from lumibot.backtesting.routed_backtesting import RoutedBacktestingPandas
 from lumibot.entities import Asset
@@ -553,3 +554,156 @@ def test_routed_backtesting_crypto_daily_prefetch_stays_unloaded_when_coverage_f
     routed._update_pandas_data(base, quote, 30, "day", start_dt=backtest_start)
     assert calls
     assert (base, quote, "day") not in routed._fully_loaded_series
+
+
+@pytest.mark.parametrize(
+    "timestep,ts_unit,expected_timeframe",
+    [
+        ("5m", "minute", "1m"),
+        ("1h", "hour", "1h"),
+        ("day", "day", "1d"),
+    ],
+)
+def test_routed_ccxt_crypto_prefetches_full_backtest_window_once(monkeypatch, timestep, ts_unit, expected_timeframe):
+    import lumibot.tools.ccxt_data_store as ccxt_data_store
+
+    calls: list[dict[str, object]] = []
+
+    class FakeCcxtCacheDB:
+        def __init__(self, exchange_id):
+            self.exchange_id = exchange_id
+
+        def download_ohlcv(self, symbol, timeframe, start, end):
+            calls.append(
+                {
+                    "exchange_id": self.exchange_id,
+                    "symbol": symbol,
+                    "timeframe": timeframe,
+                    "start": start,
+                    "end": end,
+                }
+            )
+            freq = {"minute": "1min", "hour": "1h", "day": "1D"}[ts_unit]
+            idx = pd.date_range(start=start, end=end, freq=freq)
+            if idx.empty:
+                idx = pd.DatetimeIndex([pd.Timestamp(start)])
+            df = pd.DataFrame(
+                {
+                    "open": 100.0,
+                    "high": 101.0,
+                    "low": 99.0,
+                    "close": 100.5,
+                    "volume": 10.0,
+                },
+                index=idx,
+            )
+            df.index.name = "timestamp"
+            return df
+
+    monkeypatch.setattr(ccxt_data_store, "CcxtCacheDB", FakeCcxtCacheDB)
+
+    routed = RoutedBacktestingPandas.__new__(RoutedBacktestingPandas)
+    routed._routing = {"default": "thetadata", "crypto": "coinbase"}
+    routed._data_store = {}
+
+    backtest_start = datetime(2026, 6, 17, tzinfo=timezone.utc)
+    backtest_end = datetime(2026, 6, 24, tzinfo=timezone.utc)
+    routed.datetime_start = backtest_start
+    routed.datetime_end = backtest_end
+
+    def _get_datetime(self):
+        return backtest_start
+
+    def _get_timestep(self):
+        return timestep
+
+    def _get_start_datetime_and_ts_unit(self, length, ts, start_dt=None, start_buffer=timedelta(0)):
+        end_dt = start_dt if isinstance(start_dt, datetime) else backtest_start
+        if ts_unit == "day":
+            return end_dt - timedelta(days=int(length)), "day"
+        if ts_unit == "hour":
+            return end_dt - timedelta(hours=int(length)), "hour"
+        return end_dt - timedelta(minutes=int(length)), "minute"
+
+    def _build_dataset_keys(self, asset, quote, resolved_ts_unit):
+        canonical = (asset, quote, resolved_ts_unit)
+        legacy = (asset, quote)
+        return canonical, legacy
+
+    routed.get_datetime = MethodType(_get_datetime, routed)
+    routed.get_timestep = MethodType(_get_timestep, routed)
+    routed.get_start_datetime_and_ts_unit = MethodType(_get_start_datetime_and_ts_unit, routed)
+    routed._build_dataset_keys = MethodType(_build_dataset_keys, routed)
+
+    base = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset("USDT", asset_type=Asset.AssetType.CRYPTO)
+
+    routed._update_pandas_data(base, quote, 1300, timestep, start_dt=backtest_start)
+
+    assert len(calls) == 1
+    assert calls[0]["exchange_id"] == "coinbase"
+    assert calls[0]["symbol"] == "BTC/USDT"
+    assert calls[0]["timeframe"] == expected_timeframe
+    assert calls[0]["end"] == backtest_end
+
+    canonical_key = (base, quote, ts_unit)
+    assert canonical_key in routed._data_store
+    assert canonical_key in routed._registry.adapter_for_spec(routed._provider_spec_for_asset(base))._fully_loaded_series
+
+    routed._update_pandas_data(base, quote, 1300, timestep, start_dt=backtest_start + timedelta(hours=1))
+    assert len(calls) == 1
+
+
+def test_routed_ccxt_crypto_empty_full_window_is_not_retried_each_step(monkeypatch):
+    import lumibot.tools.ccxt_data_store as ccxt_data_store
+
+    calls: list[dict[str, object]] = []
+
+    class FakeCcxtCacheDB:
+        def __init__(self, exchange_id):
+            self.exchange_id = exchange_id
+
+        def download_ohlcv(self, symbol, timeframe, start, end):
+            calls.append({"symbol": symbol, "timeframe": timeframe, "start": start, "end": end})
+            return pd.DataFrame()
+
+    monkeypatch.setattr(ccxt_data_store, "CcxtCacheDB", FakeCcxtCacheDB)
+
+    routed = RoutedBacktestingPandas.__new__(RoutedBacktestingPandas)
+    routed._routing = {"default": "thetadata", "crypto": "coinbase"}
+    routed._data_store = {}
+
+    backtest_start = datetime(2026, 6, 17, tzinfo=timezone.utc)
+    backtest_end = datetime(2026, 6, 24, tzinfo=timezone.utc)
+    routed.datetime_start = backtest_start
+    routed.datetime_end = backtest_end
+
+    def _get_datetime(self):
+        return backtest_start
+
+    def _get_timestep(self):
+        return "5m"
+
+    def _get_start_datetime_and_ts_unit(self, length, ts, start_dt=None, start_buffer=timedelta(0)):
+        end_dt = start_dt if isinstance(start_dt, datetime) else backtest_start
+        return end_dt - timedelta(minutes=int(length)), "minute"
+
+    def _build_dataset_keys(self, asset, quote, ts_unit):
+        canonical = (asset, quote, ts_unit)
+        legacy = (asset, quote)
+        return canonical, legacy
+
+    routed.get_datetime = MethodType(_get_datetime, routed)
+    routed.get_timestep = MethodType(_get_timestep, routed)
+    routed.get_start_datetime_and_ts_unit = MethodType(_get_start_datetime_and_ts_unit, routed)
+    routed._build_dataset_keys = MethodType(_build_dataset_keys, routed)
+
+    base = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset("USDT", asset_type=Asset.AssetType.CRYPTO)
+
+    routed._update_pandas_data(base, quote, 1300, "5m", start_dt=backtest_start)
+    routed._update_pandas_data(base, quote, 1300, "5m", start_dt=backtest_start + timedelta(hours=1))
+
+    assert len(calls) == 1
+    assert calls[0]["symbol"] == "BTC/USDT"
+    assert routed._data_store == {}


### PR DESCRIPTION
## What / Why

This release makes routed Coinbase/CCXT crypto history load the full requested backtest window once for minute, hour, and day bars. Greg's production BTC/USDT validation on 4.5.56 completed and no longer hit the Coinbase INVALID_ARGUMENT future-start error, but the logs still showed repeated current-edge history misses because the routed CCXT adapter was refreshing a moving simulated slice instead of hydrating the in-memory data store for the whole run.

The change preserves exact quote pairs: BTC/USDT asks Coinbase for BTC/USDT. There is no BTC/USD fallback. Future rows loaded into the Data object are still sliced by the simulated timestamp through Data.get_bars(dt), so strategy logic cannot trade on future bars.

## Risk

Low to medium. The code path is scoped to routed DataFrame providers and the new full-window behavior is only added to the CCXT crypto adapter. Main detection risk is any Coinbase window that legitimately returns empty or partial data; the adapter now avoids repeated retries for the same full window during a single run, so the backtest should fail/skip honestly instead of hammering the provider every step.

## Tests run

```bash
/Users/robertgrzesik/Development/bin/safe-timeout 240s \
  /Users/robertgrzesik/Development/lumibot/.venv/bin/python -m pytest \
  /Users/robertgrzesik/Development/lumibot/tests/test_routed_backtesting_ibkr_daily_prefetch.py \
  /Users/robertgrzesik/Development/lumibot/tests/test_ccxt_store.py \
  /Users/robertgrzesik/Development/lumibot/tests/test_backtesting_ccxt_execution_semantics.py \
  /Users/robertgrzesik/Development/lumibot/tests/test_data_entity.py -q
```

Result: 53 passed, 2 skipped.

## Docs

- CHANGELOG.md
- docs/investigations/2026-06-11_GREG_BTC_ROUTED_QUOTE_FILL.md

## Post-release validation

After PyPI release and Bot Manager dev/prod deploy, rerun Greg's exact production BotSpot backtest and verify settings.json reports lumibot_version 4.5.57, no Coinbase INVALID_ARGUMENT/future-start error appears, and the AI Agent page exposes the completed backtest/trade artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved routed crypto history loading so full backtest windows are preloaded more reliably for exact pairs.
  * Added safeguards to recognize fully loaded and empty history windows, reducing repeated fetch attempts.
* **Bug Fixes**
  * Prevented repeated “data unavailable” loops during routed crypto backtests.
  * Reduced unnecessary retries when a history request returns no data.
* **Tests**
  * Added coverage for full-window prefetch behavior and for avoiding duplicate reloads on subsequent steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->