### PR TITLE
Release 4.5.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.58 - Unreleased
+
 ## 4.5.57 - Unreleased
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,37 @@
 # Changelog
 
-## 4.5.58 - Unreleased
+## 4.5.58 - 2026-06-25
 
-## 4.5.57 - Unreleased
+Deploy marker: `deploy 4.5.58`
+
+### Fixed
+- **Routed Coinbase/CCXT crypto warmups now expand when later strategy requests
+  need deeper history.** A short early BTC/USDT request can no longer mark the
+  minute series as fully loaded and block a later `length=1300`, `timestep=5m`
+  request from fetching the required warmup data.
+- **Legacy Coinbase/CCXT cache metadata is repaired when it overstates real
+  candle coverage.** Warm reads that find no scheduled download but materially
+  underfilled candle rows rebuild `cache_dt_ranges` from executable candles and
+  refetch the missing leading or trailing window once, preventing old production
+  DuckDB metadata from hiding missing BTC/USDT rows.
+
+### Docs
+- **Crypto validation docs now record the 4.5.57 production follow-up.** The
+  runbook explains the fully-loaded routed-cache issue, the legacy metadata
+  repair, and the focused/broader test commands used before release.
+
+### Tests
+- **Routed Coinbase/CCXT regressions now cover deeper warmup expansion.** A test
+  verifies a later `1300 x 5m` BTC/USDT request refetches from an earlier start
+  after a shorter request already warmed the series.
+- **CCXT cache regressions now cover legacy overstated range metadata.** A test
+  seeds a DuckDB file whose `cache_dt_ranges` claims a full two-day window while
+  candles contain only day one, then verifies LumiBot rebuilds metadata and
+  fetches day two.
+
+## 4.5.57 - 2026-06-25
+
+Deploy marker: `4ca4a2d8`
 
 ### Fixed
 - **Routed Coinbase/CCXT crypto history now preloads the full backtest window.**

--- a/docs/CRYPTO_BACKTEST_VALIDATION.md
+++ b/docs/CRYPTO_BACKTEST_VALIDATION.md
@@ -209,6 +209,59 @@ Focused proof:
 
 Result: `45 passed, 2 skipped`.
 
+### 2026-06-25 Routed CCXT Warmup And Legacy Metadata Repair
+
+The first production run on LumiBot `4.5.57` fixed Coinbase's same-day
+`INVALID_ARGUMENT` failure, but Greg's unchanged BTC/USDT strategy still failed
+after loading real rows and writing artifacts. The routed data source showed two
+remaining problems:
+
+- A short early request could mark the in-memory BTC/USDT minute series as
+  fully loaded, then a later `length=1300`, `timestep=5m` request did not expand
+  far enough back for the strategy's warmup.
+- Production CCXT DuckDB files created by older code could still contain
+  overstated `cache_dt_ranges` metadata. A warm read could trust that metadata
+  and skip a provider request even though the actual candle rows were materially
+  underfilled.
+
+Fix:
+
+- Routed dataframe adapters now verify existing dataframe coverage before
+  honoring `_fully_loaded_series`. If the stored frame does not cover the new
+  requested start/end, the provider is refreshed.
+- Routed CCXT intraday requests prefetch the full backtest window even when a
+  previous shorter request marked the series loaded.
+- `CcxtCacheDB.download_ohlcv()` now repairs legacy overstated cache metadata
+  when no download was scheduled but actual readback proves the cached rows do
+  not materially cover the requested range. Normal partial provider responses
+  are still left as partial coverage and are not retried in a loop.
+
+Focused proof:
+
+```bash
+/Users/robertgrzesik/bin/safe-timeout 1200s .venv/bin/python -m pytest \
+  tests/test_routed_backtesting_ibkr_daily_prefetch.py \
+  tests/test_ccxt_store.py \
+  tests/test_backtesting_ccxt_execution_semantics.py -q
+```
+
+Result: `45 passed, 2 skipped`.
+
+Broader crypto regression proof:
+
+```bash
+/Users/robertgrzesik/bin/safe-timeout 1200s .venv/bin/python -m pytest \
+  tests/test_ccxt_store.py \
+  tests/test_backtesting_ccxt_execution_semantics.py \
+  tests/test_crypto_backtesting_order_matrix.py \
+  tests/test_crypto_backtest_validation_runner.py \
+  tests/test_routed_backtesting_unit.py \
+  tests/test_routed_backtesting_routing_validation.py \
+  tests/test_hour_timestep_support.py -q
+```
+
+Result: `80 passed, 2 skipped`.
+
 ### 2026-06-22 Long Coinbase Matrix And Sparse-Page Cache Fix
 
 Root cause found during long BTC/USDT validation:

