### PR TITLE
v4.5.62 - cap NumPy before market-calendar warning regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 4.5.62 - Unreleased
 
+### Fixed
+- **NumPy 2.5 calendar warning spam is avoided by dependency bounds.** Fresh
+  installs could resolve to `numpy==2.5.0`, `pandas==2.3.3`, and
+  `pandas-market-calendars==5.4.0`, causing repeated market-calendar
+  `DeprecationWarning` output whenever schedules were built. LumiBot now caps
+  NumPy below 2.5 until the pandas 2.x calendar path is quiet with NumPy's new
+  generic `timedelta64` deprecation.
+
+### Tests
+- **Dependency-bound regression coverage pins the NumPy 2.5 cap.** A focused
+  test verifies both `setup.py` and `requirements.txt` keep the runtime NumPy
+  upper bound that prevents the market-calendar warning flood.
+
 ## 4.5.61 - 2026-06-25
 
 Deploy marker: `deploy 4.5.61`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.62 - Unreleased
+## 4.5.62 - 2026-06-25
+
+Deploy marker: `deploy 4.5.62`
 
 ### Fixed
 - **NumPy 2.5 calendar warning spam is avoided by dependency bounds.** Fresh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.62 - Unreleased
+
 ## 4.5.61 - 2026-06-25
 
 Deploy marker: `deploy 4.5.61`

--- a/docs/investigations/2026-06-25_NUMPY_25_MARKET_CALENDAR_WARNINGS.md
+++ b/docs/investigations/2026-06-25_NUMPY_25_MARKET_CALENDAR_WARNINGS.md
@@ -1,0 +1,92 @@
+# NumPy 2.5 Market Calendar Warnings
+
+One-line description: Reproduction and fix for repeated pandas-market-calendars deprecation warnings under NumPy 2.5.
+
+Last Updated: 2026-06-25
+
+Status: Fixed in 4.5.62 unreleased branch
+
+Audience: LumiBot maintainers and support
+
+## Overview
+
+A user reported repeated warning spam after upgrading LumiBot. The screenshots
+showed Python warning output from `pandas_market_calendars/market_calendar.py`
+while checking bot status:
+
+- Message: `The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. '+ 1'). Please use a specific unit instead.`
+- Source frame: `pandas_market_calendars/market_calendar.py`, inside the helper
+  that returns `pd.Timedelta(days=day_offset, hours=t.hour, minutes=t.minute, seconds=t.second)`.
+
+## Reproduction
+
+The warning reproduces in a clean Python 3.12 environment with the current
+released dependency resolution for `lumibot==4.5.61`:
+
+```text
+lumibot==4.5.61
+numpy==2.5.0
+pandas==2.3.3
+pandas-market-calendars==5.4.0
+exchange-calendars==4.13.2
+```
+
+Repro command used:
+
+```bash
+python3.12 -m venv tmp/lumibot-4561-full
+tmp/lumibot-4561-full/bin/python -m pip install 'lumibot==4.5.61'
+tmp/lumibot-4561-full/bin/python - <<'PY'
+import warnings
+import pandas_market_calendars as mcal
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    mcal.get_calendar("NYSE").schedule("2026-06-22", "2026-06-24", market_times="all")
+    print(len(caught))
+    for warning in caught[:4]:
+        print(type(warning.message).__name__, warning.filename, warning.lineno, warning.message)
+PY
+```
+
+Observed result: `41` repeated `DeprecationWarning` records from
+`pandas_market_calendars/market_calendar.py`.
+
+The same calendar call is quiet with `numpy==2.5.0`, `pandas==3.0.3`, and
+`pandas-market-calendars==5.4.0`. The same calendar call is also quiet with
+`numpy==2.4.4`, `pandas==3.0.2`, and `pandas-market-calendars==5.3.2`.
+
+## Root Cause
+
+NumPy 2.5.0 exposes a new deprecation for generic, unitless
+`numpy.timedelta64` construction. The current released LumiBot dependency graph
+can still resolve to pandas 2.3.x, and that pandas/calendar combination triggers
+NumPy's warning repeatedly while pandas-market-calendars builds market schedule
+timedeltas.
+
+The warning is not emitted by strategy code, so user-side warning filters may
+not help if the status/live-bot process initializes the calendar before user code
+runs or if warnings are forced to always display.
+
+## Fix
+
+Cap NumPy below 2.5 in LumiBot runtime dependencies:
+
+```text
+numpy>=1.20.0,<2.5.0
+```
+
+This is safer than forcing `pandas>=3` because the current released LumiBot
+dependency graph still resolves to pandas 2.3.x. Once pandas 2.x or the calendar
+dependency is quiet under NumPy 2.5, the NumPy cap can be revisited.
+
+## Verification
+
+Focused verification added:
+
+```bash
+python -m pytest tests/test_dependency_bounds.py
+```
+
+Manual reproduction verified the warning exists before the cap in a clean
+released-package install and that the warning source matches the user screenshot.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ ibapi==9.81.1.post1
 yfinance>=0.2.61
 matplotlib>=3.3.3
 quandl
