### PR TITLE
v4.5.61 - Split long CCXT cache downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 4.5.61 - Unreleased
 
+### Fixed
+- **Long Coinbase/CCXT minute backtests now split provider downloads under the
+  cache limit.** BTC/USDT runs such as Greg's March 8 through May 1 replay
+  request 79,200 one-minute bars, which is larger than LumiBot's 50,000-bar
+  per-download guard. The CCXT cache now splits those windows into safe chunks
+  instead of failing before Coinbase can page through the historical data.
+
+### Tests
+- **CCXT cache regression coverage now pins the Greg long-window failure
+  shape.** Tests assert a March 8 through May 1 BTC/USDT one-minute request is
+  downloaded as a 50,000-minute chunk plus a 29,200-minute chunk and merged into
+  one cache coverage range.
+
 ## 4.5.60 - 2026-06-25
 
 Deploy marker: `deploy 4.5.60`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.61 - Unreleased
+
 ## 4.5.60 - 2026-06-25
 
 Deploy marker: `deploy 4.5.60`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.61 - Unreleased
+## 4.5.61 - 2026-06-25
+
+Deploy marker: `deploy 4.5.61`
 
 ### Fixed
 - **Long Coinbase/CCXT minute backtests now split provider downloads under the

--- a/docs/CRYPTO_BACKTEST_VALIDATION.md
+++ b/docs/CRYPTO_BACKTEST_VALIDATION.md
@@ -167,6 +167,55 @@ Public Coinbase same-day probe:
 No production deploy was performed for this fix during the local validation
 pass.
 
+### 2026-06-25 Long Coinbase Minute Window Chunking
+
+After LumiBot `4.5.60` was deployed to Bot Manager dev and production, Greg's
+unchanged May 15 BTC/USDT strategy revision
+`c376cdbf-1d59-480f-ba34-513b7b46f1f7` was replayed in production for
+`2026-03-08` through `2026-05-01`.
+
+The original Coinbase `INVALID_ARGUMENT` path was no longer the failure.
+Instead, production backtest `aaaa465a-29a3-48b5-a8ec-7029ca75ec8c` failed
+while building the CCXT cache:
+
+```text
+Exception: Request download range 79200 is greater than download limit 50000
+```
+
+Root cause:
+
+- The CCXT cache correctly expanded the requested replay to the UTC date window
+  `2026-03-08 00:00:00` through `2026-05-01 23:59:59.999999`.
+- At `1m`, that is `79,200` requested units.
+- `_get_barset_from_api()` can page Coinbase in smaller requests, but
+  `_download_and_record_coverage()` rejected any outer cache download range
+  larger than `max_download_limit` before pagination could run.
+
+Fix:
+
+- Oversized CCXT cache download ranges are split into timeframe-aligned chunks
+  no larger than `max_download_limit`.
+- Each chunk is fetched, filtered to executable provider rows, cached, and
+  converted to real-row cache coverage.
+- Adjacent proven coverage ranges are merged back into normal cache metadata.
+- This does not change pair mapping, strategy code, or fallback behavior:
+  `BTC/USDT` still means Coinbase `BTC/USDT`.
+
+Focused proof:
+
+```bash
+/Users/robertgrzesik/bin/safe-timeout 300s .venv/bin/python -m pytest \
+  tests/test_ccxt_store.py -q
+```
+
+Expected regression shape:
+
+- Request: `BTC/USDT`, `1m`, `2026-03-08 00:00:00` through
+  `2026-05-01 23:59:59.999999`.
+- Chunk 1: `50,000` minutes, ending `2026-04-11 17:19:59.999999`.
+- Chunk 2: `29,200` minutes, starting `2026-04-11 17:20:00`.
+- Final cache coverage merges to one range for the full replay window.
+
 ### 2026-06-24 Partial Provider Coverage Must Not Certify The Requested Window
 
 The first production validation after the same-day Coinbase fix no longer hit

--- a/lumibot/tools/ccxt_data_store.py
+++ b/lumibot/tools/ccxt_data_store.py
@@ -40,8 +40,8 @@ class CcxtCacheDB:
     The missing column is 1 for missing data and 0 for non-missing data.
 
     If max_download_limit is not set, both 1m and 1d will be set to 50000.
