### PR TITLE
v4.5.63 - External broker OAuth refresh mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.63 - Unreleased
+
 ## 4.5.62 - 2026-06-25
 
 Deploy marker: `deploy 4.5.62`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.63 - Unreleased
+## 4.5.63 - 2026-06-30
+
+Deploy marker: `deploy 4.5.63`
 
 ### Added
 - **Schwab and Tradier OAuth token files now support explicit external refresh mode.** Set
@@ -9,10 +11,18 @@
   `auto` mode keeps self-hosted LumiBot behavior where LumiBot may call the broker
   OAuth refresh endpoint and write the refreshed provider token file itself.
 
+### Fixed
+- **Schwab stock order submissions and replacements now use the seamless
+  session.** Stock order specs use Schwab's `SEAMLESS` session while non-stock
+  orders continue to use the normal session defaults.
+
 ### Tests
 - **OAuth refresh-mode tests now pin the managed-runtime contract.** Schwab and
   Tradier tests assert external mode skips forced provider refresh calls and
   reloads externally replaced token files, while invalid mode values fail loudly.
+- **Schwab OAuth tests no longer initialize a real local broker during pytest
+  collection.** Broker initialization imports are lazy in the test file and the
+  Schwab forced-refresh persistence fixture is noninteractive.
 
 ## 4.5.62 - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 4.5.63 - Unreleased
 
+### Added
+- **Schwab and Tradier OAuth token files now support explicit external refresh mode.** Set
+  `LUMIBOT_OAUTH_REFRESH_MODE=external` when a trusted parent process refreshes
+  broker OAuth tokens and atomically replaces the provider token file. The default
+  `auto` mode keeps self-hosted LumiBot behavior where LumiBot may call the broker
+  OAuth refresh endpoint and write the refreshed provider token file itself.
+
+### Tests
+- **OAuth refresh-mode tests now pin the managed-runtime contract.** Schwab and
+  Tradier tests assert external mode skips forced provider refresh calls and
+  reloads externally replaced token files, while invalid mode values fail loudly.
+
 ## 4.5.62 - 2026-06-25
 
 Deploy marker: `deploy 4.5.62`

--- a/docsrc/brokers.schwab.rst
+++ b/docsrc/brokers.schwab.rst
@@ -225,6 +225,10 @@ Token Life-cycle & Auto-refresh
 * The refreshed token is written back to `token.json`; it rolls the 7-day window
   forward.  As long as the bot is running (or restarted at least once a week)
   you never need to log in again.
+* In managed environments where a trusted parent process owns broker OAuth
+  refresh, set ``LUMIBOT_OAUTH_REFRESH_MODE=external``. In that mode LumiBot does
+  not call the Schwab OAuth refresh endpoint; it reloads the configured token file
+  when the parent atomically replaces it.
 * Only if the service is **offline for >7 days** will the refresh-token expire.
   In that case repeat the browser login once and redeploy the new payload or
   token file.

--- a/docsrc/brokers.tradier.rst
+++ b/docsrc/brokers.tradier.rst
@@ -71,6 +71,11 @@ point LumiBot at the provider token file:
    TRADIER_OAUTH_CLIENT_ID=your_oauth_client_id
    TRADIER_OAUTH_CLIENT_SECRET=your_oauth_client_secret
 
+Use ``LUMIBOT_OAUTH_REFRESH_MODE=external`` only when a trusted parent process
+owns OAuth refresh and atomically replaces ``TRADIER_TOKEN_PATH``. In the default
+``auto`` mode, LumiBot may call Tradier's OAuth refresh endpoint and write the
+rotated provider token payload back to the token file.
+
 ``TRADIER_ACCESS_TOKEN`` remains supported for manual API-token users. The token
 file path is for OAuth flows that need refresh-token durability.
 

--- a/docsrc/environment_variables.rst
+++ b/docsrc/environment_variables.rst
@@ -403,6 +403,20 @@ TRADIER_TOKEN_PATH
   token payload back to this file atomically. If the file cannot be written,
   refresh fails instead of silently continuing with only in-memory token state.
 
+LUMIBOT_OAUTH_REFRESH_MODE
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Controls who calls the broker OAuth refresh endpoint for Schwab and
+  Tradier token-file integrations.
+- Values:
+  - ``auto`` (default): LumiBot may refresh the provider OAuth token and write the
+    updated token payload back to the configured token file.
+  - ``external``: LumiBot does not call the provider OAuth refresh endpoint. A
+    trusted parent process must atomically replace the configured token file, and
+    LumiBot reloads it before broker requests and after auth failures.
+- Note: Use ``external`` only when another trusted process owns refresh-token
+  handling. The token file still needs a valid access token for broker API calls.
+
 TRADIER_ACCOUNT_NUMBER
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/lumibot/brokers/oauth_refresh_mode.py
+++ b/lumibot/brokers/oauth_refresh_mode.py
@@ -1,0 +1,25 @@
+import os
+
+
+OAUTH_REFRESH_MODE_ENV = "LUMIBOT_OAUTH_REFRESH_MODE"
+OAUTH_REFRESH_MODE_AUTO = "auto"
+OAUTH_REFRESH_MODE_EXTERNAL = "external"
+OAUTH_REFRESH_MODES = {OAUTH_REFRESH_MODE_AUTO, OAUTH_REFRESH_MODE_EXTERNAL}
+
+
+def get_oauth_refresh_mode(config=None) -> str:
+    value = None
+    if isinstance(config, dict):
+        value = config.get(OAUTH_REFRESH_MODE_ENV)
+    if value is None:
+        value = os.environ.get(OAUTH_REFRESH_MODE_ENV)
+
+    mode = str(value or OAUTH_REFRESH_MODE_AUTO).strip().lower()
+    if mode not in OAUTH_REFRESH_MODES:
+        allowed = ", ".join(sorted(OAUTH_REFRESH_MODES))
+        raise ValueError(f"{OAUTH_REFRESH_MODE_ENV} must be one of: {allowed}")
+    return mode
+
+
+def is_external_oauth_refresh_mode(config=None) -> bool:
+    return get_oauth_refresh_mode(config) == OAUTH_REFRESH_MODE_EXTERNAL

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -1593,6 +1593,7 @@ class Schwab(Broker):
                 order_builder,
                 order.time_in_force,
                 apply_defaults=order.order_class is not Order.OrderClass.OCO,
+                session=self._schwab_session_for_order(order),
             )
             if not order_spec:
                 return None
@@ -2055,7 +2056,20 @@ class Schwab(Broker):
             logger.error(traceback.format_exc())
             return None
 
-    def _build_order_spec_from_builder(self, order_builder, time_in_force=None, apply_defaults=True):
+    def _schwab_session_for_order(self, order):
+        """Return the Schwab session to use for an order."""
+        try:
+            from schwab.orders.common import Session
+        except ImportError:
+            logger.error(colored("Failed to import Schwab order enums. Make sure the schwab-py library is installed.", "red"))
+            return None
+
+        if order and getattr(order, "asset", None) and order.asset.asset_type == Asset.AssetType.STOCK:
+            return Session.SEAMLESS
+
+        return Session.NORMAL
+
+    def _build_order_spec_from_builder(self, order_builder, time_in_force=None, apply_defaults=True, session=None):
         """Apply Schwab defaults and return the final API order spec."""
         if not order_builder:
             return None
