### PR TITLE
v4.5.60 - Coinbase aggregate history edge fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.60 - Unreleased
+## 4.5.60 - 2026-06-25
+
+Deploy marker: `deploy 4.5.60`
 
 ### Fixed
 - **Coinbase/CCXT crypto aggregate history now tolerates complete 5-minute

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 4.5.60 - Unreleased
 
+### Fixed
+- **Coinbase/CCXT crypto aggregate history now tolerates complete 5-minute
+  bucket lag at the provider edge.** BTC/USDT strategies that request `5m`
+  history can proceed when Coinbase minute candles are up to one additional
+  completed aggregate bucket behind the simulated timestamp, while incomplete
+  buckets are still excluded and larger stale gaps still fail.
+
+### Tests
+- **Greg BTC/USDT regression coverage now pins the 15-minute aggregate edge.**
+  Data entity tests assert crypto `5m` history accepts a 15-minute provider-edge
+  gap but still rejects gaps beyond that threshold.
+
 ## 4.5.59 - Unreleased
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.60 - Unreleased
+
 ## 4.5.59 - Unreleased
 
 ### Fixed

--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -720,10 +720,12 @@ class Data:
             multiplier = 15 if str(asset_type or "").lower() == "crypto" else 3
         elif quantity > 1:
             # Aggregated intraday history (for example, 5m bars built from 1m Coinbase candles)
-            # can remain usable when the latest raw minute is a few minutes behind the request.
-            # get_bars() still drops incomplete aggregate buckets, so this does not make future
-            # or partial bars executable.
-            multiplier = 2
+            # can remain usable when the latest raw minute is a few completed buckets behind the
+            # request. get_bars() still drops incomplete aggregate buckets, so this does not make
+            # future or partial bars executable.
+            asset_type = getattr(getattr(self, "asset", None), "asset_type", None)
+            asset_type = getattr(asset_type, "value", asset_type)
+            multiplier = 3 if str(asset_type or "").lower() == "crypto" else 2
         else:
             multiplier = 1
         if unit_text == "minute":
@@ -742,7 +744,9 @@ class Data:
             return None
 
         unit_text = str(unit or "").strip().lower()
-        multiplier = 2 if quantity > 1 else 1
+        asset_type = getattr(getattr(self, "asset", None), "asset_type", None)
+        asset_type = getattr(asset_type, "value", asset_type)
+        multiplier = 3 if quantity > 1 and str(asset_type or "").lower() == "crypto" else (2 if quantity > 1 else 1)
         if unit_text == "minute":
             return datetime.timedelta(minutes=quantity * multiplier)
         if unit_text == "hour":

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.59",
+    version="4.5.60",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_data_entity.py
+++ b/tests/test_data_entity.py
@@ -270,21 +270,21 @@ class TestDataGetLastPriceTradeOnly:
         assert bars.iloc[-1]["close"] == 109.5
         assert base_dt + timedelta(minutes=10) not in bars.index
 
-    def test_strict_intraday_allows_multi_minute_history_with_coinbase_edge_gap(self):
+    def test_strict_intraday_allows_multi_minute_history_with_coinbase_aggregate_edge_gap(self):
         asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
         quote = Asset("USDT", asset_type=Asset.AssetType.CRYPTO)
         tz = pytz.timezone("America/New_York")
         base_dt = tz.localize(datetime(2026, 6, 22, 5, 0))
