### PR TITLE
v4.5.59 - Coinbase current-edge crypto history gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## 4.5.59 - Unreleased
 
+### Fixed
+- **Coinbase/CCXT crypto backtests now tolerate small current-edge gaps for
+  aggregated intraday history.** A strategy requesting `5m` BTC/USDT history no
+  longer stops just because Coinbase's latest raw minute is 6-7 minutes behind
+  the simulated timestamp, while incomplete aggregate buckets are still dropped
+  and genuinely stale data still fails loudly.
+- **Short crypto price-snapshot gaps no longer spam strategy errors.** Crypto
+  mark-to-market snapshots can use a recent last traded minute at the current
+  provider edge, but long gaps remain rejected so old prices cannot masquerade as
+  current data.
+
+### Tests
+- **Data entity regressions cover the Greg BTC/USDT production edge case.**
+  Tests assert sparse Coinbase-style minute data can satisfy `5m` history at the
+  current edge, excludes incomplete 5-minute bars, allows short BTC/USDT snapshot
+  gaps, and still rejects multi-minute requests past the tolerance.
+
 ## 4.5.58 - 2026-06-25
 
 Deploy marker: `deploy 4.5.58`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.59 - Unreleased
+
 ## 4.5.58 - 2026-06-25
 
 Deploy marker: `deploy 4.5.58`

--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -714,7 +714,18 @@ class Data:
             unit = source_timestep
 
         unit_text = str(unit or "").strip().lower()
-        multiplier = 1 if request_timestep is not None else 3
+        if request_timestep is None:
+            asset_type = getattr(getattr(self, "asset", None), "asset_type", None)
+            asset_type = getattr(asset_type, "value", asset_type)
+            multiplier = 15 if str(asset_type or "").lower() == "crypto" else 3
+        elif quantity > 1:
+            # Aggregated intraday history (for example, 5m bars built from 1m Coinbase candles)
+            # can remain usable when the latest raw minute is a few minutes behind the request.
+            # get_bars() still drops incomplete aggregate buckets, so this does not make future
+            # or partial bars executable.
+            multiplier = 2
+        else:
+            multiplier = 1
         if unit_text == "minute":
             return datetime.timedelta(minutes=quantity * multiplier)
         if unit_text == "hour":
@@ -731,10 +742,11 @@ class Data:
             return None
 
         unit_text = str(unit or "").strip().lower()
+        multiplier = 2 if quantity > 1 else 1
         if unit_text == "minute":
-            return datetime.timedelta(minutes=quantity)
+            return datetime.timedelta(minutes=quantity * multiplier)
         if unit_text == "hour":
-            return datetime.timedelta(hours=quantity)
+            return datetime.timedelta(hours=quantity * multiplier)
         return None
 
     def _timestamp_for_iter_count(self, iter_count: int) -> Optional[pd.Timestamp]:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.58",
+    version="4.5.59",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_data_entity.py
+++ b/tests/test_data_entity.py
@@ -212,6 +212,34 @@ class TestDataGetLastPriceTradeOnly:
 
         assert data.get_last_price(request_dt) == 70511.75
 
+    def test_strict_crypto_snapshot_allows_short_coinbase_edge_gap(self):
+        asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+        quote = Asset("USDT", asset_type=Asset.AssetType.CRYPTO)
+        tz = pytz.timezone("America/New_York")
+        bar_dt = tz.localize(datetime(2026, 6, 22, 5, 19))
+        request_dt = bar_dt + timedelta(minutes=6)
+        future_dt = request_dt + timedelta(minutes=10)
+        df = (
+            pd.DataFrame(
+                {
+                    "datetime": [bar_dt, future_dt],
+                    "open": [64400.0, 64500.0],
+                    "high": [64450.0, 64550.0],
+                    "low": [64350.0, 64450.0],
+                    "close": [64425.0, 64525.0],
+                    "volume": [1.0, 1.0],
+                }
+            )
+            .set_index("datetime")
+        )
+
+        data = Data(asset, df, timestep="minute", quote=quote)
+        data.strict_end_check = True
+
+        snapshot = data.get_price_snapshot(request_dt)
+
+        assert snapshot["close"] == 64425.0
+
     def test_strict_intraday_allows_multi_minute_history_at_bucket_boundary(self):
         asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
         quote = Asset("USDT", asset_type=Asset.AssetType.CRYPTO)