-numpy>=1.20.0
+numpy>=1.20.0,<2.5.0
 pandas>=2.2.0
 polars>=1.32.3
 pandas_market_calendars>=5.1.0

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,8 @@ setuptools.setup(
         "yfinance>=0.2.61",
         "matplotlib>=3.3.3",
         "quandl",
-        # NumPy 1.20.0+ supports modern features, 2.0+ adds compatibility for latest ecosystem
-        "numpy>=1.20.0",
+        # NumPy 2.5 emits noisy timedelta deprecation warnings through pandas 2.x calendar paths.
+        "numpy>=1.20.0,<2.5.0",
         "pandas>=2.2.0",
         "polars>=1.32.3",
         "pandas_market_calendars>=5.1.0",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.61",
+    version="4.5.62",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_dependency_bounds.py
+++ b/tests/test_dependency_bounds.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_NUMPY_REQUIREMENT = "numpy>=1.20.0,<2.5.0"
+
+
+def _install_requires_from_setup_py() -> list[str]:
+    tree = ast.parse((ROOT / "setup.py").read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_setup_call = (
+            (isinstance(func, ast.Attribute) and func.attr == "setup")
+            or (isinstance(func, ast.Name) and func.id == "setup")
+        )
+        if not is_setup_call:
+            continue
+        for keyword in node.keywords:
+            if keyword.arg == "install_requires":
+                return ast.literal_eval(keyword.value)
+    raise AssertionError("setup.py does not define install_requires")
+
+
+def test_numpy_dependency_cap_prevents_market_calendar_warning_flood():
+    install_requires = _install_requires_from_setup_py()
+    requirements = [
+        line.strip()
+        for line in (ROOT / "requirements.txt").read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+    assert EXPECTED_NUMPY_REQUIREMENT in install_requires
+    assert EXPECTED_NUMPY_REQUIREMENT in requirements


### PR DESCRIPTION
## Summary
- cap NumPy below 2.5.0 in setup.py and requirements.txt to avoid pandas-market-calendars warning floods in clean installs
- add dependency-bound regression coverage for the NumPy cap
- document the NumPy 2.5 calendar warning reproduction and fix

Deploy marker: ed7938a1 (`deploy 4.5.62`)

## Docs/Prompts
- Docs updated: CHANGELOG.md and docs/investigations/2026-06-25_NUMPY_25_MARKET_CALENDAR_WARNINGS.md
- No BotSpot agent prompt change needed: this is dependency resolution/release packaging only, not a strategy-generation or data-provider behavior change.
- No visual asset needed: this is a dependency bounds fix with a text investigation note.

## Tests
- `.venv/bin/python -m pytest tests/test_dependency_bounds.py -q`
- `.venv/bin/python -m ruff check tests/test_dependency_bounds.py`
- `python3 scripts/verify_release_checkout_state.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated NumPy 2.5 deprecation warning spam in calendar-related workflows by tightening the supported NumPy version range.

* **Tests**
  * Added coverage to confirm the NumPy version limit is enforced consistently in both package setup and dependency listing.

* **Chores**
  * Updated the release version to 4.5.62.
  * Added a new changelog entry and investigation note for the warning issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->