@@ -2078,7 +2092,7 @@ class Schwab(Broker):
                 elif tif == "cls":
                     order_builder = order_builder.set_duration(Duration.ON_THE_CLOSE)
 
-                order_builder = order_builder.set_session(Session.NORMAL)
+                order_builder = order_builder.set_session(session or Session.NORMAL)
             order_spec = order_builder.build()
 
             if "order_spec" in order_spec:
@@ -2136,7 +2150,11 @@ class Schwab(Broker):
                 equity_buy_to_cover_market,
                 equity_buy_to_cover_limit,
             )
-            return self._build_order_spec_from_builder(order_builder, order.time_in_force)
+            return self._build_order_spec_from_builder(
+                order_builder,
+                order.time_in_force,
+                session=self._schwab_session_for_order(order),
+            )
         finally:
             order.limit_price = original_limit_price
             order.stop_price = original_stop_price
@@ -2190,7 +2208,11 @@ class Schwab(Broker):
                 option_sell_to_close_limit,
                 OptionSymbol,
             )
-            return self._build_order_spec_from_builder(order_builder, order.time_in_force)
+            return self._build_order_spec_from_builder(
+                order_builder,
+                order.time_in_force,
+                session=self._schwab_session_for_order(order),
+            )
         finally:
             order.limit_price = original_limit_price
             order.stop_price = original_stop_price

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -45,6 +45,21 @@ def _botspot_force_broker_token_refresh() -> bool:
     }
 
 
+def _is_external_schwab_token_file_valid(token_path: Path) -> bool:
+    if not token_path.exists():
+        return False
+    try:
+        with token_path.open("r", encoding="utf-8") as fp:
+            payload = json.load(fp)
+        token = payload.get("token") if isinstance(payload.get("token"), dict) else payload
+        if not isinstance(token, dict):
+            return False
+        return bool(token.get("access_token"))
+    except Exception as exc:
+        logger.warning(f"[Schwab] Failed to validate externally managed token file {token_path}: {exc}")
+        return False
+
+
 class SchwabTokenPersistenceError(RuntimeError):
     """Raised when a refreshed Schwab OAuth token cannot be durably written."""
 
@@ -207,6 +222,7 @@ class Schwab(Broker):
         logger.debug(f"SCHWAB_BACKEND_CALLBACK_URL (final): {schwab_backend_redirect_uri}")
         logger.debug(f"SCHWAB_TOKEN (env/config): {'<set>' if token_payload_env else '<not set>'}")
         logger.debug("==== [END Schwab Broker Initialization] ====")
+        external_token_refresh = is_external_oauth_refresh_mode(config)
 
         # Determine where to store the Schwab token file.
         # Priority:
@@ -253,7 +269,12 @@ class Schwab(Broker):
             logger.info(f"[Schwab] Existing token file found at {token_path}. Validating...")
             try:
                 SchwabHelper._ensure_token_metadata(token_path)
-                if SchwabHelper._is_token_valid_for_schwab_py(token_path):
+                token_file_valid = (
+                    _is_external_schwab_token_file_valid(token_path)
+                    if external_token_refresh
+                    else SchwabHelper._is_token_valid_for_schwab_py(token_path)
+                )
+                if token_file_valid:
                     token_available_and_valid = True
                     logger.info(f"[Schwab] Existing token file {token_path} is valid after metadata check.")
                 else:
@@ -381,7 +402,6 @@ class Schwab(Broker):
 
             #add expires_at to token_dict_for_session. This is needed for the auto_refresh to work. Otherwise oauth2session always thinks it expires 30min from startup
             token_dict_for_session['expires_at'] = int(token_dict_for_session['issued_at']/1000 + (token_dict_for_session['expires_in']) - 30) #30 second buffer
-            external_token_refresh = is_external_oauth_refresh_mode(config)
 
             if external_token_refresh:
                 oauth_session = _OAS(client_id=api_key, token=token_dict_for_session)

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -44,6 +44,15 @@ def _botspot_force_broker_token_refresh() -> bool:
     }
 
 