-        dates = [base_dt + timedelta(minutes=i) for i in range(19)]
+        dates = [base_dt + timedelta(minutes=i) for i in range(11)]
         df = (
             pd.DataFrame(
                 {
                     "datetime": dates,
-                    "open": [100.0 + i for i in range(19)],
-                    "high": [101.0 + i for i in range(19)],
-                    "low": [99.0 + i for i in range(19)],
-                    "close": [100.5 + i for i in range(19)],
-                    "volume": [1.0] * 19,
+                    "open": [100.0 + i for i in range(11)],
+                    "high": [101.0 + i for i in range(11)],
+                    "low": [99.0 + i for i in range(11)],
+                    "close": [100.5 + i for i in range(11)],
+                    "volume": [1.0] * 11,
                 }
             )
             .set_index("datetime")
@@ -297,8 +297,8 @@ class TestDataGetLastPriceTradeOnly:
 
         assert bars is not None
         assert not bars.empty
-        assert bars.index.max() <= base_dt + timedelta(minutes=10)
-        assert base_dt + timedelta(minutes=15) not in bars.index
+        assert bars.index.max() <= base_dt + timedelta(minutes=5)
+        assert base_dt + timedelta(minutes=10) not in bars.index
 
     def test_strict_intraday_rejects_multi_minute_history_past_bucket_tolerance(self):
         asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)
@@ -324,7 +324,7 @@ class TestDataGetLastPriceTradeOnly:
         data.strict_end_check = True
 
         with pytest.raises(ValueError, match="after the available data's end"):
-            data.get_bars(base_dt + timedelta(minutes=25), length=3, timestep="5m")
+            data.get_bars(base_dt + timedelta(minutes=35), length=3, timestep="5m")
 
     def test_get_quote_includes_source_bar_provenance(self):
         asset = Asset("BTC", asset_type=Asset.AssetType.CRYPTO)


### PR DESCRIPTION
What / Why:
Release 4.5.60 narrows the Coinbase/CCXT crypto history tolerance fix for Greg BTC/USDT production validation. The 4.5.59 production run completed, but logs still exposed 5m data-unavailable messages when Coinbase minute candles lagged a complete aggregate bucket at the current provider edge. This release lets crypto aggregate history tolerate that complete 5-minute bucket lag while still excluding incomplete buckets and rejecting larger stale gaps.

Risk:
Low-to-moderate, isolated to strict intraday freshness checks for crypto aggregate history. Bad behavior would show up as stale-data log signatures or unexpected missing-history behavior in crypto backtests. Non-crypto aggregate tolerance remains unchanged.

Tests run:
- `pytest tests/test_data_entity.py -q` -> 12 passed
- `pytest tests/test_ccxt_store.py tests/test_routed_backtesting_ibkr_daily_prefetch.py tests/test_routed_backtesting_unit.py tests/test_backtesting_ccxt_execution_semantics.py tests/test_crypto_backtesting_order_matrix.py tests/test_crypto_backtest_validation_runner.py tests/test_data_entity.py tests/test_backtesting_order_lifecycle.py tests/test_backtesting_broker.py -q` -> 139 passed, 2 skipped
- `python3 -m pytest -m "not apitest and not downloader" --tb=short -q --durations=30` -> timed out after 900s during acceptance tests; no failure block printed. Release is gated on GitHub CI plus the targeted/broader crypto-local suite above.

Docs/Prompts:
- `CHANGELOG.md` updated for 4.5.60.
- No BotSpot agent prompt change needed: this is a provider-edge data freshness fix in LumiBot, not an agent behavior change.

Post-deploy validation plan:
- Publish `lumibot==4.5.60`.
- Deploy Bot Manager dev and prod with `LUMIBOT_VERSION=4.5.60` and forced rebuild.
- Run Greg exact production revision `dfd196a0-1145-4bd8-823d-ddf01c5b09c9` via BotSpot MCP.
- Assert `settings.json.lumibot_version == "4.5.60"`, artifacts exist, fills exist, and `logs.csv` has no `BadRequest`, `INVALID_ARGUMENT`, `5m data unavailable`, or stale-data rejection signatures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of aggregated intraday crypto history so recent provider-edge delays are accepted when they fall within the expected bucket gap.
  * Continued to exclude incomplete buckets and reject larger stale gaps, keeping history results consistent.
* **Tests**
  * Expanded coverage for aggregated 5-minute crypto history to verify both accepted edge cases and rejected stale requests.
* **Chores**
  * Bumped the package version to 4.5.60.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->