--- a/lumibot/backtesting/routed_backtesting.py
+++ b/lumibot/backtesting/routed_backtesting.py
@@ -285,8 +285,6 @@ class _DataFrameRoutingAdapter(_RoutingAdapter):
                 pass
 
         canonical_key, legacy_key = self._router._build_dataset_keys(original_asset, original_quote_asset, ts_unit)
-        if canonical_key in self._fully_loaded_series and canonical_key in self._router._data_store:
-            return None
         if canonical_key in self._empty_prefetch_series:
             return None
 
@@ -304,6 +302,16 @@ class _DataFrameRoutingAdapter(_RoutingAdapter):
                         return None
             except Exception:
                 pass
+
+        if canonical_key in self._fully_loaded_series and canonical_key in self._router._data_store:
+            logger.debug(
+                "Routed data for %s/%s timestep=%s was marked loaded but does not cover %s -> %s; refreshing.",
+                getattr(original_asset, "symbol", original_asset),
+                getattr(original_quote_asset, "symbol", original_quote_asset),
+                ts,
+                start_datetime,
+                end_dt,
+            )
 
         df = self._fetch_df(
             asset=fetch_asset,
@@ -957,7 +965,7 @@ class _CcxtRoutingAdapter(_DataFrameRoutingAdapter):
             raise RoutingProviderError(f"CCXT routing only supports minute/hour/day timesteps, got {ts_unit!r}.")
 
         symbol = f"{asset.symbol.upper()}/{quote_asset.symbol.upper()}"
-        if ts_unit in {"minute", "hour"} and canonical_key not in self._fully_loaded_series:
+        if ts_unit in {"minute", "hour"}:
             try:
                 prefetch_start = min(start_datetime, self._router.datetime_start)
             except Exception:

--- a/lumibot/tools/ccxt_data_store.py
+++ b/lumibot/tools/ccxt_data_store.py
@@ -230,52 +230,91 @@ class CcxtCacheDB:
 
         self.logger.info(f"download ranges :\n{self._table_str(download_ranges,headers=['from','to'])}")
 
-        downloaded_coverage_ranges = []
-
-        for download_start,download_end in download_ranges:
-            range_cnt = self._count_timeframe_units(download_start, download_end, timeframe)
-
-            if range_cnt > limit:
-                raise Exception(f"Request download range {range_cnt} is greater than download limit {limit}")
-
-            df = self._get_barset_from_api(symbol, timeframe,
-                                           range_cnt, download_start, download_end)
-            df = self._fill_missing_data(df, timeframe)
-            self._cache_ohlcv(symbol, df, timeframe)
-            coverage_range = self._coverage_range_from_rows(df, download_start, download_end, timeframe)
-            if coverage_range is not None:
-                downloaded_coverage_ranges.append(coverage_range)
+        attempted_download = bool(download_ranges)
+        self._download_and_record_coverage(
+            symbol=symbol,
+            timeframe=timeframe,
+            download_ranges=download_ranges,
+            overlap_range_ids=overap_range_ids,
+            limit=limit,
+        )
 
         cache_file = self.get_cache_file_name(symbol, timeframe)
-
-        if downloaded_coverage_ranges:
-            with duckdb.connect(cache_file) as con:
-                coverage_ranges = downloaded_coverage_ranges
-                if len(overap_range_ids) > 0:
-                    old_ranges = []
-                    for range_id in overap_range_ids:
-                        old_ranges.extend(
-                            con.execute(
-                                """SELECT start_dt, end_dt FROM cache_dt_ranges WHERE id = ?""",
-                                (range_id,),
-                            ).fetchall()
-                        )
-                    coverage_ranges = old_ranges + coverage_ranges
-                    params = [(id,) for id in overap_range_ids]
-                    con.executemany("""DELETE FROM cache_dt_ranges WHERE id = ?""", params)
-
-                for start_dt, end_dt in self._merge_coverage_ranges(coverage_ranges):
-                    con.execute(
-                        """INSERT INTO cache_dt_ranges VALUES (?, ?, ?)""",
-                        (str(uuid.uuid4().hex), start_dt, end_dt),
-                    )
 
         with duckdb.connect(cache_file) as con:
             df = con.execute("""select * from cache_dt_ranges""").fetch_df()
         self.logger.info(f"cache ranges:\n{self._table_str(df[['start_dt', 'end_dt']],headers=['from','to'])}")
 
         df_cache = self.get_data_from_cache(symbol, timeframe, start, end)
+        if not attempted_download and self._is_materially_underfilled(df_cache, start_dt, end_dt, timeframe):
+            self.logger.warning(
+                "CCXT cache metadata for %s %s returned underfilled rows for %s -> %s; "
+                "rebuilding coverage from real candles and refetching missing ranges once.",
+                symbol,
+                timeframe,
+                start_dt,
+                end_dt,
+            )
+            self._rebuild_cache_ranges_from_candles(symbol, timeframe)
+            retry_ranges, retry_overlap_ids, _ = self._calc_download_ranges(symbol, timeframe, start_dt, end_dt)
+            self._download_and_record_coverage(
+                symbol=symbol,
+                timeframe=timeframe,
+                download_ranges=retry_ranges,
+                overlap_range_ids=retry_overlap_ids,
+                limit=limit,
+            )
+            df_cache = self.get_data_from_cache(symbol, timeframe, start, end)
         return df_cache
+
+    def _download_and_record_coverage(
+        self,
+        *,
+        symbol: str,
+        timeframe: str,
+        download_ranges: list[tuple[datetime, datetime]],
+        overlap_range_ids: list[str],
+        limit: int,
+    ) -> None:
+        downloaded_coverage_ranges = []
+
+        for download_start, download_end in download_ranges:
+            range_cnt = self._count_timeframe_units(download_start, download_end, timeframe)
+
+            if range_cnt > limit:
+                raise Exception(f"Request download range {range_cnt} is greater than download limit {limit}")
+
+            df = self._get_barset_from_api(symbol, timeframe, range_cnt, download_start, download_end)
+            df = self._fill_missing_data(df, timeframe)
+            self._cache_ohlcv(symbol, df, timeframe)
+            coverage_range = self._coverage_range_from_rows(df, download_start, download_end, timeframe)
+            if coverage_range is not None:
+                downloaded_coverage_ranges.append(coverage_range)
+
+        if not downloaded_coverage_ranges:
+            return
+
+        cache_file = self.get_cache_file_name(symbol, timeframe)
+        with duckdb.connect(cache_file) as con:
+            coverage_ranges = downloaded_coverage_ranges
+            if len(overlap_range_ids) > 0:
+                old_ranges = []
+                for range_id in overlap_range_ids:
+                    old_ranges.extend(
+                        con.execute(
+                            """SELECT start_dt, end_dt FROM cache_dt_ranges WHERE id = ?""",
+                            (range_id,),
+                        ).fetchall()
+                    )
+                coverage_ranges = old_ranges + coverage_ranges
+                params = [(id,) for id in overlap_range_ids]
+                con.executemany("""DELETE FROM cache_dt_ranges WHERE id = ?""", params)
+
+            for coverage_start, coverage_end in self._merge_coverage_ranges(coverage_ranges):
+                con.execute(
+                    """INSERT INTO cache_dt_ranges VALUES (?, ?, ?)""",
+                    (str(uuid.uuid4().hex), coverage_start, coverage_end),
+                )
 
 
     def _cache_ohlcv(self, symbol:str, df:DataFrame, timeframe:str)->None:
@@ -330,6 +369,77 @@ class CcxtCacheDB:
             return None
 
         return coverage_start, coverage_end
+
+    def _is_materially_underfilled(
+        self,
+        df: DataFrame,
+        requested_start: datetime,
+        requested_end: datetime,
+        timeframe: str,
+    ) -> bool:
+        """Detect stale cache metadata that overstates real candle coverage."""
+        if df is None or df.empty:
+            return requested_start <= requested_end
+
+        actual_range = self._coverage_range_from_rows(df, requested_start, requested_end, timeframe)
+        if actual_range is None:
+            return True
+
+        actual_start, actual_end = actual_range
+        seconds = _TIMEFRAME_SECONDS[timeframe]
+        tolerance = max(timedelta(seconds=seconds * 3), timedelta(hours=1))
+        leading_gap = actual_start - requested_start
+        trailing_gap = requested_end - actual_end
+        return leading_gap > tolerance or trailing_gap > tolerance
+
+    def _rebuild_cache_ranges_from_candles(self, symbol: str, timeframe: str) -> None:
+        """Rebuild cache range metadata from real candle rows.
+
+        Older LumiBot versions could write `cache_dt_ranges` for the requested
+        window even when the provider returned only part of that window. Rebuild
+        the metadata from executable rows so the next range calculation refetches
+        the missing leading or trailing section instead of trusting stale metadata.
+        """
+        cache_file = self.get_cache_file_name(symbol, timeframe)
+        if not os.path.exists(cache_file):
+            return
+
+        with duckdb.connect(cache_file) as con:
+            tables = con.execute("SHOW TABLES").fetch_df()
+            table_names = set(tables.iloc[:, 0].astype(str).tolist()) if not tables.empty else set()
+            if "candles" not in table_names:
+                return
+            con.execute(
+                """CREATE TABLE IF NOT EXISTS cache_dt_ranges (
+                    id STRING,
+                    start_dt DATETIME,
+                    end_dt DATETIME
+                )"""
+            )
+            coverage = con.execute(
+                """
+                SELECT MIN(datetime) AS start_dt, MAX(datetime) AS end_dt
+                FROM candles
+                WHERE (missing IS NULL OR missing = 0)
+                  AND open IS NOT NULL
+                  AND high IS NOT NULL
+                  AND low IS NOT NULL
+                  AND close IS NOT NULL
+                """
+            ).fetchone()
+            con.execute("""DELETE FROM cache_dt_ranges""")
+            if coverage is None or coverage[0] is None or coverage[1] is None:
+                return
+            coverage_start = pd.Timestamp(coverage[0]).to_pydatetime().replace(tzinfo=None)
+            coverage_end = (
+                pd.Timestamp(coverage[1]).to_pydatetime().replace(tzinfo=None)
+                + timedelta(seconds=_TIMEFRAME_SECONDS[timeframe])
+                - timedelta(microseconds=1)
+            )
+            con.execute(
+                """INSERT INTO cache_dt_ranges VALUES (?, ?, ?)""",
+                (str(uuid.uuid4().hex), coverage_start, coverage_end),
+            )
 
     def _merge_coverage_ranges(
         self,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.57",
+    version="4.5.58",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_ccxt_store.py
+++ b/tests/test_ccxt_store.py
@@ -279,6 +279,48 @@ def test_ccxt_cache_partial_underfill_does_not_mark_missing_tail_cached(tmp_path
     assert ranges.iloc[1].end_dt == datetime(2026, 6, 17, 23, 59, 59, 999999)
 
 
+def test_ccxt_cache_repairs_legacy_overstated_range_metadata(tmp_path, monkeypatch):
+    cache = _cache_without_live_exchange(tmp_path, monkeypatch)
+    cache._cache_ohlcv(
+        "BTC/USDT",
+        cache._fill_missing_data(
+            _bars(
+                (datetime(2026, 6, 16, 0, 0), 100.0, 101.0, 99.0, 100.5, 10.0),
+                (datetime(2026, 6, 16, 23, 59), 110.0, 111.0, 109.0, 110.5, 11.0),
+            ),
+            "1m",
+        ),
+        "1m",
+    )
+    with duckdb.connect(cache.get_cache_file_name("BTC/USDT", "1m")) as con:
+        con.execute(
+            """INSERT INTO cache_dt_ranges VALUES (?, ?, ?)""",
+            ("legacy-full-window", datetime(2026, 6, 16, 0, 0), datetime(2026, 6, 17, 23, 59, 59, 999999)),
+        )
+
+    calls = []
+
+    def fake_get_barset(symbol, timeframe, limit, start, end):
+        calls.append({"start": start, "end": end})
+        return _bars(
+            (datetime(2026, 6, 17, 0, 0), 111.0, 112.0, 110.0, 111.5, 12.0),
+            (datetime(2026, 6, 17, 23, 59), 120.0, 121.0, 119.0, 120.5, 13.0),
+        )
+
+    monkeypatch.setattr(cache, "_get_barset_from_api", fake_get_barset)
+
+    df = cache.download_ohlcv("BTC/USDT", "1m", datetime(2026, 6, 16), datetime(2026, 6, 17))
+
+    assert calls, "Overstated legacy coverage must be refetched instead of trusted"
+    assert pd.Timestamp("2026-06-16 23:59:00") in df.index
+    assert pd.Timestamp("2026-06-17 00:00:00") in df.index
+
+    with duckdb.connect(cache.get_cache_file_name("BTC/USDT", "1m")) as con:
+        ranges = con.execute("select start_dt, end_dt from cache_dt_ranges order by start_dt").fetch_df()
+    assert ranges.start_dt.min() == datetime(2026, 6, 16, 0, 0)
+    assert ranges.end_dt.max() == datetime(2026, 6, 17, 23, 59, 59, 999999)
+
+
 def test_ccxt_api_pagination_advances_across_empty_sparse_pages(tmp_path, monkeypatch):
     cache = _cache_without_live_exchange(tmp_path, monkeypatch)
     calls = []

--- a/tests/test_routed_backtesting_ibkr_daily_prefetch.py
+++ b/tests/test_routed_backtesting_ibkr_daily_prefetch.py
@@ -654,6 +654,85 @@ def test_routed_ccxt_crypto_prefetches_full_backtest_window_once(monkeypatch, ti
     assert len(calls) == 1
 
 
+def test_routed_ccxt_crypto_expands_prefetch_when_later_lookback_is_deeper(monkeypatch):
+    import lumibot.tools.ccxt_data_store as ccxt_data_store
+
+    calls: list[dict[str, object]] = []
+
+    class FakeCcxtCacheDB:
+        def __init__(self, exchange_id):
+            self.exchange_id = exchange_id
+
+        def download_ohlcv(self, symbol, timeframe, start, end):
+            calls.append(
+                {
+                    "exchange_id": self.exchange_id,
+                    "symbol": symbol,
+                    "timeframe": timeframe,
+                    "start": start,
+                    "end": end,
+                }
+            )
+            idx = pd.date_range(start=start, end=end, freq="1min")
+            df = pd.DataFrame(
+                {
+                    "open": 100.0,
+                    "high": 101.0,
+                    "low": 99.0,
+                    "close": 100.5,
+                    "volume": 10.0,
+                },
+                index=idx,
+            )
+            df.index.name = "timestamp"
+            return df
+
+    monkeypatch.setattr(ccxt_data_store, "CcxtCacheDB", FakeCcxtCacheDB)
+
+    routed = RoutedBacktestingPandas.__new__(RoutedBacktestingPandas)
+    routed._routing = {"default": "thetadata", "crypto": "coinbase"}
+    routed._data_store = {}
+
+    backtest_start = datetime(2026, 6, 17, tzinfo=timezone.utc)
+    backtest_end = datetime(2026, 6, 24, tzinfo=timezone.utc)
+    routed.datetime_start = backtest_start
+    routed.datetime_end = backtest_end
+
+    def _get_datetime(self):
+        return backtest_start
+
+    def _get_timestep(self):
+        return "5m"
+
+    def _get_start_datetime_and_ts_unit(self, length, ts, start_dt=None, start_buffer=timedelta(0)):
+        end_dt = start_dt if isinstance(start_dt, datetime) else backtest_start
+        return end_dt - timedelta(minutes=int(length) * 5), "minute"
+
+    def _build_dataset_keys(self, asset, quote, ts_unit):
+        canonical = (asset, quote, ts_unit)
+        legacy = (asset, quote)
+        return canonical, legacy
+
+    routed.get_datetime = MethodType(_get_datetime, routed)
+    routed.get_timestep = MethodType(_get_timestep, routed)
+    routed.get_start_datetime_and_ts_unit = MethodType(_get_start_datetime_and_ts_unit, routed)
+    routed._build_dataset_keys = MethodType(_build_dataset_keys, routed)
+
+    base = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+    quote = Asset("USDT", asset_type=Asset.AssetType.CRYPTO)
+
+    routed._update_pandas_data(base, quote, 400, "5m", start_dt=backtest_start)
+    routed._update_pandas_data(base, quote, 1300, "5m", start_dt=backtest_start)
+
+    assert len(calls) == 2
+    assert calls[0]["symbol"] == "BTC/USDT"
+    assert calls[0]["timeframe"] == "1m"
+    assert calls[1]["symbol"] == "BTC/USDT"
+    assert calls[1]["timeframe"] == "1m"
+    assert calls[1]["start"] < calls[0]["start"]
+    assert calls[1]["end"] == backtest_end
+
+
 def test_routed_ccxt_crypto_empty_full_window_is_not_retried_each_step(monkeypatch):
     import lumibot.tools.ccxt_data_store as ccxt_data_store
 


### PR DESCRIPTION
## Summary
- repair routed CCXT/Coinbase warmup expansion for deeper later lookbacks
- repair legacy CCXT cache range metadata when warm reads prove cached candles are materially underfilled
- document 4.5.58 crypto validation follow-up

## Tests
- /Users/robertgrzesik/bin/safe-timeout 1200s .venv/bin/python -m pytest tests/test_routed_backtesting_ibkr_daily_prefetch.py tests/test_ccxt_store.py tests/test_backtesting_ccxt_execution_semantics.py -q
- /Users/robertgrzesik/bin/safe-timeout 1200s .venv/bin/python -m pytest tests/test_ccxt_store.py tests/test_backtesting_ccxt_execution_semantics.py tests/test_crypto_backtesting_order_matrix.py tests/test_crypto_backtest_validation_runner.py tests/test_routed_backtesting_unit.py tests/test_routed_backtesting_routing_validation.py tests/test_hour_timestep_support.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crypto backtesting so later requests with a deeper lookback now load the full needed price history.
  * Fixed cases where cached market data could appear complete when it was actually missing candles, preventing skipped refreshes.
  * Repaired legacy cache metadata so historical data coverage is reported more accurately and missing ranges are refetched when needed.

* **Tests**
  * Added regression coverage for expanded crypto warmup behavior and legacy cache repair scenarios.

* **Documentation**
  * Updated release notes and validation docs with the latest fixes and test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->