+def _lumibot_disable_token_refresh(config=None) -> bool:
+    value = None
+    if isinstance(config, dict):
+        value = config.get("LUMIBOT_DISABLE_TOKEN_REFRESH")
+    if value is None:
+        value = os.environ.get("LUMIBOT_DISABLE_TOKEN_REFRESH")
+    return str(value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
 class SchwabTokenPersistenceError(RuntimeError):
     """Raised when a refreshed Schwab OAuth token cannot be durably written."""
 
@@ -294,6 +303,28 @@ class Schwab(Broker):
             token_dict_for_session = wrapped_token_data.get('token')
             if not token_dict_for_session or 'access_token' not in token_dict_for_session:
                 raise ValueError("Token file is missing the 'token' object or 'access_token' within it.")
+            token_file_state = {"signature": None}
+
+            def _token_file_signature():
+                stat = token_path.stat()
+                return (stat.st_mtime_ns, stat.st_size)
+
+            def _load_token_file_for_session():
+                with open(token_path, encoding="utf-8") as fp:
+                    latest_wrapped = json.load(fp)
+                latest_token = latest_wrapped.get("token") if isinstance(latest_wrapped, dict) else latest_wrapped
+                if not isinstance(latest_token, dict) or not latest_token.get("access_token"):
+                    raise ValueError("Token file is missing a usable access_token.")
+                if not latest_token.get("refresh_token") and token_dict_for_session.get("refresh_token"):
+                    latest_token["refresh_token"] = token_dict_for_session["refresh_token"]
+                if latest_token.get("issued_at") and latest_token.get("expires_in"):
+                    latest_token["expires_at"] = int(
+                        int(latest_token["issued_at"]) / 1000 + int(float(latest_token["expires_in"])) - 30
+                    )
+                token_dict_for_session.clear()
+                token_dict_for_session.update(latest_token)
+                token_file_state["signature"] = _token_file_signature()
+                return token_dict_for_session
 
             # Build an OAuth2Session that can automatically refresh the Schwab token.
             from requests_oauthlib import OAuth2Session as _OAS
@@ -356,16 +387,21 @@ class Schwab(Broker):
 
             #add expires_at to token_dict_for_session. This is needed for the auto_refresh to work. Otherwise oauth2session always thinks it expires 30min from startup
             token_dict_for_session['expires_at'] = int(token_dict_for_session['issued_at']/1000 + (token_dict_for_session['expires_in']) - 30) #30 second buffer
-            
-            oauth_session = _OAS(
-                client_id=api_key,
-                token=token_dict_for_session,
-                auto_refresh_url="https://api.schwabapi.com/v1/oauth/token",
-                auto_refresh_kwargs=refresh_kwargs,
-                token_updater=_update_token,
-            )
+            disable_token_refresh = _lumibot_disable_token_refresh(config)
 
-            if api_key and client_secret_env:
+            if disable_token_refresh:
+                oauth_session = _OAS(client_id=api_key, token=token_dict_for_session)
+            else:
+                oauth_session = _OAS(
+                    client_id=api_key,
+                    token=token_dict_for_session,
+                    auto_refresh_url="https://api.schwabapi.com/v1/oauth/token",
+                    auto_refresh_kwargs=refresh_kwargs,
+                    token_updater=_update_token,
+                )
+            token_file_state["signature"] = _token_file_signature()
+
+            if api_key and client_secret_env and not disable_token_refresh:
                 def _refresh_token_hook(token_url, headers, body):
                     headers['Authorization'] = f"Basic {base64.b64encode(f'{api_key}:{client_secret_env}'.encode()).decode()}"
                     logger.info(f"[Schwab] Refreshing token with auth headers")
@@ -374,7 +410,42 @@ class Schwab(Broker):
                 #create refresh hook. This is beacuse oa2session does not perform refreshes with auth headers, only with json bodies. 
                 oauth_session.register_compliance_hook("refresh_token_request", _refresh_token_hook)
 
-            if _botspot_force_broker_token_refresh():
+            if disable_token_refresh:
+                original_request = oauth_session.request
+
+                def _reload_if_token_file_changed():
+                    try:
+                        current_signature = _token_file_signature()
+                    except Exception:
+                        return False
+                    if current_signature == token_file_state.get("signature"):
+                        return False
+                    try:
+                        _load_token_file_for_session()
+                        oauth_session.token = token_dict_for_session
+                        logger.info(f"[Schwab] Reloaded externally managed token file from {token_path}")
+                        return True
+                    except Exception as reload_error:
+                        logger.warning(f"[Schwab] Failed to reload externally managed token file: {reload_error}")
+                        return False
+
+                def _request_with_external_token_reload(*args, **kwargs):
+                    _reload_if_token_file_changed()
+                    try:
+                        response = original_request(*args, **kwargs)
+                    except Exception as request_error:
+                        if request_error.__class__.__name__ == "TokenExpiredError" and _reload_if_token_file_changed():
+                            return original_request(*args, **kwargs)
+                        raise
+                    status_code = getattr(response, "status_code", None)
+                    if status_code in {401, 403} and _reload_if_token_file_changed():
+                        return original_request(*args, **kwargs)
+                    return response
+
+                oauth_session.request = _request_with_external_token_reload
+                logger.info("[Schwab] Token auto-refresh disabled; using externally managed SCHWAB_TOKEN_PATH reloads.")
+
+            if _botspot_force_broker_token_refresh() and not disable_token_refresh:
                 refresh_token_value = token_dict_for_session.get("refresh_token")
                 if not refresh_token_value:
                     raise ConnectionError("[Schwab] Forced token refresh requires a refresh_token.")

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 from lumibot.tools import SchwabHelper
 from lumibot.trading_builtins import PollingStream
+from .oauth_refresh_mode import is_external_oauth_refresh_mode
 
 # ---- Lumiwealth default Schwab app configuration ----
 LUMI_DEFAULT_APP_KEY = "RfUVxotUc8p6CbeCwFmophgNZSat0TLv"
@@ -42,15 +43,6 @@ def _botspot_force_broker_token_refresh() -> bool:
         "y",
         "on",
     }
-
-
-def _lumibot_disable_token_refresh(config=None) -> bool:
-    value = None
-    if isinstance(config, dict):
-        value = config.get("LUMIBOT_DISABLE_TOKEN_REFRESH")
-    if value is None:
-        value = os.environ.get("LUMIBOT_DISABLE_TOKEN_REFRESH")
-    return str(value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
 class SchwabTokenPersistenceError(RuntimeError):
@@ -389,9 +381,9 @@ class Schwab(Broker):
 
             #add expires_at to token_dict_for_session. This is needed for the auto_refresh to work. Otherwise oauth2session always thinks it expires 30min from startup
             token_dict_for_session['expires_at'] = int(token_dict_for_session['issued_at']/1000 + (token_dict_for_session['expires_in']) - 30) #30 second buffer
-            disable_token_refresh = _lumibot_disable_token_refresh(config)
+            external_token_refresh = is_external_oauth_refresh_mode(config)
 
-            if disable_token_refresh:
+            if external_token_refresh:
                 oauth_session = _OAS(client_id=api_key, token=token_dict_for_session)
             else:
                 oauth_session = _OAS(
@@ -403,7 +395,7 @@ class Schwab(Broker):
                 )
             token_file_state["signature"] = _token_file_signature()
 
-            if api_key and client_secret_env and not disable_token_refresh:
+            if api_key and client_secret_env and not external_token_refresh:
                 def _refresh_token_hook(token_url, headers, body):
                     headers['Authorization'] = f"Basic {base64.b64encode(f'{api_key}:{client_secret_env}'.encode()).decode()}"
                     logger.info(f"[Schwab] Refreshing token with auth headers")
@@ -412,7 +404,7 @@ class Schwab(Broker):
                 #create refresh hook. This is beacuse oa2session does not perform refreshes with auth headers, only with json bodies. 
                 oauth_session.register_compliance_hook("refresh_token_request", _refresh_token_hook)
 
-            if disable_token_refresh:
+            if external_token_refresh:
                 original_request = oauth_session.request
 
                 def _reload_if_token_file_changed():
@@ -445,9 +437,9 @@ class Schwab(Broker):
                     return response
 
                 oauth_session.request = _request_with_external_token_reload
-                logger.info("[Schwab] Token auto-refresh disabled; using externally managed SCHWAB_TOKEN_PATH reloads.")
+                logger.info("[Schwab] OAuth refresh mode is external; using externally managed SCHWAB_TOKEN_PATH reloads.")
 
-            if _botspot_force_broker_token_refresh() and not disable_token_refresh:
+            if _botspot_force_broker_token_refresh() and not external_token_refresh:
                 refresh_token_value = token_dict_for_session.get("refresh_token")
                 if not refresh_token_value:
                     raise ConnectionError("[Schwab] Forced token refresh requires a refresh_token.")

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -340,6 +340,8 @@ class Schwab(Broker):
                     if not next_token.get("refresh_token") and token_dict_for_session.get("refresh_token"):
                         next_token["refresh_token"] = token_dict_for_session["refresh_token"]
                     now_ms = int(time.time() * 1000)
+                    if updated_token.get("access_token") and not updated_token.get("issued_at"):
+                        next_token["issued_at"] = now_ms
                     next_token.setdefault("issued_at", now_ms)
                     next_token.setdefault("refresh_token_issued_at", token_dict_for_session.get("refresh_token_issued_at", now_ms))
                     next_token.setdefault("expires_in", token_dict_for_session.get("expires_in", 1800))

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -24,6 +24,7 @@ from lumibot.entities import Asset, CashEvent, Order, Position
 from lumibot.tools.helpers import create_options_symbol
 from lumibot.tools.lumibot_logger import get_logger
 from lumibot.trading_builtins import PollingStream
+from .oauth_refresh_mode import OAUTH_REFRESH_MODE_EXTERNAL, get_oauth_refresh_mode
 
 logger = get_logger(__name__)
 
@@ -36,15 +37,6 @@ def _botspot_force_broker_token_refresh() -> bool:
         "y",
         "on",
     }