-    Raise an error if 'end_datetime - start_datetime' is greater than max_download_limit.
-    max_download_limit can be set in __init__.
+    Provider download windows larger than max_download_limit are split into
+    multiple requests. max_download_limit can be set in __init__.
     """
 
     def __init__(self, exchange_id:str,max_download_limit:int=None):
@@ -279,17 +279,15 @@ class CcxtCacheDB:
         downloaded_coverage_ranges = []
 
         for download_start, download_end in download_ranges:
-            range_cnt = self._count_timeframe_units(download_start, download_end, timeframe)
+            for chunk_start, chunk_end in self._split_download_range(download_start, download_end, timeframe, limit):
+                range_cnt = self._count_timeframe_units(chunk_start, chunk_end, timeframe)
 
-            if range_cnt > limit:
-                raise Exception(f"Request download range {range_cnt} is greater than download limit {limit}")
-
-            df = self._get_barset_from_api(symbol, timeframe, range_cnt, download_start, download_end)
-            df = self._fill_missing_data(df, timeframe)
-            self._cache_ohlcv(symbol, df, timeframe)
-            coverage_range = self._coverage_range_from_rows(df, download_start, download_end, timeframe)
-            if coverage_range is not None:
-                downloaded_coverage_ranges.append(coverage_range)
+                df = self._get_barset_from_api(symbol, timeframe, range_cnt, chunk_start, chunk_end)
+                df = self._fill_missing_data(df, timeframe)
+                self._cache_ohlcv(symbol, df, timeframe)
+                coverage_range = self._coverage_range_from_rows(df, chunk_start, chunk_end, timeframe)
+                if coverage_range is not None:
+                    downloaded_coverage_ranges.append(coverage_range)
 
         if not downloaded_coverage_ranges:
             return
@@ -695,6 +693,48 @@ class CcxtCacheDB:
         if seconds is None:
             raise ValueError(f"Unsupported CCXT timeframe {timeframe!r}; expected one of {sorted(_TIMEFRAME_SECONDS)}")
         return max(0, math.ceil((end - start).total_seconds() / seconds))
+
+    def _split_download_range(
+        self,
+        start: datetime,
+        end: datetime,
+        timeframe: str,
+        limit: int,
+    ) -> list[tuple[datetime, datetime]]:
+        if limit <= 0:
+            raise ValueError(f"CCXT download limit must be positive, got {limit!r}")
+
+        seconds = _TIMEFRAME_SECONDS.get(timeframe)
+        if seconds is None:
+            raise ValueError(f"Unsupported CCXT timeframe {timeframe!r}; expected one of {sorted(_TIMEFRAME_SECONDS)}")
+
+        if start > end:
+            return []
+
+        total_units = self._count_timeframe_units(start, end, timeframe)
+        if total_units <= limit:
+            return [(start, end)]
+
+        chunks = []
+        step = timedelta(seconds=seconds * limit)
+        chunk_start = start
+        while chunk_start <= end:
+            next_start = chunk_start + step
+            chunk_end = min(end, next_start - timedelta(microseconds=1))
+            if chunk_end < chunk_start:
+                break
+            chunks.append((chunk_start, chunk_end))
+            chunk_start = next_start
+
+        self.logger.info(
+            "Split CCXT %s download range %s -> %s into %s chunks under limit %s",
+            timeframe,
+            start,
+            end,
+            len(chunks),
+            limit,
+        )
+        return chunks
 
     def _filter_executable_rows(self, df:Union[DataFrame, None])->DataFrame:
         """Return only real provider bars that are safe to expose to strategies."""

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.60",
+    version="4.5.61",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_ccxt_store.py
+++ b/tests/test_ccxt_store.py
@@ -496,6 +496,50 @@ def test_ccxt_cache_keeps_quote_pairs_separate_without_usd_fallback(tmp_path, mo
     assert usd["open"].iloc[0] == 200.0
     assert cache.get_cache_file_name("BTC/USDT", "1m") != cache.get_cache_file_name("BTC/USD", "1m")
 
+
+def test_ccxt_cache_splits_long_minute_download_ranges_under_provider_limit(tmp_path, monkeypatch):
+    cache = _cache_without_live_exchange(tmp_path, monkeypatch)
+    calls = []
+    start = datetime(2026, 3, 8, 0, 0)
+    end = datetime(2026, 5, 1, 23, 59, 59, 999999)
+
+    def fake_get_barset(symbol, timeframe, limit, chunk_start, chunk_end):
+        calls.append(
+            {
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "limit": limit,
+                "start": chunk_start,
+                "end": chunk_end,
+            }
+        )
+        assert limit <= cache.max_download_limit
+        last_bar = chunk_end.replace(second=0, microsecond=0)
+        rows = [(chunk_start, 100.0, 101.0, 99.0, 100.5, 10.0)]
+        if last_bar != chunk_start:
+            rows.append((last_bar, 110.0, 111.0, 109.0, 110.5, 11.0))
+        return _bars(*rows)
+
+    monkeypatch.setattr(cache, "_get_barset_from_api", fake_get_barset)
+
+    df = cache.download_ohlcv("BTC/USDT", "1m", start, end, limit=cache.max_download_limit)
+
+    assert len(calls) == 2
+    assert calls[0]["limit"] == 50_000
+    assert calls[0]["start"] == start
+    assert calls[0]["end"] == datetime(2026, 4, 11, 17, 19, 59, 999999)
+    assert calls[1]["limit"] == 29_200
+    assert calls[1]["start"] == datetime(2026, 4, 11, 17, 20)
+    assert calls[1]["end"] == end
+    assert not df.empty
+
+    with duckdb.connect(cache.get_cache_file_name("BTC/USDT", "1m")) as con:
+        ranges = con.execute("select start_dt, end_dt from cache_dt_ranges order by start_dt").fetch_df()
+    assert len(ranges) == 1
+    assert ranges.iloc[0].start_dt == start
+    assert ranges.iloc[0].end_dt == end
+
+
 @pytest.mark.skip(reason="CCXT integration test requires stable network connection and external API availability")
 @pytest.mark.parametrize("exchange_id,symbol,timeframe,start,end",
                          [ ("bitmex","ETH/USDT","1d",datetime(2022, 8, 1),datetime(2022, 10, 30))


### PR DESCRIPTION
## What
Release LumiBot 4.5.61 with a narrow CCXT cache fix: provider download windows larger than the configured cache limit are split into timeframe-aligned chunks instead of failing before Coinbase pagination can run.

## Why
Greg's unchanged BTC/USDT March 8 through May 1 replay reached Coinbase on 4.5.60, but failed while preparing the cache because 79,200 one-minute bars exceeded the 50,000-bar guard. Coinbase can page the data, but LumiBot rejected the outer cache range too early.

## Risk
Low to moderate. The change is inside the CCXT cache download path. The main risk is off-by-one chunk boundaries, covered by a regression that pins the exact Greg-shaped 50,000 plus 29,200 split and merged cache coverage.

## Tests run
- `/Users/robertgrzesik/bin/safe-timeout 300s .venv/bin/python -m pytest tests/test_ccxt_store.py -q` -> 19 passed, 2 skipped
- `/Users/robertgrzesik/bin/safe-timeout 1200s .venv/bin/python -m pytest tests/test_ccxt_store.py tests/test_backtesting_ccxt_execution_semantics.py tests/test_crypto_backtesting_order_matrix.py tests/test_crypto_backtest_validation_runner.py tests/test_routed_backtesting_unit.py tests/test_routed_backtesting_routing_validation.py tests/test_hour_timestep_support.py -q` -> 81 passed, 2 skipped

## Docs
- `docs/CRYPTO_BACKTEST_VALIDATION.md` records the production 4.5.60 failure, root cause, fix, and regression shape.

## Perf evidence
Not a perf claim. The fix unlocks long Coinbase backtests that previously failed before provider pagination.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long historical minute-data requests are now automatically split into smaller chunks when needed, improving reliability for backtests and cache building.
* **Bug Fixes**
  * Fixed failures caused by oversized CCXT/coinbase download windows exceeding provider limits.
  * Cached results now merge back into a single continuous date range after chunked downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->