@@ -242,6 +270,36 @@ class TestDataGetLastPriceTradeOnly:
         assert bars.iloc[-1]["close"] == 109.5
         assert base_dt + timedelta(minutes=10) not in bars.index
 
+    def test_strict_intraday_allows_multi_minute_history_with_coinbase_edge_gap(self):
+        asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
+        quote = Asset("USDT", asset_type=Asset.AssetType.CRYPTO)
+        tz = pytz.timezone("America/New_York")
+        base_dt = tz.localize(datetime(2026, 6, 22, 5, 0))
+        dates = [base_dt + timedelta(minutes=i) for i in range(19)]
+        df = (
+            pd.DataFrame(
+                {
+                    "datetime": dates,
+                    "open": [100.0 + i for i in range(19)],
+                    "high": [101.0 + i for i in range(19)],
+                    "low": [99.0 + i for i in range(19)],
+                    "close": [100.5 + i for i in range(19)],
+                    "volume": [1.0] * 19,
+                }
+            )
+            .set_index("datetime")
+        )
+
+        data = Data(asset, df, timestep="minute", quote=quote)
+        data.strict_end_check = True
+
+        bars = data.get_bars(base_dt + timedelta(minutes=25), length=3, timestep="5m")
+
+        assert bars is not None
+        assert not bars.empty
+        assert bars.index.max() <= base_dt + timedelta(minutes=10)
+        assert base_dt + timedelta(minutes=15) not in bars.index
+
     def test_strict_intraday_rejects_multi_minute_history_past_bucket_tolerance(self):
         asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
         quote = Asset("USDT", asset_type=Asset.AssetType.CRYPTO)
@@ -266,7 +324,7 @@ class TestDataGetLastPriceTradeOnly:
         data.strict_end_check = True
 
         with pytest.raises(ValueError, match="after the available data's end"):
-            data.get_bars(base_dt + timedelta(minutes=20), length=3, timestep="5m")
+            data.get_bars(base_dt + timedelta(minutes=25), length=3, timestep="5m")
 
     def test_get_quote_includes_source_bar_provenance(self):
         asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)


### PR DESCRIPTION
## What / Why
Release 4.5.59 narrows the remaining Greg BTC/USDT production issue after 4.5.58. Coinbase can occasionally have the latest raw 1-minute candle 6-7 minutes behind the simulated timestamp. For aggregated intraday history such as `5m`, LumiBot should still be able to use the latest completed aggregate bucket while continuing to reject genuinely stale data and incomplete current buckets.

## Risk
Risk is concentrated in strict intraday freshness checks for crypto/CCXT backtests. Order execution safety remains guarded separately by current execution-bucket checks; stale/future execution bars are still rejected. If this regresses, Greg-style strategies will log `5m data unavailable`, or stale order-fill tests will fail.

## Tests run
- `pytest tests/test_data_entity.py tests/test_backtesting_order_lifecycle.py tests/test_backtesting_broker.py -q` -> 58 passed
- `pytest tests/test_ccxt_store.py tests/test_routed_backtesting_ibkr_daily_prefetch.py tests/test_routed_backtesting_unit.py tests/test_backtesting_ccxt_execution_semantics.py tests/test_crypto_backtesting_order_matrix.py tests/test_crypto_backtest_validation_runner.py tests/test_data_entity.py -q` -> 93 passed, 2 skipped

## Docs
- `CHANGELOG.md` updated for 4.5.59

## Deployment validation plan
After merge/tag/PyPI publish, update Bot Manager to `lumibot==4.5.59`, deploy dev then prod, rerun Greg revision `dfd196a0-1145-4bd8-823d-ddf01c5b09c9` in production, and inspect settings/logs/artifacts before calling it fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of short gaps in intraday crypto data, making 5-minute history and price snapshots more resilient around edge-of-data cases.

* **Bug Fixes**
  * Reduced false errors for Coinbase/CCXT crypto backtests when small minute gaps or short stale windows are present.
  * Tightened stale-data checks for aggregated intraday requests so incomplete or overly old bars are handled more consistently.

* **Tests**
  * Added regression coverage for crypto edge-gap scenarios, including tolerated short gaps, exclusion of incomplete bars, and rejection of larger stale windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->