-
-
-def _lumibot_disable_token_refresh(config=None) -> bool:
-    value = None
-    if isinstance(config, dict):
-        value = config.get("LUMIBOT_DISABLE_TOKEN_REFRESH")
-    if value is None:
-        value = os.environ.get("LUMIBOT_DISABLE_TOKEN_REFRESH")
-    return str(value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
 class TradierTokenPersistenceError(RuntimeError):
@@ -276,7 +268,7 @@ class Tradier(Broker):
         """Refresh Tradier OAuth token if possible. Returns True on successful refresh."""
         if not self._oauth_enabled():
             return False
-        if getattr(self, "_disable_token_refresh", False):
+        if getattr(self, "_oauth_refresh_mode", None) == OAUTH_REFRESH_MODE_EXTERNAL:
             return False
         if not force and not self._oauth_token_needs_refresh():
             return False
@@ -366,7 +358,7 @@ class Tradier(Broker):
                 return
 
             def request_with_refresh(*args, **kwargs):
-                if getattr(self, "_disable_token_refresh", False):
+                if getattr(self, "_oauth_refresh_mode", None) == OAUTH_REFRESH_MODE_EXTERNAL:
                     self._reload_oauth_token_from_path_if_changed()
                 else:
                     # Proactively refresh if near expiry.
@@ -376,7 +368,7 @@ class Tradier(Broker):
                 except Exception as e:
                     if not self._is_auth_error(e):
                         raise
-                    if getattr(self, "_disable_token_refresh", False):
+                    if getattr(self, "_oauth_refresh_mode", None) == OAUTH_REFRESH_MODE_EXTERNAL:
                         if self._reload_oauth_token_from_path_if_changed():
                             return orig_request(*args, **kwargs)
                     # Retry once on auth errors after forcing a refresh.
@@ -450,7 +442,7 @@ class Tradier(Broker):
         self._oauth_token_expires_at = None  # epoch seconds
         self._oauth_token_path = None
         self._oauth_token_path_signature = None
-        self._disable_token_refresh = _lumibot_disable_token_refresh(config)
+        self._oauth_refresh_mode = get_oauth_refresh_mode(config)
 
         payload_b64 = None
         try:
@@ -525,7 +517,7 @@ class Tradier(Broker):
         force_token_refresh = _botspot_force_broker_token_refresh()
         if self._oauth_enabled():
             refreshed = self._refresh_oauth_token(force=force_token_refresh)
-            if force_token_refresh and not self._disable_token_refresh and not refreshed:
+            if force_token_refresh and self._oauth_refresh_mode != OAUTH_REFRESH_MODE_EXTERNAL and not refreshed:
                 raise RuntimeError("[Tradier] Forced OAuth token refresh failed for BotSpot snapshot runtime.")
 
         # Create the Tradier object

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -38,6 +38,15 @@ def _botspot_force_broker_token_refresh() -> bool:
     }
 
 
+def _lumibot_disable_token_refresh(config=None) -> bool:
+    value = None
+    if isinstance(config, dict):
+        value = config.get("LUMIBOT_DISABLE_TOKEN_REFRESH")
+    if value is None:
+        value = os.environ.get("LUMIBOT_DISABLE_TOKEN_REFRESH")
+    return str(value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
 class TradierTokenPersistenceError(RuntimeError):
     """Raised when a refreshed Tradier OAuth token cannot be durably written."""
 
@@ -145,6 +154,52 @@ class Tradier(Broker):
             return False
         return time.time() >= float(expires_at) - self._OAUTH_REFRESH_SKEW_SECONDS
 
+    def _oauth_token_file_signature(self):
+        token_path = getattr(self, "_oauth_token_path", None)
+        if not token_path:
+            return None
+        stat = Path(token_path).stat()
+        return (stat.st_mtime_ns, stat.st_size)
+
+    def _apply_oauth_token_json(self, token_json: dict) -> bool:
+        if not isinstance(token_json, dict):
+            return False
+        new_access_token = token_json.get("access_token") or token_json.get("AUTH_TOKEN")
+        if not new_access_token:
+            return False
+        self._oauth_token_payload_b64 = self._encode_base64url_json(token_json)
+        if token_json.get("refresh_token"):
+            self._oauth_refresh_token = token_json.get("refresh_token")
+        try:
+            issued_at_ms = int(token_json.get("issued_at") or 0)
+            expires_in_s = int(float(token_json.get("expires_in"))) if token_json.get("expires_in") is not None else None
+            self._oauth_token_expires_at = issued_at_ms / 1000.0 + expires_in_s if issued_at_ms and expires_in_s else None
+        except Exception:
+            self._oauth_token_expires_at = None
+        self._apply_access_token(new_access_token)
+        return True
+
+    def _reload_oauth_token_from_path_if_changed(self) -> bool:
+        token_path = getattr(self, "_oauth_token_path", None)
+        if not token_path:
+            return False
+        try:
+            signature = self._oauth_token_file_signature()
+        except Exception:
+            return False
+        if signature == getattr(self, "_oauth_token_path_signature", None):
+            return False
+        try:
+            token_json = self._load_token_json_from_path(token_path)
+            if not self._apply_oauth_token_json(token_json):
+                return False
+            self._oauth_token_path_signature = signature
+            logger.info(f"[Tradier] Reloaded externally managed OAuth token file from {token_path}")
+            return True
+        except Exception as e:
+            logger.warning(f"[Tradier] Failed to reload TRADIER_TOKEN_PATH token file: {e}")
+            return False
+
     def _apply_access_token(self, new_access_token: str) -> None:
         """Update access token across broker + data source Tradier clients (best-effort)."""
         if not new_access_token or not isinstance(new_access_token, str):
@@ -220,6 +275,8 @@ class Tradier(Broker):
     def _refresh_oauth_token(self, *, force: bool = False) -> bool:
         """Refresh Tradier OAuth token if possible. Returns True on successful refresh."""
         if not self._oauth_enabled():
+            return False
+        if getattr(self, "_disable_token_refresh", False):
             return False
         if not force and not self._oauth_token_needs_refresh():
             return False
@@ -309,13 +366,21 @@ class Tradier(Broker):
                 return
 
             def request_with_refresh(*args, **kwargs):
-                # Proactively refresh if near expiry.
-                self._refresh_oauth_token(force=False)
+                if getattr(self, "_disable_token_refresh", False):
+                    self._reload_oauth_token_from_path_if_changed()
+                else:
+                    # Proactively refresh if near expiry.
+                    self._refresh_oauth_token(force=False)
                 try:
                     return orig_request(*args, **kwargs)
                 except Exception as e:
+                    if not self._is_auth_error(e):
+                        raise
+                    if getattr(self, "_disable_token_refresh", False):
+                        if self._reload_oauth_token_from_path_if_changed():
+                            return orig_request(*args, **kwargs)
                     # Retry once on auth errors after forcing a refresh.
-                    if self._is_auth_error(e) and self._refresh_oauth_token(force=True):
+                    elif self._refresh_oauth_token(force=True):
                         return orig_request(*args, **kwargs)
                     raise
 
@@ -384,6 +449,8 @@ class Tradier(Broker):
         self._oauth_client_secret = None
         self._oauth_token_expires_at = None  # epoch seconds
         self._oauth_token_path = None
+        self._oauth_token_path_signature = None
+        self._disable_token_refresh = _lumibot_disable_token_refresh(config)
 
         payload_b64 = None
         try:
@@ -437,6 +504,11 @@ class Tradier(Broker):
             except Exception:
                 # No reliable expiry metadata; refresh-on-401 hook still applies.
                 pass
+            if self._oauth_token_path:
+                try:
+                    self._oauth_token_path_signature = self._oauth_token_file_signature()
+                except Exception:
+                    self._oauth_token_path_signature = None
 
         # Check if the user has provided the necessary keys (after OAuth extraction)
         if access_token is None or account_number is None or paper is None:
@@ -453,7 +525,7 @@ class Tradier(Broker):
         force_token_refresh = _botspot_force_broker_token_refresh()
         if self._oauth_enabled():
             refreshed = self._refresh_oauth_token(force=force_token_refresh)
-            if force_token_refresh and not refreshed:
+            if force_token_refresh and not self._disable_token_refresh and not refreshed:
                 raise RuntimeError("[Tradier] Forced OAuth token refresh failed for BotSpot snapshot runtime.")
 
         # Create the Tradier object

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.62",
+    version="4.5.63",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -82,6 +82,8 @@ def test_schwab_force_refresh_on_startup_rewrites_token(monkeypatch, tmp_path):
     from lumibot.brokers import schwab as schwab_module
     import requests_oauthlib
 
+    old_issued_at = 1_700_000_000_000
+    refreshed_now = 1_782_800_000.123
     token_path = tmp_path / "schwab_token.json"
     token_path.write_text(
         json.dumps(
@@ -90,9 +92,9 @@ def test_schwab_force_refresh_on_startup_rewrites_token(monkeypatch, tmp_path):
                 "token": {
                     "access_token": "old-access",
                     "refresh_token": "old-refresh",
-                    "issued_at": int(time.time() * 1000),
+                    "issued_at": old_issued_at,
                     "expires_in": 1800,
-                    "refresh_token_issued_at": int(time.time() * 1000),
+                    "refresh_token_issued_at": old_issued_at,
                     "refresh_token_expires_in": 7776000,
                     "token_type": "Bearer",
                     "scope": "api",
@@ -138,7 +140,6 @@ def test_schwab_force_refresh_on_startup_rewrites_token(monkeypatch, tmp_path):
                 "access_token": "new-access",
                 "refresh_token": "new-refresh",
                 "expires_in": 1800,
-                "issued_at": int(time.time() * 1000),
             }
 
     class _AccountResponse:
@@ -162,6 +163,7 @@ def test_schwab_force_refresh_on_startup_rewrites_token(monkeypatch, tmp_path):
     monkeypatch.setattr(broker_module.Broker, "_start_orders_thread", lambda self: None)
     monkeypatch.setattr(schwab_module.Schwab, "_finish_initialization", lambda self, *args, **kwargs: None)
     monkeypatch.setattr(schwab_module.Schwab, "_get_stream_object", lambda self: None)
+    monkeypatch.setattr(schwab_module.time, "time", lambda: refreshed_now)
 
     broker = schwab_module.Schwab(
         config={
@@ -183,6 +185,7 @@ def test_schwab_force_refresh_on_startup_rewrites_token(monkeypatch, tmp_path):
     assert rewritten["creation_timestamp"] == 1
     assert rewritten["token"]["access_token"] == "new-access"
     assert rewritten["token"]["refresh_token"] == "new-refresh"
+    assert rewritten["token"]["issued_at"] == int(refreshed_now * 1000)
 
 
 def test_schwab_force_refresh_fails_if_token_file_cannot_be_rewritten(monkeypatch, tmp_path):

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -200,11 +200,8 @@ def test_schwab_force_refresh_fails_if_token_file_cannot_be_rewritten(monkeypatc
                 "creation_timestamp": 1,
                 "token": {
                     "access_token": "old-access",
-                    "refresh_token": "old-refresh",
                     "issued_at": int(time.time() * 1000),
                     "expires_in": 1800,
-                    "refresh_token_issued_at": int(time.time() * 1000),
-                    "refresh_token_expires_in": 7776000,
                     "token_type": "Bearer",
                     "scope": "api",
                 },
@@ -276,11 +273,8 @@ def test_schwab_external_oauth_refresh_mode_skips_forced_refresh_and_uses_extern
                 "creation_timestamp": 1,
                 "token": {
                     "access_token": "old-access",
-                    "refresh_token": "old-refresh",
                     "issued_at": int(time.time() * 1000),
                     "expires_in": 1800,
-                    "refresh_token_issued_at": int(time.time() * 1000),
-                    "refresh_token_expires_in": 7776000,
                     "token_type": "Bearer",
                     "scope": "api",
                 },
@@ -339,9 +333,11 @@ def test_schwab_external_oauth_refresh_mode_skips_forced_refresh_and_uses_extern
     )
 
     assert broker.client.session.kwargs == {}
+    assert broker.client.session.token["access_token"] == "old-access"
+    assert "refresh_token" not in broker.client.session.token
     rewritten = json.loads(token_path.read_text(encoding="utf-8"))
     assert rewritten["token"]["access_token"] == "old-access"
-    assert rewritten["token"]["refresh_token"] == "old-refresh"
+    assert "refresh_token" not in rewritten["token"]
 
 
 def test_schwab_rejects_invalid_oauth_refresh_mode(monkeypatch, tmp_path):
@@ -373,7 +369,7 @@ def test_schwab_rejects_invalid_oauth_refresh_mode(monkeypatch, tmp_path):
     monkeypatch.setattr(requests_oauthlib, "OAuth2Session", lambda *args, **kwargs: None)
     monkeypatch.setattr(broker_module.Broker, "_start_orders_thread", lambda self: None)
 
-    with pytest.raises(ConnectionError, match="Failed to initialize Schwab client"):
+    with pytest.raises(ValueError, match="LUMIBOT_OAUTH_REFRESH_MODE"):
         schwab_module.Schwab(
             config={
                 "SCHWAB_ACCOUNT_NUMBER": "5678",

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -201,8 +201,11 @@ def test_schwab_force_refresh_fails_if_token_file_cannot_be_rewritten(monkeypatc
                 "creation_timestamp": 1,
                 "token": {
                     "access_token": "old-access",
+                    "refresh_token": "old-refresh",
                     "issued_at": int(time.time() * 1000),
                     "expires_in": 1800,
+                    "refresh_token_issued_at": int(time.time() * 1000),
+                    "refresh_token_expires_in": 7776000,
                     "token_type": "Bearer",
                     "scope": "api",
                 },

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -7,9 +7,6 @@ import time
 import pytest
 from unittest.mock import patch, MagicMock
 
-from lumibot.strategies import Strategy
-from lumibot.entities import Asset
-
 
 class TestBrokerInitializationSimple:
     """Test cases for broker initialization and error handling."""
@@ -20,6 +17,8 @@ class TestBrokerInitializationSimple:
         that explains how to set up environment variables.
         """
         # Mock both the credentials imports in the strategy module
+        from lumibot.strategies import Strategy
+
         with patch('lumibot.strategies._strategy.BROKER', None):
             with patch('lumibot.credentials.IS_BACKTESTING', False):
                 # Create a minimal strategy class for testing
@@ -55,6 +54,8 @@ class TestBrokerInitializationSimple:
         mock_broker.data_source = MagicMock()
         mock_broker.data_source.datetime_start = None
         mock_broker.data_source.datetime_end = None
+
+        from lumibot.strategies import Strategy
         
         # Create a minimal strategy class for testing
         class TestStrategy(Strategy):

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -259,3 +259,83 @@ def test_schwab_force_refresh_fails_if_token_file_cannot_be_rewritten(monkeypatc
     preserved = json.loads(token_path.read_text(encoding="utf-8"))
     assert preserved["token"]["access_token"] == "old-access"
     assert preserved["token"]["refresh_token"] == "old-refresh"
+
+
+def test_schwab_disable_token_refresh_skips_forced_refresh_and_uses_external_file(monkeypatch, tmp_path):
+    from lumibot.brokers import broker as broker_module
+    from lumibot.brokers import schwab as schwab_module
+    import requests_oauthlib
+
+    token_path = tmp_path / "schwab_token.json"
+    token_path.write_text(
+        json.dumps(
+            {
+                "creation_timestamp": 1,
+                "token": {
+                    "access_token": "old-access",
+                    "refresh_token": "old-refresh",
+                    "issued_at": int(time.time() * 1000),
+                    "expires_in": 1800,
+                    "refresh_token_issued_at": int(time.time() * 1000),
+                    "refresh_token_expires_in": 7776000,
+                    "token_type": "Bearer",
+                    "scope": "api",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class _OAuth2Session:
+        def __init__(self, *, client_id, token, **kwargs):
+            self.client_id = client_id
+            self.token = token
+            self.kwargs = kwargs
+            self.request_calls = 0
+
+        def register_compliance_hook(self, hook_type, hook):
+            pytest.fail("Disabled token refresh must not install provider refresh hooks")
+
+        def refresh_token(self, *args, **kwargs):
+            pytest.fail("Disabled token refresh must not call Schwab refresh_token")
+
+        def request(self, *args, **kwargs):
+            self.request_calls += 1
+            return type("Response", (), {"status_code": 200})()
+
+    class _AccountResponse:
+        status_code = 200
+
+        def json(self):
+            return [{"accountNumber": "12345678", "hashValue": "hash-123"}]
+
+    class _Client:
+        def __init__(self, *, api_key, session):
+            self.api_key = api_key
+            self.session = session
+
+        def get_account_numbers(self):
+            return _AccountResponse()
+
+    monkeypatch.setenv("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH", "true")
+    monkeypatch.setenv("LUMIBOT_DISABLE_TOKEN_REFRESH", "true")
+    monkeypatch.setenv("SCHWAB_APP_SECRET", "secret")
+    monkeypatch.setattr(requests_oauthlib, "OAuth2Session", _OAuth2Session)
+    monkeypatch.setattr(schwab_module, "Client", _Client)
+    monkeypatch.setattr(broker_module.Broker, "_start_orders_thread", lambda self: None)
+    monkeypatch.setattr(schwab_module.Schwab, "_finish_initialization", lambda self, *args, **kwargs: None)
+    monkeypatch.setattr(schwab_module.Schwab, "_get_stream_object", lambda self: None)
+
+    broker = schwab_module.Schwab(
+        config={
+            "SCHWAB_ACCOUNT_NUMBER": "5678",
+            "SCHWAB_APP_KEY": "app-key",
+            "SCHWAB_APP_SECRET": "secret",
+            "SCHWAB_TOKEN_PATH": str(token_path),
+        }
+    )
+
+    assert broker.client.session.kwargs == {}
+    rewritten = json.loads(token_path.read_text(encoding="utf-8"))
+    assert rewritten["token"]["access_token"] == "old-access"
+    assert rewritten["token"]["refresh_token"] == "old-refresh"

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -264,7 +264,7 @@ def test_schwab_force_refresh_fails_if_token_file_cannot_be_rewritten(monkeypatc
     assert preserved["token"]["refresh_token"] == "old-refresh"
 
 
-def test_schwab_disable_token_refresh_skips_forced_refresh_and_uses_external_file(monkeypatch, tmp_path):
+def test_schwab_external_oauth_refresh_mode_skips_forced_refresh_and_uses_external_file(monkeypatch, tmp_path):
     from lumibot.brokers import broker as broker_module
     from lumibot.brokers import schwab as schwab_module
     import requests_oauthlib
@@ -297,10 +297,10 @@ def test_schwab_disable_token_refresh_skips_forced_refresh_and_uses_external_fil
             self.request_calls = 0
 
         def register_compliance_hook(self, hook_type, hook):
-            pytest.fail("Disabled token refresh must not install provider refresh hooks")
+            pytest.fail("External OAuth refresh mode must not install provider refresh hooks")
 
         def refresh_token(self, *args, **kwargs):
-            pytest.fail("Disabled token refresh must not call Schwab refresh_token")
+            pytest.fail("External OAuth refresh mode must not call Schwab refresh_token")
 
         def request(self, *args, **kwargs):
             self.request_calls += 1
@@ -321,7 +321,7 @@ def test_schwab_disable_token_refresh_skips_forced_refresh_and_uses_external_fil
             return _AccountResponse()
 
     monkeypatch.setenv("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH", "true")
-    monkeypatch.setenv("LUMIBOT_DISABLE_TOKEN_REFRESH", "true")
+    monkeypatch.setenv("LUMIBOT_OAUTH_REFRESH_MODE", "external")
     monkeypatch.setenv("SCHWAB_APP_SECRET", "secret")
     monkeypatch.setattr(requests_oauthlib, "OAuth2Session", _OAuth2Session)
     monkeypatch.setattr(schwab_module, "Client", _Client)
@@ -342,3 +342,42 @@ def test_schwab_disable_token_refresh_skips_forced_refresh_and_uses_external_fil
     rewritten = json.loads(token_path.read_text(encoding="utf-8"))
     assert rewritten["token"]["access_token"] == "old-access"
     assert rewritten["token"]["refresh_token"] == "old-refresh"
+
+
+def test_schwab_rejects_invalid_oauth_refresh_mode(monkeypatch, tmp_path):
+    from lumibot.brokers import broker as broker_module
+    from lumibot.brokers import schwab as schwab_module
+    import requests_oauthlib
+
+    token_path = tmp_path / "schwab_token.json"
+    token_path.write_text(
+        json.dumps(
+            {
+                "creation_timestamp": 1,
+                "token": {
+                    "access_token": "old-access",
+                    "refresh_token": "old-refresh",
+                    "issued_at": int(time.time() * 1000),
+                    "expires_in": 1800,
+                    "refresh_token_issued_at": int(time.time() * 1000),
+                    "refresh_token_expires_in": 7776000,
+                    "token_type": "Bearer",
+                    "scope": "api",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("LUMIBOT_OAUTH_REFRESH_MODE", "disabled")
+    monkeypatch.setattr(requests_oauthlib, "OAuth2Session", lambda *args, **kwargs: None)
+    monkeypatch.setattr(broker_module.Broker, "_start_orders_thread", lambda self: None)
+
+    with pytest.raises(ConnectionError, match="Failed to initialize Schwab client"):
+        schwab_module.Schwab(
+            config={
+                "SCHWAB_ACCOUNT_NUMBER": "5678",
+                "SCHWAB_APP_KEY": "app-key",
+                "SCHWAB_TOKEN_PATH": str(token_path),
+            }
+        )

--- a/tests/test_schwab_positions_unit.py
+++ b/tests/test_schwab_positions_unit.py
@@ -109,6 +109,21 @@ class _ReplaceClient:
         return self.response
 
 
+class _PlaceClient:
+    def __init__(self):
+        self.place_calls = []
+
+    def place_order(self, account_hash, order_spec):
+        self.place_calls.append((account_hash, order_spec))
+        return SimpleNamespace(
+            status_code=201,
+            headers={
+                "Location": "https://api.schwabapi.com/trader/v1/accounts/hash/orders/submitted-123",
+            },
+            text="",
+        )
+
+
 class _Stream:
     def __init__(self):
         self.dispatched = []
@@ -391,6 +406,41 @@ def test_schwab_option_replacement_uses_option_builder_and_updates_identifier():
     assert order.previous_identifiers == ["order-123"]
     assert order.identifier == "replacement-456"
     assert order.limit_price == 4.75
+
+
+def test_schwab_stock_submit_uses_seamless_session():
+    client = _PlaceClient()
+    stream = _Stream()
+    broker = Schwab.__new__(Schwab)
+    broker.name = "Schwab"
+    broker.schwab_authorization_error = False
+    broker.client = client
+    broker.hash_value = "account-hash"
+    broker.stream = stream
+    broker._unprocessed_orders = SafeList(RLock())
+    order = _stock_limit_order(side=Order.OrderSide.BUY, limit_price=10.0)
+
+    submitted = broker._submit_order(order)
+
+    assert submitted is order
+    assert client.place_calls[0][0] == "account-hash"
+    order_spec = client.place_calls[0][1]
+    assert order_spec["session"] == "SEAMLESS"
+    assert order_spec["duration"] == "DAY"
+    assert order.identifier == "submitted-123"
+    assert stream.dispatched[-1][0] == broker.NEW_ORDER
+
+
+def test_schwab_stock_replacement_spec_uses_seamless_session():
+    broker = Schwab.__new__(Schwab)
+    broker.name = "Schwab"
+    order = _stock_limit_order(side=Order.OrderSide.SELL, limit_price=20.0)
+
+    order_spec = broker._prepare_stock_order_spec(order, limit_price=19.5)
+
+    assert order_spec["session"] == "SEAMLESS"
+    assert order_spec["duration"] == "DAY"
+    assert order_spec["price"] in {"19.50", "19.5000"}
 
 
 def test_schwab_prepare_oto_order_builder_builds_trigger_with_cross_asset_child():

--- a/tests/test_tradier_force_refresh.py
+++ b/tests/test_tradier_force_refresh.py
@@ -207,6 +207,47 @@ def test_oauth_force_refresh_failure_raises(monkeypatch):
         )
 
 
+def test_oauth_force_refresh_is_skipped_when_lumibot_token_refresh_disabled(monkeypatch, tmp_path):
+    token_path = tmp_path / "tradier_token.json"
+    token_path.write_text(
+        json.dumps(
+            {
+                "access_token": "old-access",
+                "refresh_token": "old-refresh",
+                "expires_in": 86400,
+                "issued_at": int(time.time() * 1000),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TRADIER_TOKEN_PATH", str(token_path))
+    monkeypatch.setenv("TRADIER_REFRESH_TOKEN", "old-refresh")
+    monkeypatch.setenv("TRADIER_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("TRADIER_OAUTH_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH", "true")
+    monkeypatch.setenv("LUMIBOT_DISABLE_TOKEN_REFRESH", "true")
+    monkeypatch.setenv("DATADOWNLOADER_BASE_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("DATADOWNLOADER_API_KEY", "test")
+
+    from lumibot.brokers import tradier as tradier_module
+
+    monkeypatch.setattr(
+        tradier_module.requests,
+        "post",
+        lambda *args, **kwargs: pytest.fail("Disabled token refresh must not call Tradier refresh endpoint"),
+    )
+
+    broker = Tradier(
+        config={"ACCESS_TOKEN": None, "ACCOUNT_NUMBER": "1234", "PAPER": True},
+        connect_stream=False,
+    )
+
+    assert broker._tradier_access_token == "old-access"
+    rewritten = json.loads(token_path.read_text(encoding="utf-8"))
+    assert rewritten["access_token"] == "old-access"
+    assert rewritten["refresh_token"] == "old-refresh"
+
+
 def test_force_refresh_is_noop_for_api_token_mode(monkeypatch):
     from lumibot.brokers import tradier as tradier_module
 

--- a/tests/test_tradier_force_refresh.py
+++ b/tests/test_tradier_force_refresh.py
@@ -207,7 +207,7 @@ def test_oauth_force_refresh_failure_raises(monkeypatch):
         )
 
 
-def test_oauth_force_refresh_is_skipped_when_lumibot_token_refresh_disabled(monkeypatch, tmp_path):
+def test_oauth_force_refresh_is_skipped_when_oauth_refresh_mode_external(monkeypatch, tmp_path):
     token_path = tmp_path / "tradier_token.json"
     token_path.write_text(
         json.dumps(
@@ -225,7 +225,7 @@ def test_oauth_force_refresh_is_skipped_when_lumibot_token_refresh_disabled(monk
     monkeypatch.setenv("TRADIER_OAUTH_CLIENT_ID", "cid")
     monkeypatch.setenv("TRADIER_OAUTH_CLIENT_SECRET", "secret")
     monkeypatch.setenv("BOTSPOT_FORCE_BROKER_TOKEN_REFRESH", "true")
-    monkeypatch.setenv("LUMIBOT_DISABLE_TOKEN_REFRESH", "true")
+    monkeypatch.setenv("LUMIBOT_OAUTH_REFRESH_MODE", "external")
     monkeypatch.setenv("DATADOWNLOADER_BASE_URL", "http://127.0.0.1:1")
     monkeypatch.setenv("DATADOWNLOADER_API_KEY", "test")
 
@@ -234,7 +234,7 @@ def test_oauth_force_refresh_is_skipped_when_lumibot_token_refresh_disabled(monk
     monkeypatch.setattr(
         tradier_module.requests,
         "post",
-        lambda *args, **kwargs: pytest.fail("Disabled token refresh must not call Tradier refresh endpoint"),
+        lambda *args, **kwargs: pytest.fail("External OAuth refresh mode must not call Tradier refresh endpoint"),
     )
 
     broker = Tradier(
@@ -246,6 +246,18 @@ def test_oauth_force_refresh_is_skipped_when_lumibot_token_refresh_disabled(monk
     rewritten = json.loads(token_path.read_text(encoding="utf-8"))
     assert rewritten["access_token"] == "old-access"
     assert rewritten["refresh_token"] == "old-refresh"
+
+
+def test_rejects_invalid_oauth_refresh_mode(monkeypatch):
+    monkeypatch.setenv("LUMIBOT_OAUTH_REFRESH_MODE", "disabled")
+    monkeypatch.setenv("DATADOWNLOADER_BASE_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("DATADOWNLOADER_API_KEY", "test")
+
+    with pytest.raises(ValueError, match="LUMIBOT_OAUTH_REFRESH_MODE"):
+        Tradier(
+            config={"ACCESS_TOKEN": "access", "ACCOUNT_NUMBER": "1234", "PAPER": True},
+            connect_stream=False,
+        )
 
 
 def test_force_refresh_is_noop_for_api_token_mode(monkeypatch):

--- a/tests/test_tradier_oauth_refresh.py
+++ b/tests/test_tradier_oauth_refresh.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+import json
 
 import requests
 
@@ -65,3 +66,72 @@ def test_oauth_refresh_hook_does_not_retry_non_auth_error():
     else:
         raise AssertionError("Expected non-auth error to propagate")
     assert refresh_calls == [False]
+
+
+def test_disabled_oauth_refresh_reloads_token_file_and_retries_auth_error(tmp_path):
+    token_path = tmp_path / "tradier_token.json"
+    token_path.write_text(
+        json.dumps(
+            {
+                "access_token": "old-access",
+                "refresh_token": "old-refresh",
+                "expires_in": 86400,
+                "issued_at": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    attempts = 0
+    component = SimpleNamespace(
+        AUTH_TOKEN="old-access",
+        REQUESTS_HEADERS={"Authorization": "Bearer old-access"},
+    )
+
+    def request(endpoint):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            token_path.write_text(
+                json.dumps(
+                    {
+                        "access_token": "new-access",
+                        "refresh_token": "new-refresh",
+                        "expires_in": 86400,
+                        "issued_at": 2,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            raise requests.exceptions.RetryError("too many 401 error responses")
+        return {"ok": True, "endpoint": endpoint}
+
+    component.request = request
+
+    broker = Tradier.__new__(Tradier)
+    broker._oauth_token_payload_b64 = "present"
+    broker._disable_token_refresh = True
+    broker._oauth_token_path = str(token_path)
+    broker._oauth_token_path_signature = broker._oauth_token_file_signature()
+    broker._oauth_refresh_token = "old-refresh"
+    broker._oauth_token_expires_at = None
+    broker._tradier_access_token = "old-access"
+    broker.tradier = SimpleNamespace(account=component, orders=None, market=None)
+    broker.data_source = None
+
+    def fail_refresh(*, force=False):
+        raise AssertionError("Disabled token refresh must not call provider refresh")
+
+    broker._refresh_oauth_token = fail_refresh
+
+    broker._install_oauth_refresh_hooks()
+
+    assert broker.tradier.account.request("v1/accounts/123/balances") == {
+        "ok": True,
+        "endpoint": "v1/accounts/123/balances",
+    }
+    assert attempts == 2
+    assert broker._tradier_access_token == "new-access"
+    assert broker._oauth_refresh_token == "new-refresh"
+    assert component.AUTH_TOKEN == "new-access"
+    assert component.REQUESTS_HEADERS["Authorization"] == "Bearer new-access"

--- a/tests/test_tradier_oauth_refresh.py
+++ b/tests/test_tradier_oauth_refresh.py
@@ -68,7 +68,7 @@ def test_oauth_refresh_hook_does_not_retry_non_auth_error():
     assert refresh_calls == [False]
 
 
-def test_disabled_oauth_refresh_reloads_token_file_and_retries_auth_error(tmp_path):
+def test_external_oauth_refresh_mode_reloads_token_file_and_retries_auth_error(tmp_path):
     token_path = tmp_path / "tradier_token.json"
     token_path.write_text(
         json.dumps(
@@ -110,7 +110,7 @@ def test_disabled_oauth_refresh_reloads_token_file_and_retries_auth_error(tmp_pa
 
     broker = Tradier.__new__(Tradier)
     broker._oauth_token_payload_b64 = "present"
-    broker._disable_token_refresh = True
+    broker._oauth_refresh_mode = "external"
     broker._oauth_token_path = str(token_path)
     broker._oauth_token_path_signature = broker._oauth_token_file_signature()
     broker._oauth_refresh_token = "old-refresh"
@@ -120,7 +120,7 @@ def test_disabled_oauth_refresh_reloads_token_file_and_retries_auth_error(tmp_pa
     broker.data_source = None
 
     def fail_refresh(*, force=False):
-        raise AssertionError("Disabled token refresh must not call provider refresh")
+        raise AssertionError("External OAuth refresh mode must not call provider refresh")
 
     broker._refresh_oauth_token = fail_refresh
 


### PR DESCRIPTION
## What
Release LumiBot 4.5.63 with explicit broker OAuth refresh modes for Schwab and Tradier.

## Why
BotSpot-managed runtimes need a mode where a trusted parent process refreshes provider tokens and atomically replaces child token files, while the child strategy reloads those files without calling broker OAuth refresh endpoints itself. Self-hosted LumiBot should keep normal `auto` behavior.

## Changes
- Adds `LUMIBOT_OAUTH_REFRESH_MODE=auto|external`.
- Removes the unfinished `LUMIBOT_DISABLE_TOKEN_REFRESH` alias rather than carrying compatibility for an unreleased flag.
- Allows Schwab external mode to start from access-only token files.
- Makes Tradier external mode reload changed token files and retry auth failures without provider refresh calls.
- Preserves Schwab issued-at metadata on refresh responses that omit it.
- Uses Schwab `SEAMLESS` session for stock order submit and replacement specs.
- Keeps broker initialization tests from loading local live broker credentials during pytest collection.

## Risk
- Broker auth behavior is sensitive. If external mode is misconfigured, managed runtimes may fail with broker auth errors instead of refreshing internally.
- Schwab stock order session behavior changes from normal to seamless for stock orders only.
- BotSpot managed rollout still needs Bot Manager wiring and dev validation before production use.

## Tests run
- `python3 -m pytest -m "not apitest and not downloader" --tb=short -q --durations=30` timed out locally with no useful output before targeted isolation.
- `python3 -m pytest tests/test_broker_initialization.py tests/test_tradier_force_refresh.py tests/test_tradier_oauth_refresh.py tests/test_schwab_positions_unit.py -q` passed: 57 passed, 13 warnings.
- Focused local parent-refresh harness was run from Bot Manager against saved private Schwab and Tradier OAuth test tokens and proved external access-only file replacement/reload for both providers.

## Docs
- `CHANGELOG.md`
- `docsrc/environment_variables.rst`
- `docsrc/brokers.schwab.rst`
- `docsrc/brokers.tradier.rst`

No docs visuals are needed: this is an environment-variable/runtime behavior release, not a user-facing visual flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an external OAuth refresh mode for Schwab and Tradier token-file setups, letting token updates be managed outside the app.
* **Bug Fixes**
  * Improved Schwab stock order handling to use the correct session type for submissions and replacements.
  * Made token-file refresh behavior more resilient when tokens are updated externally or expire during use.
* **Documentation**
  * Updated broker and environment variable docs with the new OAuth refresh mode and usage guidance.
* **Chores**
  * Released version 4.5.63.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->