### PR TITLE
Release Lumibot 4.5.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## 4.5.64 - Unreleased
 
+### Fixed
+- **IBKR daily stock backtests now normalize mixed split-adjustment cache
+  segments before accounting.** A local/dev TQQQ 200-day backtest hit a mixed
+  IBKR S3 cache where 2021/2022 TQQQ split rows were already continuous but the
+  2024-01-31 through 2025-11-19 tail was raw before the real 2025-11-20 2:1
+  split. LumiBot now detects raw split-level jumps per split boundary,
+  normalizes only the raw pre-split segment into split-adjusted price space, and
+  marks the frame `_split_adjusted` so the generic broker-ledger split path does
+  not double-count already-adjusted providers such as Yahoo or normalized IBKR.
+
+### Docs
+- **The TQQQ split RCA documents the false dev crash, the false 60% intermediate
+  fix, and the corrected IBKR/Yahoo replay results.** The investigation records
+  the mixed dev-cache shape, production DB evidence that prior TQQQ 200-day
+  backtests were in the expected range, and the remaining separate dev-cache
+  completeness follow-up.
+
+### Tests
+- **IBKR split-normalization regressions now cover raw forward splits, reverse
+  splits, already-adjusted rows, and the exact mixed TQQQ cache shape.** The
+  broader split suite also verifies regular and reverse position-ledger splits,
+  idempotence, invalid ratios, non-stock positions, split-adjusted provider
+  skips, Yahoo action handling, and daily backtest hold-through behavior.
+
 ## 4.5.63 - 2026-06-30
 
 Deploy marker: `deploy 4.5.63`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 
 ## 4.5.64 - Unreleased
 
+### Added
+- **Polymarket International CLOB support now includes prediction-contract
+  assets, broker dispatch, live smoke tooling, and public docs.** LumiBot can
+  select the Polymarket broker through `TRADING_BROKER=polymarket`, represent
+  prediction contracts as a first-class asset type, normalize live CLOB response
+  shapes, and use deposit-wallet credentials with explicit signature-type
+  configuration.
+- **Polymarket prediction-contract backtesting can use real Polymarket
+  price-history bars.** `PolymarketBacktesting` loads CLOB price-history data,
+  keeps prices in the `0..1` prediction-market range, validates market tick size
+  and minimum order size, and supports deterministic examples/tests for market
+  and limit order fills.
+
 ### Fixed
+- **ThetaData option valuation is more robust for option backtests.** The
+  ThetaData backtesting path now avoids stale or missing option marks in the
+  relevant valuation path covered by the 4.5.64 release tests.
 - **Schwab and Tradier external OAuth mode now keeps managed child runtimes
   access-token-only.** When ``LUMIBOT_OAUTH_REFRESH_MODE=external`` is set,
   broker clients strip refresh-token material from in-memory token payloads,
@@ -18,6 +34,10 @@
   not double-count already-adjusted providers such as Yahoo or normalized IBKR.
 
 ### Docs
+- **Polymarket setup is documented in both published RST docs and repo
+  Markdown.** The release includes the CLOB integration research, live-proof
+  notes, environment-variable reference, broker docs, README updates, and
+  generated `llms.txt`/sitemap updates.
 - **The TQQQ split RCA documents the false dev crash, the false 60% intermediate
   fix, and the corrected IBKR/Yahoo replay results.** The investigation records
   the mixed dev-cache shape, production DB evidence that prior TQQQ 200-day
@@ -25,6 +45,10 @@
   differences, and the remaining separate dev-cache completeness follow-up.
 
 ### Tests
+- **Polymarket unit and backtesting coverage now exercises broker parsing,
+  quote/last-price behavior, prediction-contract cash accounting, limit/market
+  fills, tick-size validation, data-source defaults, and example strategy
+  imports.**
 - **External OAuth regressions now cover repeated parent-token-file
   replacement across multiple child brokers.** Schwab and Tradier tests prove
   external mode strips stale refresh tokens, skips provider refresh calls,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 4.5.64 - Unreleased
 
 ### Fixed
+- **Schwab and Tradier external OAuth mode now keeps managed child runtimes
+  access-token-only.** When ``LUMIBOT_OAUTH_REFRESH_MODE=external`` is set,
+  broker clients strip refresh-token material from in-memory token payloads,
+  reload atomically replaced access-token files, and never attempt provider
+  OAuth refresh from the strategy process.
 - **IBKR daily stock backtests now normalize mixed split-adjustment cache
   segments before accounting.** A local/dev TQQQ 200-day backtest hit a mixed
   IBKR S3 cache where 2021/2022 TQQQ split rows were already continuous but the
@@ -20,6 +25,11 @@
   differences, and the remaining separate dev-cache completeness follow-up.
 
 ### Tests
+- **External OAuth regressions now cover repeated parent-token-file
+  replacement across multiple child brokers.** Schwab and Tradier tests prove
+  external mode strips stale refresh tokens, skips provider refresh calls,
+  reloads access-only token files, and handles repeated atomic replacements
+  shared by several broker instances.
 - **IBKR split-normalization regressions now cover raw forward splits, reverse
   splits, already-adjusted rows, and the exact mixed TQQQ cache shape.** The
   suite also covers the `get_price_data()` cached daily stock path and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.64 - Unreleased
+
 ## 4.5.63 - 2026-06-30
 
 Deploy marker: `deploy 4.5.63`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,19 @@
 - **The TQQQ split RCA documents the false dev crash, the false 60% intermediate
   fix, and the corrected IBKR/Yahoo replay results.** The investigation records
   the mixed dev-cache shape, production DB evidence that prior TQQQ 200-day
-  backtests were in the expected range, and the remaining separate dev-cache
-  completeness follow-up.
+  backtests were in the expected range, the dev/prod S3 cache inventory
+  differences, and the remaining separate dev-cache completeness follow-up.
 
 ### Tests
 - **IBKR split-normalization regressions now cover raw forward splits, reverse
   splits, already-adjusted rows, and the exact mixed TQQQ cache shape.** The
-  broader split suite also verifies regular and reverse position-ledger splits,
-  idempotence, invalid ratios, non-stock positions, split-adjusted provider
-  skips, Yahoo action handling, and daily backtest hold-through behavior.
+  suite also covers the `get_price_data()` cached daily stock path and a
+  deterministic TQQQ daily backtest that buys before the 2025 split, holds
+  through it without a false equity cliff, and sells the non-doubled adjusted
+  quantity. The broader split suite also verifies regular and reverse
+  position-ledger splits, idempotence, invalid ratios, non-stock positions,
+  split-adjusted provider skips, Yahoo action handling, and daily backtest
+  hold-through behavior.
 
 ## 4.5.63 - 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Lumibot: Backtestable AI Agents and Python Algorithmic Trading
 
-**Build deterministic trading strategies, AI trading agents, and AI trading teams for stocks, options, crypto, futures, forex, SEC filings, FRED macro data, technical indicators, and real brokers.** Backtest, paper trade, or run live with the same Python code.
+**Build deterministic trading strategies, AI trading agents, and AI trading teams for stocks, options, crypto, futures, forex, prediction markets, SEC filings, FRED macro data, technical indicators, and real brokers.** Backtest, paper trade, or run live with the same Python code.
 
 **Full docs:** [lumibot.lumiwealth.com](https://lumibot.lumiwealth.com/) · **Managed cloud:** [BotSpot.trade](https://botspot.trade/sales?showLogin=1&utm_source=github&utm_medium=readme&utm_campaign=lumibot&utm_content=top_text_link&sample=lumibot_readme_deploy) · **MCP:** [BotSpot for AI coding agents](https://botspot.trade/agents?utm_source=github&utm_medium=readme&utm_campaign=lumibot&utm_content=top_mcp_link)
 
@@ -287,7 +287,7 @@ That matters because an AI trading demo is not the same thing as a trading syste
 
 | Project | Main angle | AI agents / teams | Backtest agent decisions | Paper/live broker path | Deterministic Python strategies | Hosted data/deploy/monitoring |
 |---------|------------|-------------------|--------------------------|------------------------|---------------------------------|-------------------------------|
-| **Lumibot + BotSpot** | Python strategies, flexible AI trading teams, hybrid guardrails, backtests, brokers, hosted deployment | **Flexible teams, debates, specialist desks, and deterministic gates** | **Replayable decisions, orders, traces, artifacts, charts, logs** | **Yes: Alpaca, IBKR, Tradier, Schwab, Tradovate, ProjectX, Bitunix, selected CCXT** | **Yes** | **Hosted data, parallel backtests, deployment, monitoring, MCP, alerts, kill switches** |
+| **Lumibot + BotSpot** | Python strategies, flexible AI trading teams, hybrid guardrails, backtests, brokers, hosted deployment | **Flexible teams, debates, specialist desks, and deterministic gates** | **Replayable decisions, orders, traces, artifacts, charts, logs** | **Yes: Alpaca, IBKR, Tradier, Schwab, Tradovate, ProjectX, Bitunix, Polymarket, selected CCXT** | **Yes** | **Hosted data, parallel backtests, deployment, monitoring, MCP, alerts, kill switches** |
 | TradingAgents | Multi-agent LLM trading research framework | Yes, with a specific research/debate structure | Research/demo oriented | Not the main focus | Limited | No |
 | ai-hedge-fund | Educational AI hedge fund with named investor-style agents | Yes, with investor-style personas | Demo/backtest oriented | Not the main focus | Limited | No |
 | OpenAlice | One-person Wall Street agent concept | Yes, end-to-end agent concept | Emerging/experimental | Local/self-run focus | Limited | No |
@@ -307,10 +307,11 @@ See the docs comparison pages for more detail: [Lumibot vs TradingAgents](https:
 | **Stocks** | Yes | Yes | No | Yes | Yes | No | Yes | Yes | No |
 | **Options** | **Yes** | No | No | No | No | No | No | Limited | No |
 | **Crypto** | Yes | Limited | Yes | No | Yes | Yes | Yes | Yes | Yes |
+| **Prediction markets** | Polymarket trading and backtesting | No | No | No | No | No | No | No | Limited/no |
 | **Futures** | Yes | Limited | Crypto only | Partial | Yes | Crypto only | Yes | Yes | Perpetuals/crypto venues |
 | **Forex** | Yes | Outdated | No | No | Yes | No | Yes | Yes | No |
 | **AI agent runtime** | Built-in | No | FreqAI (ML) | No | No | ML pipeline | No | No | Scripts/controllers |
-| **Broker execution** | Alpaca, IBKR, Tradier, Schwab, Tradovate, TopstepX (via ProjectX), Bitunix, selected CCXT | IB only (outdated) | Crypto exchanges | None | None | Crypto exchanges | No | Exchange adapters | Crypto exchanges |
+| **Broker execution** | Alpaca, IBKR, Tradier, Schwab, Tradovate, TopstepX (via ProjectX), Bitunix, Polymarket, selected CCXT | IB only (outdated) | Crypto exchanges | None | None | Crypto exchanges | No | Exchange adapters | Crypto exchanges |
 | **Hosted deployment path** | BotSpot | No | No | No | No | Paid cloud | No | No | Hummingbot Foundation/enterprise ecosystem |
 | **License** | MIT | GPL-3.0 | GPL-3.0 | Apache-2.0 | AGPL-3.0 | MIT | Apache-2.0 | LGPL-3.0 | Apache-2.0 |
 
@@ -358,7 +359,7 @@ trader.run_all()
 
 ## Supported Brokers
 
-Lumibot supports stocks, options, crypto, futures, forex, and indexes across several broker integrations:
+Lumibot supports stocks, options, crypto, futures, forex, indexes, and prediction contracts across several broker integrations:
 
 <p align="center">
   <img src="docs/assets/readme/lumibot_brokers_data_sources.png" alt="Lumibot broker and data source integrations" width="100%">
@@ -371,6 +372,7 @@ Lumibot supports stocks, options, crypto, futures, forex, and indexes across sev
 - Tradovate
 - TopstepX futures (via ProjectX)
 - Bitunix
+- Polymarket prediction-contract trading and backtesting
 - Selected CCXT crypto paths. Coinbase, Kraken, and WEEX have auto-detected credential paths; KuCoin, Binance, and BitMEX have documented manual CCXT setup paths; Kraken, Binance, KuCoin, BitMEX, Bybit, and OKX have documented backtesting examples. Lumibot does not claim blanket support for every CCXT exchange.
 
 ## Select Backtesting Data Sources
@@ -385,6 +387,7 @@ Lumibot can backtest from free daily data, broker data, premium market data, and
 - DataBento
 - Tradier
 - Schwab
+- Polymarket prediction-contract price history
 - CCXT backtesting examples: Kraken, Binance, KuCoin, BitMEX, Bybit, and OKX
 - Pandas/CSV dataframes
 
@@ -446,7 +449,7 @@ Browse and contribute open-source strategies: **[lumibot-strategies](https://git
 
 ## Example Strategies
 
-Lumibot includes 25+ example strategies covering stocks, options, crypto, futures, and forex:
+Lumibot includes 25+ example strategies covering stocks, options, crypto, futures, forex, and Polymarket prediction contracts:
 
 ```bash
 # Run a simple buy-and-hold backtest
@@ -458,6 +461,8 @@ ls lumibot/example_strategies/
 
 Browse all examples: [example_strategies/](lumibot/example_strategies/)
 
+Polymarket example: [polymarket_prediction_contract.py](lumibot/example_strategies/polymarket_prediction_contract.py)
+
 **External example repo:** [stock_example_algo](https://github.com/Lumiwealth-Strategies/stock_example_algo) shows a minimal strategy repository you can run yourself or adapt inside BotSpot.
 
 ## Backtesting Data Sources
@@ -465,7 +470,7 @@ Browse all examples: [example_strategies/](lumibot/example_strategies/)
 Select a data source via environment variable (overrides code):
 
 ```bash
-export BACKTESTING_DATA_SOURCE=thetadata   # or yahoo, ibkr, polygon
+export BACKTESTING_DATA_SOURCE=thetadata   # or yahoo, ibkr, polygon, polymarket
 ```
 
 Multi-provider routing by asset type:
@@ -484,6 +489,7 @@ Crypto futures/perpetual backtests can route `Asset.AssetType.CRYPTO_FUTURE` thr
 | Alpaca      | Yes   | Yes            | No        | No                        |
 | Polygon     | Yes   | Yes            | No        | No                        |
 | Tradier     | Yes   | Yes            | No        | No                        |
+| Polymarket  | Yes   | N/A            | N/A       | N/A                       |
 | Pandas*     | Yes   | Yes            | Yes       | Yes                       |
 
 *Pandas loads CSV files in Yahoo dataframe format, which can contain dividends.

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -20,6 +20,29 @@ This page documents environment variables used by LumiBot, with an emphasis on *
   - The tool date-gates requests to the strategy datetime during backtests.
   - Do not commit real key values.
 
+### Polymarket CLOB broker variables
+- Selectors:
+  - `TRADING_BROKER=polymarket` or `TRADING_BROKER=polymarket_clob`
+  - `DATA_SOURCE=polymarket` or `DATA_SOURCE=polymarket_clob` for public market data only.
+- Local prototype secret storage: `.env.local` is loaded after `.env` unless `LUMIBOT_DISABLE_DOTENV_LOCAL=1`.
+- Credential fields:
+  - `POLYMARKET_PRIVATE_KEY`: wallet private key/session signer for CLOB signing (**secret**).
+  - `POLYMARKET_WALLET_ADDRESS`: deposit wallet/funder address.
+  - `POLYMARKET_CLOB_API_KEY`, `POLYMARKET_CLOB_API_SECRET`, `POLYMARKET_CLOB_API_PASSPHRASE`: optional CLOB L2 credentials (**secret**).
+  - `POLYMARKET_API_CREDENTIALS_JSON`: optional JSON wrapper for CLOB credentials (**secret**).
+  - `POLYMARKET_RELAYER_API_KEY`, `POLYMARKET_RELAYER_API_KEY_ADDRESS`: relayer credentials for wallet deployment/approval flows when required (**secret**).
+  - `POLYMARKET_BUILDER_CODE`: optional attribution code.
+  - `POLYMARKET_AUTO_APPROVE`: truthy to attempt CLOB collateral approval setup before live trading.
+  - `POLYMARKET_MAX_MARKET_ORDER_NOTIONAL`: hard cap for market BUY dollar amount; defaults to `5`.
+- Test gates:
+  - `POLYMARKET_TEST_TOKEN_ID`: explicit token id for public/live smoke tests.
+  - `POLYMARKET_LIVE_TRADING_ENABLED=true`: required before any live submit/cancel smoke test can run.
+  - `POLYMARKET_TEST_MAX_NOTIONAL`: additional live-test cap; default path never exceeds `5`.
+- Notes:
+  - Do not auto-detect Polymarket from a private key. Use explicit `TRADING_BROKER=polymarket`.
+  - Relayer keys are not the same as CLOB trading credentials.
+  - Never commit or log raw Polymarket private keys or CLOB credentials.
+
 ### `LUMIBOT_DISABLE_DOTENV`
 - Purpose: Disable automatic `.env` discovery and loading at startup.
 - Values: truthy enables (`1`, `true`, `yes`); unset/`0` disables.

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -44,8 +44,9 @@ This page documents environment variables used by LumiBot, with an emphasis on *
   - Do not auto-detect Polymarket from a private key. Use explicit `TRADING_BROKER=polymarket`.
   - Relayer keys are not the same as CLOB trading credentials.
   - CLOB collateral balances are returned in 6-decimal raw units by `get_balance_allowance`; LumiBot scales those into dollars.
-  - Current local proof on 2026-07-01 can read balances, positions, open orders, trades, public data, and public/private WebSockets. Live submit is blocked for Rob's current Magic/proxy account by Polymarket's deposit-wallet/API-key binding error: `maker address not allowed, please use the deposit wallet flow`.
-  - Direct smoke helper: `scripts/polymarket_smoke.py`. It loads `.env.local`, redacts output, writes artifacts under gitignored `logs/`, and only submits live orders when `POLYMARKET_LIVE_TRADING_ENABLED=true` plus notional caps are present.
+  - Current local proof on 2026-07-02 can read balances, positions, open orders, trades, public data, public/private WebSockets, and live submit/cancel through LumiBot with the funded deposit wallet.
+  - BUY orders need pUSD collateral approval. SELL orders need conditional-token approvals from the deposit wallet; use `scripts/polymarket_deposit_wallet_setup.py --approve-conditional`.
+  - Direct smoke helper: `scripts/polymarket_smoke.py`. LumiBot smoke helper: `scripts/polymarket_lumibot_smoke.py`. They load `.env.local`, redact output, and only submit live orders when `POLYMARKET_LIVE_TRADING_ENABLED=true` plus notional caps are present.
   - Never commit or log raw Polymarket private keys or CLOB credentials.
 
 ### `LUMIBOT_DISABLE_DOTENV`
@@ -86,12 +87,14 @@ This page documents environment variables used by LumiBot, with an emphasis on *
 - Purpose: Selects the backtesting datasource **even if code passes an explicit `datasource_class`**.
 - Values (case-insensitive):
   - `thetadata`, `yahoo`, `polygon`, `alpaca`, `ccxt`, `databento`
+  - `polymarket` / `polymarket_clob` for Polymarket prediction-contract history
   - `ibkr` / `interactivebrokersrest` / `interactive_brokers_rest` (IBKR Client Portal REST via Data Downloader)
   - `router` (multi-provider routing; defaults to Theta for stock/option/index and IBKR for futures/crypto)
   - JSON mapping (multi-provider routing by asset type), e.g.:
     - `{"default":"thetadata","stock":"thetadata","option":"thetadata","index":"thetadata","future":"ibkr","cont_future":"ibkr","crypto":"ibkr","crypto_future":"ibkr"}`
     - Provider values are case/whitespace/_/- insensitive. Supported values include:
       - `thetadata`, `ibkr`, `polygon`, `alpaca`
+      - `polymarket` / `polymarket_clob` for prediction-contract assets
       - `ccxt` (auto-select exchange from existing env/credentials; defaults to Coinbase when no exchange credential/config is available)
       - supported CCXT backtesting exchange ids such as `coinbase`, `kraken`, `binance`, `kucoin`, `bitmex`, `bybit`, and `okx`
   - `none` to disable env override and rely on code.

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -27,7 +27,9 @@ This page documents environment variables used by LumiBot, with an emphasis on *
 - Local prototype secret storage: `.env.local` is loaded after `.env` unless `LUMIBOT_DISABLE_DOTENV_LOCAL=1`.
 - Credential fields:
   - `POLYMARKET_PRIVATE_KEY`: wallet private key/session signer for CLOB signing (**secret**).
-  - `POLYMARKET_WALLET_ADDRESS`: deposit wallet/funder address.
+  - `POLYMARKET_OWNER_ADDRESS`: optional owner/signer address for Magic/proxy accounts. Used as a fallback for Data API position/value reads.
+  - `POLYMARKET_WALLET_ADDRESS`: proxy wallet, deposit wallet, Safe, or other funder address passed to the CLOB client.
+  - `POLYMARKET_SIGNATURE_TYPE`: CLOB signature type. `0` = EOA, `1` = existing Polymarket proxy/Magic wallet, `2` = Gnosis Safe, `3` = deposit wallet / `POLY_1271`. The broker defaults to `1` when owner and wallet differ, otherwise `3`; set it explicitly for live tests.
   - `POLYMARKET_CLOB_API_KEY`, `POLYMARKET_CLOB_API_SECRET`, `POLYMARKET_CLOB_API_PASSPHRASE`: optional CLOB L2 credentials (**secret**).
   - `POLYMARKET_API_CREDENTIALS_JSON`: optional JSON wrapper for CLOB credentials (**secret**).
   - `POLYMARKET_RELAYER_API_KEY`, `POLYMARKET_RELAYER_API_KEY_ADDRESS`: relayer credentials for wallet deployment/approval flows when required (**secret**).
@@ -41,6 +43,9 @@ This page documents environment variables used by LumiBot, with an emphasis on *
 - Notes:
   - Do not auto-detect Polymarket from a private key. Use explicit `TRADING_BROKER=polymarket`.
   - Relayer keys are not the same as CLOB trading credentials.
+  - CLOB collateral balances are returned in 6-decimal raw units by `get_balance_allowance`; LumiBot scales those into dollars.
+  - Current local proof on 2026-07-01 can read balances, positions, open orders, trades, public data, and public/private WebSockets. Live submit is blocked for Rob's current Magic/proxy account by Polymarket's deposit-wallet/API-key binding error: `maker address not allowed, please use the deposit wallet flow`.
+  - Direct smoke helper: `scripts/polymarket_smoke.py`. It loads `.env.local`, redacts output, writes artifacts under gitignored `logs/`, and only submits live orders when `POLYMARKET_LIVE_TRADING_ENABLED=true` plus notional caps are present.
   - Never commit or log raw Polymarket private keys or CLOB credentials.
 
 ### `LUMIBOT_DISABLE_DOTENV`

--- a/docs/investigations/2026-07-01_POLYMARKET_BROKER_INTEGRATION_GAMEPLAN.md
+++ b/docs/investigations/2026-07-01_POLYMARKET_BROKER_INTEGRATION_GAMEPLAN.md
@@ -4,7 +4,7 @@ One-line description: Research and implementation plan for adding Polymarket pre
 
 Last Updated: 2026-07-01
 
-Status: Planning, no implementation code changed
+Status: Superseded by the international CLOB implementation/proof documents. Implementation code has now changed.
 
 Audience: LumiBot maintainers, broker-adapter implementers, BotSpot integration engineers
 
@@ -15,6 +15,7 @@ Follow-up Chrome inspection of Rob's logged-in Polymarket session showed `https:
 This document is still useful as the first-pass architecture plan, but its recommendation to start with the US SDK is stale for Rob's currently visible account. For current-account testing, use the deeper follow-up plan:
 
 - `docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md`
+- `docs/investigations/2026-07-01_POLYMARKET_INTERNATIONAL_CLOB_LIVE_PROOF.md`
 
 The product-facing BotSpot decision may still favor `polymarket.us` later, especially for US users, but the immediate LumiBot spike should verify the `polymarket.com` CLOB/relayer/private-key requirements first.
 

--- a/docs/investigations/2026-07-01_POLYMARKET_BROKER_INTEGRATION_GAMEPLAN.md
+++ b/docs/investigations/2026-07-01_POLYMARKET_BROKER_INTEGRATION_GAMEPLAN.md
@@ -8,6 +8,16 @@ Status: Planning, no implementation code changed
 
 Audience: LumiBot maintainers, broker-adapter implementers, BotSpot integration engineers
 
+## 2026-07-01 Update: Current Account Evidence Changes The First Target
+
+Follow-up Chrome inspection of Rob's logged-in Polymarket session showed `https://polymarket.com/`, a wallet-address account surface, crypto-style deposit/cash balances, and an `APIs` menu item. That looks like the international `polymarket.com` CLOB/deposit-wallet flow, not the separate `polymarket.us` account/API-key flow.
+
+This document is still useful as the first-pass architecture plan, but its recommendation to start with the US SDK is stale for Rob's currently visible account. For current-account testing, use the deeper follow-up plan:
+
+- `docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md`
+
+The product-facing BotSpot decision may still favor `polymarket.us` later, especially for US users, but the immediate LumiBot spike should verify the `polymarket.com` CLOB/relayer/private-key requirements first.
+
 ## Overview
 
 Polymarket can fit LumiBot's broker/data-source model, but it should not be treated as a stock broker clone. A Polymarket trade is still an order against a tradable asset, a position is still a quantity of outcome shares, and account value is still cash plus marked positions. The structural difference is that the tradable asset is an outcome contract inside a prediction market, priced between roughly 0 and 1 in USD collateral, with settlement at 0 or 1 after market resolution.

--- a/docs/investigations/2026-07-01_POLYMARKET_BROKER_INTEGRATION_GAMEPLAN.md
+++ b/docs/investigations/2026-07-01_POLYMARKET_BROKER_INTEGRATION_GAMEPLAN.md
@@ -1,0 +1,680 @@
+# Polymarket Broker Integration Game Plan
+
+One-line description: Research and implementation plan for adding Polymarket prediction-market trading to LumiBot without changing implementation code yet.
+
+Last Updated: 2026-07-01
+
+Status: Planning, no implementation code changed
+
+Audience: LumiBot maintainers, broker-adapter implementers, BotSpot integration engineers
+
+## Overview
+
+Polymarket can fit LumiBot's broker/data-source model, but it should not be treated as a stock broker clone. A Polymarket trade is still an order against a tradable asset, a position is still a quantity of outcome shares, and account value is still cash plus marked positions. The structural difference is that the tradable asset is an outcome contract inside a prediction market, priced between roughly 0 and 1 in USD collateral, with settlement at 0 or 1 after market resolution.
+
+The recommended architecture is:
+
+1. Add a first-class prediction contract asset type in LumiBot.
+2. Implement a `PolymarketData` data source that owns market discovery, order-book quotes, last prices, and historical price series.
+3. Implement a `Polymarket` broker adapter that owns account balances, positions, order submission, cancellation, order parsing, and private order updates.
+4. Start with the US Polymarket SDK/API path as the default for Rob/BotSpot US users, while designing the adapter so an international CLOB implementation can be added behind the same LumiBot surface later.
+5. Keep backtesting honest: use real Polymarket price/trade history only. Do not synthesize missing bars or carry prices forward to make a strategy run.
+
+This is a moderate-to-large broker integration, not a one-file adapter. The first usable milestone can be fairly small if it is scoped to US Polymarket limit/market orders, balances, positions, open orders, and quotes.
+
+## Primary Sources Reviewed
+
+### LumiBot repo sources
+
+- `lumibot/brokers/broker.py`: base live broker contract, order/position sync, order event processing, stream/polling integration.
+- `lumibot/brokers/alpaca.py`: gold-standard adapter for auth config, data-source ownership, balances, position parsing, order mapping, order submission, streaming/polling fallback, and quote passthrough.
+- `lumibot/brokers/tradier.py`: gold-standard adapter for explicit broker errors, token-file durability, polling stream, order parsing, order-side mapping, order submit/cancel/modify, and account balances.
+- `lumibot/brokers/example_broker.py`: broker skeleton. Useful checklist only, not enough to copy directly.
+- `lumibot/data_sources/data_source.py`: required data-source methods: `get_chains`, `get_historical_prices`, `get_last_price`, `get_quote`, plus batch `get_bars`.
+- `lumibot/data_sources/example_broker_data.py`: data-source skeleton. Useful checklist only.
+- `lumibot/data_sources/alpaca_data.py`: market-data client separation and multi-symbol batching pattern.
+- `lumibot/data_sources/tradier_data.py`: quote, last-price, historical-bar, and chain mapping pattern.
+- `lumibot/entities/asset.py`: current asset types do not include prediction markets.
+- `lumibot/entities/order.py`: order classes, sides, types, statuses, custom params, and serialization.
+- `lumibot/entities/position.py`: position quantity/value fields and broker-attached mark data.
+- `lumibot/entities/quote.py`: normalized quote shape with price, bid, ask, mid, sizes, timestamp, and raw data.
+- `docs/BROKER_ORDER_SEMANTICS.md`: read-path resilience policy and live broker behavior principles.
+- `docs/LIVE_ORDER_POSITION_REFRESH.md`: live strategy accessor freshness and broad-order-list reconciliation safety.
+- `docs/BACKTESTING_ARCHITECTURE.md`: no fabricated data, live-broker realism first, and backtesting data-source responsibilities.
+- `docsrc/brokers.alpaca.rst`, `docsrc/brokers.tradier.rst`, `docsrc/brokers.rst`, `docsrc/lumibot.data_sources.rst`: public docs patterns.
+- `lumibot/credentials.py`, `docs/ENV_VARS.md`, `docsrc/environment_variables.rst`: broker config, env var, and auto-detection patterns.
+
+### Polymarket sources
+
+- Polymarket developer docs home: `https://docs.polymarket.com/`
+- Polymarket API introduction: `https://docs.polymarket.com/api-reference/introduction`
+- Polymarket authentication: `https://docs.polymarket.com/api-reference/authentication`
+- Polymarket rate limits and geographic restrictions: `https://docs.polymarket.com/api-reference/rate-limits`
+- Polymarket Python tooling: `https://docs.polymarket.com/dev-tooling/python`
+- Polymarket CLOB order creation: `https://docs.polymarket.com/trading/orders/create`
+- Polymarket REST order placement reference: `https://docs.polymarket.com/api-reference/trade/post-a-new-order`
+- Polymarket markets endpoint reference: `https://docs.polymarket.com/api-reference/markets/list-markets`
+- Polymarket price history endpoint reference: `https://docs.polymarket.com/api-reference/markets/get-prices-history`
+- Polymarket portfolio positions reference: `https://docs.polymarket.com/api-reference/positions/get-current-positions-for-a-user`
+- Polymarket official Python SDK repo: `https://github.com/Polymarket/py-sdk`
+- Polymarket US SDK docs: `https://docs.polymarket.us/api-reference/sdks/introduction`
+- Polymarket US Python quickstart: `https://docs.polymarket.us/api-reference/sdks/python/quickstart`
+- Polymarket US Python orders docs: `https://docs.polymarket.us/api-reference/sdks/python/orders`
+- Polymarket US Python portfolio docs: `https://docs.polymarket.us/api-reference/sdks/python/portfolio`
+- Polymarket US Python WebSocket docs: `https://docs.polymarket.us/api-reference/sdks/python/websocket`
+
+## LumiBot Broker Architecture Findings
+
+### Required broker adapter methods
+
+Every live broker must implement:
+
+- `cancel_order(order)`: explicit state-changing broker cancel request.
+- `_modify_order(order, limit_price=None, stop_price=None)`: explicit broker modify request, or raise if unsupported.
+- `_submit_order(order)`: convert LumiBot order to provider order, submit, set broker id, set status, retain raw payload.
+- `_get_balances_at_broker(quote_asset, strategy)`: return `(cash, positions_value, portfolio_value)`.
+- `get_historical_account_value()`: return historical account value payload or a documented empty result if provider does not support it.
+- `_get_stream_object()`, `_register_stream_events()`, `_run_stream()`: either real streaming or polling stream integration.
+- `_pull_positions(strategy)`, `_pull_position(strategy, asset)`: return normalized `Position` objects.
+- `_parse_broker_order(response, strategy_name, strategy_object=None)`: convert raw broker order into LumiBot `Order`.
+- `_pull_broker_order(identifier)`, `_pull_broker_all_orders()`: direct order lookup and broad order list.
+
+The base `Broker` already handles higher-level sync, order reconciliation, event dispatch, strategy callbacks, and local trackers once provider methods return normalized entities.
+
+### Read-path resilience versus mutation failures
+
+Current docs and code draw an important distinction:
+
+- Position/order/balance reads should tolerate unfamiliar broker rows where possible. Unknown but representable rows should become `UNKNOWN` enum values with raw metadata, warnings, or skipped rows only when truly unrepresentable.
+- Submit, cancel, and modify should fail loudly. They should not silently no-op because a local order looks terminal.
+
+Polymarket should follow this exact split. For example, an unknown order status returned by Polymarket should not crash account refresh, but a failed cancel should raise a `LumibotBrokerAPIError` with a sanitized provider message.
+
+### Data source responsibilities
+
+A Polymarket data source must implement:
+
+- `get_quote(asset, quote=None, exchange=None)`: best bid, best ask, mid, last price, timestamp, sizes, raw payload.
+- `get_last_price(asset, quote=None, exchange=None)`: last traded price or last provider mark for the outcome contract.
+- `get_historical_prices(asset, length, timestep, timeshift=None, ...)`: real historical price bars only, if the API provides enough data.
+- `get_chains(asset, quote=None)`: probably not applicable. Return `{}` or raise a clear unsupported error unless we later model "markets and outcomes" as an option-chain-like surface.
+
+Because Polymarket order books are the most realistic live execution source, `get_quote()` is more important than `get_historical_prices()` for the first live implementation.
+
+## Polymarket API Findings
+
+### There are two Polymarket integration paths
+
+There are now two relevant Polymarket API families:
+
+1. `polymarket.com` international APIs:
+   - Gamma Markets API for event and market metadata.
+   - Data API for public price/trade/position-style data.
+   - CLOB API for order book, orders, trades, balances, allowances, and authenticated trading.
+   - Authentication has distinct public, API-key, and wallet-signature levels.
+   - Python docs currently point to the unified `polymarket-client` package and keep `py-clob-client-v2` available.
+   - Docs list geographic restrictions, including that users in the United States are blocked from placing orders on `polymarket.com`.
+
+2. `polymarket.us` US APIs:
+   - Separate SDK-oriented API surface.
+   - API keys are generated from account settings after sign-in and identity verification.
+   - Python package is `polymarket-us`, imported as `polymarket`.
+   - SDK surfaces include orders, portfolio, users, prices, WebSocket, and markets.
+   - Portfolio docs expose balances, positions, trade history, and related account data.
+   - WebSocket docs include public and private subscription patterns.
+
+For BotSpot and Rob's local US workflow, the practical default should be the Polymarket US API/SDK. The international CLOB path should be a second adapter mode or later implementation layer, not the initial default.
+
+### International CLOB model
+
+The international CLOB model is useful for understanding core semantics:
+
+- A market has one or more outcomes.
+- Tradable outcome tokens are identified by token ids.
+- Orders are CLOB orders against a token id, side, price, size, time-in-force, and owner credentials.
+- Prices are probabilities/collateral prices between 0 and 1.
+- The CLOB API has endpoints for markets, books, prices, order creation, open orders, order cancel, balances, allowances, and private order/trade data.
+- Authentication for private trading uses API keys and wallet-derived signing material.
+
+This model maps cleanly to a LumiBot "prediction contract" asset where the asset is one outcome token, not the entire event.
+
+### Polymarket US model
+
+The US SDK model looks more like the first implementation target:
+
+- Users create API keys from Polymarket account settings after KYC/verification.
+- SDK client configuration takes API key credentials.
+- Orders are created, listed, canceled, and inspected through the SDK.
+- Portfolio functions expose account balances and positions.
+- Price and market functions expose current prices and market metadata.
+- WebSockets can stream public market updates and private account/order updates.
+
+This aligns with LumiBot's current broker architecture without introducing wallet-private-key signing into public LumiBot code.
+
+## Recommended LumiBot Domain Model
+
+### Add a prediction-contract asset type
+
+Do not shoehorn Polymarket into `stock` or `crypto`. It may work for one smoke test, but it will create avoidable ambiguity in serialization, routing, docs, and future venues.
+
+Recommended new asset type:
+
+```python
+Asset.AssetType.PREDICTION_CONTRACT = "prediction_contract"
+```
+
+Why `prediction_contract` rather than `prediction_market`:
+
+- The tradable asset is an outcome share or contract, such as YES on one market.
+- A market/event can contain multiple tradable outcomes.
+- Positions are per outcome contract.
+- Orders are submitted against one contract id or token id.
+- This generalizes to Polymarket, Kalshi, PredictIt-style markets, and other venues.
+
+Initial representation:
+
+```python
+Asset(
+    symbol="<provider-contract-id-or-token-id>",
+    asset_type=Asset.AssetType.PREDICTION_CONTRACT,
+    precision="0.000001",
+)
+```
+
+Provider display metadata should be attached by broker/data-source raw payloads and downstream snapshots, not required in the first constructor. Longer term, we may want a generic metadata field on `Asset` because prediction contracts need human-readable market slug, event title, outcome label, condition id, token id, expiration/resolution time, venue, and collateral currency. That is larger than the first adapter and should be handled carefully because `Asset.to_dict()` is a shared serialization contract.
+
+### Asset identity rules
+
+The canonical `Asset.symbol` should be the provider's stable tradable contract identifier:
+
+- International Polymarket CLOB: outcome token id.
+- Polymarket US: SDK/API contract id or equivalent stable order-book contract identifier.
+- Future Kalshi: contract/ticker id.
+- Future PredictIt: contract id.
+
+Human-friendly names should come from helper methods and raw metadata:
+
+- `market_slug`
+- `event_slug`
+- `question`
+- `outcome`
+- `venue`
+- `condition_id`
+- `token_id`
+- `market_id`
+- `expires_at`
+- `resolution_status`
+
+This avoids breaking broker lookups when human-readable slugs change.
+
+### Quote asset
+
+Use USD/USDC as the quote side:
+
+```python
+quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+```
+
+For international CLOB, the collateral is USDC on Polygon, but LumiBot account values and BotSpot user displays should still normalize to USD unless we intentionally expose USDC as a cash asset. For US Polymarket, the SDK appears to expose account balances directly in cash terms.
+
+### Order semantics
+
+The initial support matrix should be intentionally small:
+
+Supported in milestone 1:
+
+- Simple orders only.
+- `BUY` and `SELL`.
+- `MARKET` if provider SDK supports market-style order helpers, or implemented as provider-recommended aggressive limit/FOK semantics.
+- `LIMIT`.
+- Time in force mapped only where provider supports it, such as GTC/FOK/FAK or SDK equivalents.
+- Decimal shares/contract quantities as allowed by the provider.
+
+Explicitly unsupported in milestone 1:
+
+- Shorting or sell-short style orders.
+- Bracket/OCO/OTO.
+- Stop, stop-limit, trailing stop, smart-limit.
+- Multi-leg.
+- Cross-market spread packages.
+- Automatic resolution/settlement callbacks beyond position refresh.
+
+If unsupported order shapes are submitted, the broker should raise or surface the provider/LumiBot error. Do not add regex routing, hidden tool guards, or fake order success paths.
+
+### Position semantics
+
+Each held outcome share maps to one `Position`:
+
+- `asset`: prediction contract asset.
+- `quantity`: outcome shares/contracts.
+- `avg_fill_price`: average entry price when available.
+- `current_price`: mark/last/mid price from provider.
+- `market_value`: `quantity * current_price`.
+- `pnl`: provider-reported PnL if available, otherwise derived from cost basis only when reliable.
+- `raw_broker_payload`: raw provider position row for diagnostics.
+
+At resolution, a settled winning contract is worth 1 and a losing contract is worth 0. The initial adapter can rely on provider positions/balances to reflect settlement. Later, LumiBot backtesting can model resolution explicitly if we have reliable historical resolution data.
+
+### Account value semantics
+
+`_get_balances_at_broker()` should return:
+
+- `cash`: available cash/collateral.
+- `positions_value`: marked value of all open prediction positions.
+- `portfolio_value`: cash plus positions value.
+
+Do not return `0` when balance refresh fails. Follow existing live-refresh behavior and return `None` or raise depending on the adapter path so strategy accessors can treat balance as unavailable.
+
+## Proposed File-Level Implementation Plan
+
+### Phase 0: Dependency and product-path decision
+
+Before implementation, decide whether milestone 1 targets:
+
+1. Polymarket US only.
+2. International Polymarket CLOB only.
+3. One public LumiBot `Polymarket` class with internal `mode="us"` and `mode="clob"` implementations.
+
+Recommendation: choose option 3 for public API shape, but implement only `mode="us"` first.
+
+Reason:
+
+- It keeps user-facing LumiBot imports stable: `from lumibot.brokers import Polymarket`.
+- It avoids blocking the US product path on wallet-signing details.
+- It leaves room for non-US users and future CLOB support without a separate public broker name.
+
+### Phase 1: Entity and exports
+
+Files likely touched:
+
+- `lumibot/entities/asset.py`
+- `tests/test_asset.py`
+- `lumibot/brokers/__init__.py`
+- `lumibot/data_sources/__init__.py`
+
+Work:
+
+- Add `Asset.AssetType.PREDICTION_CONTRACT`.
+- Verify constructor validation, equality, hashing, `to_minimal_dict()`, `to_dict()`, and `from_dict()` behavior.
+- Add unit tests for serialization and round-trip reconstruction.
+- Export `Polymarket` and `PolymarketData` lazily once adapter files exist.
+
+Open design choice:
+
+- Whether to add a generic `metadata` field to `Asset`. Recommendation: do not add it in milestone 1 unless serialization consumers need it immediately. Store provider metadata on raw broker/data payloads and normalized quote/position fields first.
+
+### Phase 2: PolymarketData
+
+New file:
+
+- `lumibot/data_sources/polymarket_data.py`
+
+Responsibilities:
+
+- Initialize SDK/client from config.
+- Resolve human inputs to contract ids where possible.
+- Fetch market/event metadata.
+- Fetch current order book or best bid/ask.
+- Fetch current/last price.
+- Fetch historical price data when available.
+- Return normalized `Quote` and `Bars`.
+
+Minimum methods:
+
+- `__init__(config=None, mode="us", ...)`
+- `_resolve_contract(asset)`
+- `get_quote(asset, quote=None, exchange=None)`
+- `get_last_price(asset, quote=None, exchange=None)`
+- `get_historical_prices(asset, length, timestep="", timeshift=None, quote=None, exchange=None, include_after_hours=True, **kwargs)`
+- `get_chains(asset, quote=None)`
+
+Historical bars:
+
+- Use Polymarket's price-history endpoint or US SDK equivalent where available.
+- Build OHLC bars only from real observed price points.
+- If only sparse trade prices exist, aggregate real points into bars. Empty intervals should remain missing, not filled.
+- If the API cannot provide enough historical data for the requested asset/timestep, return `None` or empty bars with a clear warning.
+
+Quote behavior:
+
+- For marketable buy, realistic execution price is ask.
+- For marketable sell, realistic execution price is bid.
+- Mid is useful for mark value, not guaranteed fill price.
+
+### Phase 3: Polymarket broker
+
+New file:
+
+- `lumibot/brokers/polymarket.py`
+
+Core implementation:
+
+- Accept config or explicit kwargs.
+- Default to `mode="us"`.
+- Construct/share `PolymarketData`.
+- Implement balances from SDK portfolio/balance endpoint.
+- Implement positions from SDK portfolio/positions endpoint.
+- Implement open/all order reads.
+- Implement direct order lookup.
+- Implement order parser.
+- Implement submit/cancel.
+- Implement modify as cancel-and-replace only if provider supports it safely, otherwise raise `NotImplementedError` with a clear message.
+- Implement polling stream first. Add WebSocket private stream after base correctness is proven.
+
+Suggested class shape:
+
+```python
+class Polymarket(Broker):
+    NAME = "Polymarket"
+
+    def __init__(
+        self,
+        config=None,
+        mode="us",
+        data_source=None,
+        connect_stream=True,
+        polling_interval=5.0,
+        max_workers=5,
+    ):
+        ...
+```
+
+Config shape:
+
+```python
+POLYMARKET_CONFIG = {
+    "MODE": os.environ.get("POLYMARKET_MODE", "us"),
+    "API_KEY": os.environ.get("POLYMARKET_API_KEY"),
+    "API_SECRET": os.environ.get("POLYMARKET_API_SECRET"),
+    "API_PASSPHRASE": os.environ.get("POLYMARKET_API_PASSPHRASE"),
+    "PRIVATE_KEY": os.environ.get("POLYMARKET_PRIVATE_KEY"),
+    "FUNDER": os.environ.get("POLYMARKET_FUNDER"),
+    "CHAIN_ID": os.environ.get("POLYMARKET_CHAIN_ID"),
+    "BASE_URL": os.environ.get("POLYMARKET_BASE_URL"),
+}
+```
+
+Only include mode-specific keys in docs once verified against the actual SDK constructors. Do not expose private keys or wallet material in logs, docs, snapshots, or errors.
+
+### Phase 4: Credentials and runtime selection
+
+Files likely touched:
+
+- `lumibot/credentials.py`
+- `docs/ENV_VARS.md`
+- `docsrc/environment_variables.rst`
+
+Work:
+
+- Add `POLYMARKET_CONFIG`.
+- Add `TRADING_BROKER=polymarket` selection.
+- Add optional auto-detect only when explicit Polymarket env vars are present.
+- Add `DATA_SOURCE=polymarket` only after `PolymarketData` can function independently.
+
+Recommendation:
+
+- Require explicit `TRADING_BROKER=polymarket` for the first release. Do not let Polymarket auto-detect outrank existing brokers just because an API key exists in a shared environment.
+
+### Phase 5: Tests
+
+Unit tests:
+
+- Asset type validation and serialization.
+- Data-source quote normalization from mocked SDK payloads.
+- Historical price aggregation from mocked sparse price-history payloads.
+- Position parsing from mocked portfolio payloads.
+- Balance parsing.
+- Order submit mapping for buy/sell, market/limit, time-in-force.
+- Unsupported order shapes raise helpful errors.
+- Cancel sends explicit broker request even if local status is terminal.
+- Unknown statuses map to `Order.OrderStatus.UNKNOWN` with raw payload retained.
+- Order-list miss behavior remains compatible with base `Broker` reconciliation.
+
+API tests:
+
+- Add `pytest.mark.apitest` tests that are skipped unless real Polymarket test credentials are configured.
+- Start read-only: balance, positions, market metadata, quote, last price.
+- Then paper/sandbox or smallest safe order flow if Polymarket US provides a sandbox.
+- If no sandbox exists, do not add live order tests that can spend real money by default. Keep destructive/live order tests behind existing apitest conventions plus explicit credential/safety gating.
+
+Docs tests:
+
+- Public broker docs page.
+- Environment variables page.
+- Example strategy with no real secrets and no real market recommendation.
+
+## Order Mapping Details
+
+### LumiBot to Polymarket
+
+| LumiBot field | Polymarket meaning |
+| --- | --- |
+| `order.asset.symbol` | Provider contract id or token id |
+| `order.asset.asset_type` | `prediction_contract` |
+| `order.side` | Buy or sell outcome shares |
+| `order.quantity` | Number of outcome shares/contracts |
+| `order.limit_price` | Limit price between 0 and 1 |
+| `order.order_type` | Provider market or limit equivalent |
+| `order.time_in_force` | Provider GTC/FOK/FAK or SDK equivalent |
+| `order.custom_params` | Advanced provider params, only passed through when documented |
+
+### Polymarket to LumiBot
+
+| Provider field | LumiBot field |
+| --- | --- |
+| order id | `Order.identifier` |
+| contract/token id | `Order.asset.symbol` |
+| side | `Order.side` |
+| original size | `Order.quantity` |
+| remaining/filled size | raw payload plus status updates |
+| price | `Order.limit_price` or `Order.avg_fill_price` |
+| status | `Order.status` |
+| created/updated timestamps | `broker_create_date`, `broker_update_date` |
+| raw order row | `order.update_raw(response)` |
+
+Status mapping should be conservative. Known active states should map to `SUBMITTED`, `OPEN`, or `PARTIALLY_FILLED`. Known terminal success maps to `FILLED`. Canceled maps to `CANCELED`. Rejections/errors map to `ERROR`. Unknown states map to `UNKNOWN` and should not crash refresh.
+
+## Backtesting Plan
+
+Backtesting should be a second milestone, not a blocker for first live broker support.
+
+Minimum honest backtesting:
+
+- Use real Polymarket historical price points only.
+- Aggregate real observed points into OHLC bars.
+- Use bid/ask snapshots only if historical book data is genuinely available.
+- If no data exists for a timestep, leave it missing.
+- Market orders can fill against ask/bid only when quote data exists for the simulated time.
+- Limit orders can fill only when observed price/book data supports the fill.
+
+Do not:
+
+- Fill every minute by carrying forward the last Polymarket price.
+- Use midpoint as a guaranteed execution price.
+- Treat a resolved/closed market as open.
+- Invent volume.
+- Invent OHLC ranges from one stale price.
+
+Later enhancements:
+
+- Resolution-aware settlement in backtests.
+- Market close/resolution calendars per contract.
+- Historical order-book replay if Polymarket exposes it.
+- Prediction-market-specific slippage model.
+
+## Structural Issues and Decisions
+
+### 1. New asset class is warranted
+
+Prediction contracts are not stocks, options, futures, forex, or crypto. They are cash-settled event outcome contracts. A first-class `prediction_contract` type is the cleanest path and makes future venues easier.
+
+### 2. International and US Polymarket must not be conflated
+
+The international API uses CLOB/wallet-signing concepts and is geographically restricted for US order placement. Polymarket US has a separate SDK/API-key model. BotSpot's US-facing path should start with Polymarket US.
+
+### 3. Market identity needs a contract-id-first model
+
+User-friendly slugs are great for discovery and logs, but order placement must use stable provider contract/token ids. The `Asset.symbol` should be canonical and stable.
+
+### 4. Market data is quote/order-book first
+
+For live trading, best bid/ask is the correct execution reference. Last price is useful but insufficient for marketable order fills.
+
+### 5. Settlement is different from normal mark-to-market
+
+Positions eventually settle to 0 or 1. Live adapter can rely on provider account state first. Backtesting settlement should be implemented only when reliable resolution data is available.
+
+### 6. Account values are straightforward but must be precise
+
+Cash, positions value, and portfolio value map cleanly. The danger is failure handling. Do not write `0` on failed balance refresh.
+
+### 7. Modify support may not exist
+
+If Polymarket does not support native modify, implement `cancel_order()` and require users to submit a replacement. Do not silently emulate modify unless cancel-and-replace semantics are explicit and safe.
+
+### 8. Rate limits need batching and polling discipline
+
+Data-source batching and polling intervals should follow existing broker patterns. A private WebSocket stream is useful later, but a polling stream is enough for first correctness.
+
+### 9. Regulatory/compliance scope is product-relevant
+
+Prediction markets have jurisdiction and eligibility constraints. LumiBot should expose provider errors clearly. BotSpot should enforce user/account eligibility outside LumiBot as product/security controls, not hidden runtime tool guards.
+
+## Milestone Sequence
+
+### Milestone 1: Read-only Polymarket US adapter
+
+Goal: instantiate broker/data source and read account/market data safely.
+
+Deliverables:
+
+- `Asset.AssetType.PREDICTION_CONTRACT`.
+- `PolymarketData` with quote, last price, market metadata, and minimal historical prices if available.
+- `Polymarket` broker with balances and positions.
+- `TRADING_BROKER=polymarket` explicit config.
+- Unit tests for parsing and config.
+- Public docs with setup and limitations.
+
+### Milestone 2: Basic order lifecycle
+
+Goal: submit and cancel simple orders.
+
+Deliverables:
+
+- Simple buy/sell limit orders.
+- Market orders if SDK/provider supports them cleanly.
+- Open order list and direct order lookup.
+- Polling stream that updates local orders.
+- Unsupported shape errors for stops, brackets, shorts, multileg, and modify.
+- Mocked unit tests for order mapping and status mapping.
+
+### Milestone 3: Private WebSocket and API smoke
+
+Goal: reduce polling lag and prove real provider integration.
+
+Deliverables:
+
+- Private WebSocket order/account updates if SDK supports them.
+- Read-only apitests.
+- Safe sandbox or manual live-order runbook if no sandbox exists.
+- Clear skip reasons when credentials or sandbox are unavailable.
+
+### Milestone 4: Backtesting support
+
+Goal: realistic historical prediction-market testing, not fake fill success.
+
+Deliverables:
+
+- Historical price endpoint integration.
+- Real-only bar aggregation.
+- Backtesting fill rules for prediction contracts.
+- Settlement modeling only after reliable resolution data is available.
+- Regression tests proving missing data does not get fabricated.
+
+### Milestone 5: Generalize for Kalshi/PredictIt
+
+Goal: make prediction markets a provider family.
+
+Deliverables:
+
+- Shared helper for prediction-contract asset construction and metadata.
+- Provider-neutral docs and examples.
+- Venue-specific brokers/data sources.
+- Optional market discovery helpers.
+
+## Initial Example Shape
+
+This is conceptual only. Do not use until the adapter exists.
+
+```python
+from lumibot.brokers import Polymarket
+from lumibot.entities import Asset
+from lumibot.strategies import Strategy
+from lumibot.traders import Trader
+
+
+class PredictionMarketStrategy(Strategy):
+    def initialize(self):
+        self.set_market("24/7")
+        self.sleeptime = "5M"
+        self.contract = Asset(
+            symbol="provider-contract-id",
+            asset_type=Asset.AssetType.PREDICTION_CONTRACT,
+            precision="0.000001",
+        )
+
+    def on_trading_iteration(self):
+        quote = self.get_quote(self.contract)
+        if quote.ask is None:
+            return
+        if quote.ask <= 0.40 and not self.get_position(self.contract):
+            order = self.create_order(
+                self.contract,
+                quantity=10,
+                side="buy",
+                order_type="limit",
+                limit_price=0.40,
+            )
+            self.submit_order(order)
+
+
+broker = Polymarket(mode="us")
+strategy = PredictionMarketStrategy(broker=broker)
+trader = Trader()
+trader.add_strategy(strategy)
+trader.run_all()
+```
+
+## Risks
+
+- SDK drift: Polymarket API/SDK surfaces are newer and may change faster than Alpaca/Tradier.
+- Jurisdiction: US versus international API behavior must be explicit.
+- No sandbox: If Polymarket lacks paper/sandbox order placement, live order tests need strong safety gates.
+- Historical data limits: Price history may not be enough for realistic high-frequency backtests.
+- Asset serialization: Adding metadata to `Asset` could have broad downstream effects if done too early.
+- Settlement modeling: Resolution and redemption mechanics are venue-specific.
+- Liquidity: Market orders can have worse execution than midpoint or last price suggests.
+
+## Open Questions
+
+1. Should milestone 1 be Polymarket US only, or should international CLOB be included from day one for open-source users outside the US?
+2. Does Polymarket US provide a sandbox or paper environment for order placement?
+3. What exact SDK fields identify a US tradable contract in orders, positions, and prices?
+4. Does Polymarket US expose native market orders, or should LumiBot only support limit orders initially?
+5. What are current min size, min price increment, tick-size, and time-in-force rules for US and international APIs?
+6. Should BotSpot store Polymarket credentials as simple API-key credentials, OAuth-style token files, or a provider-specific secret bundle?
+7. Should `Asset` gain a generic metadata field now, or should metadata remain in raw provider payloads until a second prediction-market venue exists?
+8. How should BotSpot display prediction contracts: by event question/outcome, by ticker, by slug, or by provider contract id?
+
+## Recommended Next Step
+
+Before coding, do a short credential and SDK spike outside LumiBot implementation:
+
+1. Create or identify a Polymarket US account eligible for API access.
+2. Generate API keys from the documented account settings flow.
+3. In a scratch environment, instantiate the official `polymarket-us` Python SDK.
+4. Read balance, positions, one market, one contract quote, and open orders.
+5. Save only redacted response shapes in `docs/investigations/` or ignored artifacts.
+6. Use those real shapes to implement the mocked parser tests first.
+
+After that spike, implement Milestone 1 and Milestone 2 in one version-scoped LumiBot branch/commit series with docs and tests.

--- a/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
+++ b/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
@@ -1,0 +1,858 @@
+# Polymarket Deep Integration Research
+
+One-line description: Deep research and implementation game plan for adding Polymarket prediction-market trading to LumiBot, with BotSpot and Bot Manager follow-on implications.
+
+Last Updated: 2026-07-01
+
+Status: Planning only. No implementation code changed.
+
+Audience: LumiBot maintainers, BotSpot broker-connection engineers, Bot Manager runtime engineers
+
+## Executive Summary
+
+The current browser evidence does not look like Polymarket US. The logged-in site was `https://polymarket.com/`, the account menu showed a wallet-address style identity, crypto deposit/cash balances, and an `APIs` menu item. That matches the international `polymarket.com` web3/CLOB account surface, not the separate `polymarket.us` SDK/account-key surface.
+
+This changes the first implementation target from the earlier assumption. For Rob's visible account, the practical first LumiBot spike should target the current `polymarket.com` Python SDK and CLOB/deposit-wallet flow. For a future BotSpot customer-facing product in the United States, we should still keep a separate `polymarket.us` lane because the US docs and credential model are different.
+
+The biggest structural issues are:
+
+1. Prediction contracts need a real LumiBot asset type. They are not stocks and they are not crypto spot pairs.
+2. The international Polymarket trading flow may require a private key or session signer plus wallet/funder address, not only a simple API key.
+3. The `Relayer API Key` visible in the website/docs appears to support wallet deployment and approval transactions. It is not, by itself, the full credential required for order signing and private user streams.
+4. Fast market support needs WebSockets for both public order-book updates and private user/order events. Polling alone is not enough for short-horizon markets.
+5. BotSpot can reuse the saved broker credential and runtime-secret architecture, but raw wallet private keys inside user strategy containers are a serious security boundary problem. This needs an explicit product decision before customer-facing support.
+
+I did not create or read any API keys. Key creation changes account security state and should be done only after an explicit go-ahead for that action.
+
+## Account Surface Finding
+
+### What Was Verified In Chrome
+
+Rob explicitly allowed inspection through the Codex Chrome extension. The observed account/page state:
+
+- URL: `https://polymarket.com/`
+- Logged in with visible portfolio and cash balances.
+- Account menu showed a wallet-address style identity.
+- Menu included `APIs`, `Documentation`, `Status`, `Support`, and other Polymarket web app items.
+- Deposit/cash flow was crypto-style, consistent with Rob's description.
+
+This is enough to say: the current session is on `polymarket.com`, not `polymarket.us`.
+
+### What This Means
+
+There are two different integration tracks:
+
+| Track | Site/API | Practical use | Credential shape |
+| --- | --- | --- | --- |
+| International CLOB | `polymarket.com`, `clob.polymarket.com`, Gamma/Data APIs | Rob's currently visible account, subject to availability/geographic restrictions | Private key or session signer, wallet/deposit-wallet address, SDK session credentials, optional relayer API key for wallet operations |
+| Polymarket US | `polymarket.us` docs and SDK | Future US-facing BotSpot product if available and compliant | API key, API secret, user id, and SDK config after account verification |
+
+Do not blur these together in code or docs. The same public class can eventually support both modes, but credentials, account setup, and eligibility are different.
+
+## Primary Sources Reviewed
+
+### Local LumiBot Sources
+
+- `lumibot/brokers/broker.py`: live broker abstract contract, order events, position sync, and stream lifecycle.
+- `lumibot/brokers/alpaca.py`: best current model for full broker implementation with balances, positions, order mapping, and real stream/polling fallback.
+- `lumibot/brokers/tradier.py`: best current model for explicit errors, polling stream, status reconciliation, and token/broker edge cases.
+- `lumibot/brokers/example_broker.py`: skeleton only. Useful checklist, not a production pattern.
+- `lumibot/data_sources/data_source.py`: required data-source contract.
+- `lumibot/data_sources/example_broker_data.py`: data-source skeleton.
+- `lumibot/entities/asset.py`: current asset classes do not include prediction contracts.
+- `lumibot/entities/order.py`: order type, side, status, and serialization semantics.
+- `lumibot/entities/position.py`: normalized position model.
+- `lumibot/trading_builtins/custom_stream.py`: `CustomStream` and `PollingStream` queue/event-dispatch primitives.
+- `lumibot/lumibot/credentials.py`: broker auto-detection and `TRADING_BROKER` instantiation.
+- `lumibot/docs/BROKER_ORDER_SEMANTICS.md`: read resilience versus mutation failure behavior.
+- `lumibot/docs/LIVE_ORDER_POSITION_REFRESH.md`: live position/order refresh expectations.
+- `lumibot/docs/BACKTESTING_ARCHITECTURE.md`: no fabricated market data.
+- `lumibot/docs/ENV_VARS.md` and `lumibot/docsrc/environment_variables.rst`: env var documentation patterns.
+
+### Local BotSpot And Bot Manager Sources
+
+- `botspot_react/src/site/brokerConnectionSource.js`: broker connection catalog and credential-field definitions.
+- `botspot_react/src/utils/brokerConnectionCatalog.js`: broker logo hydration and lookup.
+- `botspot_react/src/pages/BrokerConnections/BrokerConnectionsPage.tsx`: account settings UI for manual API key and OAuth broker connections.
+- `botspot_node/src/SavedSecrets/brokerCredentialRequirements.ts`: server-side broker credential requirements and allowed key names.
+- `botspot_node/src/Mcp/handlers/savedSecrets.ts`: saved broker credential MCP contract, raw-secret non-disclosure, and metadata-only responses.
+- `botspot_node/docs/security/2026-06-12_mcp-broker-data-fetch.md`: broker-data boundary through saved credentials and runtime-secret refs.
+- `botspot_node/docs/mcp/single-trades.md`: high-risk single-trade approval and broker capability model.
+- `bot_manager/flask_app.py`: allowed broker config keys for single-trade, broker-data, and portfolio-snapshot paths.
+- `bot_manager/bot_manager/runtime_secrets.py`: Bot Manager runtime-secret issuance and rotation handoff.
+- `bot_manager/bot_manager/single_trade_runner.py`: `lumibot.credentials.broker` runtime entrypoint for one-shot orders.
+- `bot_manager/bot_manager/broker_data.py`: broker-data fetch entrypoint through LumiBot.
+- `bot_manager/bot_manager/portfolio_snapshot.py`: portfolio snapshot entrypoint through LumiBot.
+
+### Polymarket Official Sources
+
+- Polymarket API introduction: `https://docs.polymarket.com/api-reference/introduction`
+- Polymarket Python SDK: `https://docs.polymarket.com/dev-tooling/python`
+- Polymarket trading quickstart: `https://docs.polymarket.com/trading/quickstart`
+- Polymarket order overview: `https://docs.polymarket.com/trading/orders/overview`
+- Polymarket order creation: `https://docs.polymarket.com/trading/orders/create`
+- Polymarket orderbook/WebSocket docs: `https://docs.polymarket.com/trading/orderbook`
+- Polymarket market channel: `https://docs.polymarket.com/market-data/websocket/market-channel`
+- Polymarket user channel: `https://docs.polymarket.com/market-data/websocket/user-channel`
+- Polymarket authentication: `https://docs.polymarket.com/developers/CLOB/authentication`
+- Polymarket public client methods: `https://docs.polymarket.com/trading/clients/public`
+- Polymarket secure client methods: `https://docs.polymarket.com/trading/clients/l2`
+- Polymarket deposit wallets: `https://docs.polymarket.com/trading/deposit-wallets`
+- Polymarket fees: `https://docs.polymarket.com/trading/fees`
+- Polymarket error codes: `https://docs.polymarket.com/resources/error-codes`
+- Polymarket rate limits/geographic restrictions entry point: `https://docs.polymarket.com/api-reference/rate-limits`
+- Polymarket relayer API keys reference: `https://docs.polymarket.com/api-reference/relayer-api-keys/get-all-relayer-api-keys`
+- Polymarket US Python quickstart: `https://docs.polymarket.us/api-reference/sdks/python/quickstart`
+- Polymarket US Python account docs: `https://docs.polymarket.us/api-reference/sdks/python/account`
+- Polymarket US Python WebSocket docs: `https://docs.polymarket.us/api-reference/sdks/python/websocket`
+
+## Polymarket API Model
+
+### International `polymarket.com`
+
+The current `polymarket.com` docs describe several distinct API families:
+
+- Gamma API: markets, events, tags, series, comments, sports, and search.
+- Data API: positions, trades, activity, holder data, leaderboard, and builder analytics.
+- CLOB API: order books, prices, tick size, orders, trades, balances, allowances, and authenticated trading.
+- Relayer API: wallet deployment and on-chain wallet transaction submission.
+- WebSocket APIs: market, user, sports, and related realtime feeds.
+
+The current Python SDK is the unifying integration point:
+
+- Package: `polymarket-client`
+- Public clients: `AsyncPublicClient` and `PublicClient`
+- Authenticated clients: `AsyncSecureClient` and `SecureClient`
+- Realtime subscriptions are async only.
+- Public stream specs include market/orderbook updates.
+- Secure stream specs add user-scoped order and trade events.
+
+The secure Python client currently matters most for LumiBot because it exposes direct trading helpers such as:
+
+- `AsyncSecureClient.create(...)`
+- `place_limit_order(...)`
+- `place_market_order(...)`
+- `create_limit_order(...)`
+- `post_order(...)`
+- `setup_trading_approvals()`
+- `subscribe(UserSpec())`
+
+The public Python client matters most for data and discovery:
+
+- `list_markets(...)`
+- `get_market(...)`
+- order-book, price, history, and stream subscriptions
+
+### Authentication Levels
+
+The CLOB docs distinguish public reads, API-key auth, and wallet-signature auth.
+
+The important implementation consequence is that placing and managing orders is not just "paste an API key":
+
+- A secure client authenticates with a local private key.
+- The wallet/funder address identifies where funds and conditional tokens sit.
+- The SDK can create or derive API credentials for authenticated sessions.
+- A relayer API key can be used when the SDK needs to deploy a deposit wallet or submit approval transactions.
+- Existing proxy, Safe, EOA, and deposit wallet flows use different signature types.
+
+For a new API user, the docs emphasize the deposit wallet flow. That flow can require:
+
+- `POLYMARKET_PRIVATE_KEY`
+- `POLYMARKET_WALLET_ADDRESS` or a default deterministic deposit wallet
+- `POLYMARKET_RELAYER_API_KEY`
+- `POLYMARKET_RELAYER_API_KEY_ADDRESS`
+- SDK session credentials if we want to reuse them instead of deriving each time
+- pUSD funding and trading approvals
+
+The website's `Relayer API Key` label is therefore not enough to assume we can trade through LumiBot. Early implementation must verify exactly which credential set the site can create for Rob's current wallet.
+
+### Orders
+
+Polymarket maps well to simple LumiBot orders, with important constraints:
+
+- The traded object is an outcome token id.
+- Prices are probabilities/collateral prices, normally between 0 and 1.
+- Tick size is market-specific and can be `0.1`, `0.01`, `0.001`, or `0.0001`.
+- Tick size can change while a market is live, especially near extremes.
+- Multi-outcome negative-risk markets require a `negRisk` flag or equivalent market metadata.
+- Limit order types include GTC and GTD.
+- Market-style orders use FAK or FOK semantics.
+- Post-only orders are only valid for resting limit orders.
+- Marketable orders may have short placement delays in selected fast categories.
+- Sports markets have special behaviors around game start.
+
+For LumiBot milestone 1:
+
+- Support simple `BUY` and `SELL`.
+- Support `LIMIT` first.
+- Add `MARKET` only after the provider helper and quantity/amount semantics are tested.
+- Reject stop, stop-limit, trailing stop, smart-limit, bracket, OCO, OTO, multileg, short, and cross-market packages.
+- Use `Decimal` internally for prices and quantities.
+- Cache and refresh tick size and `negRisk` by token id.
+
+### Market Data And WebSockets
+
+For fast markets, HTTP polling is not enough.
+
+Public market channel events include:
+
+- Full order-book snapshots.
+- Price level changes.
+- Last trade price.
+- Tick-size changes.
+- Best bid/ask events when enabled.
+- New market and market-resolved events when enabled.
+
+Private user channel events include:
+
+- User order events.
+- User trade events.
+
+The adapter should bootstrap via HTTP, then keep state fresh with WebSockets:
+
+1. Discover the market/outcome token id through the public client.
+2. Fetch an order-book snapshot and current CLOB market info.
+3. Subscribe to the market channel for that token id.
+4. Subscribe to the user channel for the authenticated wallet.
+5. Reconcile private order state with HTTP on reconnect or any missed/unknown event.
+6. Use polling as a fallback, not the primary fast-market mechanism.
+
+### Fees
+
+Fees are applied at match time by the protocol. Makers are not charged; takers can be charged depending on category. Fees need to be represented in raw order/trade payloads first, then normalized into LumiBot trade/fill accounting only after real fills show the fields consistently.
+
+Do not ignore fees in PnL. The first live adapter can rely on provider account value and positions, but any internal realized PnL view should account for taker fees once fill payloads expose them reliably.
+
+### Geographic Restrictions
+
+The docs explicitly link rate limits and geographic restrictions, and the trading quickstart calls out geoblock failures. The adapter must not try to bypass location restrictions. If provider APIs reject trading because of geography, LumiBot should surface the provider error clearly and stop.
+
+For BotSpot, this means:
+
+- `polymarket_clob` should not become a US-customer default.
+- `polymarket_us` should remain separate until we have verified its account/API eligibility and order coverage.
+- The product should not encourage VPN-based trading.
+
+## LumiBot Domain Model
+
+### Add `prediction_contract`
+
+Add:
+
+```python
+Asset.AssetType.PREDICTION_CONTRACT = "prediction_contract"
+```
+
+Do not model outcome tokens as stocks or crypto. The asset is a contract/outcome share inside a market.
+
+Recommended canonical identity:
+
+```python
+Asset(
+    symbol="<provider stable contract id>",
+    asset_type=Asset.AssetType.PREDICTION_CONTRACT,
+    precision="0.000001",
+)
+```
+
+For international Polymarket, the symbol should be the outcome token id. The market slug, question, outcome label, condition id, event id, expiration/resolution time, category, and provider should live in raw metadata or a provider-specific resolver cache, not in the core `Asset.symbol`.
+
+Why this matters:
+
+- A market/event can have multiple tradable outcomes.
+- Outcome labels can be human-friendly but are not the most stable order key.
+- Future Kalshi/PredictIt integrations need the same generic asset class.
+- BotSpot single-trade schema and broker-data schema can extend one asset type instead of adding venue-specific hacks.
+
+### Quote Asset
+
+Use USD-like collateral as the quote side:
+
+```python
+quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+```
+
+International Polymarket collateral is pUSD/USDC-like, but LumiBot account values and BotSpot displays should normalize to USD unless we intentionally expose the collateral token as a cash asset later.
+
+### Positions
+
+Each held outcome token maps to one `Position`:
+
+- `asset`: `prediction_contract`
+- `quantity`: shares/contracts
+- `avg_fill_price`: provider average entry price when available
+- `current_price`: last/mark/mid price
+- `market_value`: shares times current price
+- `pnl`: provider PnL when available, otherwise derived only when reliable
+- `raw`: raw position row for diagnosis
+
+At settlement, winning contracts are worth 1 and losing contracts are worth 0. The first live adapter should trust provider account/position reads for settled state. Backtesting can model resolution later from historical resolution data.
+
+### Orders
+
+Initial LumiBot mapping:
+
+| LumiBot | Polymarket CLOB |
+| --- | --- |
+| `OrderSide.BUY` | `BUY` |
+| `OrderSide.SELL` | `SELL` |
+| `OrderType.LIMIT` | resting limit, GTC or GTD |
+| `OrderType.MARKET` | provider market helper with FAK/FOK, after live spike |
+| `time_in_force="gtc"` | GTC |
+| `time_in_force="gtd"` | GTD with validated expiration |
+| `time_in_force="fak"` | FAK market-style order |
+| `time_in_force="fok"` | FOK market-style order |
+
+Important quantity distinction:
+
+- For BUY market orders, Polymarket SDK examples can use amount/max spend.
+- For SELL market orders, SDK examples use shares.
+- LumiBot `Order.quantity` is normally units/shares. The broker must not accidentally treat `quantity` as dollars for buy market orders.
+
+Recommended milestone 1 rule: only allow limit orders until the market order semantics are tested with tiny live orders and explicit expected behavior.
+
+## LumiBot Implementation Plan
+
+### New Files And Exports
+
+Add:
+
+- `lumibot/data_sources/polymarket_data.py`
+- `lumibot/brokers/polymarket.py`
+- Tests under the existing LumiBot test layout.
+- Public docs under `docsrc/` and `docs/ENV_VARS.md`.
+
+Update:
+
+- `lumibot/entities/asset.py`
+- `lumibot/data_sources/__init__.py`
+- `lumibot/brokers/__init__.py`
+- `lumibot/lumibot/credentials.py`
+- `docs/BROKER_ORDER_SEMANTICS.md` if prediction contracts need a new order caveat.
+- `docs/BACKTESTING_ARCHITECTURE.md` if we add prediction backtesting semantics.
+
+### Config Shape
+
+Recommended environment names for international CLOB mode:
+
+- `TRADING_BROKER=polymarket`
+- `POLYMARKET_MODE=clob`
+- `POLYMARKET_PRIVATE_KEY`
+- `POLYMARKET_WALLET_ADDRESS`
+- `POLYMARKET_RELAYER_API_KEY`
+- `POLYMARKET_RELAYER_API_KEY_ADDRESS`
+- `POLYMARKET_CLOB_API_KEY`
+- `POLYMARKET_CLOB_API_SECRET`
+- `POLYMARKET_CLOB_API_PASSPHRASE`
+- `POLYMARKET_API_CREDENTIALS_JSON`
+- `POLYMARKET_BUILDER_CODE`
+
+Credential policy:
+
+- Treat every key above as secret except wallet address and builder code.
+- Do not print these values in exceptions, logs, docs, or test output.
+- Prefer `POLYMARKET_API_CREDENTIALS_JSON` or separate CLOB fields, not both.
+- The SDK can derive session credentials from private-key auth. If we persist derived credentials, store them in the same secret store as broker credentials.
+- Do not add auto-detection based on `POLYMARKET_PRIVATE_KEY` until we are confident. Prefer explicit `TRADING_BROKER=polymarket` to avoid accidental live-wallet initialization.
+
+Potential future US mode:
+
+- `TRADING_BROKER=polymarket_us`
+- `POLYMARKET_US_API_KEY`
+- `POLYMARKET_US_API_SECRET`
+- `POLYMARKET_US_USER_ID`
+
+Keep US and international env names separate.
+
+### `PolymarketData`
+
+Responsibilities:
+
+- Own public market discovery.
+- Resolve a URL/slug/question/outcome into a token id.
+- Fetch quotes/order books.
+- Fetch last price.
+- Fetch historical prices when enough provider history exists.
+- Maintain an optional in-memory market-data cache updated by WebSocket.
+
+Required LumiBot methods:
+
+- `get_chains(asset, quote=None)`: return `{}` or a documented prediction-market structure. Do not pretend these are option chains.
+- `get_historical_prices(asset, length, timestep="", timeshift=None, quote=None, exchange=None, include_after_hours=True, **kwargs)`: return real provider data only. If the provider cannot supply reliable bars, raise a clear unsupported error rather than fabricating bars.
+- `get_last_price(asset, quote=None, exchange=None)`: return last trade/mark for token id.
+- `get_quote(asset, quote=None, exchange=None)`: return best bid, ask, mid, sizes, timestamp, and raw book/event payload.
+
+Recommended helper methods:
+
+- `resolve_market(url=None, slug=None, market_id=None, condition_id=None)`
+- `resolve_contract(market, outcome=None, token_id=None)`
+- `get_clob_market_info(condition_id)`
+- `get_tick_size(token_id)`
+- `get_neg_risk(token_id)`
+- `subscribe_market(token_ids)`
+
+Use the SDK public client first. If a required method is missing or unstable in the beta SDK, isolate direct REST/WebSocket calls behind a small internal client wrapper so the broker surface does not change.
+
+### `Polymarket` Broker
+
+Constructor:
+
+```python
+class Polymarket(Broker):
+    NAME = "Polymarket"
+
+    def __init__(self, config=None, data_source=None, polling_interval=1.0, use_websocket=True):
+        ...
+```
+
+Required methods:
+
+- `cancel_order(order)`: call provider cancel, update local status, dispatch cancel when confirmed.
+- `_modify_order(order, limit_price=None, stop_price=None)`: if Polymarket has no native modify, raise `NotImplementedError` or implement explicit cancel-replace only in a separate helper. Do not hide cancel-replace under modify unless semantics are exact.
+- `_submit_order(order)`: validate asset type, token id, side, type, price, size, tick size, `negRisk`, and available config. Submit through secure client, set identifier/status/raw, dispatch `NEW_ORDER`.
+- `_get_balances_at_broker(quote_asset, strategy)`: return cash/collateral balance, position value, and total account value using provider account/position data.
+- `get_historical_account_value()`: return provider history if available; otherwise `{}` with documented unsupported behavior.
+- `_get_stream_object()`: return a custom Polymarket stream object, not just `PollingStream`, when WebSockets are enabled.
+- `_register_stream_events()`: map provider user events to LumiBot `NEW_ORDER`, `PARTIALLY_FILLED_ORDER`, `FILLED_ORDER`, `CANCELED_ORDER`, and `ERROR_ORDER`.
+- `_run_stream()`: start the stream object.
+- `_pull_positions(strategy)`: fetch provider positions and parse into `Position`.
+- `_pull_position(strategy, asset)`: filter `_pull_positions` or provider endpoint by token id.
+- `_parse_broker_order(response, strategy_name, strategy_object=None)`: normalize status, side, type, price, size, fill quantity, and raw payload into `Order`.
+- `_pull_broker_order(identifier)`: fetch one order by provider id.
+- `_pull_broker_all_orders()`: fetch open orders, optionally with asset/market filter.
+
+Status mapping should be conservative:
+
+| Provider status | LumiBot status |
+| --- | --- |
+| submitted/live/open | `OPEN` or `SUBMITTED` after local convention choice |
+| matched/filled | `FILLED` |
+| partially matched | `PARTIALLY_FILLED` |
+| canceled/cancelled | `CANCELED` |
+| expired | `EXPIRED` |
+| rejected/error/failed | `ERROR` |
+| unknown | `UNKNOWN` on reads, exception on submit if returned by order placement |
+
+### Stream Design
+
+Implement a dedicated `PolymarketStream(CustomStream)` that owns:
+
+- An asyncio event loop in a background thread.
+- An async public market subscription for subscribed token ids.
+- An async secure user subscription for authenticated order/trade events.
+- Reconnect with backoff.
+- HTTP reconciliation after reconnect.
+- Subscription mutation when the strategy starts tracking new contracts.
+- Queue dispatch into LumiBot's existing broker stream actions.
+
+Why not `PollingStream` only:
+
+- The user specifically wants fast trading.
+- Short-duration crypto up/down markets can move faster than a polling interval.
+- Tick-size changes can reject orders if not captured promptly.
+- Private fill/cancel events should update local order state immediately.
+
+Polling still has a role:
+
+- Startup reconciliation.
+- Reconnect reconciliation.
+- Fallback when WebSockets fail.
+- Tests with fake clients.
+
+### Backtesting
+
+Do not fabricate bars.
+
+Acceptable milestone 1:
+
+- Live trading only.
+- Public market-data reads.
+- Unit tests with fake clients and recorded provider message shapes.
+
+Acceptable milestone 2:
+
+- Historical price support through provider history endpoints.
+- Use real timestamped price points only.
+- If there is no bar for a minute, either return sparse bars or fail clearly based on existing LumiBot expectations. Do not carry forward a flat price just to make backtests run.
+
+Prediction-market backtesting also needs resolution data:
+
+- Market close time.
+- Resolution status.
+- Winning outcome.
+- Final settlement value.
+- Fees.
+- Delisted/canceled market behavior.
+
+Without resolution history, PnL and drawdown can be misleading.
+
+## BotSpot And Bot Manager Implications
+
+### BotSpot React
+
+Files likely touched later:
+
+- `botspot_react/src/site/brokerConnectionSource.js`
+- `botspot_react/src/utils/brokerConnectionCatalog.js`
+- `botspot_react/src/pages/BrokerConnections/BrokerConnectionsPage.tsx`
+- Broker logo assets and tests.
+
+Needed product decisions:
+
+- Add `polymarket` or split `polymarket_clob` and `polymarket_us`.
+- Show a strong eligibility/compliance warning for international CLOB.
+- Manual credential fields are enough for first version; OAuth-style browser redirect is not the right model unless Polymarket US provides it.
+- Do not collect raw private keys in a customer-facing UI until security signs off on the runtime signer model.
+
+Possible internal-only catalog entry for first BotSpot experiments:
+
+- id: `polymarket_clob`
+- asset class: `Prediction Markets`
+- modes: `live` only
+- auth method: `api_key` or `wallet`
+- credential fields:
+  - `POLYMARKET_PRIVATE_KEY` secret
+  - `POLYMARKET_WALLET_ADDRESS`
+  - `POLYMARKET_RELAYER_API_KEY` secret
+  - `POLYMARKET_RELAYER_API_KEY_ADDRESS`
+  - optional CLOB session credential fields
+
+For public BotSpot, prefer `polymarket_us` if the US API supports the required trading and websocket workflows.
+
+### BotSpot Node
+
+Files likely touched later:
+
+- `botspot_node/src/SavedSecrets/brokerCredentialRequirements.ts`
+- `botspot_node/src/Mcp/handlers/savedSecrets.ts`
+- `botspot_node/src/Deploy/deploy.controller.ts`
+- `botspot_node/src/Trades/placeTrade.service.ts`
+- `botspot_node/src/Trades/brokerData.service.ts`
+- `botspot_node/docs/security/...`
+- `botspot_node/docs/mcp/single-trades.md`
+
+Needed backend work:
+
+- Add broker credential requirements for Polymarket.
+- Ensure raw values are never returned through MCP or frontend metadata.
+- Add broker capability checks for prediction contracts.
+- Extend single-trade schemas to include `assetType: "prediction_contract"`.
+- Add validation for Polymarket-only fields: token id, market id, outcome label, price range, tick size if supplied, and supported order types.
+- Add read-only broker-data support for quotes/order books.
+- Decide whether `place_trade` supports Polymarket in v1 or waits for deployment-only support.
+
+Security requirement:
+
+- If raw private keys are involved, add a dedicated security doc before product implementation.
+- Confirm whether the runtime secret grants expose private keys to user-authored Python strategy code. The current BotSpot runtime model treats user strategy code as untrusted, so a raw wallet private key is higher-risk than an ordinary read/write API token.
+
+### Bot Manager
+
+Files likely touched later:
+
+- `bot_manager/flask_app.py`
+- `bot_manager/bot_manager/single_trade.py`
+- `bot_manager/bot_manager/single_trade_runner.py`
+- `bot_manager/bot_manager/broker_data.py`
+- `bot_manager/bot_manager/portfolio_snapshot.py`
+- `bot_manager/bot_manager/runtime_secrets.py`
+- Lambda packaging/dependency config.
+
+Needed runtime work:
+
+- Allow Polymarket-derived server-owned config keys only when needed.
+- Add `prediction_contract` to single-trade supported asset types.
+- Ensure runtime secret key allowlists accept Polymarket credential env names.
+- Ensure the deployed Bot Manager image includes the right LumiBot version and `polymarket-client`.
+- Add broker-data operations for prediction-contract quote/last price/order book.
+- Add portfolio-snapshot support after `_get_balances_at_broker()` and `_pull_positions()` are reliable.
+
+Do not pass legacy raw `broker_config` from Node to Bot Manager. Keep using saved broker credentials and short-lived runtime-secret refs.
+
+### BotSpot Product Boundary
+
+Recommended sequencing:
+
+1. LumiBot local/internal adapter.
+2. Bot Manager internal runtime support.
+3. BotSpot saved credential support for an internal-only feature flag.
+4. Broker-data read-only quotes and portfolio snapshot.
+5. Single-trade support with high-risk approval.
+6. Deployment support.
+7. Public product support only after legal/compliance and private-key custody decisions are settled.
+
+## Structural Risks And Mitigations
+
+### Private Key Custody
+
+Risk: The international SDK examples authenticate with a private key. In BotSpot, customer strategy code is untrusted and runs in a runtime that can often see broker env vars.
+
+Mitigations:
+
+- Start local LumiBot only.
+- For BotSpot, require a design review before storing private keys.
+- Prefer provider-scoped session credentials that cannot withdraw or transfer funds if Polymarket supports them.
+- Consider a broker execution sidecar or signer service for future productization.
+- Limit accounts to small funded balances during early testing.
+
+### Geography And Compliance
+
+Risk: Rob's current account may work only because of location/VPN behavior. We should not embed that assumption into LumiBot or BotSpot.
+
+Mitigations:
+
+- Make provider errors visible.
+- Do not advise or automate geoblock bypass.
+- Keep `polymarket.com` CLOB and `polymarket.us` separate.
+- Gate customer-facing support behind compliance review.
+
+### No Paper Trading
+
+Risk: Polymarket may not offer a paper environment equivalent to Alpaca paper.
+
+Mitigations:
+
+- Heavy fake-client tests.
+- Public read-only live data tests.
+- Tiny explicit live-order smoke only after approval.
+- Per-order notional caps.
+- Market allowlist for smoke tests.
+
+### Dynamic Tick Size
+
+Risk: Orders get rejected if using stale tick size.
+
+Mitigations:
+
+- Fetch tick size before submit.
+- Subscribe to `tick_size_change`.
+- Cache tick size with short TTL and event invalidation.
+- Validate all limit prices with Decimal quantization.
+
+### Fast Market Delay And Race Conditions
+
+Risk: Order book changes between quote and submit; marketable orders may have provider delays.
+
+Mitigations:
+
+- Use current WebSocket top-of-book.
+- Add max slippage controls for market orders.
+- Prefer limit orders first.
+- Reconcile every submit response with private user events and HTTP order lookup.
+
+### Negative Risk Markets
+
+Risk: Multi-outcome markets require `negRisk` metadata and different exchange behavior.
+
+Mitigations:
+
+- Pull `negRisk` from `getClobMarketInfo` or market object.
+- Include `negRisk` in the order helper.
+- Unit-test binary and multi-outcome markets separately.
+
+### Settlement And Resolution
+
+Risk: Backtests and portfolio views can be wrong if they ignore resolution.
+
+Mitigations:
+
+- Trust provider live positions/account values in v1.
+- Backtesting only after we have resolution history.
+- Represent resolved positions from provider raw data.
+
+### Cross-Venue "Arbitrage"
+
+Risk: Polymarket, Kalshi, and PredictIt may have similar-looking markets with different resolution criteria.
+
+Mitigations:
+
+- Do not infer equivalence by title.
+- Future multi-venue strategies need explicit market-resolution comparison fields.
+- Keep venue-specific raw metadata attached to contracts.
+
+## Testing Strategy
+
+### Unit Tests
+
+Add tests for:
+
+- `Asset.AssetType.PREDICTION_CONTRACT` serialization and round trip.
+- Polymarket order type/side/time-in-force mapping.
+- Price validation by tick size.
+- `negRisk` propagation.
+- Position parsing.
+- Balance parsing.
+- Order parsing for live, matched, partially filled, canceled, expired, rejected, unknown.
+- Error redaction.
+- Credential config without logging secret values.
+
+### Stream Tests
+
+Use fake WebSocket event payloads:
+
+- `book`
+- `price_change`
+- `last_trade_price`
+- `tick_size_change`
+- `best_bid_ask`
+- user order event
+- user trade event
+- reconnect and reconciliation path
+
+### SDK Boundary Tests
+
+Wrap the SDK behind small interfaces so fake clients can test LumiBot behavior without live Polymarket credentials:
+
+- `PolymarketPublicClientProtocol`
+- `PolymarketSecureClientProtocol`
+- `PolymarketStreamProtocol`
+
+### Live Smoke Tests
+
+Only after explicit approval:
+
+1. Public quote smoke for one token id.
+2. Authenticated account/balance read.
+3. Open orders read.
+4. Positions read.
+5. Tiny limit order far from market, then cancel.
+6. Tiny marketable order only after limit/cancel works.
+
+Smoke tests must use an explicit market allowlist, maximum notional, and no hidden "fake filled" behavior.
+
+## Implementation Phases
+
+### Phase 0: Credential And Access Spike
+
+Goals:
+
+- Confirm whether Rob wants `polymarket.com` CLOB mode or a real `polymarket.us` account.
+- Confirm what the website `APIs` page can generate.
+- Determine if Relayer API Key plus private key/session signer is enough for Rob's current account.
+- Create credentials only after explicit approval.
+- Store secrets only in approved local env/secret-store paths. Do not put them in docs, chat, screenshots, git, or logs.
+
+Exit criteria:
+
+- We know the exact env vars and credential object required for one authenticated account read.
+- We can call a read-only authenticated endpoint or SDK account method without placing orders.
+- We know whether trading requires raw private-key custody.
+
+### Phase 1: LumiBot Asset And Data Source
+
+Goals:
+
+- Add `prediction_contract`.
+- Add `PolymarketData` with public market discovery, quote, last price, and real history where available.
+- Add tests for data parsing and asset serialization.
+
+Exit criteria:
+
+- A strategy can ask for a quote/last price for a known token id.
+- No live orders are possible yet.
+
+### Phase 2: Read-Only Broker
+
+Goals:
+
+- Add `Polymarket` broker with authenticated balances, positions, and open-order reads.
+- No submit/cancel yet, or submit disabled behind explicit config.
+
+Exit criteria:
+
+- `_get_balances_at_broker()` works.
+- `_pull_positions()` works.
+- `_pull_broker_all_orders()` works.
+- Raw values are redacted in logs.
+
+### Phase 3: Limit Orders And Cancel
+
+Goals:
+
+- Support simple limit orders.
+- Support cancel.
+- Support `_parse_broker_order`.
+- Add safe provider error mapping.
+
+Exit criteria:
+
+- Tiny live limit order and cancel smoke passes after explicit approval.
+- Unknown order rows do not crash refresh.
+- Submit/cancel errors fail loudly.
+
+### Phase 4: WebSockets
+
+Goals:
+
+- Add public market WebSocket for subscribed token ids.
+- Add private user WebSocket for order/trade events.
+- Add HTTP reconciliation after reconnect.
+
+Exit criteria:
+
+- Live quote state updates without polling.
+- Private order status updates dispatch into LumiBot's stream events.
+- Reconnect path does not duplicate fills.
+
+### Phase 5: Market Orders And Fast Trading Controls
+
+Goals:
+
+- Add FAK/FOK market-style order support.
+- Add slippage/max-spend controls.
+- Add per-order notional caps in examples/smoke tests.
+
+Exit criteria:
+
+- Market order semantics are proven with tiny live trades.
+- BUY amount/max_spend and SELL shares behavior is documented and tested.
+
+### Phase 6: BotSpot Internal Support
+
+Goals:
+
+- Add broker credential metadata and validation in Node.
+- Add catalog/UI behind internal flag.
+- Add Bot Manager runtime support.
+- Add read-only broker-data/portfolio snapshot before trading.
+
+Exit criteria:
+
+- Internal saved credential can run a read-only broker snapshot.
+- No raw secrets are returned through MCP/frontend APIs.
+
+### Phase 7: BotSpot Trading Support
+
+Goals:
+
+- Add single-trade support with high-risk approval.
+- Add deployment support.
+- Add product/legal gates.
+
+Exit criteria:
+
+- Single trade uses saved broker credential and high-risk approval.
+- Deployment uses runtime-secret refs only.
+- Security docs cover private-key/signing model.
+- Public launch decision is made separately for `polymarket.com` versus `polymarket.us`.
+
+## Questions For Rob
+
+1. Should the first live LumiBot spike target your current `polymarket.com` account, even though it is not Polymarket US and may have geography/compliance constraints?
+2. Do you want me to open the Polymarket `APIs` page and create/read API credentials in a later turn? If yes, where should the generated values be stored locally?
+3. Are you comfortable with a local LumiBot prototype requiring a Polymarket private key or session signer, or do we need to find a no-private-key credential path first?
+4. Is the first strategy target the fast 5-minute crypto up/down markets, or should we start with slower/liquid markets to reduce execution risk?
+5. Should BotSpot support be internal-only until `polymarket.us` support is verified, or are we planning to support international CLOB accounts for specific non-US users?
+6. What hard risk limits should we enforce in early live tests: max order size, max daily spend, market allowlist, and limit-only trading?
+
+## Recommended Immediate Next Step
+
+Do not start implementation yet. The next useful action is a credential/access spike:
+
+1. Open the `polymarket.com` account `APIs` page with explicit approval.
+2. Identify whether it creates Relayer API Keys, CLOB API session credentials, builder keys, or something else.
+3. Do not expose values in chat or logs.
+4. Save only the credential names and required env var mapping in this doc.
+5. Run a read-only authenticated SDK call if credentials can be loaded safely.
+
+After that, implement Phase 1 in LumiBot with fake-client tests and public data only.

--- a/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
+++ b/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
@@ -4,14 +4,18 @@ One-line description: Deep research and implementation game plan for adding Poly
 
 Last Updated: 2026-07-01
 
-Status: Initial LumiBot implementation in progress. Credential/login/live-trading proof still blocked by missing local
-Polymarket credentials.
+Status: Initial LumiBot implementation in progress. Credential/login/read-only/WebSocket proof completed on
+2026-07-01; live order submission is currently blocked by Polymarket's deposit-wallet/API-key binding for the tested
+Magic/proxy account.
 
 Audience: LumiBot maintainers, BotSpot broker-connection engineers, Bot Manager runtime engineers
 
 ## 2026-07-01 Implementation Status
 
-Initial LumiBot implementation has started and covers the international `polymarket.com` CLOB lane only.
+Initial LumiBot implementation has started and covers the international `polymarket.com` CLOB lane only. The current
+live proof and runbook are now documented in:
+
+- `docs/investigations/2026-07-01_POLYMARKET_INTERNATIONAL_CLOB_LIVE_PROOF.md`
 
 Implemented in LumiBot:
 
@@ -20,31 +24,31 @@ Implemented in LumiBot:
   supported price-history requests.
 - `Polymarket` broker with required broker methods, authenticated read paths, market order routing, limit order routing,
   cancel, and polling reconciliation.
-- `PolymarketCLOBStream` bridge with testable market/user event handlers and polling reconciliation.
+- `PolymarketCLOBStream` bridge with real public market and private user WebSocket workers plus polling reconciliation.
 - Explicit `TRADING_BROKER=polymarket` / `DATA_SOURCE=polymarket` plumbing.
 - `py-clob-client-v2>=1.0.1` dependency. The documented beta `polymarket-client` package was not available from PyPI in
   the local verification environment.
+- `websockets>=15.0.1` dependency for market/user streams.
 - Unit tests for asset/data/broker behavior and provider-gated live smoke tests.
 
 Verified locally:
 
-- `python3 -m py_compile lumibot/data_sources/polymarket_data.py lumibot/brokers/polymarket.py lumibot/credentials.py`
+- `python3 -m py_compile lumibot/data_sources/polymarket_data.py lumibot/brokers/polymarket.py scripts/polymarket_smoke.py`
 - `python3 -m pytest tests/test_polymarket_asset.py tests/test_polymarket_data.py tests/test_polymarket_broker.py -q`
-  passed with 15 tests.
-- `python3 -m pytest tests/test_polymarket_apitest.py -q` skipped all 3 live/API tests because local Polymarket env vars
-  are not present.
-- Public `https://clob.polymarket.com/markets` returned HTTP 200 during a no-credential sanity check.
+  passed with 19 tests.
+- `python3 -m dotenv -f .env.local run -- python3 -m pytest -q tests/test_polymarket_apitest.py` passed 3 tests and
+  xfailed the one live market-order submit for the exact current Polymarket platform-side blocker.
+- Direct read-only smoke proved account balance, positions, open orders, recent trades, order book, quote, last price,
+  supported history, public market WebSocket, and authenticated private user WebSocket.
+- Direct live market-order and limit/cancel smokes were attempted and both were blocked by
+  `maker address not allowed, please use the deposit wallet flow`.
 
-Not yet verified:
+Still blocked:
 
-- Actual credential/login proof.
-- Reading Rob's real Polymarket account value, positions, open orders, and recent trades.
-- Deriving/storing real CLOB API credentials in `.env.local`.
-- Any live order, including the approved $1-$5 market-order smoke.
-
-Current blocker: no Polymarket private key, wallet address, or CLOB credentials were present in local LumiBot `.env` or
-`.env.local` during implementation. The live smoke tests are ready but intentionally skip until those env vars are
-provided.
+- Successful live submit/fill/cancel, because the current account's CLOB credentials and funder/signature type are not
+  accepted by Polymarket for order submission.
+- Real private user stream fill reconciliation, because no order can currently be placed from this account.
+- BotSpot/Bot Manager support, intentionally deferred until LumiBot has a working live submit path.
 
 ## Executive Summary
 

--- a/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
+++ b/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
@@ -24,6 +24,71 @@ The biggest structural issues are:
 
 I did not create or read any API keys. Key creation changes account security state and should be done only after an explicit go-ahead for that action.
 
+## 2026-07-01 Follow-Up: US And International CLOB Support
+
+### Direct Answers
+
+**CLOB means Central Limit Order Book.** Polymarket's international trading docs describe it as the order-book system that matches orders offchain and settles matched trades onchain.
+
+**Yes, LumiBot can support both Polymarket US and the international CLOB, but they should not be one internally tangled adapter.** The right structure is a shared prediction-market domain model plus separate provider drivers:
+
+- `PolymarketUSDriver`: wraps the `polymarket-us` SDK, US market slugs, US order intents, US account/portfolio API, and US WebSockets.
+- `PolymarketCLOBDriver`: wraps the international SDK/CLOB/deposit-wallet path, token ids, CLOB order signing, relayer wallet operations, and market/user streams.
+- `PolymarketData`: shared public LumiBot data-source facade that can delegate to either driver by mode.
+- `Polymarket` broker: shared LumiBot broker facade that exposes the normal broker contract but owns exactly one configured provider mode per broker instance.
+
+This lets a strategy use `TRADING_BROKER=polymarket` with `POLYMARKET_MODE=us` or `POLYMARKET_MODE=clob`, while the implementation keeps different authentication and order semantics isolated. For BotSpot's saved broker credentials, I would split the product ids into `polymarket_us` and `polymarket_clob` so eligibility, compliance text, and credential fields cannot be mixed accidentally.
+
+**Polymarket US is not app-only from an API standpoint.** The Polymarket US docs say users must create an account and complete identity verification in the iOS app before generating API keys, but they also document a developer portal, official Python/TypeScript SDKs, public endpoints, authenticated account/portfolio/orders endpoints, and WebSocket support for market and private updates. The US Python SDK uses `POLYMARKET_KEY_ID` and `POLYMARKET_SECRET_KEY` style credentials. We still need to verify whether Rob personally has access to a Polymarket US account and developer portal.
+
+**Rob's current visible browser session still appears to be international `polymarket.com`, not Polymarket US.** The URL, crypto deposit surface, wallet-style identity, and `APIs` menu match the international account surface. That does not mean US cannot be supported; it means the first usable credentials from the current browser session are probably CLOB/deposit-wallet credentials unless Rob separately logs into `polymarket.us`.
+
+### Credential Model: Relayer Key vs CLOB API Key
+
+The international stack has at least three separate credential concepts. We should name them separately in LumiBot and BotSpot:
+
+| Credential layer | What it is for | Typical fields | Notes |
+| --- | --- | --- | --- |
+| Signer / L1 | Proves wallet control, creates or derives CLOB API credentials, signs order payloads | `POLYMARKET_PRIVATE_KEY`, optional session signer, wallet/deposit-wallet address | Highest-risk secret. For BotSpot, this is a private-key custody problem, not a normal broker API token. |
+| CLOB / L2 API credentials | Authenticates CLOB private REST requests, user-order reads, cancels, balances, and posting signed orders | `POLYMARKET_CLOB_API_KEY`, `POLYMARKET_CLOB_API_SECRET`, `POLYMARKET_CLOB_API_PASSPHRASE`, `POLY_ADDRESS`/wallet address | L2 auth does not remove the need to sign newly created orders. It authenticates the request around a signed order. |
+| Relayer / builder credential | Deploys deposit wallets and submits wallet-operation batches such as approvals | `POLYMARKET_RELAYER_API_KEY`, `POLYMARKET_RELAYER_API_KEY_ADDRESS`, or builder key/secret/passphrase for older relayer client paths | This is not the same thing as a CLOB trading API key. It is needed for wallet setup and approvals, not a standalone LumiBot trading credential. |
+
+The website label `Relayer API Key` is therefore not enough for trading by itself. If the API page also shows a normal API key underneath it, we need to identify whether that key is:
+
+- a CLOB L2 key/secret/passphrase for authenticated order, cancel, balance, and stream operations;
+- a relayer key/address pair for wallet deployment and approvals;
+- a builder API credential used by older relayer clients;
+- or a UI-level key that the beta unified SDK can consume directly.
+
+No implementation should infer this from the page labels alone. The next access spike should inspect the labels and required fields without exposing values in chat, then run only a read-only authenticated account or balance call.
+
+### What "Support Both At The Same Time" Should Mean
+
+Support both should mean:
+
+- The LumiBot entity model, broker contract, data-source contract, and strategy API can represent prediction contracts independent of venue.
+- One broker instance is configured for one account/provider mode at a time.
+- A strategy that needs cross-venue trading later should use multiple broker instances/accounts, not a single broker instance that silently routes some orders to US and some to CLOB.
+- Tests should share prediction-market contract behavior, but fixture payloads should remain mode-specific.
+
+Do not make one large `Polymarket` class full of `if mode == "us"` branches for every API call. Use a small facade plus two internal drivers. That matches the useful part of the Alpaca/Tradier pattern: a broker class presents LumiBot's normalized contract, while provider-specific parsing, auth, and streaming are isolated.
+
+### WebSockets Must Be In The Early Design
+
+Alpaca is the better broker model here because it uses a real trading stream when credentials support it and falls back to polling only when necessary. Its polling path also reconciles positions and tracked orders carefully instead of assuming a missing order is canceled immediately.
+
+Tradier is useful as a cautionary pattern: its polling stream explicitly cannot reliably track partial fills. That limitation is not acceptable for fast Polymarket markets where order-book levels, partial fills, tick-size changes, and private order events can move quickly.
+
+For Polymarket, the first production-quality design should include:
+
+1. HTTP snapshot at startup: market metadata, order book, balances, open orders, and positions.
+2. Public market WebSocket: book, price change, last trade, best bid/ask, tick-size change, new-market, and resolved-market events where available.
+3. Private user WebSocket: order, trade, position, and balance events where available by mode.
+4. Reconnect reconciliation: after reconnect, reread open orders, positions, balances, and the current book before trusting local state.
+5. Polling fallback: only for reconciliation and degraded operation, not as the primary fast-trading mechanism.
+
+The CLOB SDK currently exposes async realtime stream subscriptions, so `PolymarketStream` should own an asyncio loop in a background thread and dispatch normalized events into LumiBot's existing `CustomStream` action queue. US WebSockets are also documented as async-only and provide separate private and market streams, so the same `PolymarketStream` facade can work with mode-specific drivers.
+
 ## Account Surface Finding
 
 ### What Was Verified In Chrome
@@ -89,12 +154,13 @@ Do not blur these together in code or docs. The same public class can eventually
 - Polymarket API introduction: `https://docs.polymarket.com/api-reference/introduction`
 - Polymarket Python SDK: `https://docs.polymarket.com/dev-tooling/python`
 - Polymarket trading quickstart: `https://docs.polymarket.com/trading/quickstart`
+- Polymarket trading overview/CLOB definition: `https://docs.polymarket.com/trading/overview`
 - Polymarket order overview: `https://docs.polymarket.com/trading/orders/overview`
 - Polymarket order creation: `https://docs.polymarket.com/trading/orders/create`
 - Polymarket orderbook/WebSocket docs: `https://docs.polymarket.com/trading/orderbook`
 - Polymarket market channel: `https://docs.polymarket.com/market-data/websocket/market-channel`
 - Polymarket user channel: `https://docs.polymarket.com/market-data/websocket/user-channel`
-- Polymarket authentication: `https://docs.polymarket.com/developers/CLOB/authentication`
+- Polymarket authentication: `https://docs.polymarket.com/api-reference/authentication`
 - Polymarket public client methods: `https://docs.polymarket.com/trading/clients/public`
 - Polymarket secure client methods: `https://docs.polymarket.com/trading/clients/l2`
 - Polymarket deposit wallets: `https://docs.polymarket.com/trading/deposit-wallets`
@@ -102,6 +168,7 @@ Do not blur these together in code or docs. The same public class can eventually
 - Polymarket error codes: `https://docs.polymarket.com/resources/error-codes`
 - Polymarket rate limits/geographic restrictions entry point: `https://docs.polymarket.com/api-reference/rate-limits`
 - Polymarket relayer API keys reference: `https://docs.polymarket.com/api-reference/relayer-api-keys/get-all-relayer-api-keys`
+- Polymarket US SDK introduction: `https://docs.polymarket.us/api-reference/sdks/introduction`
 - Polymarket US Python quickstart: `https://docs.polymarket.us/api-reference/sdks/python/quickstart`
 - Polymarket US Python account docs: `https://docs.polymarket.us/api-reference/sdks/python/account`
 - Polymarket US Python WebSocket docs: `https://docs.polymarket.us/api-reference/sdks/python/websocket`
@@ -331,12 +398,27 @@ Update:
 - `docs/BROKER_ORDER_SEMANTICS.md` if prediction contracts need a new order caveat.
 - `docs/BACKTESTING_ARCHITECTURE.md` if we add prediction backtesting semantics.
 
+### Internal Class Structure
+
+Use a facade/driver split:
+
+- `Polymarket`: the LumiBot broker class that implements the broker abstract methods and owns one configured driver.
+- `PolymarketData`: the LumiBot data source that owns one configured public-data driver.
+- `_PolymarketCLOBDriver`: international SDK/CLOB/deposit-wallet implementation.
+- `_PolymarketUSDriver`: US SDK implementation.
+- `PolymarketStream`: shared stream wrapper that normalizes driver-specific async WebSocket events into LumiBot stream actions.
+
+This keeps the public import simple while avoiding provider-specific branches throughout every broker method.
+
 ### Config Shape
 
-Recommended environment names for international CLOB mode:
+Recommended public LumiBot selector:
 
 - `TRADING_BROKER=polymarket`
 - `POLYMARKET_MODE=clob`
+
+Recommended environment names for international CLOB mode:
+
 - `POLYMARKET_PRIVATE_KEY`
 - `POLYMARKET_WALLET_ADDRESS`
 - `POLYMARKET_RELAYER_API_KEY`
@@ -357,12 +439,12 @@ Credential policy:
 
 Potential future US mode:
 
-- `TRADING_BROKER=polymarket_us`
-- `POLYMARKET_US_API_KEY`
-- `POLYMARKET_US_API_SECRET`
-- `POLYMARKET_US_USER_ID`
+- `TRADING_BROKER=polymarket`
+- `POLYMARKET_MODE=us`
+- `POLYMARKET_US_KEY_ID`
+- `POLYMARKET_US_SECRET_KEY`
 
-Keep US and international env names separate.
+Keep US and international env names separate. For BotSpot saved credentials, prefer separate provider ids (`polymarket_us` and `polymarket_clob`) even if LumiBot has one facade class.
 
 ### `PolymarketData`
 
@@ -499,7 +581,7 @@ Files likely touched later:
 
 Needed product decisions:
 
-- Add `polymarket` or split `polymarket_clob` and `polymarket_us`.
+- Split `polymarket_clob` and `polymarket_us` in BotSpot saved credentials, even if LumiBot exposes one `Polymarket` facade with `POLYMARKET_MODE`.
 - Show a strong eligibility/compliance warning for international CLOB.
 - Manual credential fields are enough for first version; OAuth-style browser redirect is not the right model unless Polymarket US provides it.
 - Do not collect raw private keys in a customer-facing UI until security signs off on the runtime signer model.
@@ -517,7 +599,17 @@ Possible internal-only catalog entry for first BotSpot experiments:
   - `POLYMARKET_RELAYER_API_KEY_ADDRESS`
   - optional CLOB session credential fields
 
-For public BotSpot, prefer `polymarket_us` if the US API supports the required trading and websocket workflows.
+Possible US catalog entry:
+
+- id: `polymarket_us`
+- asset class: `Prediction Markets`
+- modes: `live` only
+- auth method: `api_key`
+- credential fields:
+  - `POLYMARKET_US_KEY_ID` secret
+  - `POLYMARKET_US_SECRET_KEY` secret
+
+For public BotSpot, prefer `polymarket_us` if Rob can verify US account/API eligibility and if the US API supports the required trading and WebSocket workflows.
 
 ### BotSpot Node
 
@@ -726,9 +818,10 @@ Smoke tests must use an explicit market allowlist, maximum notional, and no hidd
 
 Goals:
 
-- Confirm whether Rob wants `polymarket.com` CLOB mode or a real `polymarket.us` account.
-- Confirm what the website `APIs` page can generate.
-- Determine if Relayer API Key plus private key/session signer is enough for Rob's current account.
+- Confirm whether the first implementation target is Rob's current `polymarket.com` CLOB account, a separate `polymarket.us` account, or both in parallel.
+- Confirm what the `polymarket.com` website `APIs` page can generate: relayer key, CLOB L2 key/secret/passphrase, builder credential, or beta SDK key material.
+- Confirm whether Rob can access `polymarket.us/developer` after US app account setup and identity verification.
+- Determine whether Relayer API Key plus private key/session signer is enough for Rob's current account setup and approvals.
 - Create credentials only after explicit approval.
 - Store secrets only in approved local env/secret-store paths. Do not put them in docs, chat, screenshots, git, or logs.
 
@@ -736,7 +829,7 @@ Exit criteria:
 
 - We know the exact env vars and credential object required for one authenticated account read.
 - We can call a read-only authenticated endpoint or SDK account method without placing orders.
-- We know whether trading requires raw private-key custody.
+- We know whether CLOB trading requires raw private-key custody for Rob's account, and whether US trading can avoid private-key custody.
 
 ### Phase 1: LumiBot Asset And Data Source
 
@@ -765,7 +858,22 @@ Exit criteria:
 - `_pull_broker_all_orders()` works.
 - Raw values are redacted in logs.
 
-### Phase 3: Limit Orders And Cancel
+### Phase 3: WebSocket Stream Scaffold
+
+Goals:
+
+- Add public market WebSocket for subscribed token ids.
+- Add private user WebSocket for authenticated order/trade events where the selected provider mode supports them.
+- Add HTTP reconciliation after reconnect.
+- Add fake-event tests before placing live orders.
+
+Exit criteria:
+
+- Live quote state updates without polling.
+- Private order status updates dispatch into LumiBot's stream events in fake-client tests.
+- Reconnect path does not duplicate fills.
+
+### Phase 4: Limit Orders And Cancel
 
 Goals:
 
@@ -773,26 +881,13 @@ Goals:
 - Support cancel.
 - Support `_parse_broker_order`.
 - Add safe provider error mapping.
+- Wire live submit/cancel events into the stream/reconciliation path from Phase 3.
 
 Exit criteria:
 
 - Tiny live limit order and cancel smoke passes after explicit approval.
 - Unknown order rows do not crash refresh.
 - Submit/cancel errors fail loudly.
-
-### Phase 4: WebSockets
-
-Goals:
-
-- Add public market WebSocket for subscribed token ids.
-- Add private user WebSocket for order/trade events.
-- Add HTTP reconciliation after reconnect.
-
-Exit criteria:
-
-- Live quote state updates without polling.
-- Private order status updates dispatch into LumiBot's stream events.
-- Reconnect path does not duplicate fills.
 
 ### Phase 5: Market Orders And Fast Trading Controls
 
@@ -839,20 +934,24 @@ Exit criteria:
 ## Questions For Rob
 
 1. Should the first live LumiBot spike target your current `polymarket.com` account, even though it is not Polymarket US and may have geography/compliance constraints?
-2. Do you want me to open the Polymarket `APIs` page and create/read API credentials in a later turn? If yes, where should the generated values be stored locally?
-3. Are you comfortable with a local LumiBot prototype requiring a Polymarket private key or session signer, or do we need to find a no-private-key credential path first?
-4. Is the first strategy target the fast 5-minute crypto up/down markets, or should we start with slower/liquid markets to reduce execution risk?
-5. Should BotSpot support be internal-only until `polymarket.us` support is verified, or are we planning to support international CLOB accounts for specific non-US users?
-6. What hard risk limits should we enforce in early live tests: max order size, max daily spend, market allowlist, and limit-only trading?
+2. Do you want me to inspect the `polymarket.com` `APIs` page labels in a later turn without creating or copying secrets?
+3. Do you want to verify whether you can access `polymarket.us/developer`, or should we treat US support as a parallel code path until your US account status is clear?
+4. If credentials are created later, where should the generated values be stored locally: an approved `.env` path, macOS Keychain, 1Password/Bitwarden, or a BotSpot secret-store path?
+5. Are you comfortable with a local LumiBot prototype requiring a Polymarket private key or session signer, or do we need to find a no-private-key credential path first?
+6. Is the first strategy target the fast 5-minute crypto up/down markets, or should we start with slower/liquid markets to reduce execution risk?
+7. Should BotSpot support be internal-only until `polymarket.us` support is verified, or are we planning to support international CLOB accounts for specific non-US users?
+8. What hard risk limits should we enforce in early live tests: max order size, max daily spend, market allowlist, and limit-only trading?
 
 ## Recommended Immediate Next Step
 
 Do not start implementation yet. The next useful action is a credential/access spike:
 
-1. Open the `polymarket.com` account `APIs` page with explicit approval.
-2. Identify whether it creates Relayer API Keys, CLOB API session credentials, builder keys, or something else.
-3. Do not expose values in chat or logs.
-4. Save only the credential names and required env var mapping in this doc.
-5. Run a read-only authenticated SDK call if credentials can be loaded safely.
+1. Inspect the `polymarket.com` account `APIs` page with explicit approval, without creating or copying secrets.
+2. Identify whether it exposes Relayer API Keys, CLOB API session credentials, builder keys, beta SDK key material, or some combination.
+3. Separately check whether Rob can reach `polymarket.us/developer` and whether it offers US API key creation for his account.
+4. Do not expose values in chat or logs.
+5. Save only the credential names, required env var mapping, and source page labels in this doc.
+6. Create credentials only after a second explicit approval and an agreed storage path.
+7. Run a read-only authenticated SDK call if credentials can be loaded safely.
 
 After that, implement Phase 1 in LumiBot with fake-client tests and public data only.

--- a/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
+++ b/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
@@ -90,6 +90,140 @@ For Polymarket, the first production-quality design should include:
 
 The CLOB SDK currently exposes async realtime stream subscriptions, so `PolymarketCLOBStream` should own an asyncio loop in a background thread and dispatch normalized events into LumiBot's existing `CustomStream` action queue. US WebSockets are also documented as async-only and provide separate private and market streams, so `PolymarketUSStream` should use the same LumiBot stream pattern but remain a separate provider implementation.
 
+## 2026-07-01 Chosen Blueprint: International CLOB First
+
+Scope decision after follow-up discussion: build only the international `polymarket.com` CLOB adapter first. Polymarket US should be a later, separate broker adapter after US access is available. Starting with CLOB should still make US easier later because it establishes LumiBot's prediction-contract asset semantics, test fixtures, stream event normalization pattern, and order/position/account-value expectations, but the US API should not be treated as the same implementation.
+
+### Build Order
+
+1. Credential/login proof.
+2. Minimal `prediction_contract` asset plumbing.
+3. CLOB data source skeleton and required method implementations.
+4. CLOB broker skeleton and required method implementations.
+5. Account-value, positions, and orders read path.
+6. Market-order submit path with explicit Polymarket `custom_params` for BUY notional and slippage protection.
+7. Limit-order and cancel path.
+8. WebSocket market/user streams wired into LumiBot order events.
+9. Broader tests, examples, and documentation.
+
+### Credential/Login Proof
+
+The first proof should not be a trade. It should prove that the local LumiBot process can authenticate and read account state.
+
+Expected local secret fields:
+
+- `POLYMARKET_PRIVATE_KEY`: wallet or session signer key used to create/derive CLOB API credentials and sign orders.
+- `POLYMARKET_WALLET_ADDRESS`: deposit wallet/proxy/safe/funder address. For new API users, this is likely the deposit wallet.
+- `POLYMARKET_CLOB_API_KEY`, `POLYMARKET_CLOB_API_SECRET`, `POLYMARKET_CLOB_API_PASSPHRASE`: derived or generated CLOB L2 credentials.
+- `POLYMARKET_RELAYER_API_KEY`, `POLYMARKET_RELAYER_API_KEY_ADDRESS`: only if wallet deployment or approval setup requires relayer auth.
+- Optional `POLYMARKET_BUILDER_CODE`: attribution only, not authentication.
+
+Credential proof sequence:
+
+1. Load secrets from a local `.env`/`.env.local` path, never from committed docs.
+2. Initialize a secure client with private key and wallet address.
+3. Create or derive CLOB API credentials if they are not already stored.
+4. Initialize the authenticated CLOB client with `chain_id=137`, signature type `POLY_1271` for deposit wallets, and funder wallet address.
+5. Read CLOB collateral balance/allowance.
+6. Read portfolio value and positions through the secure unified SDK or Data API.
+7. Read open orders and recent trades.
+8. Stop if any credential, geoblock, approval, or funder mismatch error occurs.
+
+### `PolymarketData`
+
+File: `lumibot/data_sources/polymarket_data.py`
+
+Purpose: public market data and market/contract resolution for international CLOB.
+
+Required methods:
+
+- `get_chains(asset, quote=None)`: return `{}` for now because prediction markets are not option chains. Add a documented prediction-market helper instead of pretending they are chains.
+- `get_historical_prices(asset, length, timestep="", timeshift=None, quote=None, exchange=None, include_after_hours=True, **kwargs)`: call CLOB price history only when a token id is known and the requested interval can map to provider history. Return real `Bars`; raise a clear unsupported error for unavailable bars.
+- `get_last_price(asset, quote=None, exchange=None)`: for a token-id asset, call last-trade price first; fall back to midpoint if explicitly configured.
+- `get_quote(asset, quote=None, exchange=None)`: call order book or best bid/ask, return `Quote(asset, price, bid, ask, bid_size, ask_size, timestamp, raw_data)`.
+
+Provider helper methods:
+
+- `resolve_market(url=None, slug=None, condition_id=None, market_id=None)`: find a market/event and cache condition id, market id, question, slug, end date, outcomes.
+- `resolve_contract(market, outcome=None, token_id=None)`: return the tradable outcome token id and normalized `Asset(asset_type="prediction_contract")`.
+- `get_order_book(token_id)`: CLOB order book snapshot.
+- `get_clob_market_info(condition_id)`: tick size, neg-risk, min order size, fee fields.
+- `get_tick_size(token_id)` and `get_neg_risk(token_id)`: direct cacheable reads.
+- `calculate_market_price(token_id, side, amount, order_type="FOK")`: pre-trade estimate for market-order slippage controls.
+- `subscribe_market(token_ids)`: used by the stream, not by strategy code directly.
+
+### `Polymarket` Broker
+
+File: `lumibot/brokers/polymarket.py`
+
+Purpose: international CLOB live broker. It should inherit from `Broker` and be structured like Alpaca/Tradier: constructor creates/receives a data source, broker methods normalize provider payloads, stream actions dispatch into existing LumiBot order lifecycle methods.
+
+Required methods and implementation intent:
+
+- `__init__(config=None, data_source=None, polling_interval=1.0, connect_stream=True, use_websocket=True)`: build `PolymarketData` if missing, load config, set `market="24/7"`, initialize clients lazily enough that read-only imports do not accidentally place approvals.
+- `_initialize_clients()`: create public, secure, and CLOB clients. Derive/load API credentials. Do not print secrets.
+- `_ensure_trading_ready()`: run idempotent approvals only when trading is about to happen or when explicitly requested, not during every read-only balance call.
+- `_get_balances_at_broker(quote_asset, strategy)`: return `(cash, positions_value, portfolio_value)` using CLOB collateral balance/allowance plus Data API/unified SDK portfolio value.
+- `_pull_positions(strategy)`: call secure `list_positions` or Data API `/positions`, parse each row into `Position(strategy, Asset(token_id, prediction_contract), size, avg_fill_price=avgPrice)` with current price, market value, PnL, outcome, condition id, slug, and raw payload.
+- `_pull_position(strategy, asset)`: filter `_pull_positions` by token id.
+- `_pull_broker_all_orders()`: call open orders endpoint, return raw open orders. Add recent trades in a separate helper for fill reconciliation.
+- `_pull_broker_order(identifier)`: call single order endpoint; if not open, fall back to recent trades by order id when needed.
+- `_parse_broker_order(response, strategy_name, strategy_object=None)`: map CLOB raw order/trade response into `Order`, including token-id asset, side, quantity, order type, time in force, price, matched size, status, create/update timestamps, and raw payload.
+- `_submit_order(order)`: validate `prediction_contract`, side, order type, token id, min order size, tick size, neg risk, and custom market-order params. Dispatch submit through `_submit_market_order` or `_submit_limit_order`.
+- `_submit_market_order(order)`: first trading path. Use Polymarket market order semantics: BUY requires dollar `amount` and optional `max_spend`/max price; SELL requires shares. Values should come from `order.custom_params` so LumiBot's normal `quantity` meaning is not silently changed.
+- `_submit_limit_order(order)`: use limit price and size, map GTC/GTD.
+- `cancel_order(order)`: call provider cancel by order id; do not no-op only because local status says cancelling.
+- `_modify_order(order, limit_price=None, stop_price=None)`: raise unsupported or implement explicit cancel-replace later. Do not fake native modification.
+- `get_historical_account_value()`: return provider history if available later; initially return empty/unsupported like Tradier.
+- `_get_stream_object()`: return `PolymarketCLOBStream` when websockets are enabled, otherwise `PollingStream` only as a fallback.
+- `_register_stream_events()`: register `NEW_ORDER`, `PARTIALLY_FILLED_ORDER`, `FILLED_ORDER`, `CANCELED_ORDER`, `ERROR_ORDER`, plus poll/reconcile event if needed.
+- `_run_stream()`: run stream object.
+- `do_polling()`: fallback/reconcile path: sync positions, pull open orders, compare to tracked orders, query missing tracked orders individually before treating as final.
+
+Status mapping:
+
+- CLOB placement/open -> `SUBMITTED` or `OPEN`.
+- User order update with partial matched size -> `PARTIALLY_FILLED`.
+- Trade `CONFIRMED` or fully matched order -> `FILLED`.
+- Cancellation -> `CANCELED`.
+- Rejected/failed provider response -> `ERROR`.
+- Expired GTD -> `EXPIRED`.
+- Unknown provider status -> `UNKNOWN` on read, explicit exception on submit when the response is not accepted.
+
+### WebSocket Design
+
+File/class: `PolymarketCLOBStream(CustomStream)`
+
+Implementation:
+
+- Own an asyncio event loop in a background thread.
+- Maintain market subscriptions by token id using market channel or SDK `MarketSpec`.
+- Maintain private user subscription using API credentials or SDK `UserSpec`.
+- Dispatch public book/price events into a quote/order-book cache owned by `PolymarketData`.
+- Dispatch private order/trade events into broker stream actions.
+- On reconnect, reread balances, positions, open orders, and order book before trusting local state.
+- Use polling only as startup/reconnect fallback, not the primary source for fills.
+
+Event handling:
+
+- `book`: replace book snapshot for token id.
+- `price_change`: update changed levels; size `0` removes a level.
+- `best_bid_ask`: update quote cache.
+- `tick_size_change`: invalidate tick-size cache.
+- `last_trade_price`: update last price and volume/trade cache.
+- `order` placement/update/cancellation: parse broker order and dispatch new/partial/cancel as appropriate.
+- `trade` matched/mined/confirmed/failed: update fills; dispatch fill only when enough price/quantity detail exists.
+
+### Why Market Orders Can Be First
+
+Polymarket market orders are still signed CLOB orders that execute against resting liquidity using `FOK` or `FAK`. It is reasonable to make market orders the first live trade proof if the implementation makes Polymarket's quantity semantics explicit:
+
+- BUY market order: use `custom_params["amount"]` for dollars to spend and `custom_params["max_spend"]` or max price/slippage protection.
+- SELL market order: use shares, either from `order.quantity` or `custom_params["shares"]`.
+- Default first smoke should be tiny notional, liquid market, FOK or FAK chosen explicitly, with a hard max notional.
+
+Do not silently redefine LumiBot's generic `Order.quantity` as dollars for BUY market orders.
+
 ## Account Surface Finding
 
 ### What Was Verified In Chrome

--- a/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
+++ b/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
@@ -30,14 +30,15 @@ I did not create or read any API keys. Key creation changes account security sta
 
 **CLOB means Central Limit Order Book.** Polymarket's international trading docs describe it as the order-book system that matches orders offchain and settles matched trades onchain.
 
-**Yes, LumiBot can support both Polymarket US and the international CLOB, but they should not be one internally tangled adapter.** The right structure is a shared prediction-market domain model plus separate provider drivers:
+**Yes, LumiBot can support both Polymarket US and the international CLOB, but they should be separate broker adapters.** The right structure is separate public broker/data-source classes with only small shared helpers where the model is truly common:
 
-- `PolymarketUSDriver`: wraps the `polymarket-us` SDK, US market slugs, US order intents, US account/portfolio API, and US WebSockets.
-- `PolymarketCLOBDriver`: wraps the international SDK/CLOB/deposit-wallet path, token ids, CLOB order signing, relayer wallet operations, and market/user streams.
-- `PolymarketData`: shared public LumiBot data-source facade that can delegate to either driver by mode.
-- `Polymarket` broker: shared LumiBot broker facade that exposes the normal broker contract but owns exactly one configured provider mode per broker instance.
+- `Polymarket` or `PolymarketCLOB`: international `polymarket.com` CLOB/deposit-wallet broker.
+- `PolymarketData` or `PolymarketCLOBData`: international CLOB market-data source.
+- `PolymarketUS`: US `polymarket.us` broker.
+- `PolymarketUSData`: US market-data source.
+- Shared helpers only for prediction-contract parsing, decimal/tick validation, error redaction, and fake stream fixtures.
 
-This lets a strategy use `TRADING_BROKER=polymarket` with `POLYMARKET_MODE=us` or `POLYMARKET_MODE=clob`, while the implementation keeps different authentication and order semantics isolated. For BotSpot's saved broker credentials, I would split the product ids into `polymarket_us` and `polymarket_clob` so eligibility, compliance text, and credential fields cannot be mixed accidentally.
+This means a strategy chooses one broker explicitly: `TRADING_BROKER=polymarket` for international CLOB or `TRADING_BROKER=polymarket_us` for the US platform. Do not route both through a single mode-switched broker in the first implementation. For BotSpot's saved broker credentials, split the product ids into `polymarket_us` and `polymarket_clob` so eligibility, compliance text, and credential fields cannot be mixed accidentally.
 
 **Polymarket US is not app-only from an API standpoint.** The Polymarket US docs say users must create an account and complete identity verification in the iOS app before generating API keys, but they also document a developer portal, official Python/TypeScript SDKs, public endpoints, authenticated account/portfolio/orders endpoints, and WebSocket support for market and private updates. The US Python SDK uses `POLYMARKET_KEY_ID` and `POLYMARKET_SECRET_KEY` style credentials. We still need to verify whether Rob personally has access to a Polymarket US account and developer portal.
 
@@ -71,7 +72,7 @@ Support both should mean:
 - A strategy that needs cross-venue trading later should use multiple broker instances/accounts, not a single broker instance that silently routes some orders to US and some to CLOB.
 - Tests should share prediction-market contract behavior, but fixture payloads should remain mode-specific.
 
-Do not make one large `Polymarket` class full of `if mode == "us"` branches for every API call. Use a small facade plus two internal drivers. That matches the useful part of the Alpaca/Tradier pattern: a broker class presents LumiBot's normalized contract, while provider-specific parsing, auth, and streaming are isolated.
+Do not make one large `Polymarket` class full of `if mode == "us"` branches for every API call. Use two brokers and two data sources. That matches the useful part of the Alpaca/Tradier pattern: each broker presents LumiBot's normalized contract, while provider-specific parsing, auth, and streaming remain isolated.
 
 ### WebSockets Must Be In The Early Design
 
@@ -87,7 +88,7 @@ For Polymarket, the first production-quality design should include:
 4. Reconnect reconciliation: after reconnect, reread open orders, positions, balances, and the current book before trusting local state.
 5. Polling fallback: only for reconciliation and degraded operation, not as the primary fast-trading mechanism.
 
-The CLOB SDK currently exposes async realtime stream subscriptions, so `PolymarketStream` should own an asyncio loop in a background thread and dispatch normalized events into LumiBot's existing `CustomStream` action queue. US WebSockets are also documented as async-only and provide separate private and market streams, so the same `PolymarketStream` facade can work with mode-specific drivers.
+The CLOB SDK currently exposes async realtime stream subscriptions, so `PolymarketCLOBStream` should own an asyncio loop in a background thread and dispatch normalized events into LumiBot's existing `CustomStream` action queue. US WebSockets are also documented as async-only and provide separate private and market streams, so `PolymarketUSStream` should use the same LumiBot stream pattern but remain a separate provider implementation.
 
 ## Account Surface Finding
 
@@ -382,12 +383,18 @@ Recommended milestone 1 rule: only allow limit orders until the market order sem
 
 ### New Files And Exports
 
-Add:
+Add for international CLOB:
 
 - `lumibot/data_sources/polymarket_data.py`
 - `lumibot/brokers/polymarket.py`
 - Tests under the existing LumiBot test layout.
 - Public docs under `docsrc/` and `docs/ENV_VARS.md`.
+
+Add later or in parallel for US mode:
+
+- `lumibot/data_sources/polymarket_us_data.py`
+- `lumibot/brokers/polymarket_us.py`
+- Separate tests and docs for the US SDK/auth/order model.
 
 Update:
 
@@ -400,25 +407,21 @@ Update:
 
 ### Internal Class Structure
 
-Use a facade/driver split:
+Use separate public classes, with shared helpers only where the models are truly common:
 
-- `Polymarket`: the LumiBot broker class that implements the broker abstract methods and owns one configured driver.
-- `PolymarketData`: the LumiBot data source that owns one configured public-data driver.
-- `_PolymarketCLOBDriver`: international SDK/CLOB/deposit-wallet implementation.
-- `_PolymarketUSDriver`: US SDK implementation.
-- `PolymarketStream`: shared stream wrapper that normalizes driver-specific async WebSocket events into LumiBot stream actions.
+- `Polymarket`: international CLOB broker class.
+- `PolymarketData`: international CLOB data source.
+- `PolymarketUS`: US broker class.
+- `PolymarketUSData`: US data source.
+- `polymarket_common.py` or a private helper module only for shared decimal, redaction, and asset metadata utilities.
 
-This keeps the public import simple while avoiding provider-specific branches throughout every broker method.
+This keeps the public broker imports explicit and avoids provider-specific branches throughout every broker method.
 
 ### Config Shape
 
-Recommended public LumiBot selector:
+Recommended international CLOB selector:
 
 - `TRADING_BROKER=polymarket`
-- `POLYMARKET_MODE=clob`
-
-Recommended environment names for international CLOB mode:
-
 - `POLYMARKET_PRIVATE_KEY`
 - `POLYMARKET_WALLET_ADDRESS`
 - `POLYMARKET_RELAYER_API_KEY`
@@ -439,12 +442,11 @@ Credential policy:
 
 Potential future US mode:
 
-- `TRADING_BROKER=polymarket`
-- `POLYMARKET_MODE=us`
+- `TRADING_BROKER=polymarket_us`
 - `POLYMARKET_US_KEY_ID`
 - `POLYMARKET_US_SECRET_KEY`
 
-Keep US and international env names separate. For BotSpot saved credentials, prefer separate provider ids (`polymarket_us` and `polymarket_clob`) even if LumiBot has one facade class.
+Keep US and international env names separate. For BotSpot saved credentials, use separate provider ids (`polymarket_us` and `polymarket_clob`).
 
 ### `PolymarketData`
 
@@ -581,7 +583,7 @@ Files likely touched later:
 
 Needed product decisions:
 
-- Split `polymarket_clob` and `polymarket_us` in BotSpot saved credentials, even if LumiBot exposes one `Polymarket` facade with `POLYMARKET_MODE`.
+- Split `polymarket_clob` and `polymarket_us` in BotSpot saved credentials and in the LumiBot public broker classes.
 - Show a strong eligibility/compliance warning for international CLOB.
 - Manual credential fields are enough for first version; OAuth-style browser redirect is not the right model unless Polymarket US provides it.
 - Do not collect raw private keys in a customer-facing UI until security signs off on the runtime signer model.

--- a/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
+++ b/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
@@ -4,9 +4,47 @@ One-line description: Deep research and implementation game plan for adding Poly
 
 Last Updated: 2026-07-01
 
-Status: Planning only. No implementation code changed.
+Status: Initial LumiBot implementation in progress. Credential/login/live-trading proof still blocked by missing local
+Polymarket credentials.
 
 Audience: LumiBot maintainers, BotSpot broker-connection engineers, Bot Manager runtime engineers
+
+## 2026-07-01 Implementation Status
+
+Initial LumiBot implementation has started and covers the international `polymarket.com` CLOB lane only.
+
+Implemented in LumiBot:
+
+- `Asset.AssetType.PREDICTION_CONTRACT`.
+- `PolymarketData` public CLOB data source with market resolution, token resolution, order book, quote, last price, and
+  supported price-history requests.
+- `Polymarket` broker with required broker methods, authenticated read paths, market order routing, limit order routing,
+  cancel, and polling reconciliation.
+- `PolymarketCLOBStream` bridge with testable market/user event handlers and polling reconciliation.
+- Explicit `TRADING_BROKER=polymarket` / `DATA_SOURCE=polymarket` plumbing.
+- `py-clob-client-v2>=1.0.1` dependency. The documented beta `polymarket-client` package was not available from PyPI in
+  the local verification environment.
+- Unit tests for asset/data/broker behavior and provider-gated live smoke tests.
+
+Verified locally:
+
+- `python3 -m py_compile lumibot/data_sources/polymarket_data.py lumibot/brokers/polymarket.py lumibot/credentials.py`
+- `python3 -m pytest tests/test_polymarket_asset.py tests/test_polymarket_data.py tests/test_polymarket_broker.py -q`
+  passed with 15 tests.
+- `python3 -m pytest tests/test_polymarket_apitest.py -q` skipped all 3 live/API tests because local Polymarket env vars
+  are not present.
+- Public `https://clob.polymarket.com/markets` returned HTTP 200 during a no-credential sanity check.
+
+Not yet verified:
+
+- Actual credential/login proof.
+- Reading Rob's real Polymarket account value, positions, open orders, and recent trades.
+- Deriving/storing real CLOB API credentials in `.env.local`.
+- Any live order, including the approved $1-$5 market-order smoke.
+
+Current blocker: no Polymarket private key, wallet address, or CLOB credentials were present in local LumiBot `.env` or
+`.env.local` during implementation. The live smoke tests are ready but intentionally skip until those env vars are
+provided.
 
 ## Executive Summary
 

--- a/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
+++ b/docs/investigations/2026-07-01_POLYMARKET_DEEP_INTEGRATION_RESEARCH.md
@@ -96,15 +96,22 @@ Scope decision after follow-up discussion: build only the international `polymar
 
 ### Build Order
 
-1. Credential/login proof.
+Every step below should include a focused unit-test layer and, when credentials are required, a separate
+`pytest.mark.apitest` live smoke that is skipped unless explicit Polymarket env vars are present. Tests are not a final
+cleanup phase; they are the acceptance gate for each slice.
+
+1. Credential/login proof, using Rob's approved local `.env.local` storage and no implementation code changes beyond a
+   small read-only harness/test when implementation starts.
 2. Minimal `prediction_contract` asset plumbing.
-3. CLOB data source skeleton and required method implementations.
-4. CLOB broker skeleton and required method implementations.
-5. Account-value, positions, and orders read path.
-6. Market-order submit path with explicit Polymarket `custom_params` for BUY notional and slippage protection.
-7. Limit-order and cancel path.
-8. WebSocket market/user streams wired into LumiBot order events.
-9. Broader tests, examples, and documentation.
+3. CLOB data source skeleton and required public data methods.
+4. CLOB broker skeleton with all required inherited methods present, even where a method initially raises a clear
+   unsupported exception.
+5. Authenticated account-value, positions, and orders read path.
+6. Market-order submit path with explicit Polymarket `custom_params` for BUY notional and slippage protection, capped at
+   the approved $1-$5 notional for the first live proof.
+7. WebSocket market/user streams wired into LumiBot order and quote events.
+8. Limit-order and cancel path, including far-from-market limit submit/cancel live smoke.
+9. Examples, docs, BotSpot follow-on notes, and broader regression coverage.
 
 ### Credential/Login Proof
 
@@ -224,6 +231,64 @@ Polymarket market orders are still signed CLOB orders that execute against resti
 
 Do not silently redefine LumiBot's generic `Order.quantity` as dollars for BUY market orders.
 
+### Final Method Contract Matrix
+
+This is the implementation checklist for the international CLOB adapter. The goal is to make the new broker look boring
+to LumiBot strategies: strategies see normal assets, quotes, balances, positions, orders, and streams; only the adapter
+knows about token ids, wallet signing, CLOB credentials, relayer approvals, tick sizes, and `negRisk`.
+
+| Area | Class / method | Required behavior | Alpaca / Tradier comparison | Polymarket implementation detail |
+| --- | --- | --- | --- | --- |
+| Asset identity | `Asset.AssetType.PREDICTION_CONTRACT` | Add a stable core asset type for prediction contracts. | Alpaca/Tradier rely on existing stock/option/crypto types. | Use CLOB outcome token id as `Asset.symbol`; keep slug/question/outcome/condition id in raw metadata/cache. |
+| Credentials | `credentials.py` broker config branch | Instantiate broker only when `TRADING_BROKER=polymarket`. | Alpaca and Tradier have explicit config objects and env vars. | Do not auto-detect from `POLYMARKET_PRIVATE_KEY`; avoid accidental wallet initialization. |
+| Public data | `PolymarketData.get_last_price` | Return last price or a documented fallback. | Alpaca/Tradier normalize provider data into LumiBot price primitives. | Use CLOB last-trade endpoint first; optionally midpoint only when configured. |
+| Quotes | `PolymarketData.get_quote` | Return bid/ask/sizes/timestamp/raw payload. | Tradier and Alpaca expose provider quote normalization. | Use `GET /book` or cached WebSocket best bid/ask; include `min_order_size`, `tick_size`, and `neg_risk` in raw data. |
+| History | `PolymarketData.get_historical_prices` | Return real `Bars` only when provider history supports the request. | Alpaca has mature bar support; Tradier has narrower live data behavior. | Map supported intervals (`1m`, `1h`, `6h`, `1d`, `1w`, `all`, `max`); raise unsupported for unavailable bar semantics. |
+| Chains | `PolymarketData.get_chains` | Satisfy abstract method without pretending prediction contracts are options. | Both stock brokers implement real option-chain logic. | Return `{}` and add explicit prediction-market resolver helpers. |
+| Market resolver | `PolymarketData.resolve_market` | Convert URL/slug/condition id/market id into market metadata. | No direct Alpaca/Tradier equivalent; closest is option-chain lookup. | Use Gamma/public SDK market discovery; cache condition id, token ids, outcomes, close/resolution fields. |
+| Contract resolver | `PolymarketData.resolve_contract` | Convert market + outcome into tradable `prediction_contract` asset. | Similar to selecting an option contract from a chain. | Validate token id exists and market is tradable before returning an `Asset`. |
+| Client ownership | `Polymarket._initialize_clients` | Build public, secure, CLOB, and optional relayer clients. | Alpaca/Tradier constructors own provider clients. | Keep SDK clients behind internal wrapper protocols so unit tests use fakes and SDK churn is isolated. |
+| Account value | `Polymarket._get_balances_at_broker` | Return `(cash, positions_value, portfolio_value)`. | Alpaca and Tradier both implement this exact tuple. | Cash from collateral balance; positions value from secure/Data API portfolio values; total = provider portfolio/equity when available. |
+| Positions | `Polymarket._pull_positions` | Return `Position` objects for held contracts. | Same normalized broker duty as Alpaca/Tradier. | Parse wallet positions into `Position(strategy, Asset(token_id, prediction_contract), shares)` plus raw avg price/current value/PnL. |
+| Single position | `Polymarket._pull_position` | Return the matching position or `None`. | Alpaca/Tradier filter provider positions. | Filter by token id; do not match by human outcome label. |
+| Open orders | `Polymarket._pull_broker_all_orders` | Return open broker order payloads. | Alpaca pulls all statuses; Tradier normalizes list/dict shapes carefully. | Use secure `list_open_orders`; add market/token filters later. |
+| One order | `Polymarket._pull_broker_order` | Return one provider order or recent trade/fill evidence. | Alpaca has provider order lookup; Tradier fetches by id and handles empty shapes. | Use `get_order`; if closed/missing, consult recent account trades by order id before declaring final. |
+| Parsing | `Polymarket._parse_broker_order` | Normalize raw CLOB order/trade payload into LumiBot `Order`. | Alpaca is the fuller mapping model; Tradier is useful for defensive shape handling. | Map `LIVE`, `PLACEMENT`, `UPDATE`, `MATCHED`, `MINED`, `CONFIRMED`, `CANCELLATION`, `FAILED` conservatively. |
+| Submit router | `Polymarket._submit_order` | Validate and route supported order types. | Alpaca has broad type routing; Tradier rejects unsupported combinations. | Support only `prediction_contract`, buy/sell, market first, limit second; reject stop/trailing/multileg/brackets clearly. |
+| Market buy | `Polymarket._submit_market_order` | Spend dollars with hard cap and slippage guard. | This is unlike equities; avoid overloading `quantity`. | Require `order.custom_params["amount"]`; require `price` or `max_price`; use `FOK`/`FAK`; enforce live-test cap. |
+| Market sell | `Polymarket._submit_market_order` | Sell shares/contracts with worst-price guard. | Similar to selling shares, but CLOB uses market helper. | Use `order.quantity` or `custom_params["shares"]`; require worst acceptable price. |
+| Limit | `Polymarket._submit_limit_order` | Place resting order with price/size/TIF. | Alpaca/Tradier limit submit/cancel is the model. | Validate Decimal price against current tick size and `min_order_size`; support GTC/GTD. |
+| Cancel | `Polymarket.cancel_order` | Always send provider cancel when possible. | Existing broker docs require mutation failures to surface, not silently skip. | Do not no-op because local state is stale; call provider cancel and then read back/reconcile. |
+| Modify | `Polymarket._modify_order` | Explicitly unsupported or cancel-replace later. | Alpaca supports replace; Tradier has its own endpoint. | Start with clear unsupported exception; add cancel-replace only when semantics are explicit. |
+| Account history | `Polymarket.get_historical_account_value` | Return provider history or clear unsupported value. | Alpaca supports it; Tradier returns limited/unsupported behavior. | Initially unsupported unless Data API account history is reliable. |
+| Stream object | `Polymarket._get_stream_object` | Return WebSocket stream when enabled, polling only fallback. | Copy Alpaca's real-stream-first shape, not Tradier polling-only limitations. | Return `PolymarketCLOBStream(CustomStream)` with public and private subscriptions. |
+| Stream actions | `Polymarket._register_stream_events` | Register LumiBot order lifecycle events. | Alpaca dispatches order events; Tradier polling misses partial fills. | Dispatch placement/update/fill/cancel/error from user channel plus reconciliation. |
+| Polling | `Polymarket.do_polling` | Reconcile positions/orders and recover from missed streams. | Copy Alpaca's cautious tracked-order reconciliation. | Never treat a missing open order as canceled without single-order/trade lookup. |
+
+### Alpaca And Tradier Patterns To Copy Or Avoid
+
+Use Alpaca as the primary structural model:
+
+- The broker owns provider-client setup, account balances, positions, order parsing, order submission, cancellation,
+  account history, and stream lifecycle.
+- The data source owns market data and converts provider payloads into LumiBot price/quote/bar primitives.
+- Real streaming is first-class when credentials support it, and polling exists as fallback/reconciliation.
+- Order refresh does not assume local state is truth; it reads broker state and reconciles tracked orders.
+
+Use Tradier for defensive lessons:
+
+- Its account and order parsing handles provider payloads that change shape or return empty results.
+- Its polling-stream limitation around partial fills is a warning. A Polymarket adapter cannot rely on polling only,
+  especially for short-duration crypto markets.
+- Broker auth failures and unsupported order mutations should surface as real broker errors, not hidden waiting states.
+
+Do not copy the wrong parts:
+
+- Do not build a polling-only first version and call it production-ready.
+- Do not make one combined `Polymarket` class with `if us else clob` branches. US and CLOB should be separate public
+  brokers later.
+- Do not fake account value, fills, or bars to make tests pass.
+
 ## Account Surface Finding
 
 ### What Was Verified In Chrome
@@ -288,13 +353,15 @@ Do not blur these together in code or docs. The same public class can eventually
 
 - Polymarket API introduction: `https://docs.polymarket.com/api-reference/introduction`
 - Polymarket Python SDK: `https://docs.polymarket.com/dev-tooling/python`
-- Polymarket trading quickstart: `https://docs.polymarket.com/trading/quickstart`
+- Polymarket quickstart: `https://docs.polymarket.com/quickstart`
 - Polymarket trading overview/CLOB definition: `https://docs.polymarket.com/trading/overview`
 - Polymarket order overview: `https://docs.polymarket.com/trading/orders/overview`
 - Polymarket order creation: `https://docs.polymarket.com/trading/orders/create`
-- Polymarket orderbook/WebSocket docs: `https://docs.polymarket.com/trading/orderbook`
-- Polymarket market channel: `https://docs.polymarket.com/market-data/websocket/market-channel`
-- Polymarket user channel: `https://docs.polymarket.com/market-data/websocket/user-channel`
+- Polymarket CLOB order endpoint: `https://docs.polymarket.com/api-reference/trade/post-a-new-order`
+- Polymarket order book endpoint: `https://docs.polymarket.com/api-reference/market-data/get-order-book`
+- Polymarket price history endpoint: `https://docs.polymarket.com/api-reference/markets/get-prices-history`
+- Polymarket market WebSocket channel: `https://docs.polymarket.com/api-reference/wss/market`
+- Polymarket user WebSocket channel: `https://docs.polymarket.com/api-reference/wss/user`
 - Polymarket authentication: `https://docs.polymarket.com/api-reference/authentication`
 - Polymarket public client methods: `https://docs.polymarket.com/trading/clients/public`
 - Polymarket secure client methods: `https://docs.polymarket.com/trading/clients/l2`
@@ -304,6 +371,7 @@ Do not blur these together in code or docs. The same public class can eventually
 - Polymarket rate limits/geographic restrictions entry point: `https://docs.polymarket.com/api-reference/rate-limits`
 - Polymarket relayer API keys reference: `https://docs.polymarket.com/api-reference/relayer-api-keys/get-all-relayer-api-keys`
 - Polymarket US SDK introduction: `https://docs.polymarket.us/api-reference/sdks/introduction`
+- Polymarket US quickstart: `https://docs.polymarket.us/getting-started/quickstart`
 - Polymarket US Python quickstart: `https://docs.polymarket.us/api-reference/sdks/python/quickstart`
 - Polymarket US Python account docs: `https://docs.polymarket.us/api-reference/sdks/python/account`
 - Polymarket US Python WebSocket docs: `https://docs.polymarket.us/api-reference/sdks/python/websocket`
@@ -383,11 +451,13 @@ Polymarket maps well to simple LumiBot orders, with important constraints:
 - Marketable orders may have short placement delays in selected fast categories.
 - Sports markets have special behaviors around game start.
 
-For LumiBot milestone 1:
+For the first trading milestone, after login/account reads work:
 
 - Support simple `BUY` and `SELL`.
-- Support `LIMIT` first.
-- Add `MARKET` only after the provider helper and quantity/amount semantics are tested.
+- Support tiny `MARKET` orders first because Rob wants the fastest usable proof, but require explicit BUY notional and
+  worst-price/slippage controls in `Order.custom_params`.
+- Add `LIMIT` plus cancel immediately after the market-order smoke works, because far-from-market limit/cancel is the
+  safest order-lifecycle proof.
 - Reject stop, stop-limit, trailing stop, smart-limit, bracket, OCO, OTO, multileg, short, and cross-market packages.
 - Use `Decimal` internally for prices and quantities.
 - Cache and refresh tick size and `negRisk` by token id.
@@ -511,7 +581,9 @@ Important quantity distinction:
 - For SELL market orders, SDK examples use shares.
 - LumiBot `Order.quantity` is normally units/shares. The broker must not accidentally treat `quantity` as dollars for buy market orders.
 
-Recommended milestone 1 rule: only allow limit orders until the market order semantics are tested with tiny live orders and explicit expected behavior.
+Recommended rule: do not overload `Order.quantity` for BUY market notional. Require explicit `custom_params` such as
+`{"amount": "1.00", "max_price": "0.52", "order_type": "FAK"}` for BUY market orders, and cap first live smoke tests at
+the approved $1-$5 notional.
 
 ## LumiBot Implementation Plan
 
@@ -900,194 +972,347 @@ Mitigations:
 
 ## Testing Strategy
 
-### Unit Tests
+### Test Marker And Credential Gating
 
-Add tests for:
+Current test infrastructure has a broad `apitest` marker and provider-specific markers for some data providers. A
+Polymarket implementation should add a provider marker instead of reusing the legacy Polygon/Theta default path.
 
-- `Asset.AssetType.PREDICTION_CONTRACT` serialization and round trip.
-- Polymarket order type/side/time-in-force mapping.
-- Price validation by tick size.
-- `negRisk` propagation.
-- Position parsing.
-- Balance parsing.
-- Order parsing for live, matched, partially filled, canceled, expired, rejected, unknown.
-- Error redaction.
-- Credential config without logging secret values.
+Required test-runner changes when implementation starts:
 
-### Stream Tests
+- Add `polymarket: Polymarket CLOB live/API tests` to `setup.cfg`.
+- Extend `tests/conftest.py` so tests marked `@pytest.mark.apitest` and `@pytest.mark.polymarket` require only
+  Polymarket-specific env vars, not Polygon and ThetaData credentials.
+- Keep the default coverage command excluding `apitest`, so live CLOB tests never run in ordinary unit-test/CI paths.
+- Add a `POLYMARKET_LIVE_TRADING_ENABLED=true` gate for submit/cancel/market-order apitests.
+- Add `POLYMARKET_TEST_MAX_NOTIONAL=5` or lower; default to `1` when absent.
+- Add `POLYMARKET_TEST_TOKEN_ID` and optionally `POLYMARKET_TEST_MARKET_ID` for smoke tests, so tests never auto-pick a
+  random live market to trade.
 
-Use fake WebSocket event payloads:
+### Unit Test Files
 
-- `book`
-- `price_change`
-- `last_trade_price`
-- `tick_size_change`
-- `best_bid_ask`
-- user order event
-- user trade event
-- reconnect and reconciliation path
+Recommended new tests, created incrementally with the implementation phase they validate:
 
-### SDK Boundary Tests
+| Test file | Purpose | Should use live network? |
+| --- | --- | --- |
+| `tests/test_polymarket_asset.py` | `prediction_contract` asset validation, equality, serialization, invalid type rejection. | No |
+| `tests/test_polymarket_credentials.py` | Config loading, missing-secret errors, redaction, explicit broker selection. | No |
+| `tests/test_polymarket_data.py` | Market resolver, quote parsing, order-book parsing, history interval mapping, unsupported history failures. | No by default |
+| `tests/test_polymarket_broker.py` | Balance/position/order parsing, submit validation, market BUY/SELL payload construction, unsupported order types. | No |
+| `tests/test_polymarket_stream.py` | Fake `book`, `price_change`, `best_bid_ask`, `last_trade_price`, `tick_size_change`, order, trade, reconnect events. | No |
+| `tests/test_polymarket_credentials_apitest.py` | Create/derive or reuse CLOB API credentials and perform read-only authenticated account proof. | Yes, skipped by env |
+| `tests/test_polymarket_data_apitest.py` | Public market/order-book/quote/history smoke on an explicit token id. | Yes, skipped by env |
+| `tests/test_polymarket_broker_apitest.py` | Account value, positions, open orders, tiny market order, limit/cancel lifecycle. | Yes, skipped by env and live-trading flag |
+| `tests/test_polymarket_stream_apitest.py` | Short market/user WebSocket smoke with clean close and HTTP reconciliation. | Yes, skipped by env |
 
-Wrap the SDK behind small interfaces so fake clients can test LumiBot behavior without live Polymarket credentials:
+### Fake Client Boundary
 
-- `PolymarketPublicClientProtocol`
-- `PolymarketSecureClientProtocol`
-- `PolymarketStreamProtocol`
+Wrap Polymarket SDK and REST/WebSocket access behind small internal protocols so most tests never need real credentials:
 
-### Live Smoke Tests
+- `PolymarketPublicClientProtocol`: market discovery, market info, order book, prices, price history.
+- `PolymarketSecureClientProtocol`: account value, positions, open orders, trades, order placement, cancel, approvals.
+- `PolymarketStreamClientProtocol`: public market stream, private user stream, close/reconnect.
+- `PolymarketCredentialStore`: env loading, credential derivation result, redaction.
 
-Only after explicit approval:
+This is important because the official Python SDK is beta and CLOB libraries have already had multiple naming/version
+surfaces (`polymarket-client`, `py-clob-client-v2`, relayer clients). The LumiBot adapter should not make every test
+depend on the third-party SDK's exact class names.
 
-1. Public quote smoke for one token id.
-2. Authenticated account/balance read.
-3. Open orders read.
-4. Positions read.
-5. Tiny limit order far from market, then cancel.
-6. Tiny marketable order only after limit/cancel works.
+### Live Smoke Safety Rules
 
-Smoke tests must use an explicit market allowlist, maximum notional, and no hidden "fake filled" behavior.
+Live smoke tests should be small and explicit:
+
+- No live submit/cancel test runs without `POLYMARKET_LIVE_TRADING_ENABLED=true`.
+- No live submit/cancel test runs without an explicit `POLYMARKET_TEST_TOKEN_ID`.
+- No live market order exceeds `min(POLYMARKET_TEST_MAX_NOTIONAL, 5)`.
+- First market BUY must use explicit `amount`, `max_price`, and `FOK` or `FAK`.
+- First market SELL must be skipped unless the account already holds enough of the selected token or the test first
+  bought a tiny amount and then sells that exact amount.
+- No test should claim a fill happened unless provider HTTP or user WebSocket evidence confirms it.
+- Geoblock, approval, insufficient balance, or restricted-market errors should fail or skip clearly; tests must not try
+  to route around them.
 
 ## Implementation Phases
 
-### Phase 0: Credential And Access Spike
+### Phase 0: Credential And Login Proof
 
 Goals:
 
-- Confirm whether the first implementation target is Rob's current `polymarket.com` CLOB account, a separate `polymarket.us` account, or both in parallel.
-- Confirm what the `polymarket.com` website `APIs` page can generate: relayer key, CLOB L2 key/secret/passphrase, builder credential, or beta SDK key material.
-- Confirm whether Rob can access `polymarket.us/developer` after US app account setup and identity verification.
-- Determine whether Relayer API Key plus private key/session signer is enough for Rob's current account setup and approvals.
-- Create credentials only after explicit approval.
+- Target only Rob's current `polymarket.com` international CLOB account.
+- Create or derive CLOB API credentials from that account if needed. Rob approved this in the 2026-07-01 planning
+  thread.
+- Store local prototype credentials in `.env.local`. Rob approved this for the prototype.
+- Determine whether the visible website API page exposes relayer keys, CLOB L2 credentials, builder credentials, or SDK
+  session material.
+- Determine exactly when relayer approval setup is needed versus ordinary CLOB order/account authentication.
 - Store secrets only in approved local env/secret-store paths. Do not put them in docs, chat, screenshots, git, or logs.
+
+Methods/classes touched:
+
+- None for the first manual credential proof if using a disposable local harness.
+- When implementation starts: `PolymarketCredentialStore`, `Polymarket._initialize_clients()`, and redaction helpers.
+
+Tests:
+
+- Unit: missing env vars produce clear errors; secret values are redacted; config refuses to initialize live trading
+  without explicit broker selection.
+- Live apitest: authenticated read-only account snapshot: collateral balance/allowance, portfolio value, positions, open
+  orders, recent trades.
 
 Exit criteria:
 
 - We know the exact env vars and credential object required for one authenticated account read.
 - We can call a read-only authenticated endpoint or SDK account method without placing orders.
-- We know whether CLOB trading requires raw private-key custody for Rob's account, and whether US trading can avoid private-key custody.
+- We know whether CLOB trading for Rob's account requires raw private-key custody or can reuse safer derived/session
+  credentials for reads and order posting around locally signed orders.
 
-### Phase 1: LumiBot Asset And Data Source
+### Phase 1: Asset Type And Broker Plumbing
 
 Goals:
 
 - Add `prediction_contract`.
-- Add `PolymarketData` with public market discovery, quote, last price, and real history where available.
-- Add tests for data parsing and asset serialization.
+- Add Polymarket imports/exports and explicit `TRADING_BROKER=polymarket` config path.
+- Add stub `PolymarketData` and `Polymarket` classes with all abstract/required methods present.
+- Unsupported methods should fail clearly rather than silently returning fake data.
+
+Methods/classes touched:
+
+- `Asset.AssetType.PREDICTION_CONTRACT`
+- `lumibot/data_sources/polymarket_data.py`
+- `lumibot/brokers/polymarket.py`
+- `lumibot/data_sources/__init__.py`
+- `lumibot/brokers/__init__.py`
+- `lumibot/credentials.py`
+
+Tests:
+
+- Unit: asset type accepts `prediction_contract`; invalid unrelated types still fail.
+- Unit: credentials only instantiate Polymarket on explicit `TRADING_BROKER=polymarket`.
+- Unit: broker and data source instantiate with fake clients and no accidental network calls.
 
 Exit criteria:
 
-- A strategy can ask for a quote/last price for a known token id.
-- No live orders are possible yet.
+- A Polymarket broker object can be constructed with fake clients.
+- Abstract method requirements are satisfied.
+- No live order path is enabled.
 
-### Phase 2: Read-Only Broker
+### Phase 2: Public Data Source
 
 Goals:
 
-- Add `Polymarket` broker with authenticated balances, positions, and open-order reads.
-- No submit/cancel yet, or submit disabled behind explicit config.
+- Resolve market/event/outcome into token id.
+- Fetch order book, best bid/ask, last price, and supported price history.
+- Expose `get_quote`, `get_last_price`, `get_historical_prices`, and `get_chains`.
+
+Methods/classes touched:
+
+- `PolymarketData.resolve_market(...)`
+- `PolymarketData.resolve_contract(...)`
+- `PolymarketData.get_order_book(...)`
+- `PolymarketData.get_quote(...)`
+- `PolymarketData.get_last_price(...)`
+- `PolymarketData.get_historical_prices(...)`
+- `PolymarketData.get_chains(...)`
+
+Tests:
+
+- Unit: parse CLOB order-book payload into bid/ask sizes and quote raw data.
+- Unit: history interval mapping accepts only provider-supported intervals.
+- Unit: `get_chains` returns documented empty/unsupported behavior.
+- Live apitest: public quote/order-book/last-price call for `POLYMARKET_TEST_TOKEN_ID`, no credentials required.
 
 Exit criteria:
 
-- `_get_balances_at_broker()` works.
-- `_pull_positions()` works.
-- `_pull_broker_all_orders()` works.
-- Raw values are redacted in logs.
+- A strategy can get a real quote/last price for a known token id.
+- No account credentials are needed for public data.
+- No fabricated bars are returned.
 
-### Phase 3: WebSocket Stream Scaffold
+### Phase 3: Read-Only Broker
+
+Goals:
+
+- Read account value, cash/collateral, positions, open orders, and recent trades.
+- Normalize provider positions and orders into LumiBot entities.
+- Keep submit/cancel disabled except for validation stubs.
+
+Methods/classes touched:
+
+- `Polymarket._initialize_clients()`
+- `Polymarket._get_balances_at_broker(...)`
+- `Polymarket._pull_positions(...)`
+- `Polymarket._pull_position(...)`
+- `Polymarket._pull_broker_all_orders()`
+- `Polymarket._pull_broker_order(identifier)`
+- `Polymarket._parse_broker_order(...)`
+
+Tests:
+
+- Unit: parse positions with shares, avg price, current price/value, PnL, outcome, slug, and raw payload.
+- Unit: parse order statuses into LumiBot statuses.
+- Unit: missing/unknown provider fields do not crash refresh.
+- Live apitest: account snapshot reads balances, portfolio values, positions, and open orders.
+
+Exit criteria:
+
+- `_get_balances_at_broker()` returns numeric cash, positions value, and portfolio value.
+- `_pull_positions()` works for current account.
+- `_pull_broker_all_orders()` works for current account.
+- Secrets are redacted in all exceptions/logs.
+
+### Phase 4: Market Orders First Live Trading Proof
+
+Goals:
+
+- Support simple market BUY and SELL using Polymarket FAK/FOK semantics.
+- Require explicit market BUY dollar amount and worst-price limit in `custom_params`.
+- Enforce tiny notional cap for first live proof.
+- Surface geoblock, approval, balance, or restricted-market provider errors clearly.
+
+Methods/classes touched:
+
+- `Polymarket._submit_order(order)`
+- `Polymarket._submit_market_order(order)`
+- `Polymarket._ensure_trading_ready()`
+- `PolymarketData.calculate_market_price(...)` or equivalent pre-trade estimate helper.
+
+Tests:
+
+- Unit: BUY market rejects missing `custom_params["amount"]`.
+- Unit: BUY market does not treat `Order.quantity` as dollars.
+- Unit: SELL market uses shares and validates sufficient quantity when available.
+- Unit: all submit payloads include tick size, `negRisk`, worst price, FAK/FOK, and token id.
+- Live apitest: one tiny market BUY with max notional $1-$5 on explicit token id, then read account/order/trade evidence.
+
+Exit criteria:
+
+- Tiny live market-order proof either fills or returns a clear provider error with no hidden fake success.
+- Account value, positions, orders, and recent trades can be read immediately after the attempt.
+- No submit test exceeds the configured cap.
+
+### Phase 5: WebSocket Market And User Streams
 
 Goals:
 
 - Add public market WebSocket for subscribed token ids.
-- Add private user WebSocket for authenticated order/trade events where the selected provider mode supports them.
+- Add private user WebSocket for authenticated order/trade events.
+- Maintain quote/order-book cache inside `PolymarketData`.
+- Dispatch private order/trade events into LumiBot order lifecycle events.
 - Add HTTP reconciliation after reconnect.
-- Add fake-event tests before placing live orders.
+
+Methods/classes touched:
+
+- `PolymarketCLOBStream(CustomStream)`
+- `Polymarket._get_stream_object()`
+- `Polymarket._register_stream_events()`
+- `Polymarket._run_stream()`
+- `Polymarket.do_polling()` as fallback/reconciliation.
+- `PolymarketData` quote/order-book cache mutation helpers.
+
+Tests:
+
+- Unit: fake market events update book, best bid/ask, last trade, and tick-size cache.
+- Unit: fake user order/trade events dispatch `NEW_ORDER`, `PARTIALLY_FILLED_ORDER`, `FILLED_ORDER`, `CANCELED_ORDER`,
+  and `ERROR_ORDER` as appropriate.
+- Unit: reconnect calls HTTP reconciliation and does not double-count fills.
+- Live apitest: subscribe briefly to `POLYMARKET_TEST_TOKEN_ID`, receive or time out cleanly, close without thread leaks.
 
 Exit criteria:
 
-- Live quote state updates without polling.
-- Private order status updates dispatch into LumiBot's stream events in fake-client tests.
-- Reconnect path does not duplicate fills.
+- Live public stream can update quote state without polling.
+- Private stream event handling is proven with fake events and can connect with live credentials.
+- Polling remains available as fallback, not the primary fast-market source.
 
-### Phase 4: Limit Orders And Cancel
+### Phase 6: Limit Orders And Cancel
 
 Goals:
 
-- Support simple limit orders.
+- Support simple limit GTC/GTD orders.
 - Support cancel.
-- Support `_parse_broker_order`.
-- Add safe provider error mapping.
-- Wire live submit/cancel events into the stream/reconciliation path from Phase 3.
+- Add safe provider error mapping and order readback after submit/cancel.
+
+Methods/classes touched:
+
+- `Polymarket._submit_limit_order(order)`
+- `Polymarket.cancel_order(order)`
+- `Polymarket._pull_broker_order(identifier)`
+- `Polymarket._parse_broker_order(...)`
+
+Tests:
+
+- Unit: limit price quantizes to current tick size.
+- Unit: post-only only works for GTC/GTD, not FAK/FOK.
+- Unit: cancel calls provider even when local status is stale.
+- Live apitest: place far-from-market tiny limit order, confirm identifier, cancel, poll/read back canceled status.
 
 Exit criteria:
 
-- Tiny live limit order and cancel smoke passes after explicit approval.
+- Limit submit/cancel lifecycle works or fails loudly with provider error.
 - Unknown order rows do not crash refresh.
-- Submit/cancel errors fail loudly.
+- Submit/cancel behavior is covered by fake-client unit tests and one gated live smoke.
 
-### Phase 5: Market Orders And Fast Trading Controls
+### Phase 7: Examples, Docs, And Release Hardening
 
 Goals:
 
-- Add FAK/FOK market-style order support.
-- Add slippage/max-spend controls.
-- Add per-order notional caps in examples/smoke tests.
+- Add user-facing LumiBot examples for quote/account read and tiny controlled order.
+- Add env-var docs.
+- Add broker order semantics docs for prediction contracts.
+- Run focused unit suites and skipped-live apitest discovery.
+- Keep BotSpot implementation as follow-on, not part of this first LumiBot adapter.
 
 Exit criteria:
 
-- Market order semantics are proven with tiny live trades.
-- BUY amount/max_spend and SELL shares behavior is documented and tested.
+- New unit tests pass locally.
+- Live apitests are provider-gated and skipped unless env vars are present.
+- Docs explain market BUY notional semantics and private-key/session-credential risks.
+- Release notes clearly state this is international CLOB only, not Polymarket US.
 
-### Phase 6: BotSpot Internal Support
+### Phase 8: BotSpot And Bot Manager Follow-On
+
+Do this only after the LumiBot adapter is proven locally.
 
 Goals:
 
-- Add broker credential metadata and validation in Node.
-- Add catalog/UI behind internal flag.
-- Add Bot Manager runtime support.
-- Add read-only broker-data/portfolio snapshot before trading.
+- Add BotSpot saved credential metadata and validation behind an internal flag.
+- Add Bot Manager runtime-secret allowlist and dependency packaging.
+- Add broker-data read-only quotes and portfolio snapshots before trading.
+- Add single-trade support only after high-risk approval, private-key/signing design, and compliance review.
 
 Exit criteria:
 
 - Internal saved credential can run a read-only broker snapshot.
 - No raw secrets are returned through MCP/frontend APIs.
-
-### Phase 7: BotSpot Trading Support
-
-Goals:
-
-- Add single-trade support with high-risk approval.
-- Add deployment support.
-- Add product/legal gates.
-
-Exit criteria:
-
-- Single trade uses saved broker credential and high-risk approval.
-- Deployment uses runtime-secret refs only.
-- Security docs cover private-key/signing model.
-- Public launch decision is made separately for `polymarket.com` versus `polymarket.us`.
+- Single-trade and deployment support use runtime-secret refs only.
+- Public launch decision is made separately for `polymarket.com` CLOB versus `polymarket.us`.
 
 ## Questions For Rob
 
-1. Should the first live LumiBot spike target your current `polymarket.com` account, even though it is not Polymarket US and may have geography/compliance constraints?
-2. Do you want me to inspect the `polymarket.com` `APIs` page labels in a later turn without creating or copying secrets?
-3. Do you want to verify whether you can access `polymarket.us/developer`, or should we treat US support as a parallel code path until your US account status is clear?
-4. If credentials are created later, where should the generated values be stored locally: an approved `.env` path, macOS Keychain, 1Password/Bitwarden, or a BotSpot secret-store path?
-5. Are you comfortable with a local LumiBot prototype requiring a Polymarket private key or session signer, or do we need to find a no-private-key credential path first?
-6. Is the first strategy target the fast 5-minute crypto up/down markets, or should we start with slower/liquid markets to reduce execution risk?
-7. Should BotSpot support be internal-only until `polymarket.us` support is verified, or are we planning to support international CLOB accounts for specific non-US users?
-8. What hard risk limits should we enforce in early live tests: max order size, max daily spend, market allowlist, and limit-only trading?
+Answered in the 2026-07-01 planning thread:
+
+- Target the international `polymarket.com` CLOB account first. Do not block on Polymarket US.
+- Create or derive CLOB credentials if needed.
+- Store prototype credentials in `.env.local`.
+- First live trading proof can use $1-$5 maximum notional.
+- More liquid markets are acceptable for the first proof; slower markets are not required if sizing and max-price controls
+  are tight.
+
+Remaining non-blocking decisions:
+
+1. Which explicit `POLYMARKET_TEST_TOKEN_ID` should be used for first live smoke, or should the implementation include a
+   read-only discovery command that suggests a liquid token id before any order is placed?
+2. Should early live tests sell/reduce the tiny position after a successful market BUY, or leave the small position open
+   for subsequent position/order stream testing?
+3. Should the first implementation depend on the beta unified `polymarket-client`, the lower-level
+   `py-clob-client-v2`, or both behind a wrapper? My recommendation is wrapper-first with the unified SDK preferred for
+   account/stream ergonomics and lower-level CLOB client available for any missing order helper.
 
 ## Recommended Immediate Next Step
 
-Do not start implementation yet. The next useful action is a credential/access spike:
+The next implementation action is a credential/login proof for international CLOB:
 
-1. Inspect the `polymarket.com` account `APIs` page with explicit approval, without creating or copying secrets.
-2. Identify whether it exposes Relayer API Keys, CLOB API session credentials, builder keys, beta SDK key material, or some combination.
-3. Separately check whether Rob can reach `polymarket.us/developer` and whether it offers US API key creation for his account.
-4. Do not expose values in chat or logs.
-5. Save only the credential names, required env var mapping, and source page labels in this doc.
-6. Create credentials only after a second explicit approval and an agreed storage path.
-7. Run a read-only authenticated SDK call if credentials can be loaded safely.
+1. Inspect the `polymarket.com` account `APIs` page and identify which fields it exposes, without exposing values.
+2. Create or derive CLOB credentials if the SDK/login proof requires them.
+3. Store only local prototype secrets in `.env.local`.
+4. Run a read-only authenticated account snapshot.
+5. Commit the smallest implementation slice only after the read-only proof and unit tests are in place.
 
-After that, implement Phase 1 in LumiBot with fake-client tests and public data only.
+After that, implement Phase 1 and Phase 2 in small slices with tests after each slice.

--- a/docs/investigations/2026-07-01_POLYMARKET_INTERNATIONAL_CLOB_LIVE_PROOF.md
+++ b/docs/investigations/2026-07-01_POLYMARKET_INTERNATIONAL_CLOB_LIVE_PROOF.md
@@ -1,0 +1,258 @@
+# Polymarket International CLOB Live Proof
+
+One-line description: Verified credential, data, WebSocket, and live-submit status for LumiBot's international Polymarket CLOB adapter.
+
+Last Updated: 2026-07-01
+
+Status: Read-only account/data/WebSocket proof complete; live order submission blocked by Polymarket account/API-key binding.
+
+Audience: LumiBot maintainers, broker-adapter implementers, BotSpot/Bot Manager follow-on engineers
+
+## Overview
+
+This document records the current verified state of the Polymarket international `polymarket.com` CLOB integration. It
+supersedes earlier planning notes that said credentials had not been created or tested.
+
+Scope is international CLOB only. Polymarket US remains a later, separate adapter because account access, credential
+shape, and compliance/product flow are materially different.
+
+## Source Documents Checked
+
+- Polymarket CLOB authentication docs: `https://docs.polymarket.com/api-reference/authentication`
+- Polymarket deposit-wallet docs: `https://docs.polymarket.com/trading/deposit-wallets`
+- Polymarket market WebSocket docs: `https://docs.polymarket.com/market-data/websocket/market-channel`
+- Polymarket user WebSocket docs: `https://docs.polymarket.com/market-data/websocket/user-channel`
+- Public SDK issue for deposit-wallet/API-key signer mismatch:
+  `https://github.com/Polymarket/py-clob-client-v2/issues`
+- More specific public issue describing the L1 API-key binding problem:
+  `https://github.com/Polymarket/clob-client-v2/issues/65`
+
+Key source conclusions:
+
+- CLOB auth has L1 private-key signing plus L2 API credentials. L2 is still not enough to create orders; order payloads
+  are signed locally.
+- Signature types are provider-specific: `0` EOA, `1` existing Polymarket proxy/Magic wallet, `2` Gnosis Safe, `3`
+  deposit wallet / `POLY_1271`.
+- Deposit-wallet trading requires a funder/deposit wallet, CLOB L2 credentials, and order options such as `tick_size`
+  and `neg_risk`.
+- Market WebSocket endpoint is `wss://ws-subscriptions-clob.polymarket.com/ws/market`.
+- User WebSocket endpoint is `wss://ws-subscriptions-clob.polymarket.com/ws/user` and authenticates with CLOB API key,
+  secret, and passphrase in the subscription payload.
+
+## Local Credentials And Storage
+
+Rob authorized local credential handling for this prototype. Credentials were created/derived from the logged-in
+`polymarket.com` account and stored only in:
+
+- `/Users/robertgrzesik/Development/lumibot/.env.local`
+
+Security state:
+
+- `.env.local` is gitignored.
+- File mode is `0600`.
+- Raw private key, CLOB API key, CLOB secret, and passphrase are not documented here and must not be committed, logged, or
+  pasted into chat.
+
+Credential model currently present:
+
+- `TRADING_BROKER=polymarket`
+- `POLYMARKET_PRIVATE_KEY`
+- `POLYMARKET_OWNER_ADDRESS`
+- `POLYMARKET_WALLET_ADDRESS`
+- `POLYMARKET_SIGNATURE_TYPE`
+- `POLYMARKET_CLOB_API_KEY`
+- `POLYMARKET_CLOB_API_SECRET`
+- `POLYMARKET_CLOB_API_PASSPHRASE`
+- `POLYMARKET_TEST_TOKEN_ID`
+- `POLYMARKET_LIVE_TRADING_ENABLED=true`
+- `POLYMARKET_TEST_MAX_NOTIONAL=5`
+
+Important distinction:
+
+- `POLYMARKET_OWNER_ADDRESS` is the signer/owner identity.
+- `POLYMARKET_WALLET_ADDRESS` is the funder/proxy/deposit wallet passed to CLOB.
+- For the current Magic/proxy account, read paths work with signature type `1`. Order submission is still blocked by the
+  platform-side deposit-wallet/API-key mismatch described below.
+
+## Direct API Proof
+
+Proof script:
+
+- `/Users/robertgrzesik/Development/lumibot/scripts/polymarket_smoke.py`
+
+Read-only smoke command:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 90s python3 scripts/polymarket_smoke.py
+```
+
+Redacted artifact:
+
+- `/Users/robertgrzesik/Development/lumibot/logs/polymarket_smoke_20260701_190525.json`
+
+Verified read-only results:
+
+- CLOB credentials were loaded from `.env.local`; no in-process derivation was needed.
+- CLOB collateral balance read succeeded.
+- Raw balance was returned in 6-decimal units and scaled to about `$29.185517`.
+- Open orders count: `0`.
+- Recent trades count: `0`.
+- Data API positions count: `0` for both owner and funder/proxy addresses.
+- Data API position value: `0` for both owner and funder/proxy addresses.
+- Public order book read succeeded for the selected test token.
+- Quote read succeeded with bid/ask/mid.
+- Last trade price read succeeded.
+- Supported price history read succeeded.
+- Public market WebSocket connected and returned events.
+- Authenticated user WebSocket connected with CLOB L2 credentials; it returned no events because there were no account
+  order/trade events during the proof window.
+
+## Live Submit Proof
+
+Market-order smoke command:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 90s python3 scripts/polymarket_smoke.py --live-order
+```
+
+Redacted artifact:
+
+- `/Users/robertgrzesik/Development/lumibot/logs/polymarket_smoke_20260701_190551.json`
+
+Result:
+
+- The tiny FAK market BUY did not submit.
+- Polymarket returned `maker address not allowed, please use the deposit wallet flow`.
+- Balance, open orders, and trades remained unchanged.
+
+Limit/cancel smoke command:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 90s python3 scripts/polymarket_smoke.py --limit-cancel
+```
+
+Redacted artifact:
+
+- `/Users/robertgrzesik/Development/lumibot/logs/polymarket_smoke_20260701_190611.json`
+
+Result:
+
+- The tiny far-from-market limit order did not submit.
+- Polymarket returned the same deposit-wallet-flow blocker before an order id existed, so cancel could not be exercised.
+
+## Interpretation Of The Blocker
+
+This is not currently a LumiBot mapping bug. The same rejection occurs through direct `py-clob-client-v2` calls before
+LumiBot broker normalization is involved.
+
+The public GitHub issue tracker has multiple recent open reports around the same credential/address family:
+
+- `POLY_1271 deposit wallet order rejected: "the order signer address has to be the address of the API KEY"`.
+- `create_or_derive_api_key()` binding API credentials to one address while order signing uses another address.
+- Web/proxy accounts and deposit-wallet accounts seeing read APIs work while order submission fails due signer/API-key
+  address mismatch.
+
+For this account, the observed local matrix was:
+
+- Signature type `1` with the current funder/proxy reads balances/orders/trades but order submit returns
+  `maker address not allowed, please use the deposit wallet flow`.
+- Signature type `3` with the current funder/proxy returns the order-signer/API-key mismatch.
+- Signature types `0` and `2` did not produce a usable order path.
+
+Next practical fix is not another LumiBot order mapping change. We need one of:
+
+- A supported Polymarket deposit-wallet setup that yields CLOB credentials bound to the order signer/funder address.
+- Polymarket-side SDK/API fix for Magic/proxy or deposit-wallet API-key binding.
+- A documented and supported workaround from Polymarket for registering API credentials under the exact address CLOB
+  validates during `POST /order`.
+
+## LumiBot Changes Made From This Proof
+
+Implementation updates:
+
+- `PolymarketData` now exposes the real market/user WebSocket URLs and handles list payloads from the public market
+  stream.
+- `PolymarketCLOBStream` now has real WebSocket workers for public market and private user streams, plus HTTP polling
+  reconciliation.
+- `Polymarket` scales collateral balance/allowance raw units from 6-decimal USDC-like integer units into dollars.
+- `Polymarket` stores optional `OWNER_ADDRESS` separately from `WALLET_ADDRESS`.
+- `Polymarket` chooses a safer default signature type: proxy when owner and funder differ, deposit-wallet otherwise.
+- Market and limit submits now pass SDK `PartialCreateOrderOptions(tick_size=..., neg_risk=...)` from the live book.
+- Known platform-side signer/funder/deposit-wallet rejections are wrapped in a clear `LumibotBrokerAPIError`.
+- `requirements.txt` now includes `websockets>=15.0.1`.
+
+Tests added or expanded:
+
+- Balance raw-unit scaling.
+- SDK order args and `PartialCreateOrderOptions` mapping.
+- Known deposit-wallet/order-signer blocker wrapping.
+- WebSocket subscription payload shape.
+- Data source handling for market-stream list payloads.
+- Public WebSocket API smoke.
+- Live tiny order API smoke xfails only for the exact current platform-side blocker.
+
+## Test Commands And Results
+
+Mocked/unit:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 120s python3 -m pytest -q tests/test_polymarket_asset.py tests/test_polymarket_data.py tests/test_polymarket_broker.py
+```
+
+Result:
+
+- `19 passed`
+
+Live/API with `.env.local` loaded:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 120s python3 -m dotenv -f .env.local run -- python3 -m pytest -q tests/test_polymarket_apitest.py
+```
+
+Result:
+
+- `3 passed, 1 xfailed`
+- The xfail is the tiny live market order, and only for the current deposit-wallet/API-key binding blocker.
+
+Direct smoke:
+
+- Read-only direct smoke: passed.
+- Live market-order direct smoke: blocked by Polymarket deposit-wallet flow.
+- Limit/cancel direct smoke: blocked by Polymarket deposit-wallet flow before cancelable order creation.
+
+## What Works Now
+
+- Credential loading from `.env.local`.
+- CLOB L2 credential use for authenticated read paths.
+- Account cash read and scaling.
+- Position and account-value reads through Data API fallback.
+- Open order reads.
+- Recent trade reads.
+- Market discovery/token data through `PolymarketData`.
+- Order book, quote, last price, and supported price history.
+- Public market WebSocket connection and event ingestion.
+- Private user WebSocket authenticated subscription.
+- LumiBot broker/data-source selection with `TRADING_BROKER=polymarket`.
+- Unit and API tests around the implemented mapping.
+
+## What Is Still Blocked
+
+- Live order submit on Rob's current account.
+- Limit-order cancel proof, because limit order creation is blocked before an order id exists.
+- Real fill/private-event reconciliation, because no live order can currently be placed.
+- BotSpot/Bot Manager credential UI/runtime support. That should wait until the LumiBot adapter has a working live
+  submit path or a clear product decision around private-key/deposit-wallet custody.
+
+## Next Steps
+
+1. Decide whether to pursue a true deposit-wallet setup for this account or wait for Polymarket's SDK/API fix.
+2. If pursuing deposit wallet, identify the exact builder/relayer credential shape required by the current UI/API. The
+   visible one-value `RELAYER_API_KEY` is not the same as CLOB L2 credentials, and the Python relayer client examples use
+   builder key/secret/passphrase.
+3. Once a supported order path exists, rerun:
+   - direct `scripts/polymarket_smoke.py --live-order`
+   - direct `scripts/polymarket_smoke.py --limit-cancel`
+   - `pytest -q tests/test_polymarket_apitest.py` with `.env.local` loaded
+4. After live submit/cancel proof works, add one end-to-end LumiBot strategy smoke that places a tiny order, reconciles
+   private user WebSocket events, refreshes positions/orders, and exits.
+5. Only then start BotSpot/Bot Manager credential schema and UI work.

--- a/docs/investigations/2026-07-01_POLYMARKET_INTERNATIONAL_CLOB_LIVE_PROOF.md
+++ b/docs/investigations/2026-07-01_POLYMARKET_INTERNATIONAL_CLOB_LIVE_PROOF.md
@@ -395,3 +395,89 @@ Residual note:
 4. Run a real strategy loop with WebSockets enabled and capture a private user fill event during the loop.
 5. Start BotSpot/Bot Manager credential schema and UI work only after deciding how hosted runtime should custody or
    receive the private key, builder key, CLOB L2 creds, and deposit-wallet address.
+
+## July 2 Follow-Up: Full LumiBot Matrix, WebSockets, Backtesting
+
+Scope: same international `polymarket.com` CLOB account and deposit wallet. Raw secret values remain only in
+`.env.local`; console output and docs use redacted identifiers.
+
+Additional implementation updates:
+
+- Added safe generic prediction-market data methods on base `DataSource` so non-Polymarket brokers return empty or
+  unsupported values instead of failing when strategy code calls `search_markets`, `get_event`, `get_market_metadata`,
+  `get_market_rules`, `get_resolution_status`, `get_spread`, `get_midpoint`, `get_recent_trades`, `get_open_interest`,
+  or `get_holders`.
+- Expanded `PolymarketData` for market/event metadata, rules, resolution status, spread, midpoint, recent trades,
+  open interest, holders, close time, resolution source, minimum order size, settlement price, and token/outcome
+  resolution.
+- Added GTD expiration, post-only, cancel-all, cancel-multiple, cancel-by-market, batch limit order support, recent
+  trade retrieval, and conditional-token sell allowance sync to the `Polymarket` broker.
+- Added conditional-token `setApprovalForAll` support to `scripts/polymarket_deposit_wallet_setup.py`.
+- Added `PolymarketBacktesting`, exported it from `lumibot.backtesting`, and wired prediction-contract cash accounting
+  in `BacktestingBroker`.
+- Added `lumibot/example_strategies/polymarket_prediction_contract.py`.
+- Updated README, public RST docs, and env docs for Polymarket live and backtesting support.
+
+Additional live proof through normal LumiBot code:
+
+- Read-only LumiBot state after refilling deposit wallet: cash about `$5.88`, portfolio about `$9.95`, one position, no
+  open orders.
+- FAK BUY filled: about `$1` notional, quantity about `34.482757`, average fill about `0.029`.
+- FOK BUY filled: about `$1` notional, quantity about `34.482757`, average fill about `0.029`.
+- Conditional-token sell approval was required before live SELL. After `--approve-conditional`, FAK SELL and FOK SELL
+  filled and parsed correctly as quantity `1.0` at average fill `0.028`.
+- GTC BUY, GTD BUY, post-only BUY, GTC SELL, GTD SELL, and post-only SELL all submitted as resting open orders and were
+  canceled with `cancel_all_orders`.
+- Marketable post-only BUY rejected with the expected CLOB error: `invalid post-only order: order crosses book`, now
+  wrapped as a readable `LumibotBrokerAPIError`.
+- Single cancel, multiple cancel, cancel-all, and cancel-by-market helpers executed through LumiBot. Resting orders were
+  cleaned up; final read-only state showed zero open orders.
+- Final WebSocket smoke with `scripts/polymarket_lumibot_smoke.py --websocket --order-kind fak-sell --limit-size 1`
+  received public market events, one private user trade event, one broker trade-event row, quote-cache updates, and
+  HTTP recent-trade reconciliation without subscriber errors.
+
+Additional tests:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 120s python3 -m pytest -q tests/test_prediction_market_data_source_defaults.py tests/test_polymarket_asset.py tests/test_polymarket_data.py tests/test_polymarket_broker.py tests/test_polymarket_backtesting.py
+```
+
+Result:
+
+- `41 passed, 1 warning`
+
+Current open items after the July 2 live-follow-up:
+
+- The deposit wallet has less idle pUSD after repeated live smoke trades. Re-fund before running more BUY market-order
+  tests.
+- BotSpot/Bot Manager support is still a separate product/runtime-secret project.
+
+## July 2 Backtesting Hardening Follow-Up
+
+Backtesting fixes added after the live matrix:
+
+- `PolymarketBacktesting.get_quote()` and `get_last_price()` now read from loaded Polymarket/Pandas bars only for
+  `prediction_contract` assets.
+- Prediction-contract backtests no longer fall through to IBKR, Yahoo, or other default stock/crypto data sources when
+  `DATA_SOURCE=polymarket` is set in the live environment.
+- The example strategy runs end-to-end as a real backtest with `.env.local` loaded.
+- Backtesting validates 0-to-1 prices, Polymarket tick-size rules, minimum order sizes, market close, and settlement to
+  `$1` or `$0` when resolved metadata is available.
+- Public README/RST wording now describes Polymarket trading and backtesting directly. Detailed docs still explain
+  test-safety limits such as real-money live smoke tests being off by default.
+
+Additional focused test result:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 180s python3 -m pytest -q tests/test_polymarket_backtesting.py tests/test_backtesting_data_source_env.py tests/test_prediction_market_data_source_defaults.py tests/test_polymarket_asset.py tests/test_polymarket_data.py tests/test_polymarket_broker.py
+```
+
+- `55 passed, 1 warning`
+
+Example backtest proof:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 180s python3 -m dotenv -f .env.local run -- env IS_BACKTESTING=true BACKTESTING_START=2026-06-30 BACKTESTING_END=2026-07-01 BACKTESTING_SHOW_PROGRESS_BAR=false python3 -m lumibot.example_strategies.polymarket_prediction_contract
+```
+
+- Completed successfully with `PolymarketBacktesting`.

--- a/docs/investigations/2026-07-01_POLYMARKET_INTERNATIONAL_CLOB_LIVE_PROOF.md
+++ b/docs/investigations/2026-07-01_POLYMARKET_INTERNATIONAL_CLOB_LIVE_PROOF.md
@@ -4,7 +4,7 @@ One-line description: Verified credential, data, WebSocket, and live-submit stat
 
 Last Updated: 2026-07-01
 
-Status: Read-only account/data/WebSocket proof complete; live order submission blocked by Polymarket account/API-key binding.
+Status: Deposit-wallet flow complete; direct SDK and LumiBot live market order plus limit/cancel proofs succeeded.
 
 Audience: LumiBot maintainers, broker-adapter implementers, BotSpot/Bot Manager follow-on engineers
 
@@ -71,8 +71,37 @@ Important distinction:
 
 - `POLYMARKET_OWNER_ADDRESS` is the signer/owner identity.
 - `POLYMARKET_WALLET_ADDRESS` is the funder/proxy/deposit wallet passed to CLOB.
-- For the current Magic/proxy account, read paths work with signature type `1`. Order submission is still blocked by the
-  platform-side deposit-wallet/API-key mismatch described below.
+- `POLYMARKET_PROXY_WALLET_ADDRESS` preserves the old proxy wallet used to fund the deposit wallet.
+- `POLYMARKET_DEPOSIT_WALLET_ADDRESS` is the deterministic deposit wallet.
+- The current active trading configuration uses `POLYMARKET_WALLET_ADDRESS=<deposit wallet>` and
+  `POLYMARKET_SIGNATURE_TYPE=3`.
+
+## Deposit Wallet Setup Proof
+
+Helper script:
+
+- `/Users/robertgrzesik/Development/lumibot/scripts/polymarket_deposit_wallet_setup.py`
+
+Verified setup actions on 2026-07-01:
+
+- Created builder HMAC credentials through the CLOB SDK and stored them only in `.env.local`.
+- Derived deterministic deposit wallet for the current signer.
+- Deployed the deposit wallet through the Polymarket relayer.
+- Funded the deposit wallet with `5` pUSD from the existing proxy wallet via a gasless relayer proxy transfer.
+- Approved all three CLOB-reported pUSD spender contracts from the deposit wallet via a relayer `WALLET` batch.
+- Activated the deposit wallet in `.env.local` with `POLYMARKET_SIGNATURE_TYPE=3`.
+
+Read-only verification command:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 90s python3 scripts/polymarket_deposit_wallet_setup.py
+```
+
+Latest result:
+
+- Deposit wallet balance was present.
+- Allowance count: `3`.
+- Zero allowance count: `0`.
 
 ## Direct API Proof
 
@@ -107,7 +136,7 @@ Verified read-only results:
 - Authenticated user WebSocket connected with CLOB L2 credentials; it returned no events because there were no account
   order/trade events during the proof window.
 
-## Live Submit Proof
+## Earlier Proxy-Mode Live Submit Proof
 
 Market-order smoke command:
 
@@ -140,10 +169,100 @@ Result:
 - The tiny far-from-market limit order did not submit.
 - Polymarket returned the same deposit-wallet-flow blocker before an order id existed, so cancel could not be exercised.
 
-## Interpretation Of The Blocker
+## Deposit-Wallet Live Submit Proof
 
-This is not currently a LumiBot mapping bug. The same rejection occurs through direct `py-clob-client-v2` calls before
-LumiBot broker normalization is involved.
+Direct SDK read-only proof after activation:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 90s python3 scripts/polymarket_smoke.py
+```
+
+Latest redacted artifact:
+
+- `/Users/robertgrzesik/Development/lumibot/logs/polymarket_smoke_20260701_200400.json`
+
+Verified:
+
+- Deposit-wallet CLOB cash read succeeded.
+- Positions count by deposit wallet: `1`.
+- Recent trades count: `4`.
+- Open orders count: `0`.
+- Public market WebSocket returned events.
+- Private user WebSocket authenticated.
+- Order book, quote, last price, and history worked.
+
+Direct SDK live market order proof:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 90s python3 scripts/polymarket_smoke.py --live-order --amount 1.00
+```
+
+Result:
+
+- `status=submitted`.
+- Polymarket response had `success=true`, `status=matched`, a real `orderID`, and a transaction hash.
+
+Direct SDK limit/cancel proof:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 90s python3 scripts/polymarket_smoke.py --limit-cancel --limit-price 0.01 --limit-size 5
+```
+
+Latest redacted artifact:
+
+- `/Users/robertgrzesik/Development/lumibot/logs/polymarket_smoke_20260701_200430.json`
+
+Result:
+
+- Limit order submitted as `status=live`.
+- Cancel response returned the order id under `canceled`.
+
+LumiBot-level smoke helper:
+
+- `/Users/robertgrzesik/Development/lumibot/scripts/polymarket_lumibot_smoke.py`
+
+Read-only:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 90s python3 scripts/polymarket_lumibot_smoke.py
+```
+
+Verified:
+
+- `strategy.get_cash()` returned the real deposit-wallet CLOB cash.
+- `strategy.get_portfolio_value()` returned cash plus position value.
+- Positions and open orders loaded through the broker.
+
+Live market order through LumiBot:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 90s python3 scripts/polymarket_lumibot_smoke.py --market-order --amount 1.00
+```
+
+Equivalent inline proof also verified:
+
+- `Strategy.create_order(...)` built a Polymarket prediction-contract market BUY.
+- `Strategy.submit_order(order)` submitted through the LumiBot broker and returned `status=fill`.
+- The returned normalized order included the real CLOB order id, filled quantity, and average fill price.
+- Fresh reconciliation showed recent trades increased and open orders stayed `0`.
+
+Live limit/cancel through LumiBot:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 90s python3 scripts/polymarket_lumibot_smoke.py --limit-cancel
+```
+
+Equivalent inline proof verified:
+
+- `Strategy.create_order(...)` built a tiny limit BUY.
+- `Strategy.submit_order(order)` returned an open CLOB order id.
+- `broker.cancel_order(submitted)` canceled it.
+- Open orders were `0` afterward.
+
+## Interpretation Of The Original Blocker
+
+The original proxy-mode blocker was not a LumiBot mapping bug. The same rejection occurred through direct
+`py-clob-client-v2` calls before LumiBot broker normalization was involved.
 
 The public GitHub issue tracker has multiple recent open reports around the same credential/address family:
 
@@ -159,12 +278,9 @@ For this account, the observed local matrix was:
 - Signature type `3` with the current funder/proxy returns the order-signer/API-key mismatch.
 - Signature types `0` and `2` did not produce a usable order path.
 
-Next practical fix is not another LumiBot order mapping change. We need one of:
-
-- A supported Polymarket deposit-wallet setup that yields CLOB credentials bound to the order signer/funder address.
-- Polymarket-side SDK/API fix for Magic/proxy or deposit-wallet API-key binding.
-- A documented and supported workaround from Polymarket for registering API credentials under the exact address CLOB
-  validates during `POST /order`.
+The working fix was Polymarket's documented deposit-wallet flow: deploy deterministic deposit wallet, fund it with pUSD,
+approve CLOB spenders from the deposit wallet, switch `POLYMARKET_WALLET_ADDRESS` to the deposit wallet, and use
+`POLYMARKET_SIGNATURE_TYPE=3`.
 
 ## LumiBot Changes Made From This Proof
 
@@ -176,8 +292,10 @@ Implementation updates:
   reconciliation.
 - `Polymarket` scales collateral balance/allowance raw units from 6-decimal USDC-like integer units into dollars.
 - `Polymarket` stores optional `OWNER_ADDRESS` separately from `WALLET_ADDRESS`.
-- `Polymarket` chooses a safer default signature type: proxy when owner and funder differ, deposit-wallet otherwise.
+- `Polymarket` honors explicit `POLYMARKET_SIGNATURE_TYPE` from env/config before falling back to inference.
 - Market and limit submits now pass SDK `PartialCreateOrderOptions(tick_size=..., neg_risk=...)` from the live book.
+- Market submit responses now parse `orderID`, `makingAmount`, `takingAmount`, and `status=matched`.
+- Limit submit responses with empty amount fields parse cleanly and preserve the original LumiBot limit price.
 - Known platform-side signer/funder/deposit-wallet rejections are wrapped in a clear `LumibotBrokerAPIError`.
 - `requirements.txt` now includes `websockets>=15.0.1`.
 
@@ -189,7 +307,8 @@ Tests added or expanded:
 - WebSocket subscription payload shape.
 - Data source handling for market-stream list payloads.
 - Public WebSocket API smoke.
-- Live tiny order API smoke xfails only for the exact current platform-side blocker.
+- Explicit deposit-wallet signature type selection.
+- Live CLOB response parsing for matched market orders and live limit orders.
 
 ## Test Commands And Results
 
@@ -209,21 +328,39 @@ Live/API with `.env.local` loaded:
 /Users/robertgrzesik/Development/bin/safe-timeout 120s python3 -m dotenv -f .env.local run -- python3 -m pytest -q tests/test_polymarket_apitest.py
 ```
 
-Result:
+Earlier result before deposit-wallet activation:
 
-- `3 passed, 1 xfailed`
-- The xfail is the tiny live market order, and only for the current deposit-wallet/API-key binding blocker.
+- `3 passed, 1 xfailed`.
+- The xfail was the tiny live market order under proxy-mode configuration.
 
-Direct smoke:
+Current result for focused Polymarket broker unit tests:
 
-- Read-only direct smoke: passed.
-- Live market-order direct smoke: blocked by Polymarket deposit-wallet flow.
-- Limit/cancel direct smoke: blocked by Polymarket deposit-wallet flow before cancelable order creation.
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 120s python3 -m pytest tests/test_polymarket_broker.py -q
+```
+
+- `16 passed`
+
+Direct and LumiBot live smoke:
+
+- Direct read-only smoke: passed.
+- Direct live market order: passed.
+- Direct live limit/cancel: passed.
+- LumiBot read-only smoke: passed.
+- LumiBot live market order: passed.
+- LumiBot live limit/cancel: passed.
+
+Residual note:
+
+- Immediate post-submit cash reads can lag inside the same SDK client. A fresh CLOB/account read reconciles the correct
+  balance.
 
 ## What Works Now
 
 - Credential loading from `.env.local`.
 - CLOB L2 credential use for authenticated read paths.
+- Builder HMAC credential creation through the CLOB SDK.
+- Deposit-wallet derivation, relayer deployment, proxy funding transfer, and deposit-wallet pUSD approvals.
 - Account cash read and scaling.
 - Position and account-value reads through Data API fallback.
 - Open order reads.
@@ -233,26 +370,28 @@ Direct smoke:
 - Public market WebSocket connection and event ingestion.
 - Private user WebSocket authenticated subscription.
 - LumiBot broker/data-source selection with `TRADING_BROKER=polymarket`.
+- Direct SDK market order.
+- Direct SDK limit order and cancel.
+- LumiBot `Strategy.create_order(...)` / `Strategy.submit_order(...)` market order.
+- LumiBot limit order and cancel.
 - Unit and API tests around the implemented mapping.
 
-## What Is Still Blocked
+## What Is Still Open
 
-- Live order submit on Rob's current account.
-- Limit-order cancel proof, because limit order creation is blocked before an order id exists.
-- Real fill/private-event reconciliation, because no live order can currently be placed.
-- BotSpot/Bot Manager credential UI/runtime support. That should wait until the LumiBot adapter has a working live
-  submit path or a clear product decision around private-key/deposit-wallet custody.
+- The deposit wallet now has less than `$1` idle pUSD after the live proofs. Fund it again before additional market-order
+  smoke tests.
+- Immediate post-submit cash reads can be stale inside the same SDK client; use a fresh read/reconciliation for final
+  account values.
+- Private user WebSocket authenticated successfully, but a fill-event callback was not captured live during a running
+  LumiBot strategy loop. HTTP reconciliation worked.
+- BotSpot/Bot Manager credential UI/runtime support remains deferred until product decisions are made around private-key,
+  builder-key, and deposit-wallet custody.
 
 ## Next Steps
 
-1. Decide whether to pursue a true deposit-wallet setup for this account or wait for Polymarket's SDK/API fix.
-2. If pursuing deposit wallet, identify the exact builder/relayer credential shape required by the current UI/API. The
-   visible one-value `RELAYER_API_KEY` is not the same as CLOB L2 credentials, and the Python relayer client examples use
-   builder key/secret/passphrase.
-3. Once a supported order path exists, rerun:
-   - direct `scripts/polymarket_smoke.py --live-order`
-   - direct `scripts/polymarket_smoke.py --limit-cancel`
-   - `pytest -q tests/test_polymarket_apitest.py` with `.env.local` loaded
-4. After live submit/cancel proof works, add one end-to-end LumiBot strategy smoke that places a tiny order, reconciles
-   private user WebSocket events, refreshes positions/orders, and exits.
-5. Only then start BotSpot/Bot Manager credential schema and UI work.
+1. Add a safer balance-reconciliation hook after successful submit so same-client cash reads are less stale.
+2. Add an integration test path for `scripts/polymarket_lumibot_smoke.py` with live trading disabled by default.
+3. Fund the deposit wallet again before more live market-order testing.
+4. Run a real strategy loop with WebSockets enabled and capture a private user fill event during the loop.
+5. Start BotSpot/Bot Manager credential schema and UI work only after deciding how hosted runtime should custody or
+   receive the private key, builder key, CLOB L2 creds, and deposit-wallet address.

--- a/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
+++ b/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
@@ -255,57 +255,82 @@ Do not over-interpret every scan flag as a trading bug. Leveraged ETFs can have 
 
 If a future provider/cache omits `stock_splits` entirely, LumiBot still cannot safely infer true corporate actions from price moves alone without risking false positives. Provider enrichment and cache quality remain required.
 
-## Cache And Deployment Game Plan
+## Cache Audit Results And Revised Game Plan
 
-Additional read-only checks on 2026-07-02 found that cache namespace selection matters:
+Additional read-only cache audit on 2026-07-02 changed the recommended next step. Do not add a per-request internal-gap scan to LumiBot's hot `get_price_data()` path unless a separate performance design proves it is safe. The next step is offline cache audit plus targeted object repair.
+
+Audit artifacts:
+
+- `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/cache-audit-2026-07-02/ibkr_cache_audit_all.json`
+- `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/cache-audit-2026-07-02/ibkr_daily_stock_index_realrow_audit.json`
+- `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/cache-audit-2026-07-02/prod_v1_daily_flagged_yahoo_comparison.json`
+
+Read-only namespace facts:
 
 - Production BotSpot Node task definition `botspot-prod:130` explicitly injects `LUMIBOT_CACHE_S3_VERSION=v1`, `bucket=lumibot-cache-prod`, `prefix=prod/cache`, `mode=readwrite`, and Data Downloader URL `http://data-downloader.lumiwealth.com:8080`.
-- BotSpot Node code defaults provider environments to `LUMIBOT_CACHE_S3_VERSION=v44` when the env var is absent, but production overrides that default to `v1`.
-- `prod/cache/v44` was empty at scan time, so it is not the production market-data cache namespace for this incident.
-- `dev/cache/v44` exists and contains IBKR stock/day objects. The exact RTH TQQQ object there was clean around the 2025 split, but other TQQQ source variants (`AUTO_TRADES`, `AUTO_BID_ASK`, `AUTO_MIDPOINT`) had raw split-like jumps and lacked split markers.
-- `dev/cache/v1` contains the original bad TQQQ RTH object class: incomplete history, a 2016-2019 internal hole, and non-split level spikes. One local readwrite replay later normalized its 2025 raw tail, so historical copies under `support-artifacts/` are the better forensic source than the current object alone.
-- `prod/cache/v1` TQQQ RTH was clean and matched Yahoo closely, but the broader prod stock/day scan still flagged follow-up candidates such as `TECL` (raw split-like boundary) and `UPRO` (large non-split jump).
+- BotSpot Node code defaults provider environments to `v44` when the env var is absent, but production overrides that default to `v1`.
+- `prod/cache/v44` was empty at scan time; it is not the production market-data namespace for this incident.
+- Active production `prod/cache/v1/ibkr/**/bars` contained `488` parquet bar objects.
+- Dev `dev/cache/v1/ibkr/**/bars` contained `320` parquet bar objects.
+- Dev `dev/cache/v44/ibkr/**/bars` contained `137` parquet bar objects.
 
-Recommended order:
+Production findings:
 
-1. Freeze evidence before repair.
-   - Copy or version every object targeted for repair into an audit prefix or durable local artifact.
-   - Do this before any `readwrite` reproduction that could rewrite S3 objects.
+- Non-daily production IBKR bar objects had no real-row structural flags in this audit: no real-row close NaNs, nonpositive closes, duplicate indexes, or non-monotonic indexes.
+- Production TQQQ RTH (`prod/cache/v1/ibkr/stock/day/bars/stock_TQQQ_USD_day_AUTO_TRADES_RTH.parquet`) was clean and matched Yahoo closely. It is not the bad local/dev TQQQ object.
+- Production daily stock/index audit found `45` placeholder-only objects. These are persisted no-data markers, not corrupt price rows. They should not be treated as repair targets unless a strategy actually needs those symbols/windows.
+- Production daily stock/index audit produced `42` split-like or large-jump event rows for Yahoo comparison. `30` matched Yahoo close levels and are likely real market moves, not cache problems.
+- Confirmed production repair candidates:
+  - `TECL`: `244` real rows from `2020-03-12` through `2021-03-01` are exactly `10x` Yahoo close, followed by the real `2021-03-02` 10:1 split row. This is a mixed split-adjustment cache segment.
+  - `UPRO`: `270` real rows from `2020-03-12` through `2021-04-07` are exactly `2x` Yahoo close, then return to Yahoo level on `2021-04-08`. This is a mixed adjustment splice without a same-day split marker.
+  - `SPXU`: one bad reverse-split date, `2021-01-21`; IBKR close `116.20`, Yahoo close `541.80`, Yahoo split `0.2`.
+  - `OUST`: one bad reverse-split date, `2023-04-21`; IBKR close `0.40`, Yahoo close `3.72`, Yahoo split `0.1`.
+- Needs manual review before any repair:
+  - `AMC`: `330` real rows from `2021-04-30` through `2022-08-19` sit at a constant `0.6198x` Yahoo close. This may be an AMC/APE special-action adjustment difference rather than a simple split bug.
+  - `VIX9D`: differs from Yahoo on two jump dates; this may be index-close/vendor methodology rather than a cache splice.
+  - `AMR` and one `APLD` action event could not be verified cleanly through Yahoo in the audit window.
 
-2. Add a reusable S3 cache audit tool.
-   - Scope first to `ibkr/stock/day/bars` and `ibkr/index/day/bars`.
-   - Inputs: bucket, prefix, version, provider namespace, symbols or all symbols, readonly/repair mode.
-   - Output: JSON + CSV with row counts, first/last dates, split rows, raw split jumps, large non-split jumps, internal gaps, duplicate timestamps, source variants, and dev/prod comparisons.
-   - The default mode must be read-only and must not require secrets in logs.
+Dev findings:
 
-3. Add cache self-healing for internal holes.
-   - `get_price_data()` already detects empty windows and missing coverage at request boundaries.
-   - It does not detect a large internal hole when a broad requested window has rows at both ends.
-   - Add daily stock/index internal-gap detection so a cache like old dev TQQQ cannot satisfy a 2016-2026 request while silently missing 2016-2019.
-   - Unit-test this with a cached frame that has rows near the requested start and end but a multi-year interior hole; assert the downloader is called for the missing segment and the merged frame is returned.
+- `dev/cache/v1` has confirmed bad long-window objects:
+  - `TQQQ` RTH: real internal gap `2016-03-31` to `2019-02-04`, plus non-split jumps around `2019-02-04` and `2022-11-01/02`.
+  - `SQQQ` RTH: real internal gap `2020-04-01` to `2021-04-29`, with a corresponding level jump.
+  - `SPY` RTH: real internal gap `2019-03-27` to `2020-04-16`.
+- `dev/cache/v44` has clean TQQQ RTH around the 2025 split, but non-RTH TQQQ source variants (`AUTO_TRADES`, `AUTO_BID_ASK`, `AUTO_MIDPOINT`) contain duplicate dates and raw split-like jumps. Do not assume all source variants are clean because the RTH object is clean.
 
-4. Make split normalization and gap repair deploy before cache writes.
-   - Release LumiBot first so future cache reads normalize mixed split-adjustment data and do not double-count already-adjusted frames.
-   - Keep Yahoo/auto-adjusted providers covered by existing tests so Yahoo is not double-adjusted.
+Revised plan:
 
-5. Repair caches surgically.
-   - Do not wipe broad `prod/cache/v1`.
-   - For dev, either repair/rebuild known-bad IBKR stock/day objects or move dev to a new cache version after warming high-usage symbols from IBKR/Data Downloader.
-   - For prod, start with audit-only, then repair only confirmed bad objects such as `TECL` after comparing against Yahoo/another reference and preserving the old object.
-   - Include all TQQQ source variants, not only `AUTO_TRADES_RTH`.
+1. Do not change the hot cache-read path for internal gap scanning right now.
+   - The backtest cache is performance-sensitive.
+   - Treat this as an offline audit/repair problem unless a future design proves near-zero overhead.
 
-6. Validate with a fixed matrix.
-   - Local unit suite: stock split accounting, IBKR equity action normalization, Yahoo split behavior, broker/backtesting smoke.
-   - Local replay matrix: dev `v1`, dev `v44`, prod `v1`, Yahoo, all using the saved revision and fresh `LUMIBOT_CACHE_FOLDER`.
-   - Expected sanity range for the 2016-03-04 to 2026-03-04 TQQQ strategy: prod IBKR should remain close to Yahoo (`38.90%` CAGR / `-48.20%` max DD versus Yahoo `38.17%` / `-48.57%` in the local replay). Dev should not be trusted until its cache object is repaired or rebuilt.
-   - Artifact checks: no `-50%` one-day portfolio cliff on 2025-11-20, 2025 split-window price around `50.03 -> 46.45`, no 2021/2022 double-counted split ledger events, and `settings.json.lumibot_version` equals the released version.
+2. Keep the LumiBot split-normalization fix.
+   - The TQQQ local/dev chart cliff is still a real split-normalization bug.
+   - The existing unit/backtest coverage should stay because it prevents double-counting adjusted providers like Yahoo and mixed IBKR split rows like TQQQ/TECL.
 
-7. Release and deploy.
-   - Follow `docs/DEPLOYMENT.md`: preflight, PR to `dev`, merge latest `dev`, tag the `dev` merge commit, verify `pip install lumibot==4.5.64`, move local checkout to the next version branch, then trigger Bot Manager.
-   - Bot Manager currently pins `LUMIBOT_VERSION=4.5.63`; update it to the released version only after the LumiBot release is published and installable.
-   - Deploy Bot Manager dev first, run the backtest/version canary, then deploy production.
-   - Use `force_rebuild_images=true` if the post-deploy artifact still shows an older LumiBot version.
+3. Build a reusable offline audit/repair script.
+   - Default mode: read-only audit, exactly like this pass.
+   - Scope first: `ibkr/stock/day/bars` and `ibkr/index/day/bars`.
+   - Output JSON/CSV with symbol, source variant, real-row spans, split markers, Yahoo comparison for flagged events, and repair recommendation.
+   - This can run before deployments or as an operations task without slowing every backtest.
 
-8. Add deployment-gating regression.
-   - Add a Bot Manager/BotSpot backtest canary that runs a short stock/day split-sensitive strategy and asserts the runtime LumiBot version plus split-window equity behavior.
-   - This canary should be a deployment gate, not a manual-only or advisory check.
+4. Repair production surgically.
+   - Back up each target object before writing.
+   - Start with `TECL`, `UPRO`, `SPXU`, and `OUST`.
+   - Do not repair `AMC`, `VIX9D`, `AMR`, or `APLD` until manually reviewed.
+   - Do not delete or reset broad `prod/cache/v1`.
+
+5. Repair or retire bad dev objects.
+   - Dev can be fixed more aggressively because it is lower-stakes, but still back up objects first.
+   - Repair/rebuild `TQQQ`, `SQQQ`, and `SPY` in `dev/cache/v1`.
+   - Repair or remove dirty non-RTH TQQQ variants in `dev/cache/v44`.
+
+6. Validate after repair.
+   - Rerun the offline audit and require zero confirmed repair candidates for active production symbols.
+   - Rerun the TQQQ 2016-03-04 to 2026-03-04 matrix: prod IBKR should remain close to Yahoo (`38.90%` CAGR / `-48.20%` max DD versus Yahoo `38.17%` / `-48.57%` in the local replay).
+   - Add symbol-level validation for repaired objects: TECL, UPRO, SPXU, and OUST should match Yahoo close levels around the repaired spans.
+
+7. Release and deploy after cache plan is clear.
+   - Follow `docs/DEPLOYMENT.md`: release LumiBot `4.5.64`, verify installability, then update Bot Manager.
+   - Bot Manager currently pins `LUMIBOT_VERSION=4.5.63`; update after the LumiBot release is published.
+   - Deploy Bot Manager dev first, run version/backtest canaries, then production.

--- a/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
+++ b/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
@@ -1,65 +1,136 @@
 # TQQQ Stock Split Position Accounting RCA
 
-One-line description: Root cause, fix, and validation for the TQQQ 2025-11-20 split causing a false 50 percent backtest equity drop.
+One-line description: Root cause, fix, and validation for the TQQQ 2025-11-20 split causing a false local/dev backtest equity drop.
 Created: 2026-07-01
-Status: Fixed locally on branch `version/4.5.64`
+Last Updated: 2026-07-01
+Status: Fixed locally on branch `version/4.5.64`; production release still required
 Audience: Engineering (Backtesting, BotSpot Auto, Data Routing)
 
-## Incident
+## Overview
 
-Backtest `22f6c3fd-90e0-4c03-a9d5-0a9a6cc994c3` for strategy `TQQQ 200-Day Trend Bot` dropped roughly in half around the real TQQQ 2:1 split effective before market open on 2025-11-20. The dev S3 IBKR daily cache already contained the split:
+Backtest `22f6c3fd-90e0-4c03-a9d5-0a9a6cc994c3` for strategy `TQQQ 200-Day Trend Bot` dropped roughly in half around the real TQQQ 2:1 split effective before market open on 2025-11-20. The bad run was local/dev, used BotSpot Auto routing with stock/index data routed to IBKR/Data Downloader, and used S3 cache hydration.
 
-- S3 cache: `s3://lumibot-cache-dev/dev/cache/v1/ibkr/stock/day/bars/stock_TQQQ_USD_day_AUTO_TRADES_RTH.parquet`
-- 2025-11-19 close: `100.05`, `stock_splits=0`
-- 2025-11-20 close: `46.45`, `stock_splits=2.0`
+The final root cause was not a React/chart problem. It was also not simply "LumiBot never handled splits." Past TQQQ 200-day style backtests did work. The failing local/dev cache contained a mixed-adjustment IBKR daily TQQQ series:
 
-The bad local replay held 3012 shares on 2025-11-19, still held 3012 shares on 2025-11-20, then sold 3012 shares on 2025-11-21 at 46.85. The price series was post-split, but the position ledger was not split-adjusted.
+- Older split rows, including 2021-01-21 and 2022-01-13, were already continuous/split-adjusted.
+- The local/dev cache segment from about 2024-01-31 through 2025-11-19 was raw by a factor of 2.
+- The 2025-11-20 split row and later rows were back in the post-split price level.
 
-## Root Cause
+That mixed cache made the 2025 split look like a raw price halving while the held position was not doubled. A first ledger-only fix removed that 2025 crash but wrongly doubled positions on the already-adjusted 2021 and 2022 split rows, creating a false 60% CAGR result. The durable fix normalizes IBKR stock/day bars into split-adjusted price space before backtesting, marks those frames as `_split_adjusted`, and keeps the generic position-ledger split path only for genuinely raw/unadjusted frames.
 
-This was a LumiBot accounting bug, not a React chart bug and not a Data Downloader/S3 cache bug.
+## What Failed
 
-LumiBot had several split-related data fixes, but no broker-ledger path that consumed `stock_splits` and mutated open stock positions during backtests. Dividends had a cash-event path (`_update_cash_with_dividends`), but splits had no equivalent position-event path. As a result, a real split row could be present in data while held quantity stayed unchanged.
+Bad local/dev replay before the fix:
 
-There was also a second chart artifact: once quantity adjustment was added, routed daily valuation could still mark the new doubled share count against the previous pre-split close before the split-date daily bar timestamp. That created a synthetic 2x spike followed by a synthetic -50 percent raw-stat move. Daily split-date snapshots now adjust stale previous prices by the split ratio until the split-date bar is available.
+- Replay folder: `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/local-replay-prodlike-10k/run/`
+- 2025-11-19: held `3012` TQQQ, close about `100.05`
+- 2025-11-20: still held `3012` TQQQ, close about `46.45`
+- 2025-11-20 one-step equity move: about `-52.83%`
+- 2025-11-21: sold only `3012` shares at about `46.85`
+- Final value: about `$145,217.79`
+- Independent CAGR: about `30.69%`
+- Independent max drawdown: about `-60.78%`
 
-The fix must be provider-aware. Raw/unadjusted daily bars (the IBKR/Data Downloader path in this incident) need a position-ledger split. Split-adjusted data sources already express historical fills in current share units and must not multiply held quantities again. The implementation now skips position-ledger split application when a data frame carries LumiBot's `_split_adjusted` marker or when a provider explicitly declares that `auto_adjust=True` means split-adjusted prices.
+The `30.69%` CAGR was not comforting because the max drawdown and split-window rows proved the path was mathematically wrong.
 
-## Why Earlier Fixes Did Not Cover This
+## Why The 60% Result Was Wrong
 
-The prior fixes were adjacent, not equivalent:
+The first local fix added broker-ledger stock split accounting. That was directionally useful for raw data, but it was incomplete for IBKR cache reality.
 
-- `docs/investigations/2026-03-03_IBKR_STOCK_INDEX_PARITY_AND_CORPORATE_ACTIONS.md` fixed IBKR corporate-action enrichment so `dividend` and `stock_splits` columns exist.
-- `tests/test_ibkr_daily_split_spike_repair.py` covers isolated bad data spikes and explicitly leaves persistent level shifts alone. A real split is a persistent level shift plus a corporate-action event, not a bar-rewrite problem.
-- `tests/test_split_adjustment.py` covers ThetaData historical price/dividend/option normalization. It does not simulate a broker account holding shares through a split.
+After that first fix, the same strategy replay produced:
 
-The missing regression surface was position accounting: buy before a split, hold through the split effective date, verify share quantity, basis, valuation, and later sell quantity.
+- Replay folder: `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/local-replay-after-fix6-10k/run/`
+- Final value: about `$1,150,153.82`
+- Independent CAGR: about `60.75%`
+- Max drawdown: about `-47.89%`
 
-Production backtest history also explains why this looked fine recently. The high-return, long-window TQQQ/200-day-style examples that worked in April used `theta_data`, whose historical stock path normalizes prices to current share units. Example rows from production Postgres:
+That result was false. It double-counted earlier TQQQ splits:
 
-- `10fcefe2-d4fc-4144-b978-883f12893c43`, created `2026-04-22`, window `2016-01-21` to `2026-04-16`, provider `theta_data`, CAGR `42.56%`, max drawdown `-70.36%`.
-- `c4b0c46a-54ca-4a29-9aef-d502245caa73`, created `2026-04-22`, same window family, provider `theta_data`, CAGR `55.34%`, max drawdown `-28.92%`.
+- 2021-01-21: position doubled even though the price series was already continuous (`24.75` to `25.36` around the split).
+- 2022-01-13: position doubled even though the price series was already continuous (`38.17` to `35.40` around the split).
+- 2025-11-20: position doubled correctly for the local raw tail, but by then the earlier false doublings had already inflated the account.
 
-The bad replay was different: `botspot_auto` routed stocks to IBKR/Data Downloader raw daily bars, over a window that held TQQQ through the real 2025-11-20 split. Recent `botspot_auto` TQQQ rows found in production either used shorter windows that did not hold through that split, or were different strategies. This is why earlier user-visible TQQQ results could be correct while this local/dev V6 run failed.
+This is why a 60% CAGR was out of range compared with past TQQQ 200-day results.
+
+## Cache Evidence
+
+The relevant IBKR daily TQQQ cache objects were copied and inspected locally:
+
+- Dev cache copy: `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/cache-comparison/dev_stock_TQQQ_USD_day_AUTO_TRADES_RTH.parquet`
+- Prod cache copy: `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/cache-comparison/prod_stock_TQQQ_USD_day_AUTO_TRADES_RTH.parquet`
+
+Observed dev/prod difference:
+
+| Date | Dev close | Prod close | Interpretation |
+| --- | ---: | ---: | --- |
+| 2024-01-30 | `27.97` | `27.97` | Same adjusted level |
+| 2024-01-31 | `52.64` | `26.32` | Dev cache raw segment begins |
+| 2025-01-02 | `78.63` | `39.32` | Dev remains roughly 2x prod |
+| 2025-11-19 | `100.05` | `50.03` | Dev remains raw pre-split |
+| 2025-11-20 | `46.45` | `46.45` | Dev returns to post-split level |
+
+Both dev and prod were already continuous through older splits:
+
+| Date | Dev close | Prod close | Split |
+| --- | ---: | ---: | ---: |
+| 2021-01-20 | `24.75` | `24.75` | `0` |
+| 2021-01-21 | `25.36` | `25.36` | `2` |
+| 2022-01-12 | `38.17` | `38.17` | `0` |
+| 2022-01-13 | `35.40` | `35.40` | `2` |
+
+This proves the regression was a mixed-adjustment cache shape, not a simple "all IBKR bars are raw" rule.
+
+Direct historical artifact inspection from production S3 was attempted but blocked by permissions: the Bot Manager profile could list the target object names but could not decrypt/copy those backtest artifacts due missing KMS decrypt permission, and the BotSpot artifact read path returned `Forbidden`. Production DB metrics and local cache/replay artifacts were used instead.
+
+## Historical BotSpot Evidence
+
+Production BotSpot database queries found recent TQQQ 200-day style backtests in the expected range. This supports the user report that these strategies were working recently.
+
+Representative completed rows:
+
+| Backtest ID | Created | Strategy | Window | CAGR | Max DD | Total Return |
+| --- | --- | --- | --- | ---: | ---: | ---: |
+| `9000f410-8316-4882-b9cd-64c876808f83` | 2026-06-29 | `TQQQ SMA 200 (Copy 2)` | 2025-01-01 to 2026-06-28 | `22.91%` | `-29.02%` | `35.68%` |
+| `2891a903-3a77-4585-9198-6734d1398508` | 2026-05-22 | `TQQQ 200-Day Trend Follower` | 2025-04-01 to 2026-04-30 | `-5.62%` | `-23.96%` | `-6.04%` |
+
+The reported local/dev backtest id and revision id were not present in production `backtest`, matching the report that the bad run was local/dev.
+
+## Why Earlier Fixes Did Not Permanently Solve This
+
+Prior split/corporate-action fixes were real but on adjacent surfaces:
+
+- `acb83ca1` (`2025-12-17`): stabilized ThetaData split/dividend normalization and day-mode quotes.
+- `b73ec373` (`2026-01-04`): added ThetaData intraday corporate action support.
+- `47f73693` (`2026-03-02`): hardened IBKR stock/index routing and corporate-action enrichment so daily frames can contain `dividend` and `stock_splits`.
+- `tests/test_ibkr_daily_split_spike_repair.py`: covered isolated split-like price spikes, but intentionally did not rewrite persistent level shifts.
+- `86dc17e6` (`2026-07-01`): added generic backtest position-ledger split accounting, but by itself double-counted already-adjusted split rows in the mixed IBKR cache.
+
+The missing permanent invariant was provider/data-shape aware:
+
+1. If daily bars are raw/unadjusted, held stock quantity must be multiplied by the split ratio and average fill price divided by the split ratio.
+2. If daily bars are already split-adjusted, the strategy fills and marks are already in current share units, so the ledger must not multiply shares again.
+3. If an IBKR cache is mixed, LumiBot must first normalize the affected raw pre-split segment into split-adjusted price space, then mark the frame `_split_adjusted`.
+
+The current fix adds that third invariant for IBKR stock/day cache data.
 
 ## Fix
 
-Implemented split handling in the backtest accounting path:
+Implemented in `lumibot/tools/ibkr_helper.py`:
 
-- Preserve `stock_splits` in `Data`/`Bars` slices and avoid forward-filling corporate-action event columns.
-- Add `DataSource.get_yesterday_stock_splits()` with a full preloaded daily-frame lookup before normal historical slices. This matters for IBKR daily bars timestamped at 16:00 when the split is effective before market open.
-- Add `Strategy._update_positions_with_splits()` and call it before dividend handling and strategy iteration/lifecycle work.
-- Multiply open stock position quantity by the split ratio and divide average fill price by the same ratio.
-- Keep split application idempotent by `(date, symbol, ratio)`.
-- Emit `corporate_action` rows in trade events so split applications are auditable.
-- Adjust stale daily mark-to-market prices across split boundaries for pandas, Theta/routed snapshots, Theta/routed last-trade lookup, and standalone IBKR daily stock/index valuation.
-- Skip ledger split accounting for already split-adjusted frames (`_split_adjusted`) and provider-declared auto-adjusted data, preventing double counting on Theta/Yahoo adjusted paths.
+- After IBKR daily stock corporate-action enrichment, normalize equity daily prices for split boundaries before returning/cache-writing the frame.
+- Detect whether each split row still has a raw split-level jump by comparing local close continuity against the split ratio.
+- For mixed caches, scan backward to find the splice where the raw segment begins instead of adjusting the entire historical series.
+- Adjust only the raw pre-split segment:
+  - price columns (`open`, `high`, `low`, `close`, `bid`, `ask`, `last`, `vwap`) are divided by the split ratio;
+  - `dividend` is divided by the split ratio;
+  - `volume` is multiplied by the split ratio.
+- Mark the resulting frame `_split_adjusted=True`.
+- Keep the existing generic stock-position split ledger for raw/unadjusted providers.
+- Preserve Yahoo and other already-adjusted providers because `DataSource.should_apply_stock_splits_to_positions()` skips ledger split multiplication when frames are `_split_adjusted` or the provider declares `AUTO_ADJUST_IMPLIES_SPLIT_ADJUSTED_PRICES`.
 
 ## Regression Tests
 
-New test file: `tests/test_stock_split_accounting.py`
-
-Covered cases:
+Existing split accounting coverage from `tests/test_stock_split_accounting.py` covers:
 
 - Regular splits: 2:1, 3:1, 7:1, 10:1.
 - Reverse splits: 1:2 (`0.5`) and 1:10 (`0.1`).
@@ -70,59 +141,58 @@ Covered cases:
 - Options are not adjusted by the stock-position path.
 - `stock_splits` survives `Data` repair/slicing and is not forward-filled.
 - Same-date/pre-open lookup for close-timestamped daily bars.
-- Pre-close valuation uses split-adjusted previous close instead of the stale pre-split price.
-- Daily backtest hold-through-split sells the adjusted quantity and does not create a false 50 percent equity drop.
-- Split-adjusted frames do not apply a second ledger split.
-- Provider-declared auto-adjusted data sources do not apply ledger splits.
+- Pre-close valuation uses split-adjusted previous close instead of stale pre-split price.
+- Daily backtest hold-through-split sells the adjusted quantity and does not create a false 50% equity drop.
+- Split-adjusted frames and provider-declared auto-adjusted data sources do not apply a second ledger split.
 
-Commands run:
+New IBKR normalization coverage in `tests/backtest/test_ibkr_equity_actions.py` covers:
+
+- Raw 2:1 forward split normalization.
+- Raw reverse split normalization.
+- Already-adjusted split rows are marked `_split_adjusted` without double-adjusting prices.
+- The exact mixed TQQQ cache shape: 2021/2022 already continuous, 2025 raw tail. The test asserts 2021 and 2022 are not halved again, while 2025-11-19 is normalized from `100.05` to `50.025`.
+
+Focused command run:
 
 ```bash
-LUMIBOT_DISABLE_DOTENV=1 /Users/robertgrzesik/bin/safe-timeout 180s python3 -m pytest tests/test_stock_split_accounting.py -q
-# 33 passed, 1 warning
-
-LUMIBOT_DISABLE_DOTENV=1 /Users/robertgrzesik/bin/safe-timeout 240s python3 -m pytest tests/test_stock_split_accounting.py tests/test_ibkr_daily_split_spike_repair.py tests/backtest/test_ibkr_equity_actions.py tests/test_strategy_dividend_cash_batch.py tests/test_split_adjustment.py -q
-# 58 passed, 1 warning
-
-LUMIBOT_DISABLE_DOTENV=1 /Users/robertgrzesik/bin/safe-timeout 300s python3 -m pytest tests/test_backtesting_broker.py tests/backtest/test_pandas_backtest.py -q
-# 38 passed, 1 warning
-
 LUMIBOT_DISABLE_DOTENV=1 /Users/robertgrzesik/bin/safe-timeout 300s python3 -m pytest tests/test_stock_split_accounting.py tests/test_ibkr_daily_split_spike_repair.py tests/backtest/test_ibkr_equity_actions.py tests/test_strategy_dividend_cash_batch.py tests/test_split_adjustment.py tests/test_backtesting_broker.py tests/backtest/test_pandas_backtest.py tests/backtest/test_yahoo.py tests/backtest/test_yahoo_helper_actions.py -q
-# 103 passed, 1 warning
+# 108 passed, 1 warning
 ```
 
-## Exact Replay Validation
+## Replay Validation
 
-Replay command used the saved revision files, BotSpot Auto routing, IBKR stock data, Data Downloader URL, and dev S3 cache:
+All replay commands used the saved revision file:
 
+- Strategy file: `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/revision-files/main.py`
 - Strategy hash: `ea07dbb637c922c8aa6c4a3e3e1479b7ef3c0f282dffdfc4490fbd5171e66a6b`
 - Window: 2016-03-04 to 2026-03-04
-- Budget: 10000
-- Data source router: `{"default":"ibkr","stock":"ibkr","index":"ibkr","option":"thetadata","crypto":"coinbase","crypto_future":"coinbase","future":"ibkr","cont_future":"ibkr"}`
-- `DATADOWNLOADER_BASE_URL=http://data-downloader.lumiwealth.com:8080`
-- `AWS_PROFILE=BotManager`
-- S3 cache bucket/prefix/version: `lumibot-cache-dev` / `dev/cache` / `v1`
-- Final replay folder after provider-safety tightening: `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/local-replay-after-fix6-10k/run/`
+- Budget: `$10,000`
 
-Final replay results:
+The IBKR reruns used BotSpot Auto style routing, Data Downloader settings loaded from the local BotSpot dotenv file, explicit `AWS_PROFILE=BotManager`, and S3 cache settings supplied via environment/script flags. The real downloader URL and credentials are intentionally not written into this document.
 
-- 2025-11-19 16:00: portfolio value `1,228,154.55`, cash `17,049.56`, position `12,105` TQQQ.
-- 2025-11-20 08:30 and 09:30: portfolio value stays `1,228,154.55`, position is `24,210` TQQQ after the split, no synthetic 2x spike.
-- 2025-11-20 16:00: portfolio value `1,141,604.06`, position `24,210` TQQQ, return `-7.0472%`.
-- 2025-11-21 09:30: sell fill for `24,210` TQQQ at `46.85`.
-- 2025-11-21 16:00 onward: flat cash about `1,150,154`.
-- Tearsheet CAGR: `60.73%`.
-- Independently computed CAGR from stats CSV: `60.7469%`.
-- Tearsheet max drawdown: `-47.89%`.
-- Independently computed max drawdown from stats CSV: `-47.8937%`.
-- Worst one-step raw-stat move is now 2020-03-09 at about `-20.2159%`, not the split date.
+| Scenario | Folder | Final PV | Independent CAGR | Independent Max DD | Worst one-step EOD move | Split-window result |
+| --- | --- | ---: | ---: | ---: | --- | --- |
+| Bad local/dev before fix | `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/local-replay-prodlike-10k/run/` | `$145,217.79` | `30.69%` | `-60.78%` | `-52.83%` on 2025-11-20 | Broken |
+| Ledger-only intermediate | `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/local-replay-after-fix6-10k/run/` | `$1,150,153.82` | `60.75%` | `-47.89%` | normal 2025 date, but false 2021/2022 jumps | Broken high |
+| Dev IBKR cache after normalization | `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/local-replay-after-normalize-dev-readonly-clean-10k/run/` | `$132,872.63` | `29.53%` | `-47.89%` | `-20.22%` on 2020-03-09 | Fixed |
+| Prod IBKR cache after normalization | `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/local-replay-after-normalize-prod-readonly-10k/run/` | `$267,230.90` | `38.90%` | `-48.20%` | `-20.42%` on 2020-03-09 | Fixed |
+| Yahoo current code | `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/local-replay-yahoo-current2-10k/run/` | `$253,478.59` | `38.17%` | `-48.57%` | `-16.90%` on 2020-03-02 | Fixed / unchanged |
 
-Corporate-action events emitted:
+Important split-window checks after the final fix:
 
-- 2021-01-21: TQQQ split ratio 2, quantity `1481 -> 2962`.
-- 2022-01-13: TQQQ split ratio 2, quantity `2962 -> 5924`.
-- 2025-11-20: TQQQ split ratio 2, quantity `12105 -> 24210`.
+| Scenario | 2021-01-21 | 2022-01-13 | 2025-11-20 |
+| --- | --- | --- | --- |
+| Dev IBKR fixed | Quantity stayed `1481`; return about `+2.49%` | Quantity stayed `1481`; return about `-7.30%` | Quantity stayed `2713`; return about `-7.04%` |
+| Prod IBKR fixed | Quantity stayed `2978`; return about `+2.49%` | Quantity stayed `2978`; return about `-7.30%` | Quantity stayed `5457`; return about `-7.05%` |
+| Yahoo current | Quantity stayed `5272` through 2025 split; no split/corporate ledger events | No split/corporate ledger events | 2025-11-20 move about `-1.30%`; no false halving |
 
-## Follow-Up Risk
+The final IBKR and Yahoo runs emitted zero stock-split/corporate-action ledger events because their data frames were treated as split-adjusted. That is expected for these adjusted-price backtests and prevents double counting.
 
-The fix consumes split rows already present in the daily data. If a provider/cache omits `stock_splits`, LumiBot still cannot infer true corporate actions from price moves alone without risking false positives. Data Downloader/provider enrichment should remain monitored separately, but this incident was fixed in LumiBot because the split data was already available.
+## Remaining Non-Split Follow-Up
+
+The dev cache result (`29.53%`) is below prod IBKR (`38.90%`) and Yahoo (`38.17%`) because the inspected dev S3 TQQQ cache also had completeness/coverage differences around early 2016. That is separate from the 2025 split crash:
+
+- The split crash is fixed by normalization and verified by the 2021/2022/2025 split windows.
+- The dev/prod result gap should be tracked as a dev-cache completeness issue, not as a split accounting issue.
+
+If a future provider/cache omits `stock_splits` entirely, LumiBot still cannot safely infer true corporate actions from price moves alone without risking false positives. Provider enrichment and cache quality remain required.

--- a/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
+++ b/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
@@ -1,0 +1,128 @@
+# TQQQ Stock Split Position Accounting RCA
+
+One-line description: Root cause, fix, and validation for the TQQQ 2025-11-20 split causing a false 50 percent backtest equity drop.
+Created: 2026-07-01
+Status: Fixed locally on branch `version/4.5.64`
+Audience: Engineering (Backtesting, BotSpot Auto, Data Routing)
+
+## Incident
+
+Backtest `22f6c3fd-90e0-4c03-a9d5-0a9a6cc994c3` for strategy `TQQQ 200-Day Trend Bot` dropped roughly in half around the real TQQQ 2:1 split effective before market open on 2025-11-20. The dev S3 IBKR daily cache already contained the split:
+
+- S3 cache: `s3://lumibot-cache-dev/dev/cache/v1/ibkr/stock/day/bars/stock_TQQQ_USD_day_AUTO_TRADES_RTH.parquet`
+- 2025-11-19 close: `100.05`, `stock_splits=0`
+- 2025-11-20 close: `46.45`, `stock_splits=2.0`
+
+The bad local replay held 3012 shares on 2025-11-19, still held 3012 shares on 2025-11-20, then sold 3012 shares on 2025-11-21 at 46.85. The price series was post-split, but the position ledger was not split-adjusted.
+
+## Root Cause
+
+This was a LumiBot accounting bug, not a React chart bug and not a Data Downloader/S3 cache bug.
+
+LumiBot had several split-related data fixes, but no broker-ledger path that consumed `stock_splits` and mutated open stock positions during backtests. Dividends had a cash-event path (`_update_cash_with_dividends`), but splits had no equivalent position-event path. As a result, a real split row could be present in data while held quantity stayed unchanged.
+
+There was also a second chart artifact: once quantity adjustment was added, routed daily valuation could still mark the new doubled share count against the previous pre-split close before the split-date daily bar timestamp. That created a synthetic 2x spike followed by a synthetic -50 percent raw-stat move. Daily split-date snapshots now adjust stale previous prices by the split ratio until the split-date bar is available.
+
+The fix must be provider-aware. Raw/unadjusted daily bars (the IBKR/Data Downloader path in this incident) need a position-ledger split. Split-adjusted data sources already express historical fills in current share units and must not multiply held quantities again. The implementation now skips position-ledger split application when a data frame carries LumiBot's `_split_adjusted` marker or when a provider explicitly declares that `auto_adjust=True` means split-adjusted prices.
+
+## Why Earlier Fixes Did Not Cover This
+
+The prior fixes were adjacent, not equivalent:
+
+- `docs/investigations/2026-03-03_IBKR_STOCK_INDEX_PARITY_AND_CORPORATE_ACTIONS.md` fixed IBKR corporate-action enrichment so `dividend` and `stock_splits` columns exist.
+- `tests/test_ibkr_daily_split_spike_repair.py` covers isolated bad data spikes and explicitly leaves persistent level shifts alone. A real split is a persistent level shift plus a corporate-action event, not a bar-rewrite problem.
+- `tests/test_split_adjustment.py` covers ThetaData historical price/dividend/option normalization. It does not simulate a broker account holding shares through a split.
+
+The missing regression surface was position accounting: buy before a split, hold through the split effective date, verify share quantity, basis, valuation, and later sell quantity.
+
+Production backtest history also explains why this looked fine recently. The high-return, long-window TQQQ/200-day-style examples that worked in April used `theta_data`, whose historical stock path normalizes prices to current share units. Example rows from production Postgres:
+
+- `10fcefe2-d4fc-4144-b978-883f12893c43`, created `2026-04-22`, window `2016-01-21` to `2026-04-16`, provider `theta_data`, CAGR `42.56%`, max drawdown `-70.36%`.
+- `c4b0c46a-54ca-4a29-9aef-d502245caa73`, created `2026-04-22`, same window family, provider `theta_data`, CAGR `55.34%`, max drawdown `-28.92%`.
+
+The bad replay was different: `botspot_auto` routed stocks to IBKR/Data Downloader raw daily bars, over a window that held TQQQ through the real 2025-11-20 split. Recent `botspot_auto` TQQQ rows found in production either used shorter windows that did not hold through that split, or were different strategies. This is why earlier user-visible TQQQ results could be correct while this local/dev V6 run failed.
+
+## Fix
+
+Implemented split handling in the backtest accounting path:
+
+- Preserve `stock_splits` in `Data`/`Bars` slices and avoid forward-filling corporate-action event columns.
+- Add `DataSource.get_yesterday_stock_splits()` with a full preloaded daily-frame lookup before normal historical slices. This matters for IBKR daily bars timestamped at 16:00 when the split is effective before market open.
+- Add `Strategy._update_positions_with_splits()` and call it before dividend handling and strategy iteration/lifecycle work.
+- Multiply open stock position quantity by the split ratio and divide average fill price by the same ratio.
+- Keep split application idempotent by `(date, symbol, ratio)`.
+- Emit `corporate_action` rows in trade events so split applications are auditable.
+- Adjust stale daily mark-to-market prices across split boundaries for pandas, Theta/routed snapshots, Theta/routed last-trade lookup, and standalone IBKR daily stock/index valuation.
+- Skip ledger split accounting for already split-adjusted frames (`_split_adjusted`) and provider-declared auto-adjusted data, preventing double counting on Theta/Yahoo adjusted paths.
+
+## Regression Tests
+
+New test file: `tests/test_stock_split_accounting.py`
+
+Covered cases:
+
+- Regular splits: 2:1, 3:1, 7:1, 10:1.
+- Reverse splits: 1:2 (`0.5`) and 1:10 (`0.1`).
+- Short positions.
+- Basis adjustment.
+- Idempotent repeated calls on the same split date.
+- Invalid ratios: zero, one, negative, NaN, infinity, `None`, and non-numeric strings.
+- Options are not adjusted by the stock-position path.
+- `stock_splits` survives `Data` repair/slicing and is not forward-filled.
+- Same-date/pre-open lookup for close-timestamped daily bars.
+- Pre-close valuation uses split-adjusted previous close instead of the stale pre-split price.
+- Daily backtest hold-through-split sells the adjusted quantity and does not create a false 50 percent equity drop.
+- Split-adjusted frames do not apply a second ledger split.
+- Provider-declared auto-adjusted data sources do not apply ledger splits.
+
+Commands run:
+
+```bash
+LUMIBOT_DISABLE_DOTENV=1 /Users/robertgrzesik/bin/safe-timeout 180s python3 -m pytest tests/test_stock_split_accounting.py -q
+# 33 passed, 1 warning
+
+LUMIBOT_DISABLE_DOTENV=1 /Users/robertgrzesik/bin/safe-timeout 240s python3 -m pytest tests/test_stock_split_accounting.py tests/test_ibkr_daily_split_spike_repair.py tests/backtest/test_ibkr_equity_actions.py tests/test_strategy_dividend_cash_batch.py tests/test_split_adjustment.py -q
+# 58 passed, 1 warning
+
+LUMIBOT_DISABLE_DOTENV=1 /Users/robertgrzesik/bin/safe-timeout 300s python3 -m pytest tests/test_backtesting_broker.py tests/backtest/test_pandas_backtest.py -q
+# 38 passed, 1 warning
+
+LUMIBOT_DISABLE_DOTENV=1 /Users/robertgrzesik/bin/safe-timeout 300s python3 -m pytest tests/test_stock_split_accounting.py tests/test_ibkr_daily_split_spike_repair.py tests/backtest/test_ibkr_equity_actions.py tests/test_strategy_dividend_cash_batch.py tests/test_split_adjustment.py tests/test_backtesting_broker.py tests/backtest/test_pandas_backtest.py tests/backtest/test_yahoo.py tests/backtest/test_yahoo_helper_actions.py -q
+# 103 passed, 1 warning
+```
+
+## Exact Replay Validation
+
+Replay command used the saved revision files, BotSpot Auto routing, IBKR stock data, Data Downloader URL, and dev S3 cache:
+
+- Strategy hash: `ea07dbb637c922c8aa6c4a3e3e1479b7ef3c0f282dffdfc4490fbd5171e66a6b`
+- Window: 2016-03-04 to 2026-03-04
+- Budget: 10000
+- Data source router: `{"default":"ibkr","stock":"ibkr","index":"ibkr","option":"thetadata","crypto":"coinbase","crypto_future":"coinbase","future":"ibkr","cont_future":"ibkr"}`
+- `DATADOWNLOADER_BASE_URL=http://data-downloader.lumiwealth.com:8080`
+- `AWS_PROFILE=BotManager`
+- S3 cache bucket/prefix/version: `lumibot-cache-dev` / `dev/cache` / `v1`
+- Final replay folder after provider-safety tightening: `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/local-replay-after-fix6-10k/run/`
+
+Final replay results:
+
+- 2025-11-19 16:00: portfolio value `1,228,154.55`, cash `17,049.56`, position `12,105` TQQQ.
+- 2025-11-20 08:30 and 09:30: portfolio value stays `1,228,154.55`, position is `24,210` TQQQ after the split, no synthetic 2x spike.
+- 2025-11-20 16:00: portfolio value `1,141,604.06`, position `24,210` TQQQ, return `-7.0472%`.
+- 2025-11-21 09:30: sell fill for `24,210` TQQQ at `46.85`.
+- 2025-11-21 16:00 onward: flat cash about `1,150,154`.
+- Tearsheet CAGR: `60.73%`.
+- Independently computed CAGR from stats CSV: `60.7469%`.
+- Tearsheet max drawdown: `-47.89%`.
+- Independently computed max drawdown from stats CSV: `-47.8937%`.
+- Worst one-step raw-stat move is now 2020-03-09 at about `-20.2159%`, not the split date.
+
+Corporate-action events emitted:
+
+- 2021-01-21: TQQQ split ratio 2, quantity `1481 -> 2962`.
+- 2022-01-13: TQQQ split ratio 2, quantity `2962 -> 5924`.
+- 2025-11-20: TQQQ split ratio 2, quantity `12105 -> 24210`.
+
+## Follow-Up Risk
+
+The fix consumes split rows already present in the daily data. If a provider/cache omits `stock_splits`, LumiBot still cannot infer true corporate actions from price moves alone without risking false positives. Data Downloader/provider enrichment should remain monitored separately, but this incident was fixed in LumiBot because the split data was already available.

--- a/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
+++ b/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
@@ -257,7 +257,7 @@ If a future provider/cache omits `stock_splits` entirely, LumiBot still cannot s
 
 ## Cache Audit Results And Revised Game Plan
 
-Additional read-only cache audit on 2026-07-02 changed the recommended next step. Do not add a per-request internal-gap scan to LumiBot's hot `get_price_data()` path unless a separate performance design proves it is safe. The next step is offline cache audit plus targeted object repair.
+Additional read-only cache audit on 2026-07-02 changed the recommended next step. Do not add a per-request internal-gap scan to LumiBot's hot `get_price_data()` path unless a separate performance design proves it is safe. The next step is offline cache audit plus targeted cache deletion/refill for confirmed bad IBKR objects. Do not do row-level surgical repair unless delete/refill fails and a separate RCA proves the provider still returns bad data.
 
 Audit artifacts:
 
@@ -280,12 +280,12 @@ Production findings:
 - Production TQQQ RTH (`prod/cache/v1/ibkr/stock/day/bars/stock_TQQQ_USD_day_AUTO_TRADES_RTH.parquet`) was clean and matched Yahoo closely. It is not the bad local/dev TQQQ object.
 - Production daily stock/index audit found `45` placeholder-only objects. These are persisted no-data markers, not corrupt price rows. They should not be treated as repair targets unless a strategy actually needs those symbols/windows.
 - Production daily stock/index audit produced `42` split-like or large-jump event rows for Yahoo comparison. `30` matched Yahoo close levels and are likely real market moves, not cache problems.
-- Confirmed production repair candidates:
+- Confirmed production delete/refill candidates:
   - `TECL`: `244` real rows from `2020-03-12` through `2021-03-01` are exactly `10x` Yahoo close, followed by the real `2021-03-02` 10:1 split row. This is a mixed split-adjustment cache segment.
   - `UPRO`: `270` real rows from `2020-03-12` through `2021-04-07` are exactly `2x` Yahoo close, then return to Yahoo level on `2021-04-08`. This is a mixed adjustment splice without a same-day split marker.
   - `SPXU`: one bad reverse-split date, `2021-01-21`; IBKR close `116.20`, Yahoo close `541.80`, Yahoo split `0.2`.
   - `OUST`: one bad reverse-split date, `2023-04-21`; IBKR close `0.40`, Yahoo close `3.72`, Yahoo split `0.1`.
-- Needs manual review before any repair:
+- Needs manual review before any delete/refill:
   - `AMC`: `330` real rows from `2021-04-30` through `2022-08-19` sit at a constant `0.6198x` Yahoo close. This may be an AMC/APE special-action adjustment difference rather than a simple split bug.
   - `VIX9D`: differs from Yahoo on two jump dates; this may be index-close/vendor methodology rather than a cache splice.
   - `AMR` and one `APLD` action event could not be verified cleanly through Yahoo in the audit window.
@@ -302,33 +302,36 @@ Revised plan:
 
 1. Do not change the hot cache-read path for internal gap scanning right now.
    - The backtest cache is performance-sensitive.
-   - Treat this as an offline audit/repair problem unless a future design proves near-zero overhead.
+   - Treat this as an offline audit and targeted invalidation problem unless a future design proves near-zero overhead.
 
 2. Keep the LumiBot split-normalization fix.
    - The TQQQ local/dev chart cliff is still a real split-normalization bug.
    - The existing unit/backtest coverage should stay because it prevents double-counting adjusted providers like Yahoo and mixed IBKR split rows like TQQQ/TECL.
 
-3. Build a reusable offline audit/repair script.
+3. Build a reusable offline audit script.
    - Default mode: read-only audit, exactly like this pass.
    - Scope first: `ibkr/stock/day/bars` and `ibkr/index/day/bars`.
-   - Output JSON/CSV with symbol, source variant, real-row spans, split markers, Yahoo comparison for flagged events, and repair recommendation.
+   - Output JSON/CSV with symbol, source variant, real-row spans, split markers, Yahoo comparison for flagged events, and delete/refill recommendation.
    - This can run before deployments or as an operations task without slowing every backtest.
+   - Do not build a row-level repair script as the primary path. It is more complex than needed and risks preserving stale provider mistakes.
 
-4. Repair production surgically.
-   - Back up each target object before writing.
+4. Delete/refill production confirmed targets.
+   - Back up each target object first by copying it to a dated S3 backup prefix or local durable artifact path.
    - Start with `TECL`, `UPRO`, `SPXU`, and `OUST`.
-   - Do not repair `AMC`, `VIX9D`, `AMR`, or `APLD` until manually reviewed.
+   - Delete only those exact S3 objects, not broad `prod/cache/v1`.
+   - Refill them by running a fixed LumiBot `4.5.64+` backtest or data-hydration job that requests those symbols through the normal IBKR/Data Downloader/S3 path.
+   - Do not delete/refill `AMC`, `VIX9D`, `AMR`, or `APLD` until manually reviewed.
    - Do not delete or reset broad `prod/cache/v1`.
 
-5. Repair or retire bad dev objects.
-   - Dev can be fixed more aggressively because it is lower-stakes, but still back up objects first.
-   - Repair/rebuild `TQQQ`, `SQQQ`, and `SPY` in `dev/cache/v1`.
-   - Repair or remove dirty non-RTH TQQQ variants in `dev/cache/v44`.
+5. Delete/refill or retire bad dev objects.
+   - Dev can be fixed more aggressively because it is lower-stakes, but still back up objects first if they are useful evidence.
+   - Delete/refill `TQQQ`, `SQQQ`, and `SPY` in `dev/cache/v1`.
+   - Delete/refill or remove dirty non-RTH TQQQ variants in `dev/cache/v44`.
 
-6. Validate after repair.
+6. Validate after refill.
    - Rerun the offline audit and require zero confirmed repair candidates for active production symbols.
    - Rerun the TQQQ 2016-03-04 to 2026-03-04 matrix: prod IBKR should remain close to Yahoo (`38.90%` CAGR / `-48.20%` max DD versus Yahoo `38.17%` / `-48.57%` in the local replay).
-   - Add symbol-level validation for repaired objects: TECL, UPRO, SPXU, and OUST should match Yahoo close levels around the repaired spans.
+   - Add symbol-level validation for refilled objects: TECL, UPRO, SPXU, and OUST should match Yahoo close levels around the bad spans.
 
 7. Release and deploy after cache plan is clear.
    - Follow `docs/DEPLOYMENT.md`: release LumiBot `4.5.64`, verify installability, then update Bot Manager.

--- a/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
+++ b/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
@@ -254,3 +254,58 @@ Do not over-interpret every scan flag as a trading bug. Leveraged ETFs can have 
 4. Prefer rebuilding or replacing bad dev IBKR stock/day objects from a known-good source over broad cache deletion.
 
 If a future provider/cache omits `stock_splits` entirely, LumiBot still cannot safely infer true corporate actions from price moves alone without risking false positives. Provider enrichment and cache quality remain required.
+
+## Cache And Deployment Game Plan
+
+Additional read-only checks on 2026-07-02 found that cache namespace selection matters:
+
+- Production BotSpot Node task definition `botspot-prod:130` explicitly injects `LUMIBOT_CACHE_S3_VERSION=v1`, `bucket=lumibot-cache-prod`, `prefix=prod/cache`, `mode=readwrite`, and Data Downloader URL `http://data-downloader.lumiwealth.com:8080`.
+- BotSpot Node code defaults provider environments to `LUMIBOT_CACHE_S3_VERSION=v44` when the env var is absent, but production overrides that default to `v1`.
+- `prod/cache/v44` was empty at scan time, so it is not the production market-data cache namespace for this incident.
+- `dev/cache/v44` exists and contains IBKR stock/day objects. The exact RTH TQQQ object there was clean around the 2025 split, but other TQQQ source variants (`AUTO_TRADES`, `AUTO_BID_ASK`, `AUTO_MIDPOINT`) had raw split-like jumps and lacked split markers.
+- `dev/cache/v1` contains the original bad TQQQ RTH object class: incomplete history, a 2016-2019 internal hole, and non-split level spikes. One local readwrite replay later normalized its 2025 raw tail, so historical copies under `support-artifacts/` are the better forensic source than the current object alone.
+- `prod/cache/v1` TQQQ RTH was clean and matched Yahoo closely, but the broader prod stock/day scan still flagged follow-up candidates such as `TECL` (raw split-like boundary) and `UPRO` (large non-split jump).
+
+Recommended order:
+
+1. Freeze evidence before repair.
+   - Copy or version every object targeted for repair into an audit prefix or durable local artifact.
+   - Do this before any `readwrite` reproduction that could rewrite S3 objects.
+
+2. Add a reusable S3 cache audit tool.
+   - Scope first to `ibkr/stock/day/bars` and `ibkr/index/day/bars`.
+   - Inputs: bucket, prefix, version, provider namespace, symbols or all symbols, readonly/repair mode.
+   - Output: JSON + CSV with row counts, first/last dates, split rows, raw split jumps, large non-split jumps, internal gaps, duplicate timestamps, source variants, and dev/prod comparisons.
+   - The default mode must be read-only and must not require secrets in logs.
+
+3. Add cache self-healing for internal holes.
+   - `get_price_data()` already detects empty windows and missing coverage at request boundaries.
+   - It does not detect a large internal hole when a broad requested window has rows at both ends.
+   - Add daily stock/index internal-gap detection so a cache like old dev TQQQ cannot satisfy a 2016-2026 request while silently missing 2016-2019.
+   - Unit-test this with a cached frame that has rows near the requested start and end but a multi-year interior hole; assert the downloader is called for the missing segment and the merged frame is returned.
+
+4. Make split normalization and gap repair deploy before cache writes.
+   - Release LumiBot first so future cache reads normalize mixed split-adjustment data and do not double-count already-adjusted frames.
+   - Keep Yahoo/auto-adjusted providers covered by existing tests so Yahoo is not double-adjusted.
+
+5. Repair caches surgically.
+   - Do not wipe broad `prod/cache/v1`.
+   - For dev, either repair/rebuild known-bad IBKR stock/day objects or move dev to a new cache version after warming high-usage symbols from IBKR/Data Downloader.
+   - For prod, start with audit-only, then repair only confirmed bad objects such as `TECL` after comparing against Yahoo/another reference and preserving the old object.
+   - Include all TQQQ source variants, not only `AUTO_TRADES_RTH`.
+
+6. Validate with a fixed matrix.
+   - Local unit suite: stock split accounting, IBKR equity action normalization, Yahoo split behavior, broker/backtesting smoke.
+   - Local replay matrix: dev `v1`, dev `v44`, prod `v1`, Yahoo, all using the saved revision and fresh `LUMIBOT_CACHE_FOLDER`.
+   - Expected sanity range for the 2016-03-04 to 2026-03-04 TQQQ strategy: prod IBKR should remain close to Yahoo (`38.90%` CAGR / `-48.20%` max DD versus Yahoo `38.17%` / `-48.57%` in the local replay). Dev should not be trusted until its cache object is repaired or rebuilt.
+   - Artifact checks: no `-50%` one-day portfolio cliff on 2025-11-20, 2025 split-window price around `50.03 -> 46.45`, no 2021/2022 double-counted split ledger events, and `settings.json.lumibot_version` equals the released version.
+
+7. Release and deploy.
+   - Follow `docs/DEPLOYMENT.md`: preflight, PR to `dev`, merge latest `dev`, tag the `dev` merge commit, verify `pip install lumibot==4.5.64`, move local checkout to the next version branch, then trigger Bot Manager.
+   - Bot Manager currently pins `LUMIBOT_VERSION=4.5.63`; update it to the released version only after the LumiBot release is published and installable.
+   - Deploy Bot Manager dev first, run the backtest/version canary, then deploy production.
+   - Use `force_rebuild_images=true` if the post-deploy artifact still shows an older LumiBot version.
+
+8. Add deployment-gating regression.
+   - Add a Bot Manager/BotSpot backtest canary that runs a short stock/day split-sensitive strategy and asserts the runtime LumiBot version plus split-window equity behavior.
+   - This canary should be a deployment gate, not a manual-only or advisory check.

--- a/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
+++ b/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
@@ -2,7 +2,7 @@
 
 One-line description: Root cause, fix, and validation for the TQQQ 2025-11-20 split causing a false local/dev backtest equity drop.
 Created: 2026-07-01
-Last Updated: 2026-07-01
+Last Updated: 2026-07-02
 Status: Fixed locally on branch `version/4.5.64`; production release still required
 Audience: Engineering (Backtesting, BotSpot Auto, Data Routing)
 
@@ -17,6 +17,8 @@ The final root cause was not a React/chart problem. It was also not simply "Lumi
 - The 2025-11-20 split row and later rows were back in the post-split price level.
 
 That mixed cache made the 2025 split look like a raw price halving while the held position was not doubled. A first ledger-only fix removed that 2025 crash but wrongly doubled positions on the already-adjusted 2021 and 2022 split rows, creating a false 60% CAGR result. The durable fix normalizes IBKR stock/day bars into split-adjusted price space before backtesting, marks those frames as `_split_adjusted`, and keeps the generic position-ledger split path only for genuinely raw/unadjusted frames.
+
+The remaining dev/prod result gap is a separate cache-quality issue. The prod IBKR TQQQ object is continuous and matches Yahoo closely. The dev/local TQQQ object was not a mirror of prod: it had fewer rows, missing split events, a 2016-03-31 to 2019-02-04 hole, and non-split level spikes. That explains why the fixed dev replay landed around 29.5% CAGR while prod IBKR and Yahoo landed around 38% CAGR.
 
 ## What Failed
 
@@ -80,6 +82,33 @@ Both dev and prod were already continuous through older splits:
 
 This proves the regression was a mixed-adjustment cache shape, not a simple "all IBKR bars are raw" rule.
 
+The full dev/prod S3 stock/day cache scan is stored here:
+
+- JSON scan: `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/cache-scan/ibkr_stock_day_cache_scan.json`
+- Interesting subset: `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/cache-scan/ibkr_stock_day_cache_scan_interesting.json`
+- Summary CSV: `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/cache-scan/ibkr_stock_day_cache_scan_summary.csv`
+- Dev/prod comparison CSV: `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/cache-scan/ibkr_stock_day_cache_dev_prod_comparison.csv`
+
+Cache namespace inventory at scan time:
+
+| Namespace | Stock/day objects | Stock/day bytes | Index/day objects | Index/day bytes |
+| --- | ---: | ---: | ---: | ---: |
+| Dev S3 prefix `dev/cache/v1/ibkr/...` | `126` | `8,772,815` | `2` | `116,177` |
+| Prod S3 prefix `prod/cache/v1/ibkr/...` | `340` | `23,894,640` | `4` | `335,058` |
+
+The TQQQ cache comparison was especially clear:
+
+| Field | Dev | Prod |
+| --- | ---: | ---: |
+| Rows | `3114` | `4115` |
+| First row | `2011-04-04` | `2010-02-22` |
+| Last row | `2026-06-29` | `2026-06-29` |
+| Split events | `5` | `8` |
+| Gaps > 7 days | `1` | `0` |
+| Large non-split jumps | `3` | `0` |
+
+The largest dev TQQQ gap was `2016-03-31` to `2019-02-04` (`1040` days). Dev also missed TQQQ split events that existed in prod (`2011-02-25`, `2017-01-12`, and `2018-05-24`) and had a non-split `2022-11-01` close of `20.30` where prod had `10.15`. Those are not cash-accounting bugs. They are cache data quality and completeness differences.
+
 Direct historical artifact inspection from production S3 was attempted but blocked by permissions: the Bot Manager profile could list the target object names but could not decrypt/copy those backtest artifacts due missing KMS decrypt permission, and the BotSpot artifact read path returned `Forbidden`. Production DB metrics and local cache/replay artifacts were used instead.
 
 ## Historical BotSpot Evidence
@@ -112,6 +141,8 @@ The missing permanent invariant was provider/data-shape aware:
 3. If an IBKR cache is mixed, LumiBot must first normalize the affected raw pre-split segment into split-adjusted price space, then mark the frame `_split_adjusted`.
 
 The current fix adds that third invariant for IBKR stock/day cache data.
+
+There was also an operational reason this surfaced in local/dev first. `BacktestCacheManager.on_local_update()` only uploads to S3 in `S3_READWRITE` mode, and several local reproduction runs used dev readwrite cache settings. The original local replay log shows `remote_cache.mode=readwrite`, bucket `lumibot-cache-dev`, prefix `dev/cache`, version `v1`, and `uploads=2`. A later normalization replay also wrote a normalized TQQQ object back into the dev namespace. For incident diagnosis, use S3 readonly first; dev readwrite can mutate the evidence while debugging.
 
 ## Fix
 
@@ -151,12 +182,17 @@ New IBKR normalization coverage in `tests/backtest/test_ibkr_equity_actions.py` 
 - Raw reverse split normalization.
 - Already-adjusted split rows are marked `_split_adjusted` without double-adjusting prices.
 - The exact mixed TQQQ cache shape: 2021/2022 already continuous, 2025 raw tail. The test asserts 2021 and 2022 are not halved again, while 2025-11-19 is normalized from `100.05` to `50.025`.
+- The old-dev-cache class where a non-split spike remains visible for cache-quality audits while only the persistent raw pre-split tail is adjusted.
+- The actual IBKR `get_price_data()` cached daily stock path: cached parquet in, normalized frame out, and persisted `_split_adjusted` marker.
+- A deterministic daily TQQQ backtest that buys before the 2025-11-20 split, holds through it, sells after it, emits no split double-count event on adjusted data, and asserts the split-day portfolio move is a normal price move rather than a false 50% cliff.
+
+These are ordinary pytest tests, not live downloader/S3 acceptance tests, so they should run in the normal LumiBot deployment gate. A live S3/read-only cache audit can be added on top, but the core split regression does not need network access to catch this class of bug.
 
 Focused command run:
 
 ```bash
 LUMIBOT_DISABLE_DOTENV=1 /Users/robertgrzesik/bin/safe-timeout 300s python3 -m pytest tests/test_stock_split_accounting.py tests/test_ibkr_daily_split_spike_repair.py tests/backtest/test_ibkr_equity_actions.py tests/test_strategy_dividend_cash_batch.py tests/test_split_adjustment.py tests/test_backtesting_broker.py tests/backtest/test_pandas_backtest.py tests/backtest/test_yahoo.py tests/backtest/test_yahoo_helper_actions.py -q
-# 108 passed, 1 warning
+# 111 passed, 1 warning
 ```
 
 ## Replay Validation
@@ -188,11 +224,33 @@ Important split-window checks after the final fix:
 
 The final IBKR and Yahoo runs emitted zero stock-split/corporate-action ledger events because their data frames were treated as split-adjusted. That is expected for these adjusted-price backtests and prevents double counting.
 
-## Remaining Non-Split Follow-Up
+## Other Symbols And Cache Quality
 
-The dev cache result (`29.53%`) is below prod IBKR (`38.90%`) and Yahoo (`38.17%`) because the inspected dev S3 TQQQ cache also had completeness/coverage differences around early 2016. That is separate from the 2025 split crash:
+The dev cache result (`29.53%`) is below prod IBKR (`38.90%`) and Yahoo (`38.17%`) because the inspected dev S3 TQQQ cache had broader completeness and quality differences. That is separate from the 2025 split crash:
 
 - The split crash is fixed by normalization and verified by the 2021/2022/2025 split windows.
-- The dev/prod result gap should be tracked as a dev-cache completeness issue, not as a split accounting issue.
+- The dev/prod result gap should be tracked as a dev-cache completeness issue, not as a split accounting or cash-ledger issue.
+
+The scan also found that dev and prod are not mirrors for other common stock/day objects:
+
+| Symbol | Dev rows | Prod rows | Row delta | Notable scan finding |
+| --- | ---: | ---: | ---: | --- |
+| `QQQ` | `1554` | `3990` | `-2436` | Dev starts in 2020; prod starts in 1982 |
+| `SPY` | `4135` | `6009` | `-1874` | Dev starts in 2009; prod starts in 1981 |
+| `AMZN` | `1263` | `2594` | `-1331` | Dev starts in 2021; prod starts in 2016 |
+| `GOOG` | `1255` | `2509` | `-1254` | Dev starts in 2021; prod starts in 2016 |
+| `SGOV` | `3` | `1298` | `-1295` | Dev object is effectively unusable for long windows |
+| `TNA` | `1252` | `2929` | `-1677` | Dev is missing a split event that prod has |
+| `TECL` | `1561` | `2929` | `-1368` | Prod scan flags one raw split-like boundary for follow-up |
+| `UPRO` | `1734` | `2928` | `-1194` | Prod scan flags one large non-split jump for follow-up |
+| `SQQQ` | `2540` | `1795` | `745` | Dev scan flags one large non-split jump |
+| `O` | `1257` | `1257` | `0` | The split ratio is `1.032`; likely a special corporate-action style row, not a TQQQ-style 2:1 cliff |
+
+Do not over-interpret every scan flag as a trading bug. Leveraged ETFs can have very large legitimate moves, small split ratios can represent spinoff/special-action data, and dev/prod row-count differences can be expected when dev cache is warmed by ad hoc tests. But dev cache should not be used as the canonical truth for long-horizon parity. For future incidents:
+
+1. Reproduce with prod S3 readonly before mutating any cache.
+2. Keep dev/local readwrite cache off until the evidence object has been copied or versioned.
+3. Add a small S3 read-only cache audit gate for high-usage daily-stock symbols if the deployment pipeline can tolerate networked checks.
+4. Prefer rebuilding or replacing bad dev IBKR stock/day objects from a known-good source over broad cache deletion.
 
 If a future provider/cache omits `stock_splits` entirely, LumiBot still cannot safely infer true corporate actions from price moves alone without risking false positives. Provider enrichment and cache quality remain required.

--- a/docs/investigations/2026-07-02_external-oauth-managed-child-validation.md
+++ b/docs/investigations/2026-07-02_external-oauth-managed-child-validation.md
@@ -1,0 +1,99 @@
+# External OAuth Managed-Child Validation - 2026-07-02
+
+## Scope
+
+This note covers the LumiBot-only fix for BotSpot-managed Schwab and Tradier
+OAuth deployments. The goal is that a managed child strategy process can run
+with `LUMIBOT_OAUTH_REFRESH_MODE=external`, read only access-token files, reload
+atomic parent file replacements, and never receive or retain refresh-token
+material.
+
+Release branch: `version/4.5.64`
+Fix commit: `4d68831dd573a5ff23d063d34f69137f12eeea0f`
+
+## What Changed
+
+- Schwab external OAuth mode strips refresh-token fields from in-memory token
+  payloads before creating the OAuth session and on every token-file reload.
+- Schwab external OAuth mode no longer shows the missing app-secret auto-refresh
+  warning, because the child is not supposed to refresh provider tokens.
+- Schwab external OAuth mode no longer deletes the externally managed token file
+  after a client-init failure; parent-managed files should not be removed by the
+  child runtime.
+- Tradier external OAuth mode strips refresh-token fields from token-file payloads
+  and clears `_oauth_refresh_token` in child broker state.
+- Provider docs and the changelog now describe external mode as an access-token
+  only managed-child contract.
+
+## Local Test Evidence
+
+Passed:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 180 python3 -m pytest tests/test_broker_initialization.py -k 'schwab'
+```
+
+Result: `6 passed, 2 deselected, 1 warning`.
+
+Passed:
+
+```bash
+/Users/robertgrzesik/Development/bin/safe-timeout 180 python3 -m pytest tests/test_tradier_oauth_refresh.py tests/test_tradier_force_refresh.py
+```
+
+Result: `13 passed, 1 warning`.
+
+The tests include:
+
+- Schwab external mode strips stale refresh-token material.
+- Schwab external mode reloads an atomically replaced access-token file after an
+  auth-expiry path without calling provider refresh.
+- Schwab external mode supports multiple child broker instances sharing one
+  externally replaced token file across repeated replacements.
+- Tradier external mode strips stale refresh-token material.
+- Tradier external mode retries after an auth error by reloading an access-token
+  file and never calling provider refresh.
+- Tradier external mode supports multiple child broker instances sharing one
+  externally replaced token file across repeated replacements.
+
+## Live Harness Evidence
+
+Existing harness:
+
+```bash
+/Users/robertgrzesik/Development/bot_manager/scripts/oauth_parent_refresh_harness.py
+```
+
+The Tradier half passed with saved local token material:
+
+```text
+tradier_parent_external_reload=pass account=****2015
+run_dir=/Users/robertgrzesik/.config/botspot/oauth-test-tokens/tradier-only-parent-harness-20260702T052032Z
+```
+
+The Schwab half did not reach LumiBot child reload because every saved local
+Schwab refresh-token snapshot was rejected by Schwab with HTTP 400 during the
+parent refresh call. This points to stale/invalid local Schwab refresh-token
+material, not the child reload path. A fresh Schwab external login is required
+before completing the live Schwab parent/child harness proof.
+
+## Deployment Handoff
+
+The LumiBot deploy agent should release from `version/4.5.64` at commit
+`4d68831dd573a5ff23d063d34f69137f12eeea0f` or a later commit that includes it,
+following `docs/DEPLOYMENT.md`.
+
+After the LumiBot package release, Bot Manager dev validation should rebuild
+against the released LumiBot version before testing managed Schwab/Tradier
+deployments. Do not treat Bot Manager dev validation as meaningful if the dev
+image still has an older LumiBot package.
+
+The remaining external proof before widening rollout is:
+
+- Fresh Schwab local login, then rerun the parent/child live harness.
+- Bot Manager dev managed-run proof for Schwab always-on through access-token
+  replacement.
+- Bot Manager dev managed-run proof for multiple Schwab child deployments on the
+  same broker authorization.
+- Bot Manager dev managed-run proof for Tradier multi-account authorization and
+  access-token replacement.

--- a/docsrc/_extra/sitemap.xml
+++ b/docsrc/_extra/sitemap.xml
@@ -2,618 +2,622 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://lumibot.lumiwealth.com/</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_builtin_tools.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_canonical_demos.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_example_bill_ackman_concentrated.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_example_bull_bear_large_cap_stocks.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_example_bull_bear_leveraged_etf.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_example_citadel_sector_pods.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_example_ray_dalio_idea_meritocracy.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_example_warren_buffett_value.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_examples.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_flows.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_memory.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_notifications.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_observability.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/agents_quickstart.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/ai_trading_project_comparison.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.backtesting_function.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.databento.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.how_to_backtest.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.ibkr.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.indicators_files.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.logs_csv.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.pandas.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.performance.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.polygon.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.tearsheet_html.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.thetadata.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.trades_files.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/backtesting.yahoo.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/botspot_mcp.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.alpaca.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.bitunix.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.ccxt.binance.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.ccxt.bitmex.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.ccxt.bybit.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.ccxt.coinbase.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.ccxt.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.ccxt.kraken.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.ccxt.kucoin.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.ccxt.okx.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.ccxt.weex.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.interactive_brokers.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.interactive_brokers_legacy.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
+  </url>
+  <url>
+    <loc>https://lumibot.lumiwealth.com/brokers.polymarket.html</loc>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.projectx.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.schwab.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.tradier.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.tradovate.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/cash_accounting.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/common_mistakes.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/deployment.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/entities.asset.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/entities.bars.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/entities.chains.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/entities.data.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/entities.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/entities.order.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/entities.position.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/entities.smart_limit.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/entities.trading_fee.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/entities.trading_slippage.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/environment_variables.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/examples.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/faq.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/fundamentals.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/futures.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/getting_started.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/imports_and_startup.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/index.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/indicators.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.after_market_closes.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.before_market_closes.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.before_market_opens.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.before_starting_trading.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.initialize.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.on_abrupt_closing.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.on_bot_crash.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.on_canceled_order.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.on_filled_order.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.on_new_order.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.on_parameters_updated.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.on_partially_filled_order.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.on_trading_iteration.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.summary.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.tearsheet_custom_metrics.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.trace_stats.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lumibot.backtesting.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lumibot.data_sources.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lumibot.strategies.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lumibot.traders.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lumibot_vs_ai_hedge_fund.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lumibot_vs_openalice.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lumibot_vs_quantdinger.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lumibot_vs_tradingagents.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/macro_data.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/options_helper.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/reference.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/smart_limit.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.account.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.chart.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.chart/lumibot.strategies.strategy.Strategy.add_line.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.chart/lumibot.strategies.strategy.Strategy.add_marker.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.chart/lumibot.strategies.strategy.Strategy.get_lines_df.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.chart/lumibot.strategies.strategy.Strategy.get_markers_df.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.data.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.datetime.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.datetime/lumibot.strategies.strategy.Strategy.get_datetime.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.datetime/lumibot.strategies.strategy.Strategy.get_datetime_range.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.datetime/lumibot.strategies.strategy.Strategy.get_last_day.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.datetime/lumibot.strategies.strategy.Strategy.get_last_minute.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.datetime/lumibot.strategies.strategy.Strategy.get_round_day.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.datetime/lumibot.strategies.strategy.Strategy.get_round_minute.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.datetime/lumibot.strategies.strategy.Strategy.get_timestamp.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.datetime/lumibot.strategies.strategy.Strategy.localize_datetime.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.datetime/lumibot.strategies.strategy.Strategy.to_default_timezone.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.misc.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.misc/lumibot.strategies.strategy.Strategy.await_market_to_close.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.misc/lumibot.strategies.strategy.Strategy.await_market_to_open.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.misc/lumibot.strategies.strategy.Strategy.get_parameters.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.misc/lumibot.strategies.strategy.Strategy.log_message.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.misc/lumibot.strategies.strategy.Strategy.register_cron_callback.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.misc/lumibot.strategies.strategy.Strategy.set_market.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.misc/lumibot.strategies.strategy.Strategy.sleep.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.misc/lumibot.strategies.strategy.Strategy.update_parameters.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.misc/lumibot.strategies.strategy.Strategy.wait_for_order_execution.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.misc/lumibot.strategies.strategy.Strategy.wait_for_order_registration.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.misc/lumibot.strategies.strategy.Strategy.wait_for_orders_execution.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.misc/lumibot.strategies.strategy.Strategy.wait_for_orders_registration.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/lumibot.strategies.strategy.Strategy.get_chain.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/lumibot.strategies.strategy.Strategy.get_chains.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/lumibot.strategies.strategy.Strategy.get_expiration.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/lumibot.strategies.strategy.Strategy.get_greeks.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/lumibot.strategies.strategy.Strategy.get_multiplier.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/lumibot.strategies.strategy.Strategy.get_next_trading_day.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/lumibot.strategies.strategy.Strategy.get_strikes.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/lumibot.strategies.strategy.Strategy.options_expiry_to_datetime_date.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/strategies.strategy.Strategy.get_chain.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/strategies.strategy.Strategy.get_chains.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/strategies.strategy.Strategy.get_expiration.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/strategies.strategy.Strategy.get_greeks.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/strategies.strategy.Strategy.get_multiplier.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/strategies.strategy.Strategy.get_next_trading_day.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/strategies.strategy.Strategy.get_option_expiration_after_date.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/strategies.strategy.Strategy.get_strikes.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.options/strategies.strategy.Strategy.options_expiry_to_datetime_date.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.orders.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_methods.parameters.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/strategy_properties.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/vars.html</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-07-02</lastmod>
   </url>
 </urlset>

--- a/docsrc/agents_builtin_tools.rst
+++ b/docsrc/agents_builtin_tools.rst
@@ -139,9 +139,13 @@ clearly.
 News
 ----
 
-If Alpaca credentials are configured, LumiBot can expose Alpaca/Benzinga news
-tools to agents. In backtests, news tools should use the strategy datetime as
-the cutoff so the agent cannot read future headlines.
+If the active broker is Alpaca, LumiBot can use that broker connection for
+Alpaca/Benzinga news. If the active broker is not Alpaca, configure the
+news-only ``ALPACA_NEWS_API_KEY`` / ``ALPACA_NEWS_API_SECRET`` env vars instead.
+Generic Alpaca broker env vars are intentionally not used for news-only access,
+so news credentials do not confuse broker selection for Tradier, IBKR, or other
+brokers. In backtests, news tools should use the strategy datetime as the cutoff
+so the agent cannot read future headlines.
 
 DuckDB And Documentation Search
 -------------------------------

--- a/docsrc/backtesting.how_to_backtest.rst
+++ b/docsrc/backtesting.how_to_backtest.rst
@@ -1,7 +1,7 @@
 How To Backtest
 ===================================
 
-Backtesting is a vital step in validating your trading strategies using historical data. With LumiBot, you can backtest strategies across various data sources such as **ThetaData** (our recommended vendor), **Polygon.io**, **Yahoo Finance**, or even your own custom **CSV** files. This guide will walk you through each step of backtesting, explain the data sources, and introduce the files that LumiBot generates during backtesting.
+Backtesting is a vital step in validating your trading strategies using historical data. With LumiBot, you can backtest strategies across various data sources such as **ThetaData** (our recommended vendor), **Polygon.io**, **Yahoo Finance**, **Polymarket CLOB prediction-contract history**, or even your own custom **CSV** files. This guide will walk you through each step of backtesting, explain the data sources, and introduce the files that LumiBot generates during backtesting.
 
 .. note::
 
@@ -81,6 +81,15 @@ For more details, see the :ref:`Polygon.io Backtesting <backtesting.polygon>` se
 - Ideal for advanced users but requires more manual configuration.
 
 For more details, see the :ref:`Pandas Backtesting <backtesting.pandas>` section.
+
+**5. Polymarket CLOB**
+
+- Uses real Polymarket CLOB price-history data for prediction-contract close-price bars.
+- Trades CLOB outcome tokens as ``prediction_contract`` assets priced between ``0`` and ``1``.
+- Uses LumiBot's normal market and limit backtesting fills from loaded Polymarket bars while enforcing prediction-contract price bounds, tick-size rules, minimum order size rules, market-close behavior, and resolved-market settlement when metadata is available.
+- Keeps prediction-contract backtests on Polymarket/Pandas bars so they do not fall through to stock, Yahoo, or IBKR data paths.
+
+For more details, see the :doc:`Polymarket broker guide <brokers.polymarket>`.
 
 Running a Backtest with Polygon.io
 -----------------------------------
@@ -162,7 +171,7 @@ If they are set, LumiBot will automatically pick them up. For example:
      - End date in the format "YYYY-MM-DD".
      - 2025-05-01
    * - BACKTESTING_DATA_SOURCE
-     - Backtesting data source. This value is case-insensitive and takes precedence even when your code passes a ``datasource_class`` argument. Set it to ``none`` (or leave it unset) if you prefer to control the data source from code. Valid options: **Polygon**, **ThetaData**, **Yahoo**, **Alpaca**, **CCXT**, **DataBento** (defaults to ThetaData).
+     - Backtesting data source. This value is case-insensitive and takes precedence even when your code passes a ``datasource_class`` argument. Set it to ``none`` (or leave it unset) if you prefer to control the data source from code. Valid options: **Polygon**, **ThetaData**, **Yahoo**, **Alpaca**, **CCXT**, **DataBento**, **Polymarket** (defaults to ThetaData).
      - Polygon
 
 Below is a short example showing how you might rely *entirely* on environment variables and **omit** any explicit date or data source definitions in code. Set ``BACKTESTING_DATA_SOURCE=Polygon`` in your environment to use Polygon.io (API key still required):

--- a/docsrc/backtesting.rst
+++ b/docsrc/backtesting.rst
@@ -9,8 +9,9 @@ Lumibot has multiple modes for backtesting:
 4. **DataBento Backtesting:** Backtesting with high-quality data from DataBento for stocks, futures, and options.
 5. **ThetaData Backtesting:** Backtesting with ThetaData (via the LumiBot Data Downloader).
 6. **Interactive Brokers (REST) Backtesting:** Backtesting with IBKR Client Portal Gateway (via the LumiBot Data Downloader).
+7. **Polymarket Backtesting:** Prediction-contract backtesting from real Polymarket price history.
 
-It is recommended to use Yahoo Backtesting for daily stock backtesting, ThetaData Backtesting for stocks/options/index data, and Interactive Brokers (REST) Backtesting for futures and crypto data. Pandas Backtesting is an advanced feature that allows you to test any type of data you have in CSV format but requires more work to setup and is not recommended for most users.
+It is recommended to use Yahoo Backtesting for daily stock backtesting, ThetaData Backtesting for stocks/options/index data, Interactive Brokers (REST) Backtesting for futures and crypto data, and Polymarket Backtesting for Polymarket prediction-contract strategies. Pandas Backtesting is an advanced feature that allows you to test any type of data you have in CSV format but requires more work to setup and is not recommended for most users.
 
 Managed Backtesting on BotSpot
 ==============================

--- a/docsrc/brokers.polymarket.rst
+++ b/docsrc/brokers.polymarket.rst
@@ -1,97 +1,27 @@
 Polymarket
 ===================================
 
-This guide covers the LumiBot broker adapter for the international ``polymarket.com`` CLOB. It does not cover
-Polymarket US, which uses a separate account/API surface and should be implemented as a separate broker adapter.
+LumiBot supports Polymarket prediction-contract trading and backtesting through the ``Polymarket`` broker,
+``PolymarketData`` data source, and ``PolymarketBacktesting`` historical data source. A Polymarket outcome token is a
+``prediction_contract`` asset priced between ``0`` and ``1`` in USD collateral. The same strategy structure can discover
+markets, read order books, backtest historical prices, and submit live orders through the normal LumiBot broker API.
 
-Status
-------
+Quick Start
+-----------
 
-The current adapter supports authenticated read paths, market data, WebSocket subscriptions, market orders, limit
-orders, and cancels for Polymarket International CLOB deposit-wallet accounts. On Rob's verified 2026-07-01 local
-account, the deposit wallet was deployed, funded with pUSD, approved for CLOB spenders, and then proven with:
-
-- direct SDK read/account/data/WebSocket smoke;
-- direct SDK tiny market order;
-- direct SDK tiny limit order plus cancel;
-- LumiBot ``Strategy.create_order(...)`` and ``Strategy.submit_order(...)`` tiny market order;
-- LumiBot tiny limit order plus ``broker.cancel_order(...)``.
-
-Configuration
--------------
-
-Use explicit broker selection:
+Use the Polymarket broker explicitly:
 
 .. code-block:: bash
 
    TRADING_BROKER=polymarket
 
-Only set ``DATA_SOURCE=polymarket`` when you intentionally want the Polymarket public data source as a separate data
-source override. Normal live trading should select the broker with ``TRADING_BROKER=polymarket``.
-
-Required and optional variables:
+Use Polymarket historical data explicitly for backtests:
 
 .. code-block:: bash
 
-   POLYMARKET_PRIVATE_KEY=0x...
-   POLYMARKET_OWNER_ADDRESS=0x...        # optional but recommended for Magic/proxy accounts
-   POLYMARKET_PROXY_WALLET_ADDRESS=0x... # optional old proxy wallet kept for funding/migration
-   POLYMARKET_DEPOSIT_WALLET_ADDRESS=0x...
-   POLYMARKET_WALLET_ADDRESS=0x...       # active CLOB funder; use deposit wallet for trading
-   POLYMARKET_SIGNATURE_TYPE=3           # 0 EOA, 1 proxy/Magic, 2 Safe, 3 deposit wallet
-   POLYMARKET_CLOB_API_KEY=...
-   POLYMARKET_CLOB_API_SECRET=...
-   POLYMARKET_CLOB_API_PASSPHRASE=...
-   POLYMARKET_BUILDER_API_KEY=...        # relayer/deposit-wallet setup only
-   POLYMARKET_BUILDER_SECRET=...
-   POLYMARKET_BUILDER_PASSPHRASE=...
-   POLYMARKET_MAX_MARKET_ORDER_NOTIONAL=5
+   BACKTESTING_DATA_SOURCE=polymarket
 
-Never commit these values. For local prototypes, keep them in ``.env.local`` and make sure that file is ignored by git.
-
-Credential Model
-----------------
-
-Polymarket CLOB uses two authentication layers:
-
-- L1 wallet signing with ``POLYMARKET_PRIVATE_KEY``. LumiBot uses this to create/derive CLOB API credentials and sign
-  order payloads locally.
-- L2 CLOB credentials: ``POLYMARKET_CLOB_API_KEY``, ``POLYMARKET_CLOB_API_SECRET``, and
-  ``POLYMARKET_CLOB_API_PASSPHRASE``. LumiBot uses these for private balance/order/trade reads, posting signed orders,
-  cancellations, and the private user WebSocket.
-
-Relayer/builder API keys are separate from CLOB trading credentials. They are for wallet deployment, proxy transfers,
-and deposit-wallet approval batches, not standalone order-trading credentials. LumiBot order submission still uses CLOB
-L1/L2 auth after the deposit wallet is ready.
-
-Deposit Wallet Setup
---------------------
-
-Use the helper script to create builder credentials, deploy/discover the deterministic deposit wallet, optionally fund it
-from the existing Polymarket proxy wallet, approve CLOB pUSD spenders, and activate it as the trading funder:
-
-.. code-block:: bash
-
-   python3 scripts/polymarket_deposit_wallet_setup.py --create-builder-key
-   python3 scripts/polymarket_deposit_wallet_setup.py --deploy
-   python3 scripts/polymarket_deposit_wallet_setup.py --fund-amount 5
-   python3 scripts/polymarket_deposit_wallet_setup.py --approve
-   python3 scripts/polymarket_deposit_wallet_setup.py --activate
-
-For a fresh local prototype, ``--all --fund-amount 5`` runs deploy, fund, approve, and activate in one pass after builder
-credentials already exist. The script writes only to ``.env.local`` and redacts values in console output.
-
-Deposit-wallet trading requires:
-
-- pUSD held by the deposit wallet, not only by the owner EOA or old proxy wallet;
-- pUSD approvals submitted from the deposit wallet through a relayer ``WALLET`` batch;
-- ``POLYMARKET_SIGNATURE_TYPE=3``;
-- ``POLYMARKET_WALLET_ADDRESS`` set to the deposit wallet.
-
-Assets
-------
-
-Polymarket outcome tokens use:
+In code, create prediction-contract assets from CLOB token ids:
 
 .. code-block:: python
 
@@ -103,29 +33,153 @@ Polymarket outcome tokens use:
        precision="0.000001",
    )
 
-Use ``PolymarketData.resolve_market(...)`` and ``PolymarketData.resolve_contract(...)`` to resolve a market slug, URL,
-condition id, or outcome label into the CLOB token id.
+For a complete runnable example, see:
 
-Market Data
------------
+.. code-block:: bash
 
-``PolymarketData`` handles:
+   python -m lumibot.example_strategies.polymarket_prediction_contract
 
-- market and outcome token resolution;
-- order-book snapshots;
-- quotes and last trade price;
-- supported CLOB price history;
-- public market WebSocket cache updates.
+Configuration
+-------------
 
-History is only returned from real Polymarket data. LumiBot must not synthesize missing prediction-market bars.
+The live broker uses the same environment-driven broker selection as other LumiBot brokers. ``TRADING_BROKER`` selects
+the trading broker. ``DATA_SOURCE`` is a separate optional data-source override and should not be used as the primary
+live broker selector.
+
+Required and optional live variables:
+
+.. code-block:: bash
+
+   TRADING_BROKER=polymarket
+   POLYMARKET_PRIVATE_KEY=0x...
+   POLYMARKET_OWNER_ADDRESS=0x...
+   POLYMARKET_PROXY_WALLET_ADDRESS=0x...
+   POLYMARKET_DEPOSIT_WALLET_ADDRESS=0x...
+   POLYMARKET_WALLET_ADDRESS=0x...
+   POLYMARKET_SIGNATURE_TYPE=3
+   POLYMARKET_CLOB_API_KEY=...
+   POLYMARKET_CLOB_API_SECRET=...
+   POLYMARKET_CLOB_API_PASSPHRASE=...
+   POLYMARKET_BUILDER_API_KEY=...
+   POLYMARKET_BUILDER_SECRET=...
+   POLYMARKET_BUILDER_PASSPHRASE=...
+   POLYMARKET_MAX_MARKET_ORDER_NOTIONAL=5
+
+Backtesting variables:
+
+.. code-block:: bash
+
+   IS_BACKTESTING=true
+   BACKTESTING_DATA_SOURCE=polymarket
+   POLYMARKET_TEST_TOKEN_ID=<clob_token_id>
+
+Keep private keys, CLOB credentials, and builder credentials in a local ignored file such as ``.env.local`` or a real
+secret manager. Never commit or log raw values.
+
+Credential Model
+----------------
+
+Polymarket CLOB trading uses two authentication layers:
+
+- L1 wallet signing with ``POLYMARKET_PRIVATE_KEY``. LumiBot signs order payloads locally and can derive CLOB
+  credentials from this signer.
+- L2 CLOB credentials: ``POLYMARKET_CLOB_API_KEY``, ``POLYMARKET_CLOB_API_SECRET``, and
+  ``POLYMARKET_CLOB_API_PASSPHRASE``. LumiBot uses these for private balance, order, trade, cancel, and user-WebSocket
+  requests.
+
+Builder or relayer credentials are separate. They are used for deposit-wallet setup, relayer transactions, proxy
+transfers, and approval batches. They do not replace the CLOB trading credentials used for normal order placement.
+
+Deposit Wallet Flow
+-------------------
+
+Polymarket accounts that use the deposit-wallet flow must trade from the deposit wallet, not from the owner EOA or an
+old proxy wallet. LumiBot includes a helper for the setup flow:
+
+.. code-block:: bash
+
+   python3 scripts/polymarket_deposit_wallet_setup.py --create-builder-key
+   python3 scripts/polymarket_deposit_wallet_setup.py --deploy
+   python3 scripts/polymarket_deposit_wallet_setup.py --fund-amount 5
+   python3 scripts/polymarket_deposit_wallet_setup.py --approve
+   python3 scripts/polymarket_deposit_wallet_setup.py --approve-conditional
+   python3 scripts/polymarket_deposit_wallet_setup.py --activate
+
+The deposit wallet needs:
+
+- pUSD collateral held by the deposit wallet;
+- pUSD approvals submitted from the deposit wallet for CLOB spenders;
+- conditional-token ``setApprovalForAll`` approvals for sells;
+- ``POLYMARKET_WALLET_ADDRESS`` set to the deposit wallet;
+- ``POLYMARKET_SIGNATURE_TYPE=3``.
+
+If the platform returns ``maker address not allowed, please use the deposit wallet flow`` or a signer/API-key address
+mismatch, migrate the account through the deposit-wallet helper and re-run the read-only smoke before submitting orders.
+
+Market And Token Discovery
+--------------------------
+
+``PolymarketData`` resolves markets, outcomes, and token ids. The most common flow is:
+
+.. code-block:: python
+
+   from lumibot.data_sources.polymarket_data import PolymarketData
+
+   data = PolymarketData()
+
+   markets = data.search_markets("fed decision", limit=5)
+   market = data.resolve_market(slug="will-the-fed-cut-rates-in-july")
+   yes = data.resolve_contract(market, outcome="Yes")
+
+   quote = data.get_quote(yes)
+   book = data.get_order_book(yes)
+   history = data.get_historical_prices(yes, length=None, timestep="minute", start=start, end=end)
+
+Prediction-Market Data Methods
+------------------------------
+
+The following methods are implemented on ``PolymarketData``. The base ``DataSource`` class also exposes safe default
+implementations so strategy code can call these helpers without breaking other brokers or data sources.
+
+``search_markets(query, limit=...)``
+   Search Polymarket markets/events/profiles and return matching rows from Polymarket search APIs.
+
+``get_event(event_id=None, slug=None)``
+   Return event-level metadata such as title, description, markets, tags, and category when Polymarket exposes it.
+
+``get_market_metadata(market=None, slug=None, url=None, market_id=None, condition_id=None, token_id=None)``
+   Return normalized Gamma market metadata. This is the source used by most other helpers.
+
+``get_market_rules(market)``
+   Return tradability rules: question, description, outcome labels, CLOB token ids, tick size, minimum order size,
+   negative-risk flag, market close, accepting-orders flag, and raw metadata.
+
+``get_resolution_status(market)``
+   Return resolution status, closed flag, winner when known, condition id, and raw metadata.
+
+``get_spread(asset)``
+   Return the CLOB spread for an outcome token.
+
+``get_midpoint(asset)``
+   Return the CLOB midpoint for an outcome token.
+
+``get_recent_trades(market=None, limit=...)``
+   Return recent trades for a market, user, or token depending on the supplied filters.
+
+``get_open_interest(market)``
+   Return open interest when available from Polymarket's data API.
+
+``get_holders(market, limit=...)``
+   Return holder rows for a token or market.
+
+Additional helpers include ``get_market_close``, ``get_resolution_source``, ``get_min_order_size``, and
+``get_settlement_price``.
 
 Orders
 ------
 
-Market BUY orders require explicit dollar notional in ``custom_params["amount"]`` because Polymarket market BUY
-semantics are not the same as a stock quantity order.
-
-Example tiny FAK market order:
+Polymarket market BUY orders use dollar notional, not share quantity. Pass the dollar amount in
+``custom_params["amount"]``:
 
 .. code-block:: python
 
@@ -134,6 +188,7 @@ Example tiny FAK market order:
        quantity=1,
        side="buy",
        order_type="market",
+       time_in_force="fak",
        custom_params={
            "amount": "1.00",
            "price": "0.99",
@@ -142,61 +197,131 @@ Example tiny FAK market order:
    )
    self.submit_order(order)
 
-The broker enforces ``POLYMARKET_MAX_MARKET_ORDER_NOTIONAL`` for market BUY orders. The default cap is ``5``.
+Supported order and cancel surface:
 
-Limit orders use the LumiBot limit price and quantity. LumiBot passes Polymarket SDK order options using the live book's
-``tick_size`` and ``neg_risk`` fields.
+- FAK market BUY: dollar amount in ``custom_params["amount"]``.
+- FOK market BUY: dollar amount plus ``custom_params["order_type"]="FOK"``.
+- FAK/FOK market SELL: shares in ``order.quantity`` or ``custom_params["shares"]``.
+- GTC limit BUY/SELL: ``order_type="limit"``, ``time_in_force="gtc"``.
+- GTD limit BUY/SELL: ``time_in_force="gtd"`` with ``good_till_date`` or ``custom_params["expiration"]``.
+- Post-only limit BUY/SELL: ``custom_params["post_only"]=True`` on GTC/GTD limit orders.
+- Single cancel: ``cancel_order(order)``.
+- Multiple cancel: ``cancel_orders([order1, order2])``.
+- Cancel all: ``cancel_all_orders()``.
+- Cancel by market: ``cancel_market_orders(market=..., asset_id=...)``.
+- Batch limit orders: ``submit_orders(..., batch=True)`` for up to 15 limit orders when the SDK exposes ``post_orders``.
+
+The live broker reads the market's tick size and negative-risk setting from the order book/market metadata and passes
+those values into the CLOB SDK. Market BUY orders are capped by ``POLYMARKET_MAX_MARKET_ORDER_NOTIONAL``.
+
+Buy And Sell Semantics
+----------------------
+
+BUY and SELL are not symmetric on Polymarket:
+
+- BUY market orders spend pUSD/collateral from the active funder wallet.
+- SELL market orders sell existing outcome-token shares.
+- BUYs need collateral allowance.
+- SELLs need conditional-token approvals for the token being sold.
+- Limit prices must be inside ``0`` and ``1`` and should conform to the market tick size.
 
 WebSockets
 ----------
 
-The adapter subscribes to:
+The broker can use both public and private WebSocket streams:
 
 - public market stream: ``wss://ws-subscriptions-clob.polymarket.com/ws/market``;
 - private user stream: ``wss://ws-subscriptions-clob.polymarket.com/ws/user``.
 
-HTTP polling remains active as reconciliation after reconnects and as a degraded fallback. The user stream is filtered by
-CLOB API credentials and dispatches normalized LumiBot order lifecycle events where possible.
+Public market events update the ``PolymarketData`` quote cache. Private user events are authenticated with CLOB L2
+credentials, deduplicated, and normalized into LumiBot order lifecycle events. HTTP polling remains active as
+reconciliation after reconnects and as a fallback.
 
-Testing
--------
+Backtesting
+-----------
+
+Use ``PolymarketBacktesting`` for historical prediction-contract tests:
+
+.. code-block:: python
+
+   from datetime import datetime, timezone
+   from lumibot.backtesting import PolymarketBacktesting
+   from lumibot.entities import Asset
+   from lumibot.example_strategies.polymarket_prediction_contract import PolymarketPredictionContractStrategy
+
+   asset = Asset("<clob_token_id>", asset_type=Asset.AssetType.PREDICTION_CONTRACT, precision="0.000001")
+
+   PolymarketPredictionContractStrategy.backtest(
+       PolymarketBacktesting,
+       datetime(2026, 6, 1, tzinfo=timezone.utc),
+       datetime(2026, 6, 2, tzinfo=timezone.utc),
+       assets=[asset],
+       market="24/7",
+       timestep="minute",
+       parameters={"token_id": asset.symbol, "backtest_trade": True},
+       benchmark_asset=None,
+   )
+
+Polymarket backtesting:
+
+- loads real Polymarket CLOB ``prices-history`` data as OHLCV bars;
+- keeps prediction-contract prices between ``0`` and ``1``;
+- preserves sub-cent prediction prices instead of rounding them to stock-style cents;
+- uses USD collateral accounting for ``prediction_contract`` assets;
+- fills simple market and limit orders from the Polymarket backtesting data source;
+- validates tick size and minimum order size when rules are available;
+- honors market close metadata when available;
+- marks resolved outcome tokens to ``1`` or ``0`` when resolved metadata is available.
+
+Live Smoke Tests
+----------------
+
+The live smoke matrix is intentionally off by default because Polymarket orders use real funds. Read-only tests can run
+with credentials. Live tests require explicit environment flags and hard notional caps.
 
 Focused unit tests:
 
 .. code-block:: bash
 
-   python3 -m pytest -q tests/test_polymarket_asset.py tests/test_polymarket_data.py tests/test_polymarket_broker.py
+   python3 -m pytest -q tests/test_prediction_market_data_source_defaults.py tests/test_polymarket_asset.py tests/test_polymarket_data.py tests/test_polymarket_broker.py tests/test_polymarket_backtesting.py
 
-Live/API smoke tests with local credentials:
-
-.. code-block:: bash
-
-   python3 -m dotenv -f .env.local run -- python3 -m pytest -q tests/test_polymarket_apitest.py
-
-Direct SDK/API proof helper:
+Read-only/API smoke:
 
 .. code-block:: bash
 
-   python3 scripts/polymarket_smoke.py
-   python3 scripts/polymarket_smoke.py --live-order
-   python3 scripts/polymarket_smoke.py --limit-cancel
+   python3 -m dotenv -f .env.local run -- python3 -m pytest -q tests/test_polymarket_apitest.py -k "not tiny_market_buy_smoke"
 
-LumiBot-level proof helper:
+Live LumiBot smoke examples:
 
 .. code-block:: bash
 
-   python3 scripts/polymarket_lumibot_smoke.py
-   python3 scripts/polymarket_lumibot_smoke.py --market-order --amount 1.00
-   python3 scripts/polymarket_lumibot_smoke.py --limit-cancel
+   POLYMARKET_LIVE_TRADING_ENABLED=true python3 scripts/polymarket_lumibot_smoke.py --order-kind fak-buy --amount 1.00
+   POLYMARKET_LIVE_TRADING_ENABLED=true python3 scripts/polymarket_lumibot_smoke.py --order-kind fok-buy --amount 1.00
+   POLYMARKET_LIVE_TRADING_ENABLED=true python3 scripts/polymarket_lumibot_smoke.py --order-kind fak-sell --limit-size 1 --limit-price 0.01
+   POLYMARKET_LIVE_TRADING_ENABLED=true python3 scripts/polymarket_lumibot_smoke.py --order-kind cancel-single --limit-size 5 --limit-price 0.01
+   POLYMARKET_LIVE_TRADING_ENABLED=true python3 scripts/polymarket_lumibot_smoke.py --websocket --order-kind fak-sell --limit-size 1 --limit-price 0.01
 
-The direct smoke helper redacts secrets and writes proof artifacts under gitignored ``logs/``.
+The smoke helper also supports ``fok-sell``, ``gtc-buy``, ``gtc-sell``, ``gtd-buy``, ``gtd-sell``,
+``post-only-buy``, ``post-only-sell``, ``cancel-multiple``, ``cancel-all``, and ``cancel-market``.
 
-Known Limitations
------------------
+Troubleshooting
+---------------
 
-- Polymarket US is not supported by this adapter.
-- Old Magic/proxy accounts can read balances but can be rejected for live order submit unless migrated to the supported
-  deposit-wallet flow.
-- Immediate post-submit cash reads can lag inside the same SDK client. A fresh CLOB read reconciles the final balance.
-- BotSpot/Bot Manager credential UI and runtime-secret injection are intentionally deferred until LumiBot has a working
-  live submit path.
+``maker address not allowed, please use the deposit wallet flow``
+   Deploy/fund/approve/activate the deposit wallet and set ``POLYMARKET_SIGNATURE_TYPE=3``.
+
+``the order signer address has to be the address of the API KEY``
+   Re-check owner address, funder wallet, CLOB API credentials, and signature type. The active CLOB credentials must
+   match the signer/funder path being used.
+
+``invalid post-only order: order crosses book``
+   The post-only order is marketable. Use a less aggressive limit price or submit a normal GTC/GTD limit order.
+
+Backtest tries another provider for a long token id
+   Set ``BACKTESTING_DATA_SOURCE=polymarket`` or pass ``PolymarketBacktesting`` directly. Prediction contracts should
+   stay on Polymarket data and must not fall through to stock/IBKR/Yahoo lookup paths.
+
+No fake-money live matrix
+   The public Polymarket CLOB docs expose staging hosts in places, but LumiBot does not treat them as a complete
+   fake-money paper trading environment. Use mocked unit tests for CI and run live smoke tests only when explicitly
+   funded and approved.

--- a/docsrc/brokers.polymarket.rst
+++ b/docsrc/brokers.polymarket.rst
@@ -7,10 +7,15 @@ Polymarket US, which uses a separate account/API surface and should be implement
 Status
 ------
 
-The current adapter supports authenticated read paths, market data, and WebSocket subscriptions. Live order submission
-is implemented, but existing Magic/proxy accounts can be rejected by Polymarket's current deposit-wallet/API-key binding
-rules. On Rob's verified 2026-07-01 local account, balances, positions, open orders, recent trades, quotes, history, and
-public/private WebSockets worked; tiny market and limit orders were rejected by Polymarket before any order was created.
+The current adapter supports authenticated read paths, market data, WebSocket subscriptions, market orders, limit
+orders, and cancels for Polymarket International CLOB deposit-wallet accounts. On Rob's verified 2026-07-01 local
+account, the deposit wallet was deployed, funded with pUSD, approved for CLOB spenders, and then proven with:
+
+- direct SDK read/account/data/WebSocket smoke;
+- direct SDK tiny market order;
+- direct SDK tiny limit order plus cancel;
+- LumiBot ``Strategy.create_order(...)`` and ``Strategy.submit_order(...)`` tiny market order;
+- LumiBot tiny limit order plus ``broker.cancel_order(...)``.
 
 Configuration
 -------------
@@ -30,11 +35,16 @@ Required and optional variables:
 
    POLYMARKET_PRIVATE_KEY=0x...
    POLYMARKET_OWNER_ADDRESS=0x...        # optional but recommended for Magic/proxy accounts
-   POLYMARKET_WALLET_ADDRESS=0x...       # funder/proxy/deposit wallet
-   POLYMARKET_SIGNATURE_TYPE=1           # 0 EOA, 1 proxy/Magic, 2 Safe, 3 deposit wallet
+   POLYMARKET_PROXY_WALLET_ADDRESS=0x... # optional old proxy wallet kept for funding/migration
+   POLYMARKET_DEPOSIT_WALLET_ADDRESS=0x...
+   POLYMARKET_WALLET_ADDRESS=0x...       # active CLOB funder; use deposit wallet for trading
+   POLYMARKET_SIGNATURE_TYPE=3           # 0 EOA, 1 proxy/Magic, 2 Safe, 3 deposit wallet
    POLYMARKET_CLOB_API_KEY=...
    POLYMARKET_CLOB_API_SECRET=...
    POLYMARKET_CLOB_API_PASSPHRASE=...
+   POLYMARKET_BUILDER_API_KEY=...        # relayer/deposit-wallet setup only
+   POLYMARKET_BUILDER_SECRET=...
+   POLYMARKET_BUILDER_PASSPHRASE=...
    POLYMARKET_MAX_MARKET_ORDER_NOTIONAL=5
 
 Never commit these values. For local prototypes, keep them in ``.env.local`` and make sure that file is ignored by git.
@@ -50,8 +60,33 @@ Polymarket CLOB uses two authentication layers:
   ``POLYMARKET_CLOB_API_PASSPHRASE``. LumiBot uses these for private balance/order/trade reads, posting signed orders,
   cancellations, and the private user WebSocket.
 
-Relayer API keys are separate from CLOB trading credentials. They are for wallet deployment or wallet-operation batches
-in deposit-wallet flows, not a standalone order-trading credential.
+Relayer/builder API keys are separate from CLOB trading credentials. They are for wallet deployment, proxy transfers,
+and deposit-wallet approval batches, not standalone order-trading credentials. LumiBot order submission still uses CLOB
+L1/L2 auth after the deposit wallet is ready.
+
+Deposit Wallet Setup
+--------------------
+
+Use the helper script to create builder credentials, deploy/discover the deterministic deposit wallet, optionally fund it
+from the existing Polymarket proxy wallet, approve CLOB pUSD spenders, and activate it as the trading funder:
+
+.. code-block:: bash
+
+   python3 scripts/polymarket_deposit_wallet_setup.py --create-builder-key
+   python3 scripts/polymarket_deposit_wallet_setup.py --deploy
+   python3 scripts/polymarket_deposit_wallet_setup.py --fund-amount 5
+   python3 scripts/polymarket_deposit_wallet_setup.py --approve
+   python3 scripts/polymarket_deposit_wallet_setup.py --activate
+
+For a fresh local prototype, ``--all --fund-amount 5`` runs deploy, fund, approve, and activate in one pass after builder
+credentials already exist. The script writes only to ``.env.local`` and redacts values in console output.
+
+Deposit-wallet trading requires:
+
+- pUSD held by the deposit wallet, not only by the owner EOA or old proxy wallet;
+- pUSD approvals submitted from the deposit wallet through a relayer ``WALLET`` batch;
+- ``POLYMARKET_SIGNATURE_TYPE=3``;
+- ``POLYMARKET_WALLET_ADDRESS`` set to the deposit wallet.
 
 Assets
 ------
@@ -146,15 +181,22 @@ Direct SDK/API proof helper:
    python3 scripts/polymarket_smoke.py --live-order
    python3 scripts/polymarket_smoke.py --limit-cancel
 
+LumiBot-level proof helper:
+
+.. code-block:: bash
+
+   python3 scripts/polymarket_lumibot_smoke.py
+   python3 scripts/polymarket_lumibot_smoke.py --market-order --amount 1.00
+   python3 scripts/polymarket_lumibot_smoke.py --limit-cancel
+
 The direct smoke helper redacts secrets and writes proof artifacts under gitignored ``logs/``.
 
 Known Limitations
 -----------------
 
 - Polymarket US is not supported by this adapter.
-- Current live submit may fail for Magic/proxy or deposit-wallet accounts if Polymarket rejects the signer/funder/API-key
-  relationship.
-- Private user WebSocket fill reconciliation has been connection-tested, but real fill events are not proven until
-  Polymarket accepts a live order for the account.
+- Old Magic/proxy accounts can read balances but can be rejected for live order submit unless migrated to the supported
+  deposit-wallet flow.
+- Immediate post-submit cash reads can lag inside the same SDK client. A fresh CLOB read reconciles the final balance.
 - BotSpot/Bot Manager credential UI and runtime-secret injection are intentionally deferred until LumiBot has a working
   live submit path.

--- a/docsrc/brokers.polymarket.rst
+++ b/docsrc/brokers.polymarket.rst
@@ -1,0 +1,160 @@
+Polymarket
+===================================
+
+This guide covers the LumiBot broker adapter for the international ``polymarket.com`` CLOB. It does not cover
+Polymarket US, which uses a separate account/API surface and should be implemented as a separate broker adapter.
+
+Status
+------
+
+The current adapter supports authenticated read paths, market data, and WebSocket subscriptions. Live order submission
+is implemented, but existing Magic/proxy accounts can be rejected by Polymarket's current deposit-wallet/API-key binding
+rules. On Rob's verified 2026-07-01 local account, balances, positions, open orders, recent trades, quotes, history, and
+public/private WebSockets worked; tiny market and limit orders were rejected by Polymarket before any order was created.
+
+Configuration
+-------------
+
+Use explicit broker selection:
+
+.. code-block:: bash
+
+   TRADING_BROKER=polymarket
+
+Only set ``DATA_SOURCE=polymarket`` when you intentionally want the Polymarket public data source as a separate data
+source override. Normal live trading should select the broker with ``TRADING_BROKER=polymarket``.
+
+Required and optional variables:
+
+.. code-block:: bash
+
+   POLYMARKET_PRIVATE_KEY=0x...
+   POLYMARKET_OWNER_ADDRESS=0x...        # optional but recommended for Magic/proxy accounts
+   POLYMARKET_WALLET_ADDRESS=0x...       # funder/proxy/deposit wallet
+   POLYMARKET_SIGNATURE_TYPE=1           # 0 EOA, 1 proxy/Magic, 2 Safe, 3 deposit wallet
+   POLYMARKET_CLOB_API_KEY=...
+   POLYMARKET_CLOB_API_SECRET=...
+   POLYMARKET_CLOB_API_PASSPHRASE=...
+   POLYMARKET_MAX_MARKET_ORDER_NOTIONAL=5
+
+Never commit these values. For local prototypes, keep them in ``.env.local`` and make sure that file is ignored by git.
+
+Credential Model
+----------------
+
+Polymarket CLOB uses two authentication layers:
+
+- L1 wallet signing with ``POLYMARKET_PRIVATE_KEY``. LumiBot uses this to create/derive CLOB API credentials and sign
+  order payloads locally.
+- L2 CLOB credentials: ``POLYMARKET_CLOB_API_KEY``, ``POLYMARKET_CLOB_API_SECRET``, and
+  ``POLYMARKET_CLOB_API_PASSPHRASE``. LumiBot uses these for private balance/order/trade reads, posting signed orders,
+  cancellations, and the private user WebSocket.
+
+Relayer API keys are separate from CLOB trading credentials. They are for wallet deployment or wallet-operation batches
+in deposit-wallet flows, not a standalone order-trading credential.
+
+Assets
+------
+
+Polymarket outcome tokens use:
+
+.. code-block:: python
+
+   from lumibot.entities import Asset
+
+   asset = Asset(
+       "<clob_token_id>",
+       asset_type=Asset.AssetType.PREDICTION_CONTRACT,
+       precision="0.000001",
+   )
+
+Use ``PolymarketData.resolve_market(...)`` and ``PolymarketData.resolve_contract(...)`` to resolve a market slug, URL,
+condition id, or outcome label into the CLOB token id.
+
+Market Data
+-----------
+
+``PolymarketData`` handles:
+
+- market and outcome token resolution;
+- order-book snapshots;
+- quotes and last trade price;
+- supported CLOB price history;
+- public market WebSocket cache updates.
+
+History is only returned from real Polymarket data. LumiBot must not synthesize missing prediction-market bars.
+
+Orders
+------
+
+Market BUY orders require explicit dollar notional in ``custom_params["amount"]`` because Polymarket market BUY
+semantics are not the same as a stock quantity order.
+
+Example tiny FAK market order:
+
+.. code-block:: python
+
+   order = self.create_order(
+       asset,
+       quantity=1,
+       side="buy",
+       order_type="market",
+       custom_params={
+           "amount": "1.00",
+           "price": "0.99",
+           "order_type": "FAK",
+       },
+   )
+   self.submit_order(order)
+
+The broker enforces ``POLYMARKET_MAX_MARKET_ORDER_NOTIONAL`` for market BUY orders. The default cap is ``5``.
+
+Limit orders use the LumiBot limit price and quantity. LumiBot passes Polymarket SDK order options using the live book's
+``tick_size`` and ``neg_risk`` fields.
+
+WebSockets
+----------
+
+The adapter subscribes to:
+
+- public market stream: ``wss://ws-subscriptions-clob.polymarket.com/ws/market``;
+- private user stream: ``wss://ws-subscriptions-clob.polymarket.com/ws/user``.
+
+HTTP polling remains active as reconciliation after reconnects and as a degraded fallback. The user stream is filtered by
+CLOB API credentials and dispatches normalized LumiBot order lifecycle events where possible.
+
+Testing
+-------
+
+Focused unit tests:
+
+.. code-block:: bash
+
+   python3 -m pytest -q tests/test_polymarket_asset.py tests/test_polymarket_data.py tests/test_polymarket_broker.py
+
+Live/API smoke tests with local credentials:
+
+.. code-block:: bash
+
+   python3 -m dotenv -f .env.local run -- python3 -m pytest -q tests/test_polymarket_apitest.py
+
+Direct SDK/API proof helper:
+
+.. code-block:: bash
+
+   python3 scripts/polymarket_smoke.py
+   python3 scripts/polymarket_smoke.py --live-order
+   python3 scripts/polymarket_smoke.py --limit-cancel
+
+The direct smoke helper redacts secrets and writes proof artifacts under gitignored ``logs/``.
+
+Known Limitations
+-----------------
+
+- Polymarket US is not supported by this adapter.
+- Current live submit may fail for Magic/proxy or deposit-wallet accounts if Polymarket rejects the signer/funder/API-key
+  relationship.
+- Private user WebSocket fill reconciliation has been connection-tested, but real fill events are not proven until
+  Polymarket accepts a live order for the account.
+- BotSpot/Bot Manager credential UI and runtime-secret injection are intentionally deferred until LumiBot has a working
+  live submit path.

--- a/docsrc/brokers.rst
+++ b/docsrc/brokers.rst
@@ -30,6 +30,7 @@ Broker setup is easier on `BotSpot <https://botspot.trade/sales?showLogin=1&utm_
    brokers.ccxt
    brokers.interactive_brokers
    brokers.interactive_brokers_legacy
+   brokers.polymarket
    brokers.projectx
    brokers.schwab
    brokers.tradier

--- a/docsrc/brokers.schwab.rst
+++ b/docsrc/brokers.schwab.rst
@@ -227,8 +227,9 @@ Token Life-cycle & Auto-refresh
   you never need to log in again.
 * In managed environments where a trusted parent process owns broker OAuth
   refresh, set ``LUMIBOT_OAUTH_REFRESH_MODE=external``. In that mode LumiBot does
-  not call the Schwab OAuth refresh endpoint; it reloads the configured token file
-  when the parent atomically replaces it.
+  not call the Schwab OAuth refresh endpoint; it reloads an access-token-only
+  token file when the parent atomically replaces it. Refresh-token fields are
+  stripped from LumiBot's child broker state in this mode.
 * Only if the service is **offline for >7 days** will the refresh-token expire.
   In that case repeat the browser login once and redeploy the new payload or
   token file.

--- a/docsrc/brokers.tradier.rst
+++ b/docsrc/brokers.tradier.rst
@@ -72,9 +72,11 @@ point LumiBot at the provider token file:
    TRADIER_OAUTH_CLIENT_SECRET=your_oauth_client_secret
 
 Use ``LUMIBOT_OAUTH_REFRESH_MODE=external`` only when a trusted parent process
-owns OAuth refresh and atomically replaces ``TRADIER_TOKEN_PATH``. In the default
-``auto`` mode, LumiBot may call Tradier's OAuth refresh endpoint and write the
-rotated provider token payload back to the token file.
+owns OAuth refresh and atomically replaces ``TRADIER_TOKEN_PATH`` with an
+access-token-only payload. In external mode, LumiBot strips refresh-token fields
+from child broker state and does not call Tradier's OAuth refresh endpoint. In
+the default ``auto`` mode, LumiBot may call Tradier's OAuth refresh endpoint and
+write the rotated provider token payload back to the token file.
 
 ``TRADIER_ACCESS_TOKEN`` remains supported for manual API-token users. The token
 file path is for OAuth flows that need refresh-token durability.

--- a/docsrc/environment_variables.rst
+++ b/docsrc/environment_variables.rst
@@ -71,13 +71,13 @@ BACKTESTING_DATA_SOURCE
 
 - Purpose: Select the backtesting datasource **even if your code passes a `datasource_class`**.
 - Values (case-insensitive):
-  - ``thetadata``, ``yahoo``, ``polygon``, ``alpaca``, ``ccxt``, ``databento``
+  - ``thetadata``, ``yahoo``, ``polygon``, ``alpaca``, ``ccxt``, ``databento``, ``polymarket``, ``polymarket_clob``
   - ``ibkr`` / ``interactivebrokersrest`` / ``interactive_brokers_rest`` (IBKR Client Portal REST)
   - ``router`` (multi-provider routing; defaults to Theta for stock/option/index and IBKR for futures/crypto)
   - JSON mapping (multi-provider routing by asset type), e.g. ``{"default":"thetadata","stock":"thetadata","option":"thetadata","index":"thetadata","future":"ibkr","crypto":"ibkr"}``
 
     - Provider values are case/whitespace/_/- insensitive.
-    - Supported values include ``thetadata``, ``ibkr``, ``polygon``, ``alpaca``, and ``ccxt``.
+    - Supported values include ``thetadata``, ``ibkr``, ``polygon``, ``alpaca``, ``ccxt``, and ``polymarket``.
     - For CCXT backtesting, you may use ``ccxt`` (auto-select exchange from existing env/credentials) **or** specify a supported CCXT backtesting exchange id directly. Documented backtesting examples are ``kraken``, ``binance``, ``kucoin``, ``bitmex``, ``bybit``, and ``okx``.
     - Routing keys are the canonical asset types (``future``, ``cont_future``, ``crypto``, etc.). Common plural aliases like ``futures``/``cont_futures`` are accepted.
 
@@ -464,8 +464,11 @@ POLYMARKET_TEST_TOKEN_ID / POLYMARKET_LIVE_TRADING_ENABLED / POLYMARKET_TEST_MAX
 - Purpose: Test-only gates for Polymarket live smoke tests.
 - Values: Explicit CLOB token id; ``POLYMARKET_LIVE_TRADING_ENABLED=true`` to allow live submit/cancel tests; decimal max notional.
 - Note: Live tests are skipped unless the required env vars are present. Default live-test max notional is capped at ``5``.
-- Smoke helper: ``scripts/polymarket_smoke.py`` loads local ``.env.local`` values, redacts output, writes proof artifacts
-  under gitignored ``logs/``, and only submits live orders when the live gate and caps are present.
+- Smoke helpers: ``scripts/polymarket_smoke.py`` and ``scripts/polymarket_lumibot_smoke.py`` load local ``.env.local``
+  values, redact output, and only submit live orders when the live gate and caps are present. The LumiBot smoke helper
+  supports explicit order-matrix cases such as ``fak-buy``, ``fok-buy``, ``fak-sell``, ``fok-sell``, ``gtc-buy``,
+  ``gtd-buy``, ``post-only-buy``, ``cancel-single``, ``cancel-multiple``, ``cancel-all``, ``cancel-market``, and
+  ``--websocket``.
 
 Polymarket CLOB implementation notes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -476,8 +479,11 @@ Polymarket CLOB implementation notes
   into dollars before returning account cash.
 - The current international CLOB adapter supports read-only account state, market discovery, token resolution, order
   books, quotes, last price, supported price history, public market WebSockets, and authenticated user WebSocket
-  subscription. Live submit/cancel is implemented, but existing Magic/proxy accounts may be rejected by Polymarket with
-  a deposit-wallet/API-key binding error until the account is migrated through the supported deposit-wallet flow.
+  subscription. Live submit/cancel is implemented and has been proven through the LumiBot broker with a funded deposit
+  wallet, pUSD approvals, and conditional-token sell approvals. Existing Magic/proxy accounts may still be rejected by
+  Polymarket with a deposit-wallet/API-key binding error until migrated through the supported deposit-wallet flow.
+- SELL orders need conditional-token approvals from the deposit wallet. The local setup helper can submit these approvals
+  with ``scripts/polymarket_deposit_wallet_setup.py --approve-conditional``.
 
 Tradier broker
 --------------
@@ -503,12 +509,10 @@ LUMIBOT_OAUTH_REFRESH_MODE
 
 - Purpose: Controls who calls the broker OAuth refresh endpoint for Schwab and
   Tradier token-file integrations.
-- Values:
-  - ``auto`` (default): LumiBot may refresh the provider OAuth token and write the
-    updated token payload back to the configured token file.
-  - ``external``: LumiBot does not call the provider OAuth refresh endpoint. A
-    trusted parent process must atomically replace the configured token file, and
-    LumiBot reloads it before broker requests and after auth failures.
+- Values: ``auto`` (default) lets LumiBot refresh the provider OAuth token and write the updated token payload back to
+  the configured token file. ``external`` means LumiBot does not call the provider OAuth refresh endpoint; a trusted
+  parent process must atomically replace the configured token file, and LumiBot reloads it before broker requests and
+  after auth failures.
 - Note: Use ``external`` only when another trusted process owns refresh-token
   handling. The token file still needs a valid access token for broker API calls.
 

--- a/docsrc/environment_variables.rst
+++ b/docsrc/environment_variables.rst
@@ -397,8 +397,24 @@ POLYMARKET_PRIVATE_KEY
 POLYMARKET_WALLET_ADDRESS
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Purpose: Polymarket wallet/deposit wallet/funder address used for positions, balances, and signed CLOB orders.
+- Purpose: Polymarket proxy wallet, deposit wallet, Safe, or other funder address passed to the CLOB client.
 - Values: Wallet address.
+
+POLYMARKET_OWNER_ADDRESS
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Optional owner/signer address for Magic/proxy accounts. LumiBot uses it as a fallback for Data API position
+  and value reads when it differs from ``POLYMARKET_WALLET_ADDRESS``.
+- Values: Wallet address.
+
+POLYMARKET_SIGNATURE_TYPE
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Polymarket CLOB signature type used by the authenticated client.
+- Values: ``0`` for EOA, ``1`` for existing Polymarket proxy/Magic wallets, ``2`` for Gnosis Safe, ``3`` for deposit
+  wallet / ``POLY_1271``.
+- Default: ``1`` when ``POLYMARKET_OWNER_ADDRESS`` and ``POLYMARKET_WALLET_ADDRESS`` differ, otherwise ``3``. Set this
+  explicitly for live testing and Bot Manager deployments.
 
 POLYMARKET_CLOB_API_KEY / POLYMARKET_CLOB_API_SECRET / POLYMARKET_CLOB_API_PASSPHRASE
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -419,7 +435,8 @@ POLYMARKET_RELAYER_API_KEY / POLYMARKET_RELAYER_API_KEY_ADDRESS
 
 - Purpose: Relayer credentials for wallet deployment/approval flows when required by the Polymarket account setup.
 - Values: Relayer credential fields (**do not hardcode**).
-- Note: Relayer credentials are not the same as CLOB trading credentials.
+- Note: Relayer credentials are not the same as CLOB trading credentials. The CLOB client still needs L2 API key,
+  secret, and passphrase fields for private order/balance/trade endpoints and WebSocket user streams.
 
 POLYMARKET_BUILDER_CODE
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -447,6 +464,20 @@ POLYMARKET_TEST_TOKEN_ID / POLYMARKET_LIVE_TRADING_ENABLED / POLYMARKET_TEST_MAX
 - Purpose: Test-only gates for Polymarket live smoke tests.
 - Values: Explicit CLOB token id; ``POLYMARKET_LIVE_TRADING_ENABLED=true`` to allow live submit/cancel tests; decimal max notional.
 - Note: Live tests are skipped unless the required env vars are present. Default live-test max notional is capped at ``5``.
+- Smoke helper: ``scripts/polymarket_smoke.py`` loads local ``.env.local`` values, redacts output, writes proof artifacts
+  under gitignored ``logs/``, and only submits live orders when the live gate and caps are present.
+
+Polymarket CLOB implementation notes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Set ``TRADING_BROKER=polymarket`` for the normal live broker path. ``DATA_SOURCE=polymarket`` is only the optional
+  separate public-market-data override.
+- CLOB collateral balances are returned in 6-decimal raw units by balance/allowance reads. LumiBot scales those values
+  into dollars before returning account cash.
+- The current international CLOB adapter supports read-only account state, market discovery, token resolution, order
+  books, quotes, last price, supported price history, public market WebSockets, and authenticated user WebSocket
+  subscription. Live submit/cancel is implemented, but existing Magic/proxy accounts may be rejected by Polymarket with
+  a deposit-wallet/API-key binding error until the account is migrated through the supported deposit-wallet flow.
 
 Tradier broker
 --------------

--- a/docsrc/environment_variables.rst
+++ b/docsrc/environment_variables.rst
@@ -341,7 +341,7 @@ TRADING_BROKER
 - Values (case-insensitive):
   - ``alpaca``, ``tradier``, ``ccxt``, ``coinbase``, ``kraken``, ``weex``
   - ``ib``, ``interactivebrokers``, ``ibrest``, ``interactivebrokersrest``
-  - ``tradovate``, ``schwab``, ``bitunix``
+  - ``tradovate``, ``schwab``, ``bitunix``, ``polymarket``, ``polymarket_clob``
   - ``projectx`` / ``projectx-topstepx`` for TopstepX futures (via ProjectX)
 - Note: If not set, broker is auto-detected based on available credentials.
 
@@ -351,7 +351,7 @@ DATA_SOURCE
 - Purpose: Explicitly specify which data source to use.
 - Values (case-insensitive):
   - ``alpaca``, ``tradier``, ``polygon``, ``yahoo``, ``thetadata``, ``databento``
-  - ``ccxt``, ``coinbase``, ``kraken``, ``weex``, ``schwab``, ``bitunix``, ``projectx``
+  - ``ccxt``, ``coinbase``, ``kraken``, ``weex``, ``schwab``, ``bitunix``, ``projectx``, ``polymarket``, ``polymarket_clob``
 - Note: If not set, uses broker's default data source.
 
 Alpaca broker
@@ -383,6 +383,70 @@ ALPACA_NEWS_API_KEY / ALPACA_NEWS_API_SECRET
 - Purpose: Optional bring-your-own-key credentials for ``BuiltinTools.news.alpaca_news()`` when the active broker is not Alpaca.
 - Values: Alpaca API credentials with news/data access (**do not hardcode**).
 - Note: When the active broker is Alpaca, the built-in news tool reuses that broker's OAuth token or API key/secret instead. If the active broker is not Alpaca and these news-specific variables are absent, the built-in news tool is not exposed to agents.
+
+Polymarket CLOB broker
+----------------------
+
+POLYMARKET_PRIVATE_KEY
+^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Wallet private key or session signer used to sign Polymarket CLOB orders and derive API credentials.
+- Values: Provider/wallet secret (**do not hardcode**).
+- Note: Required for authenticated CLOB reads and trading. Treat this as a high-risk wallet credential.
+
+POLYMARKET_WALLET_ADDRESS
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Polymarket wallet/deposit wallet/funder address used for positions, balances, and signed CLOB orders.
+- Values: Wallet address.
+
+POLYMARKET_CLOB_API_KEY / POLYMARKET_CLOB_API_SECRET / POLYMARKET_CLOB_API_PASSPHRASE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Optional derived/generated CLOB API credentials for authenticated order, trade, cancel, and balance requests.
+- Values: CLOB API credentials (**do not hardcode**).
+- Note: If omitted, LumiBot attempts to derive/create credentials in memory through ``py-clob-client-v2`` when a private key is available.
+
+POLYMARKET_API_CREDENTIALS_JSON
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Optional JSON wrapper for CLOB API credentials.
+- Values: JSON object containing key/secret/passphrase fields (**do not hardcode**).
+- Note: Prefer separate env vars for readability unless a secret store provides one JSON payload.
+
+POLYMARKET_RELAYER_API_KEY / POLYMARKET_RELAYER_API_KEY_ADDRESS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Relayer credentials for wallet deployment/approval flows when required by the Polymarket account setup.
+- Values: Relayer credential fields (**do not hardcode**).
+- Note: Relayer credentials are not the same as CLOB trading credentials.
+
+POLYMARKET_BUILDER_CODE
+^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Optional Polymarket builder attribution code.
+- Values: Builder code.
+
+POLYMARKET_AUTO_APPROVE
+^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: When truthy, attempt CLOB collateral approval setup before live trading.
+- Values: truthy enables (``1``, ``true``, ``yes``, ``on``); unset disables.
+- Default: disabled.
+
+POLYMARKET_MAX_MARKET_ORDER_NOTIONAL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Hard cap for Polymarket market BUY order dollar amount.
+- Values: Positive decimal.
+- Default: ``5``.
+
+POLYMARKET_TEST_TOKEN_ID / POLYMARKET_LIVE_TRADING_ENABLED / POLYMARKET_TEST_MAX_NOTIONAL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Test-only gates for Polymarket live smoke tests.
+- Values: Explicit CLOB token id; ``POLYMARKET_LIVE_TRADING_ENABLED=true`` to allow live submit/cancel tests; decimal max notional.
+- Note: Live tests are skipped unless the required env vars are present. Default live-test max notional is capped at ``5``.
 
 Tradier broker
 --------------

--- a/docsrc/generate_llms_txt.py
+++ b/docsrc/generate_llms_txt.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 LLMS_TXT_CONTENT = '''# Lumibot
 
-> Python trading and backtesting framework for stocks, options, crypto, and futures.
-> Supports Alpaca, Interactive Brokers, Tradier, Schwab, ThetaData, Yahoo Finance, and Polygon.
+> Python trading and backtesting framework for stocks, options, crypto, futures, forex, and prediction markets.
+> Supports Alpaca, Interactive Brokers, Tradier, Schwab, ThetaData, Yahoo Finance, Polygon, and Polymarket.
 > Includes built-in AI trading agents, agentic backtesting, DuckDB query tools, replay caching, and external MCP tool support.
 
 ## Critical Rules for Code Generation
@@ -112,6 +112,9 @@ asset = Asset(symbol="BTC", asset_type=Asset.AssetType.CRYPTO)
 
 # Future
 asset = Asset(symbol="ES", asset_type=Asset.AssetType.FUTURE, expiration=datetime.date(2024, 3, 15))
+
+# Polymarket prediction contract
+asset = Asset(symbol="1234567890", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
 ```
 
 ### Basic Strategy Template
@@ -147,8 +150,9 @@ class MyStrategy(Strategy):
 - `YahooDataBacktesting` - Free, good for stocks
 - `PolygonDataBacktesting` - Crypto and stocks (requires API key)
 - `ThetaDataBacktesting` - Options and stocks (requires subscription)
+- `PolymarketBacktesting` - Prediction-contract history from Polymarket price-history data
 
-Set via environment variable: `BACKTESTING_DATA_SOURCE=yahoo|polygon|thetadata`
+Set via environment variable: `BACKTESTING_DATA_SOURCE=yahoo|polygon|thetadata|polymarket`
 '''
 
 

--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -1,7 +1,7 @@
 Lumibot: Backtestable AI Agents and Python Algorithmic Trading
 ==============================================================
 
-**Build deterministic trading strategies, AI trading agents, and AI trading teams for stocks, options, crypto, futures, forex, SEC filings, FRED macro data, technical indicators, and real brokers. Backtest, paper trade, or run live with the same Python code.**
+**Build deterministic trading strategies, AI trading agents, and AI trading teams for stocks, options, crypto, futures, forex, prediction markets, SEC filings, FRED macro data, technical indicators, and real brokers. Backtest, paper trade, or run live with the same Python code.**
 
 .. raw:: html
    :file: _html/main.html
@@ -404,6 +404,16 @@ Compared With AI Trading Agent Projects
 
 Read the detailed comparison page: :doc:`ai_trading_project_comparison`.
 
+Polymarket Trading And Backtesting
+----------------------------------
+
+LumiBot supports Polymarket prediction-contract trading and backtesting through the normal broker, data-source, and
+backtesting abstractions. Strategies can search markets, resolve outcomes to CLOB token ids, read order books and
+quotes, inspect market rules and resolution status, backtest historical Polymarket prices, and submit live orders using
+``create_order`` and ``submit_order``.
+
+Start with the full setup and reference guide: :doc:`brokers.polymarket`.
+
 Compared With Backtesting Libraries
 -----------------------------------
 
@@ -419,9 +429,9 @@ Compared With Backtesting Libraries
      - Hosted deployment
    * - Lumibot
      - Yes
-     - Stocks, options, crypto, futures, forex
+     - Stocks, options, crypto, futures, forex, prediction markets
      - Built-in
-     - Alpaca, IBKR, Tradier, Schwab, Tradovate, ProjectX, Bitunix, selected CCXT
+     - Alpaca, IBKR, Tradier, Schwab, Tradovate, ProjectX, Bitunix, Polymarket, selected CCXT
      - BotSpot
    * - Backtrader
      - Yes

--- a/llms.txt
+++ b/llms.txt
@@ -1,7 +1,8 @@
 # Lumibot
 
-> Python trading and backtesting framework for stocks, options, crypto, and futures.
-> Supports Alpaca, Interactive Brokers, Tradier, Schwab, ThetaData, Yahoo Finance, and Polygon.
+> Python trading and backtesting framework for stocks, options, crypto, futures, forex, and prediction markets.
+> Supports Alpaca, Interactive Brokers, Tradier, Schwab, ThetaData, Yahoo Finance, Polygon, and Polymarket.
+> Includes built-in AI trading agents, agentic backtesting, DuckDB query tools, replay caching, and external MCP tool support.
 
 ## Critical Rules for Code Generation
 
@@ -14,10 +15,23 @@
 - Access portfolio with `self.portfolio_value`, `self.cash`, `self.positions`
 - Implement `on_trading_iteration()` for main strategy logic - runs once per bar/iteration
 - For options: Use `self.create_asset(symbol, asset_type=Asset.AssetType.OPTION, expiration=date, strike=price, right='call'|'put')`
+- AI agents live on `self.agents` and should be created in `initialize()`
+- Use DuckDB for agent time-series analysis instead of pasting large historical bar payloads into prompts
 
 ## Full Documentation
 
 For complete API documentation with all method signatures, parameters, return types, and examples, see **llms-full.txt** in this repository.
+
+## AI Trading Agents
+
+- LumiBot supports **AI trading agents** directly inside the `Strategy` lifecycle with `self.agents.create(...)`
+- Agents can run from `initialize()`, `on_trading_iteration()`, `on_filled_order()`, and other lifecycle methods
+- Agentic backtests can replay identical runs from cache without another model call
+- DuckDB is the built-in SQL query surface for time-series analysis
+- External MCP servers can be mounted with explicit tool allowlists
+- Main docs page: `https://lumibot.lumiwealth.com/agents.html`
+- Backtesting docs: `https://lumibot.lumiwealth.com/backtesting.html`
+- GitHub guide: `https://github.com/Lumiwealth/lumibot/blob/dev/docs/AI_TRADING_AGENTS.md`
 
 ## Quick Reference
 
@@ -91,6 +105,9 @@ asset = Asset(symbol="BTC", asset_type=Asset.AssetType.CRYPTO)
 
 # Future
 asset = Asset(symbol="ES", asset_type=Asset.AssetType.FUTURE, expiration=datetime.date(2024, 3, 15))
+
+# Polymarket prediction contract
+asset = Asset(symbol="1234567890", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
 ```
 
 ### Basic Strategy Template
@@ -122,29 +139,12 @@ class MyStrategy(Strategy):
             self.submit_order(order)
 ```
 
-### Trading Fees
-```python
-# Stocks: use percent_fee (percentage of order value)
-TradingFee(percent_fee=0.001)  # 0.1% of order value
-
-# Options: use per_contract_fee (multiplied by number of contracts)
-TradingFee(per_contract_fee=0.65)  # $0.65 per contract (IBKR standard)
-
-# Futures: use per_contract_fee
-TradingFee(per_contract_fee=0.85)  # $0.85 per standard contract
-
-# Flat fee: fixed amount per ORDER regardless of quantity
-TradingFee(flat_fee=5.00)  # $5 per order
-
-# Pass to backtest:
-result = MyStrategy.backtest(datasource, buy_trading_fees=[fee], sell_trading_fees=[fee])
-```
-
 ## Backtesting Data Sources
 - `YahooDataBacktesting` - Free, good for stocks
 - `PolygonDataBacktesting` - Crypto and stocks (requires API key)
 - `ThetaDataBacktesting` - Options and stocks (requires subscription)
+- `PolymarketBacktesting` - Prediction-contract history from Polymarket price-history data
 
-Set via environment variable: `BACKTESTING_DATA_SOURCE=yahoo|polygon|thetadata`
+Set via environment variable: `BACKTESTING_DATA_SOURCE=yahoo|polygon|thetadata|polymarket`
 
-# Generated: 2026-01-05T06:59:12Z
+# Generated: 2026-07-02T05:46:54Z

--- a/lumibot/backtesting/__init__.py
+++ b/lumibot/backtesting/__init__.py
@@ -12,6 +12,7 @@ _NAME_TO_MODULE = {
     "DataBentoDataBacktestingPolars": "databento_backtesting_polars",
     "InteractiveBrokersRESTBacktesting": "interactive_brokers_rest_backtesting",
     "PandasDataBacktesting": "pandas_backtesting",
+    "PolymarketBacktesting": "polymarket_backtesting",
     "PolygonDataBacktesting": "polygon_backtesting",
     "RoutedBacktestingPandas": "routed_backtesting",
     "ThetaDataBacktesting": "thetadata_backtesting",

--- a/lumibot/backtesting/alpaca_backtesting.py
+++ b/lumibot/backtesting/alpaca_backtesting.py
@@ -29,6 +29,7 @@ from lumibot.tools.alpaca_helpers import sanitize_base_and_quote_asset
 
 class AlpacaBacktesting(DataSourceBacktesting):
     SOURCE = "ALPACA"
+    APPLY_BACKTEST_POSITION_SPLITS = False
     MIN_TIMESTEP = "minute"
     TIMESTEP_MAPPING = [
         {"timestep": "day", "representations": [TimeFrame.Day]},

--- a/lumibot/backtesting/backtesting_broker.py
+++ b/lumibot/backtesting/backtesting_broker.py
@@ -1130,6 +1130,8 @@ class BacktestingBroker(Broker):
     def _submit_order(self, order):
         """Submit an order for an asset"""
 
+        self._validate_data_source_order(order)
+
         # Optional audit trail (submission-time context).
         #
         # Invariant: audit collection must never break backtests; any errors must be swallowed.
@@ -1257,6 +1259,11 @@ class BacktestingBroker(Broker):
             return [parent_order]
 
         return results
+
+    def _validate_data_source_order(self, order):
+        validator = getattr(getattr(self, "data_source", None), "validate_order", None)
+        if callable(validator):
+            validator(order)
 
     def cancel_order(self, order):
         """Cancel an order"""
@@ -1825,13 +1832,19 @@ class BacktestingBroker(Broker):
         ):
             self._process_futures_fill(strategy, order, float(price), float(filled_quantity))
 
-        # For crypto base with forex quote (like BTC/USD where USD is forex), use cash
-        # For crypto base with crypto quote (like BTC/USDT where both are crypto), use positions
+        # For crypto base with forex quote (like BTC/USD where USD is forex), use cash.
+        # Prediction contracts are also cash-collateral instruments: price is
+        # between 0 and 1 and quantity is contract shares.
+        # For crypto base with crypto quote (like BTC/USDT where both are crypto), use positions.
         elif (
             not is_multileg_parent
-            and asset_type == Asset.AssetType.CRYPTO
-            and quote_asset_type == Asset.AssetType.FOREX
+            and (
+                (asset_type == Asset.AssetType.CRYPTO and quote_asset_type == Asset.AssetType.FOREX)
+                or asset_type == Asset.AssetType.PREDICTION_CONTRACT
+            )
         ):
+            if asset_type == Asset.AssetType.PREDICTION_CONTRACT and not 0 <= float(price) <= 1:
+                raise ValueError(f"Prediction-contract fill price must be between 0 and 1, got {price}")
             trade_amount = float(filled_quantity) * price
             if hasattr(order.asset, 'multiplier') and order.asset.multiplier:
                 trade_amount *= order.asset.multiplier
@@ -1870,7 +1883,10 @@ class BacktestingBroker(Broker):
         # Only apply trade cost if it's not crypto with forex quote (already handled above)
         if (
             not is_multileg_parent
-            and not (asset_type == Asset.AssetType.CRYPTO and quote_asset_type == Asset.AssetType.FOREX)
+            and not (
+                (asset_type == Asset.AssetType.CRYPTO and quote_asset_type == Asset.AssetType.FOREX)
+                or asset_type == Asset.AssetType.PREDICTION_CONTRACT
+            )
         ):
             self._apply_trade_cost(strategy, trade_cost)
 
@@ -1896,8 +1912,12 @@ class BacktestingBroker(Broker):
 
         # Skip position-based quote processing for:
         # 1. Crypto+forex trades (handled with direct cash updates)
-        # 2. Futures contracts (use margin, only realize P&L on close, not full notional)
+        # 2. Prediction contracts (cash-collateral instruments)
+        # 3. Futures contracts (use margin, only realize P&L on close, not full notional)
         if asset_type == Asset.AssetType.CRYPTO and quote_asset_type == Asset.AssetType.FOREX:
+            return
+
+        if asset_type == Asset.AssetType.PREDICTION_CONTRACT:
             return
 
         if asset_type in (Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE):

--- a/lumibot/backtesting/interactive_brokers_rest_backtesting.py
+++ b/lumibot/backtesting/interactive_brokers_rest_backtesting.py
@@ -272,7 +272,8 @@ class InteractiveBrokersRESTBacktesting(PandasData):
             day_data = self._data_store.get(day_key)
             if day_data is not None:
                 try:
-                    return day_data.get_last_price(now)
+                    price = day_data.get_last_price(now)
+                    return self._adjust_stale_daily_price_for_stock_split(day_data, price, now)
                 except Exception:
                     pass
 
@@ -297,7 +298,8 @@ class InteractiveBrokersRESTBacktesting(PandasData):
                     return None
             if day_data is not None:
                 try:
-                    return day_data.get_last_price(now)
+                    price = day_data.get_last_price(now)
+                    return self._adjust_stale_daily_price_for_stock_split(day_data, price, now)
                 except Exception:
                     try:
                         self._refresh_window_around_datetime(
@@ -310,7 +312,8 @@ class InteractiveBrokersRESTBacktesting(PandasData):
                         )
                         day_data = self._data_store.get(day_key)
                         if day_data is not None:
-                            return day_data.get_last_price(now)
+                            price = day_data.get_last_price(now)
+                            return self._adjust_stale_daily_price_for_stock_split(day_data, price, now)
                     except Exception:
                         return None
             return None

--- a/lumibot/backtesting/polymarket_backtesting.py
+++ b/lumibot/backtesting/polymarket_backtesting.py
@@ -1,0 +1,359 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+import pandas as pd
+
+from lumibot.data_sources import PandasData
+from lumibot.data_sources.polymarket_data import PolymarketData
+from lumibot.entities import Asset, Data, Order, Quote
+
+
+class PolymarketBacktesting(PandasData):
+    """Backtesting data source for Polymarket prediction contracts.
+
+    Uses Polymarket's real CLOB price-history endpoint as close-price bars and
+    keeps prediction-contract prices inside Polymarket's 0..1 price range.
+    """
+
+    SOURCE = "POLYMARKET_BACKTESTING"
+    TIMESTEP_MAPPING = [
+        {"timestep": "day", "representations": ["1D", "day"]},
+        {"timestep": "hour", "representations": ["1H", "hour"]},
+        {"timestep": "minute", "representations": ["1M", "minute"]},
+    ]
+
+    def __init__(
+        self,
+        datetime_start: datetime,
+        datetime_end: datetime,
+        *,
+        assets: list[Asset] | None = None,
+        markets: list[dict] | None = None,
+        pandas_data=None,
+        polymarket_data: PolymarketData | None = None,
+        timestep: str = "minute",
+        quote: Asset | None = None,
+        **kwargs,
+    ):
+        self.polymarket_data = polymarket_data or PolymarketData(config=kwargs.get("config"))
+        self.quote_asset = quote or Asset("USD", Asset.AssetType.FOREX)
+        self._prediction_timestep = timestep
+        auto_adjust = kwargs.pop("auto_adjust", False)
+
+        source_data = []
+        if pandas_data is not None:
+            source_data = pandas_data
+        else:
+            source_data = self._load_assets(
+                assets=assets or [],
+                markets=markets or [],
+                start=datetime_start,
+                end=datetime_end,
+                timestep=timestep,
+                quote=self.quote_asset,
+            )
+
+        super().__init__(
+            datetime_start=datetime_start,
+            datetime_end=datetime_end,
+            pandas_data=source_data,
+            auto_adjust=auto_adjust,
+            **kwargs,
+        )
+        self.name = "polymarket_backtesting"
+
+    def get_market_metadata(self, market=None, **kwargs) -> dict:
+        return self.polymarket_data.get_market_metadata(market, **kwargs)
+
+    def get_market_rules(self, market=None, **kwargs) -> dict:
+        return self.polymarket_data.get_market_rules(market, **kwargs)
+
+    def get_resolution_status(self, market=None, **kwargs) -> dict:
+        return self.polymarket_data.get_resolution_status(market, **kwargs)
+
+    def get_settlement_price(self, asset: Asset, market=None, **kwargs) -> float | None:
+        return self.polymarket_data.get_settlement_price(asset, market=market, **kwargs)
+
+    def get_historical_prices(
+        self,
+        asset,
+        length,
+        timestep="",
+        timeshift=None,
+        quote=None,
+        exchange=None,
+        include_after_hours=True,
+        **kwargs,
+    ):
+        quote = quote or self.quote_asset
+        return super().get_historical_prices(
+            asset,
+            length,
+            timestep=timestep,
+            timeshift=timeshift,
+            quote=quote,
+            exchange=exchange,
+            include_after_hours=include_after_hours,
+            **kwargs,
+        )
+
+    def get_quote(self, asset, quote=None, exchange=None) -> Quote:
+        asset = self._coerce_prediction_asset(asset)
+        data = self._get_loaded_prediction_data(asset, quote=quote or self.quote_asset)
+        if data is None:
+            return Quote(asset=asset)
+
+        row, bar_timestamp = self._current_prediction_row(data)
+        if row is None:
+            return Quote(asset=asset)
+
+        price = self._row_price(row, "close")
+        bid = self._row_price(row, "bid")
+        ask = self._row_price(row, "ask")
+        if bid is None:
+            bid = price
+        if ask is None:
+            ask = price
+
+        return Quote(
+            asset=asset,
+            price=price,
+            bid=bid,
+            ask=ask,
+            volume=self._row_price(row, "volume"),
+            timestamp=self.get_datetime(),
+            raw_data={
+                "open": self._row_price(row, "open"),
+                "high": self._row_price(row, "high"),
+                "low": self._row_price(row, "low"),
+                "close": price,
+                "bid": bid,
+                "ask": ask,
+                "volume": self._row_price(row, "volume"),
+                "bar_timestamp": bar_timestamp,
+                "bar_timestep": getattr(data, "timestep", None),
+                "source": "polymarket_backtesting",
+            },
+        )
+
+    def get_last_price(self, asset, quote=None, exchange=None):
+        asset = self._coerce_prediction_asset(asset)
+        data = self._get_loaded_prediction_data(asset, quote=quote or self.quote_asset)
+        if data is None:
+            return None
+
+        row, _ = self._current_prediction_row(data)
+        if row is None:
+            return None
+        return self._row_price(row, "close")
+
+    def validate_order(self, order: Order) -> None:
+        asset = getattr(order, "asset", None)
+        if getattr(asset, "asset_type", None) != Asset.AssetType.PREDICTION_CONTRACT:
+            return
+
+        try:
+            rules = self.get_market_rules(getattr(asset, "polymarket_market", None) or asset)
+        except Exception:
+            rules = {}
+        min_order_size = rules.get("min_order_size")
+        if min_order_size is not None:
+            min_size = Decimal(str(min_order_size))
+            quantity = Decimal(str(getattr(order, "quantity", "0") or "0"))
+            if quantity < min_size:
+                raise ValueError(
+                    f"Polymarket order size {quantity} is below the market minimum order size {min_size}"
+                )
+
+        limit_price = getattr(order, "limit_price", None)
+        if limit_price is None:
+            return
+
+        price = Decimal(str(limit_price))
+        if price < Decimal("0") or price > Decimal("1"):
+            raise ValueError(f"Polymarket limit price must be between 0 and 1, got {price}")
+
+        tick_size = rules.get("tick_size")
+        if tick_size is None:
+            return
+        tick = Decimal(str(tick_size))
+        if tick <= 0:
+            return
+        units = price / tick
+        if units != units.to_integral_value():
+            raise ValueError(f"Polymarket limit price {price} does not conform to market tick size {tick}")
+
+    def _load_assets(
+        self,
+        *,
+        assets: list[Asset],
+        markets: list[dict],
+        start: datetime,
+        end: datetime,
+        timestep: str,
+        quote: Asset,
+    ) -> list[Data]:
+        resolved_assets = list(assets)
+        market_by_symbol = {}
+        for market_spec in markets:
+            market = self.polymarket_data.resolve_market(
+                url=market_spec.get("url"),
+                slug=market_spec.get("slug"),
+                market_id=market_spec.get("market_id") or market_spec.get("id"),
+                condition_id=market_spec.get("condition_id") or market_spec.get("conditionId"),
+            )
+            resolved = self.polymarket_data.resolve_contract(
+                market,
+                outcome=market_spec.get("outcome"),
+                token_id=market_spec.get("token_id"),
+            )
+            resolved_assets.append(resolved)
+            market_by_symbol[str(resolved.symbol)] = market
+
+        data_objects = []
+        for asset in resolved_assets:
+            if asset.asset_type != Asset.AssetType.PREDICTION_CONTRACT:
+                raise ValueError("PolymarketBacktesting assets must use asset_type='prediction_contract'")
+            bars = self.polymarket_data.get_historical_prices(
+                asset,
+                length=None,
+                timestep=timestep,
+                quote=quote,
+                start=start,
+                end=end,
+            )
+            df = bars.df.copy()
+            market = market_by_symbol.get(str(asset.symbol)) or getattr(asset, "polymarket_market", None)
+            df = self._apply_market_close_and_settlement(df, asset, market=market, start=start, end=end)
+            self._validate_price_frame(df, asset)
+            data_objects.append(Data(asset, df, timestep=self._normalize_timestep(timestep), quote=quote))
+        return data_objects
+
+    def _get_loaded_prediction_data(self, asset: Asset, *, quote: Asset):
+        for candidate_quote in (quote, self.quote_asset, None):
+            tuple_to_find = self.find_asset_in_data_store(asset, candidate_quote)
+            if tuple_to_find in self._data_store:
+                return self._data_store[tuple_to_find]
+        return None
+
+    def _current_prediction_row(self, data):
+        try:
+            iter_count = data.get_iter_count(self.get_datetime())
+        except Exception:
+            return None, None
+        if iter_count is None or iter_count < 0:
+            return None, None
+        try:
+            row = data.df.iloc[iter_count]
+        except Exception:
+            return None, None
+        try:
+            timestamp = data._timestamp_for_iter_count(iter_count)
+            timestamp = timestamp.to_pydatetime() if timestamp is not None else None
+        except Exception:
+            timestamp = None
+        return row, timestamp
+
+    @staticmethod
+    def _row_price(row, key: str):
+        if row is None or key not in row:
+            return None
+        value = row.get(key)
+        if pd.isna(value):
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return value
+
+    @staticmethod
+    def _coerce_prediction_asset(asset) -> Asset:
+        if isinstance(asset, Asset):
+            if asset.asset_type != Asset.AssetType.PREDICTION_CONTRACT:
+                raise ValueError("PolymarketBacktesting requires prediction_contract assets")
+            return asset
+        return Asset(str(asset), asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+
+    def _apply_market_close_and_settlement(
+        self,
+        df: pd.DataFrame,
+        asset: Asset,
+        *,
+        market: dict | None,
+        start: datetime,
+        end: datetime,
+    ) -> pd.DataFrame:
+        result = df.copy()
+        close_dt = None
+        if market is not None:
+            try:
+                close_dt = self.polymarket_data.get_market_close(market)
+            except Exception:
+                close_dt = None
+        if close_dt is not None:
+            close_ts = self._normalize_timestamp(close_dt, result.index)
+            result = result[result.index <= close_ts]
+
+        try:
+            settlement_price = self.get_settlement_price(asset, market=market)
+        except Exception:
+            settlement_price = None
+        if settlement_price is None:
+            return result
+
+        settlement_ts = close_dt or end
+        settlement_ts = self._normalize_timestamp(settlement_ts, result.index)
+        start_ts = self._normalize_timestamp(start, result.index)
+        end_ts = self._normalize_timestamp(end, result.index)
+        if settlement_ts < start_ts or settlement_ts > end_ts:
+            return result
+
+        settlement_row = {
+            "open": settlement_price,
+            "high": settlement_price,
+            "low": settlement_price,
+            "close": settlement_price,
+            "volume": 0,
+            "bid": settlement_price,
+            "ask": settlement_price,
+        }
+        result.loc[settlement_ts, list(settlement_row.keys())] = list(settlement_row.values())
+        return result.sort_index()
+
+    @staticmethod
+    def _normalize_timestamp(value, index) -> pd.Timestamp:
+        timestamp = pd.Timestamp(value)
+        tz = getattr(index, "tz", None)
+        if tz is not None:
+            if timestamp.tzinfo is None:
+                timestamp = timestamp.tz_localize(tz)
+            else:
+                timestamp = timestamp.tz_convert(tz)
+        elif timestamp.tzinfo is not None:
+            timestamp = timestamp.tz_localize(None)
+        return timestamp
+
+    @staticmethod
+    def _validate_price_frame(df: pd.DataFrame, asset: Asset) -> None:
+        if df.empty:
+            return
+        for column in ("open", "high", "low", "close"):
+            if column not in df.columns:
+                raise ValueError(f"Polymarket history for {asset} is missing {column} prices")
+            values = pd.to_numeric(df[column], errors="coerce")
+            if values.isna().any():
+                raise ValueError(f"Polymarket history for {asset} contains non-numeric {column} prices")
+            if ((values < 0) | (values > 1)).any():
+                raise ValueError(f"Polymarket prediction-contract prices must be between 0 and 1 for {asset}")
+
+    @staticmethod
+    def _normalize_timestep(timestep: str) -> str:
+        normalized = str(timestep or "minute").lower()
+        if normalized in {"1m", "minute"}:
+            return "minute"
+        if normalized in {"1h", "hour"}:
+            return "hour"
+        if normalized in {"1d", "day"}:
+            return "day"
+        raise ValueError(f"Unsupported Polymarket backtesting timestep: {timestep!r}")

--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -2910,7 +2910,7 @@ class ThetaDataBacktestingPandas(PandasData):
                 frame_last_dt = frame_last_dt.isoformat()
             except AttributeError:
                 frame_last_dt = str(frame_last_dt)
-            return float(frame_last_close)
+            return float(self._adjust_stale_daily_price_for_stock_split(data_obj, frame_last_close, dt))
         if tuple_key is not None:
             if isinstance(tuple_key, tuple) and len(tuple_key) != 3:
                 legacy_hit = True
@@ -3108,6 +3108,15 @@ class ThetaDataBacktestingPandas(PandasData):
 
         try:
             snapshot = data.get_price_snapshot(dt)
+            if isinstance(snapshot, dict):
+                snapshot = dict(snapshot)
+                for price_key in ("open", "high", "low", "close", "bid", "ask"):
+                    if price_key in snapshot:
+                        snapshot[price_key] = self._adjust_stale_daily_price_for_stock_split(
+                            data,
+                            snapshot.get(price_key),
+                            dt,
+                        )
             logger.debug(
                 "[THETA][DEBUG][THETADATA-PANDAS] get_price_snapshot succeeded for %s/%s: %s",
                 asset,

--- a/lumibot/backtesting/thetadata_backtesting_pandas.py
+++ b/lumibot/backtesting/thetadata_backtesting_pandas.py
@@ -2778,6 +2778,7 @@ class ThetaDataBacktestingPandas(PandasData):
         return AssetsMapping(result)
 
     def get_last_price(self, asset, timestep="minute", quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:
+        allow_stale_option_last = bool(kwargs.pop("allow_stale_option_last", True))
         dt = self.get_datetime()
         self._update_cadence_from_dt(dt)
         # In day mode, use day data for price lookups instead of defaulting to minute.
@@ -2927,6 +2928,7 @@ class ThetaDataBacktestingPandas(PandasData):
         # causes strategies to incorrectly treat contracts as untradeable (even when a stale last trade exists).
         if (
             value is None
+            and allow_stale_option_last
             and getattr(asset, "asset_type", None) == Asset.AssetType.OPTION
             and timestep == "day"
             and tuple_key is not None
@@ -3928,6 +3930,42 @@ class ThetaDataBacktestingPandas(PandasData):
                 if existing is None or (not math.isfinite(existing)) or existing <= 0:
                     existing = None
                 quote_obj.price = existing
+
+            # Mark-to-market fallback only. Sparse historical option quote snapshots can be empty
+            # even when ThetaData has daily trade/OHLC data for the contract. Fill logic must still
+            # require quote-side evidence; this fallback only gives portfolio valuation a finite
+            # option price after quote lookup has failed.
+            if getattr(quote_obj, "price", None) is None:
+                fallback_enabled = str(
+                    os.environ.get("THETADATA_OPTION_MTM_OHLC_FALLBACK", "true")
+                ).strip().lower() not in {"0", "false", "no", "off"}
+                if fallback_enabled:
+                    fallback_price = None
+                    try:
+                        fallback_price = self.get_last_price(
+                            asset,
+                            timestep="day",
+                            quote=quote,
+                            exchange=exchange,
+                            allow_stale_option_last=True,
+                        )
+                    except Exception:
+                        logger.debug(
+                            "[THETA][QUOTE][MTM_FALLBACK] daily option OHLC fallback failed for %s",
+                            asset,
+                            exc_info=True,
+                        )
+                    try:
+                        fallback_price = float(fallback_price) if fallback_price is not None else None
+                    except (TypeError, ValueError):
+                        fallback_price = None
+                    if fallback_price is not None and math.isfinite(fallback_price) and fallback_price > 0:
+                        quote_obj.price = fallback_price
+                        quote_obj.raw_data = {
+                            "source": "thetadata_daily_ohlc_mtm_fallback",
+                            "price": fallback_price,
+                            "timestamp": dt.isoformat() if hasattr(dt, "isoformat") else str(dt),
+                        }
 
         # [INSTRUMENTATION] Final quote result with all details
         if logger.isEnabledFor(logging.DEBUG):

--- a/lumibot/brokers/__init__.py
+++ b/lumibot/brokers/__init__.py
@@ -12,6 +12,7 @@ _NAME_TO_MODULE = {
     "InteractiveBrokers": "interactive_brokers",
     "InteractiveBrokersREST": "interactive_brokers_rest",
     "ProjectX": "projectx",
+    "Polymarket": "polymarket",
     "Schwab": "schwab",
     "Tradier": "tradier",
     "Tradovate": "tradovate",

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -255,6 +255,135 @@ class Broker(ABC):
         self._trade_event_log_rows.append(new_row)
         self._trade_event_log_df_cache = None
 
+    def record_corporate_action_event(
+        self,
+        *,
+        action_type: str,
+        asset: Asset,
+        strategy: str | None = None,
+        ratio: float | None = None,
+        quantity_before: float | None = None,
+        quantity_after: float | None = None,
+        occurred_at: datetime | None = None,
+        description: str | None = None,
+    ) -> None:
+        """Append a non-cash corporate-action row to the trade-event stream."""
+        if not getattr(self, "_trade_event_log_enabled", True):
+            return
+
+        event_time = occurred_at
+        if event_time is None:
+            data_source = getattr(self, "data_source", None)
+            event_time = getattr(data_source, "_datetime", None)
+            if event_time is None and data_source is not None:
+                get_datetime = getattr(data_source, "get_datetime", None)
+                if callable(get_datetime):
+                    event_time = get_datetime()
+        if event_time is None:
+            event_time = datetime.now(timezone.utc)
+
+        symbol = getattr(asset, "symbol", str(asset))
+        normalized_action_type = str(action_type or "corporate_action").strip().lower() or "corporate_action"
+        ratio_text = "" if ratio is None else f":{float(ratio):.12g}"
+        event_id = f"corporate_action:{normalized_action_type}:{strategy or ''}:{symbol}:{event_time.date()}{ratio_text}"
+        event_description = description or (
+            f"{symbol} {normalized_action_type}"
+            + (f" ratio={float(ratio):.6f}" if ratio is not None else "")
+            + (
+                f" quantity {float(quantity_before):.6f}->{float(quantity_after):.6f}"
+                if quantity_before is not None and quantity_after is not None
+                else ""
+            )
+        )
+        raw_subtype_parts = []
+        if ratio is not None:
+            raw_subtype_parts.append(f"ratio={float(ratio):.12g}")
+        if quantity_before is not None:
+            raw_subtype_parts.append(f"quantity_before={float(quantity_before):.12g}")
+        if quantity_after is not None:
+            raw_subtype_parts.append(f"quantity_after={float(quantity_after):.12g}")
+        raw_subtype = ";".join(raw_subtype_parts) or None
+
+        audit_enabled = getattr(self, "_backtest_audit_enabled", None)
+        if audit_enabled is None:
+            audit_enabled = self._truthy_env(os.environ.get("LUMIBOT_BACKTEST_AUDIT"))
+
+        if audit_enabled:
+            new_row = {
+                "time": event_time,
+                "strategy": strategy,
+                "exchange": None,
+                "identifier": event_id,
+                "symbol": symbol,
+                "side": "neutral",
+                "type": "corporate_action",
+                "status": normalized_action_type,
+                "price": ratio,
+                "filled_quantity": quantity_after,
+                "multiplier": None,
+                "trade_cost": None,
+                "trade_slippage": None,
+                "time_in_force": None,
+                "asset.right": asset.right if asset is not None else None,
+                "asset.strike": asset.strike if asset is not None else None,
+                "asset.multiplier": asset.multiplier if asset is not None else None,
+                "asset.expiration": asset.expiration if asset is not None else None,
+                "asset.asset_type": asset.asset_type if asset is not None else None,
+                "price_source": None,
+                "event_kind": "corporate_action",
+                "event_id": event_id,
+                "cash_event_type": None,
+                "cash_event_amount": None,
+                "cash_event_currency": None,
+                "cash_event_description": event_description,
+                "cash_event_direction": "neutral",
+                "cash_event_reason": normalized_action_type,
+                "is_external_cash_flow": False,
+                "cash_event_raw_type": normalized_action_type,
+                "cash_event_raw_subtype": raw_subtype,
+                "cash_event_broker_name": self.name,
+                "cash_event_broker_event_id": event_id,
+            }
+        else:
+            new_row = (
+                event_time,
+                strategy,
+                None,
+                event_id,
+                symbol,
+                "neutral",
+                "corporate_action",
+                normalized_action_type,
+                ratio,
+                quantity_after,
+                None,
+                None,
+                None,
+                None,
+                asset.right if asset is not None else None,
+                asset.strike if asset is not None else None,
+                asset.multiplier if asset is not None else None,
+                asset.expiration if asset is not None else None,
+                asset.asset_type if asset is not None else None,
+                None,
+                "corporate_action",
+                event_id,
+                None,
+                None,
+                None,
+                event_description,
+                "neutral",
+                normalized_action_type,
+                False,
+                normalized_action_type,
+                raw_subtype,
+                self.name,
+                event_id,
+            )
+
+        self._trade_event_log_rows.append(new_row)
+        self._trade_event_log_df_cache = None
+
     def __init__(self, name="", connect_stream=True, data_source: DataSource = None, option_source: DataSource = None,
                  config=None, max_workers=20, extended_trading_minutes=0, cleanup_config=None):
         """Broker constructor"""

--- a/lumibot/brokers/polymarket.py
+++ b/lumibot/brokers/polymarket.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import queue
+import threading
 import time
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
@@ -30,6 +32,7 @@ POLYMARKET_SECRET_KEYS = {
 @dataclass(frozen=True)
 class PolymarketCredentials:
     private_key: str | None = None
+    owner_address: str | None = None
     wallet_address: str | None = None
     clob_api_key: str | None = None
     clob_api_secret: str | None = None
@@ -51,6 +54,7 @@ class PolymarketCredentialStore:
     def load(self) -> PolymarketCredentials:
         return PolymarketCredentials(
             private_key=self._get("PRIVATE_KEY"),
+            owner_address=self._get("OWNER_ADDRESS"),
             wallet_address=self._get("WALLET_ADDRESS"),
             clob_api_key=self._get("CLOB_API_KEY"),
             clob_api_secret=self._get("CLOB_API_SECRET"),
@@ -84,9 +88,8 @@ class PolymarketCredentialStore:
 class PolymarketCLOBStream(CustomStream):
     """LumiBot stream bridge for Polymarket market/user events.
 
-    The class exposes event handlers that are fully unit-testable with fake payloads. Live WebSocket connection support
-    is intentionally conservative and optional because authenticated stream connection details depend on the beta SDK
-    and generated CLOB credentials.
+    Public market events update the attached PolymarketData quote cache. Private user events are reconciled into the
+    normal LumiBot order lifecycle events. HTTP polling remains active as the reconciliation source of truth.
     """
 
     def __init__(
@@ -95,11 +98,21 @@ class PolymarketCLOBStream(CustomStream):
         *,
         polling_interval: float = 5.0,
         use_websocket: bool = True,
+        market_token_ids: list[str] | None = None,
+        websocket_factory: Any | None = None,
     ):
         super().__init__()
         self.broker = broker
         self.polling_interval = polling_interval
         self.use_websocket = use_websocket
+        self.market_token_ids = {str(token_id) for token_id in (market_token_ids or []) if token_id}
+        self.websocket_factory = websocket_factory
+        self._websocket_threads: list[threading.Thread] = []
+
+    def subscribe_market_assets(self, token_ids: list[str] | tuple[str, ...] | set[str]) -> None:
+        for token_id in token_ids or []:
+            if token_id:
+                self.market_token_ids.add(str(token_id))
 
     def handle_market_event(self, event: Any) -> None:
         self.broker.data_source.apply_market_event(event)
@@ -120,28 +133,128 @@ class PolymarketCLOBStream(CustomStream):
             self.dispatch(self.broker.NEW_ORDER, order=parsed)
 
     def _run(self):
-        # The SDK stream implementation is async-only. Until live credentials and SDK availability are verified, keep
-        # the stream thread useful as a reconciliation loop and route event handling through tested handler methods.
+        if self.use_websocket:
+            self._start_websocket_threads()
+        self.broker._stream_established()
         last_poll = 0.0
-        while not self._stop_event.is_set():
-            timeout = min(max(self.polling_interval, 0.1), 0.5)
-            try:
-                event, payload = self._queue.get(timeout=timeout)
-                self._process_queue_event(event, payload)
-                self._queue.task_done()
-                continue
-            except queue.Empty:
-                pass
-            except Exception:
-                self.broker.logger.exception("Polymarket stream event processing failed")
+        try:
+            while not self._stop_event.is_set():
+                timeout = min(max(self.polling_interval, 0.1), 0.5)
+                try:
+                    event, payload = self._queue.get(timeout=timeout)
+                    self._process_queue_event(event, payload)
+                    self._queue.task_done()
+                    continue
+                except queue.Empty:
+                    pass
+                except Exception:
+                    self.broker.logger.exception("Polymarket stream event processing failed")
 
-            if time.monotonic() - last_poll < self.polling_interval:
+                if time.monotonic() - last_poll < self.polling_interval:
+                    continue
+                try:
+                    self.broker.do_polling()
+                    last_poll = time.monotonic()
+                    self._refresh_market_subscriptions_from_broker_state()
+                except Exception:
+                    self.broker.logger.exception("Polymarket stream reconciliation failed")
+        finally:
+            for thread in self._websocket_threads:
+                thread.join(timeout=1.0)
+
+    def _start_websocket_threads(self) -> None:
+        if self._websocket_threads:
+            return
+        workers = [("market", self._run_market_websocket), ("user", self._run_user_websocket)]
+        for label, target in workers:
+            thread = threading.Thread(target=target, name=f"PolymarketCLOBStream-{label}", daemon=True)
+            self._websocket_threads.append(thread)
+            thread.start()
+
+    def _run_market_websocket(self) -> None:
+        try:
+            asyncio.run(self._market_websocket_loop())
+        except Exception:
+            if not self._stop_event.is_set():
+                self.broker.logger.exception("Polymarket market WebSocket stopped unexpectedly")
+
+    def _run_user_websocket(self) -> None:
+        try:
+            asyncio.run(self._user_websocket_loop())
+        except Exception:
+            if not self._stop_event.is_set():
+                self.broker.logger.exception("Polymarket user WebSocket stopped unexpectedly")
+
+    async def _market_websocket_loop(self) -> None:
+        factory = await self._websocket_connect_factory()
+        while not self._stop_event.is_set():
+            token_ids = sorted(self.market_token_ids)
+            if not token_ids:
+                await asyncio.sleep(min(max(self.polling_interval, 0.25), 1.0))
                 continue
             try:
-                self.broker.do_polling()
-                last_poll = time.monotonic()
+                async with factory(PolymarketData.MARKET_WS_URL, ping_interval=20, close_timeout=5) as websocket:
+                    await websocket.send(json.dumps(self._market_subscription_payload(token_ids)))
+                    while not self._stop_event.is_set():
+                        message = await asyncio.wait_for(websocket.recv(), timeout=1.0)
+                        self.handle_market_event(json.loads(message))
+            except asyncio.TimeoutError:
+                continue
             except Exception:
-                self.broker.logger.exception("Polymarket stream reconciliation failed")
+                if not self._stop_event.is_set():
+                    self.broker.logger.debug("Polymarket market WebSocket reconnecting", exc_info=True)
+                    await asyncio.sleep(min(max(self.polling_interval, 0.5), 5.0))
+
+    async def _user_websocket_loop(self) -> None:
+        auth = self.broker._websocket_auth_payload()
+        if not auth:
+            return
+        factory = await self._websocket_connect_factory()
+        while not self._stop_event.is_set():
+            try:
+                async with factory(PolymarketData.USER_WS_URL, ping_interval=20, close_timeout=5) as websocket:
+                    await websocket.send(json.dumps(self._user_subscription_payload(auth)))
+                    while not self._stop_event.is_set():
+                        message = await asyncio.wait_for(websocket.recv(), timeout=1.0)
+                        payload = json.loads(message)
+                        for event in payload if isinstance(payload, list) else [payload]:
+                            self.handle_user_event(event)
+            except asyncio.TimeoutError:
+                continue
+            except Exception:
+                if not self._stop_event.is_set():
+                    self.broker.logger.debug("Polymarket user WebSocket reconnecting", exc_info=True)
+                    await asyncio.sleep(min(max(self.polling_interval, 0.5), 5.0))
+
+    async def _websocket_connect_factory(self):
+        if self.websocket_factory is not None:
+            return self.websocket_factory
+        try:
+            import websockets
+        except Exception as exc:
+            raise LumibotBrokerAPIError("websockets is required for Polymarket CLOB streaming") from exc
+        return websockets.connect
+
+    def _refresh_market_subscriptions_from_broker_state(self) -> None:
+        token_ids = set()
+        for raw in self.broker._recent_order_cache.values():
+            token_id = self.broker._first_present(raw, "asset_id", "assetId", "token_id", "tokenId", "asset")
+            if token_id:
+                token_ids.add(str(token_id))
+        try:
+            for position in self.broker._pull_positions(self.broker._strategy_name or self.broker.name):
+                token_ids.add(str(position.asset.symbol))
+        except Exception:
+            return
+        self.subscribe_market_assets(token_ids)
+
+    @staticmethod
+    def _market_subscription_payload(token_ids: list[str]) -> dict:
+        return {"assets_ids": token_ids, "type": "market", "custom_feature_enabled": True}
+
+    @staticmethod
+    def _user_subscription_payload(auth: dict) -> dict:
+        return {"auth": auth, "type": "user"}
 
 
 class Polymarket(Broker):
@@ -169,6 +282,7 @@ class Polymarket(Broker):
         self._owns_data_api_client = data_api_client is None
         self._clients_initialized = secure_client is not None
         self._trading_ready = False
+        self._derived_api_creds = None
         self._recent_order_cache: dict[str, Any] = {}
         self._recent_trade_cache: dict[str, Any] = {}
 
@@ -218,7 +332,7 @@ class Polymarket(Broker):
         if self.credentials.builder_code:
             builder_config = BuilderConfig(builder_code=self.credentials.builder_code)
 
-        signature_type = int(self.config.get("SIGNATURE_TYPE", SignatureTypeV2.POLY_1271))
+        signature_type = int(self.config.get("SIGNATURE_TYPE") or self._default_signature_type(SignatureTypeV2))
         self._secure_client = ClobClient(
             self.config.get("CLOB_URL", PolymarketData.CLOB_URL),
             chain_id=int(self.config.get("CHAIN_ID", POLYGON)),
@@ -259,6 +373,12 @@ class Polymarket(Broker):
             )
         return None
 
+    def _default_signature_type(self, signature_type_cls) -> int:
+        if self.credentials.owner_address and self.credentials.wallet_address:
+            if self.credentials.owner_address.lower() != self.credentials.wallet_address.lower():
+                return int(signature_type_cls.POLY_PROXY)
+        return int(signature_type_cls.POLY_1271)
+
     def _ensure_trading_ready(self) -> None:
         if self._trading_ready:
             return
@@ -294,7 +414,13 @@ class Polymarket(Broker):
 
     def _get_stream_object(self):
         if self.use_websocket:
-            return PolymarketCLOBStream(self, polling_interval=self.polling_interval, use_websocket=True)
+            token_ids = self._configured_stream_token_ids()
+            return PolymarketCLOBStream(
+                self,
+                polling_interval=self.polling_interval,
+                use_websocket=True,
+                market_token_ids=token_ids,
+            )
         return PollingStream(self.polling_interval)
 
     def _register_stream_events(self):
@@ -478,11 +604,17 @@ class Polymarket(Broker):
             if rows is not None:
                 return self._listify(rows)
 
-        wallet = self.credentials.wallet_address
-        if not wallet:
+        addresses = self._position_query_addresses()
+        if not addresses:
             raise LumibotBrokerAPIError("Missing POLYMARKET_WALLET_ADDRESS for Polymarket position reads")
-        payload = self._data_api_get("/positions", params={"user": wallet})
-        return self._listify(payload)
+        last_rows = []
+        for address in addresses:
+            payload = self._data_api_get("/positions", params={"user": address})
+            rows = self._listify(payload)
+            if rows:
+                return rows
+            last_rows = rows
+        return last_rows
 
     def _get_positions_value(self) -> float:
         secure_client = self._maybe_secure_client()
@@ -492,17 +624,18 @@ class Polymarket(Broker):
             if value is not None:
                 return self._to_float(value)
 
-        wallet = self.credentials.wallet_address
-        if not wallet:
+        addresses = self._position_query_addresses()
+        if not addresses:
             return 0.0
-        try:
-            payload = self._data_api_get("/value", params={"user": wallet})
-        except Exception:
-            return 0.0
-        rows = self._listify(payload)
-        if not rows:
-            return 0.0
-        return self._to_float(self._first_present(rows[0], "value") or 0.0)
+        for address in addresses:
+            try:
+                payload = self._data_api_get("/value", params={"user": address})
+            except Exception:
+                continue
+            rows = self._listify(payload)
+            if rows:
+                return self._to_float(self._first_present(rows[0], "value") or 0.0)
+        return 0.0
 
     def _get_collateral_cash(self) -> float:
         secure_client = self._maybe_secure_client()
@@ -521,7 +654,7 @@ class Polymarket(Broker):
                     value = self._call_if_exists(secure_client, method_name)
                 balance = self._first_present(value, "balance", "available", "cash", "collateral", "collateral_balance")
                 if balance is not None:
-                    return self._to_float(balance)
+                    return self._collateral_balance_to_float(balance, raw_units=(method_name == "get_balance_allowance"))
         override = self.config.get("CASH_BALANCE") or self.config.get("POLYMARKET_CASH_BALANCE")
         return self._to_float(override or 0.0)
 
@@ -562,7 +695,11 @@ class Polymarket(Broker):
         if self.credentials.builder_code:
             order_kwargs["builder_code"] = self.credentials.builder_code
         order_args = MarketOrderArgs(**order_kwargs)
-        return secure_client.create_and_post_market_order(order_args, order_type=order_type)
+        options = self._create_order_options(kwargs["token_id"])
+        try:
+            return secure_client.create_and_post_market_order(order_args, options=options, order_type=order_type)
+        except Exception as exc:
+            self._raise_order_error(exc)
 
     def _create_and_post_limit_order(self, **kwargs):
         secure_client = self._initialize_clients()
@@ -587,7 +724,37 @@ class Polymarket(Broker):
         if self.credentials.builder_code:
             order_kwargs["builder_code"] = self.credentials.builder_code
         order_args = OrderArgs(**order_kwargs)
-        return secure_client.create_and_post_order(order_args, order_type=getattr(OrderType, tif))
+        options = self._create_order_options(kwargs["token_id"])
+        try:
+            return secure_client.create_and_post_order(order_args, options=options, order_type=getattr(OrderType, tif))
+        except Exception as exc:
+            self._raise_order_error(exc)
+
+    def _create_order_options(self, token_id: str):
+        try:
+            from py_clob_client_v2.clob_types import PartialCreateOrderOptions
+        except Exception:
+            return None
+
+        tick_size = None
+        neg_risk = None
+        try:
+            book = self.data_source.get_order_book(token_id)
+            tick_size = self._first_present(book, "tick_size", "tickSize", "minimum_tick_size", "minimumTickSize")
+            neg_risk = self._first_present(book, "neg_risk", "negRisk")
+        except Exception:
+            book = {}
+
+        if tick_size is None:
+            try:
+                tick_size = self.data_source.get_tick_size(token_id)
+            except Exception:
+                tick_size = None
+
+        return PartialCreateOrderOptions(
+            tick_size=self._normalize_tick_size(tick_size) if tick_size is not None else None,
+            neg_risk=self._optional_bool(neg_risk),
+        )
 
     @staticmethod
     def _call_if_exists(obj: Any, method_name: str, *args, **kwargs):
@@ -641,6 +808,98 @@ class Polymarket(Broker):
         price = self._decimal(price)
         if price % tick_size != 0:
             raise ValueError(f"Polymarket limit price {price} is not aligned to tick size {tick_size}")
+
+    def _configured_stream_token_ids(self) -> list[str]:
+        values = []
+        for key in ("STREAM_TOKEN_IDS", "POLYMARKET_STREAM_TOKEN_IDS", "TEST_TOKEN_ID", "POLYMARKET_TEST_TOKEN_ID"):
+            raw = self.config.get(key) or os.environ.get(key)
+            if not raw:
+                continue
+            values.extend(str(raw).replace(";", ",").split(","))
+        return [value.strip() for value in values if value.strip()]
+
+    def _position_query_addresses(self) -> list[str]:
+        seen = set()
+        addresses = []
+        for address in (self.credentials.wallet_address, self.credentials.owner_address):
+            if not address:
+                continue
+            normalized = address.lower()
+            if normalized not in seen:
+                seen.add(normalized)
+                addresses.append(address)
+        return addresses
+
+    def _websocket_auth_payload(self) -> dict | None:
+        self._initialize_clients()
+        creds = self._derived_api_creds or self._build_api_creds_from_loaded_values()
+        if not creds:
+            return None
+        api_key = self._first_present(creds, "api_key", "apiKey", "key")
+        api_secret = self._first_present(creds, "api_secret", "apiSecret", "secret")
+        api_passphrase = self._first_present(creds, "api_passphrase", "apiPassphrase", "passphrase")
+        if not (api_key and api_secret and api_passphrase):
+            return None
+        return {"apiKey": api_key, "secret": api_secret, "passphrase": api_passphrase}
+
+    def _build_api_creds_from_loaded_values(self) -> dict | None:
+        if self.credentials.api_credentials_json:
+            try:
+                return json.loads(self.credentials.api_credentials_json)
+            except json.JSONDecodeError:
+                return None
+        if (
+            self.credentials.clob_api_key
+            and self.credentials.clob_api_secret
+            and self.credentials.clob_api_passphrase
+        ):
+            return {
+                "api_key": self.credentials.clob_api_key,
+                "api_secret": self.credentials.clob_api_secret,
+                "api_passphrase": self.credentials.clob_api_passphrase,
+            }
+        return None
+
+    @classmethod
+    def _collateral_balance_to_float(cls, value: Any, *, raw_units: bool) -> float:
+        decimal_value = cls._decimal(value)
+        if raw_units and decimal_value == decimal_value.to_integral_value():
+            decimal_value = decimal_value / Decimal("1000000")
+        return float(decimal_value)
+
+    @classmethod
+    def _normalize_tick_size(cls, value: Any) -> str:
+        tick_size = cls._decimal(value)
+        text = format(tick_size.normalize(), "f")
+        if text in {"0.1", "0.01", "0.001", "0.0001"}:
+            return text
+        return str(value)
+
+    @classmethod
+    def _optional_bool(cls, value: Any) -> bool | None:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+    @staticmethod
+    def _raise_order_error(exc: Exception):
+        message = str(exc)
+        lowered = message.lower()
+        if (
+            "maker address not allowed" in lowered
+            or "deposit wallet flow" in lowered
+            or "order signer address has to be the address of the api key" in lowered
+            or "no deposit wallet found" in lowered
+        ):
+            raise LumibotBrokerAPIError(
+                "Polymarket rejected the order because the account's CLOB API credentials, signer, and funder/deposit "
+                "wallet are not aligned. Existing Magic/proxy accounts can read balances/orders with CLOB credentials "
+                "but may need Polymarket's deposit-wallet flow, relayer/builder credentials, and regenerated CLOB L2 "
+                f"credentials before live order submission works. Raw Polymarket error: {message}"
+            ) from exc
+        raise exc
 
     @staticmethod
     def _token_id(asset: Asset) -> str:

--- a/lumibot/brokers/polymarket.py
+++ b/lumibot/brokers/polymarket.py
@@ -25,6 +25,10 @@ POLYMARKET_SECRET_KEYS = {
     "CLOB_API_PASSPHRASE",
     "RELAYER_API_KEY",
     "RELAYER_API_KEY_ADDRESS",
+    "BUILDER_API_KEY",
+    "BUILDER_SECRET",
+    "BUILDER_PASSPHRASE",
+    "BUILDER_PASS_PHRASE",
     "API_CREDENTIALS_JSON",
 }
 
@@ -34,6 +38,7 @@ class PolymarketCredentials:
     private_key: str | None = None
     owner_address: str | None = None
     wallet_address: str | None = None
+    signature_type: str | None = None
     clob_api_key: str | None = None
     clob_api_secret: str | None = None
     clob_api_passphrase: str | None = None
@@ -56,6 +61,7 @@ class PolymarketCredentialStore:
             private_key=self._get("PRIVATE_KEY"),
             owner_address=self._get("OWNER_ADDRESS"),
             wallet_address=self._get("WALLET_ADDRESS"),
+            signature_type=self._get("SIGNATURE_TYPE"),
             clob_api_key=self._get("CLOB_API_KEY"),
             clob_api_secret=self._get("CLOB_API_SECRET"),
             clob_api_passphrase=self._get("CLOB_API_PASSPHRASE"),
@@ -332,7 +338,7 @@ class Polymarket(Broker):
         if self.credentials.builder_code:
             builder_config = BuilderConfig(builder_code=self.credentials.builder_code)
 
-        signature_type = int(self.config.get("SIGNATURE_TYPE") or self._default_signature_type(SignatureTypeV2))
+        signature_type = self._configured_signature_type(SignatureTypeV2)
         self._secure_client = ClobClient(
             self.config.get("CLOB_URL", PolymarketData.CLOB_URL),
             chain_id=int(self.config.get("CHAIN_ID", POLYGON)),
@@ -378,6 +384,13 @@ class Polymarket(Broker):
             if self.credentials.owner_address.lower() != self.credentials.wallet_address.lower():
                 return int(signature_type_cls.POLY_PROXY)
         return int(signature_type_cls.POLY_1271)
+
+    def _configured_signature_type(self, signature_type_cls) -> int:
+        value = self.config.get("SIGNATURE_TYPE") or self.config.get("POLYMARKET_SIGNATURE_TYPE")
+        value = value or self.credentials.signature_type
+        if value is None:
+            return self._default_signature_type(signature_type_cls)
+        return int(value)
 
     def _ensure_trading_ready(self) -> None:
         if self._trading_ready:
@@ -481,8 +494,18 @@ class Polymarket(Broker):
         asset = Asset(str(token_id or "UNKNOWN"), asset_type=Asset.AssetType.PREDICTION_CONTRACT, precision="0.000001")
         side = self._map_side(self._first_present(payload, "side", "direction"))
         price = self._optional_float(self._first_present(payload, "price", "limitPrice", "average_price", "avgPrice"))
+        avg_fill_price = self._average_fill_price(payload, fallback=price)
         quantity = self._optional_float(
-            self._first_present(payload, "size", "original_size", "originalSize", "shares", "quantity")
+            self._first_present(
+                payload,
+                "size",
+                "original_size",
+                "originalSize",
+                "shares",
+                "quantity",
+                "taking_amount",
+                "takingAmount",
+            )
         )
         if quantity is None:
             quantity = self._optional_float(self._first_present(payload, "matched_size", "matchedSize")) or 0.0
@@ -495,9 +518,9 @@ class Polymarket(Broker):
             side=side,
             limit_price=price if order_type == Order.OrderType.LIMIT else None,
             order_type=order_type,
-            identifier=str(self._first_present(payload, "id", "order_id", "orderId") or ""),
+            identifier=str(self._first_present(payload, "id", "order_id", "orderId", "orderID") or ""),
             status=self._map_status(self._first_present(payload, "status", "state", "event_type", "eventType", "type")),
-            avg_fill_price=self._optional_float(self._first_present(payload, "average_price", "avgPrice", "price")),
+            avg_fill_price=avg_fill_price,
             time_in_force=str(self._first_present(payload, "time_in_force", "timeInForce", "tif") or "gtc").lower(),
         )
         order._raw = payload
@@ -779,6 +802,8 @@ class Polymarket(Broker):
             parsed.side = original_order.side
         if parsed.order_type == Order.OrderType.UNKNOWN:
             parsed.order_type = original_order.order_type
+        if parsed.limit_price is None:
+            parsed.limit_price = original_order.limit_price
         return parsed
 
     def _validate_order(self, order: Order):
@@ -928,11 +953,11 @@ class Polymarket(Broker):
     @staticmethod
     def _map_status(value: Any):
         status = str(value or "").lower()
-        if status in {"placement", "placed", "submitted", "live", "open", "matched"}:
+        if status in {"placement", "placed", "submitted", "live", "open"}:
             return Order.OrderStatus.OPEN
         if status in {"partially_filled", "partial_fill", "partially matched", "partial"}:
             return Order.OrderStatus.PARTIALLY_FILLED
-        if status in {"filled", "fill", "mined", "confirmed"}:
+        if status in {"filled", "fill", "mined", "confirmed", "matched"}:
             return Order.OrderStatus.FILLED
         if status in {"canceled", "cancelled", "cancellation"}:
             return Order.OrderStatus.CANCELED
@@ -951,6 +976,24 @@ class Polymarket(Broker):
             if key in mapping and mapping[key] is not None:
                 return mapping[key]
         return None
+
+    @classmethod
+    def _average_fill_price(cls, payload: dict, *, fallback: float | None = None) -> float | None:
+        explicit = cls._optional_float(cls._first_present(payload, "average_price", "avgPrice", "price"))
+        if explicit is not None:
+            return explicit
+        making_amount = cls._first_present(payload, "making_amount", "makingAmount")
+        taking_amount = cls._first_present(payload, "taking_amount", "takingAmount")
+        if making_amount is None or taking_amount is None:
+            return fallback
+        if isinstance(making_amount, str) and not making_amount.strip():
+            return fallback
+        if isinstance(taking_amount, str) and not taking_amount.strip():
+            return fallback
+        taking_decimal = cls._decimal(taking_amount)
+        if taking_decimal == 0:
+            return fallback
+        return float(cls._decimal(making_amount) / taking_decimal)
 
     @staticmethod
     def _listify(value: Any) -> list:
@@ -984,6 +1027,8 @@ class Polymarket(Broker):
     @classmethod
     def _optional_float(cls, value: Any) -> float | None:
         if value is None:
+            return None
+        if isinstance(value, str) and not value.strip():
             return None
         return cls._to_float(value)
 

--- a/lumibot/brokers/polymarket.py
+++ b/lumibot/brokers/polymarket.py
@@ -1,0 +1,733 @@
+from __future__ import annotations
+
+import json
+import os
+import queue
+import time
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+import httpx
+
+from lumibot.brokers.broker import Broker, LumibotBrokerAPIError
+from lumibot.data_sources.polymarket_data import PolymarketData
+from lumibot.entities import Asset, Order, Position
+from lumibot.trading_builtins import CustomStream, PollingStream
+
+
+POLYMARKET_SECRET_KEYS = {
+    "PRIVATE_KEY",
+    "CLOB_API_KEY",
+    "CLOB_API_SECRET",
+    "CLOB_API_PASSPHRASE",
+    "RELAYER_API_KEY",
+    "RELAYER_API_KEY_ADDRESS",
+    "API_CREDENTIALS_JSON",
+}
+
+
+@dataclass(frozen=True)
+class PolymarketCredentials:
+    private_key: str | None = None
+    wallet_address: str | None = None
+    clob_api_key: str | None = None
+    clob_api_secret: str | None = None
+    clob_api_passphrase: str | None = None
+    relayer_api_key: str | None = None
+    relayer_api_key_address: str | None = None
+    api_credentials_json: str | None = None
+    builder_code: str | None = None
+
+
+class PolymarketCredentialStore:
+    """Loads Polymarket CLOB credentials without logging raw secret values."""
+
+    ENV_PREFIX = "POLYMARKET_"
+
+    def __init__(self, config: dict | None = None):
+        self.config = config or {}
+
+    def load(self) -> PolymarketCredentials:
+        return PolymarketCredentials(
+            private_key=self._get("PRIVATE_KEY"),
+            wallet_address=self._get("WALLET_ADDRESS"),
+            clob_api_key=self._get("CLOB_API_KEY"),
+            clob_api_secret=self._get("CLOB_API_SECRET"),
+            clob_api_passphrase=self._get("CLOB_API_PASSPHRASE"),
+            relayer_api_key=self._get("RELAYER_API_KEY"),
+            relayer_api_key_address=self._get("RELAYER_API_KEY_ADDRESS"),
+            api_credentials_json=self._get("API_CREDENTIALS_JSON"),
+            builder_code=self._get("BUILDER_CODE"),
+        )
+
+    def redacted_config(self) -> dict:
+        redacted = {}
+        for key, value in self.config.items():
+            if self._is_secret_key(key):
+                redacted[key] = "<redacted>" if value else value
+            else:
+                redacted[key] = value
+        return redacted
+
+    def _get(self, suffix: str) -> str | None:
+        return self.config.get(suffix) or self.config.get(f"{self.ENV_PREFIX}{suffix}") or os.environ.get(
+            f"{self.ENV_PREFIX}{suffix}"
+        )
+
+    @staticmethod
+    def _is_secret_key(key: str) -> bool:
+        normalized = key.removeprefix("POLYMARKET_")
+        return normalized in POLYMARKET_SECRET_KEYS
+
+
+class PolymarketCLOBStream(CustomStream):
+    """LumiBot stream bridge for Polymarket market/user events.
+
+    The class exposes event handlers that are fully unit-testable with fake payloads. Live WebSocket connection support
+    is intentionally conservative and optional because authenticated stream connection details depend on the beta SDK
+    and generated CLOB credentials.
+    """
+
+    def __init__(
+        self,
+        broker: "Polymarket",
+        *,
+        polling_interval: float = 5.0,
+        use_websocket: bool = True,
+    ):
+        super().__init__()
+        self.broker = broker
+        self.polling_interval = polling_interval
+        self.use_websocket = use_websocket
+
+    def handle_market_event(self, event: Any) -> None:
+        self.broker.data_source.apply_market_event(event)
+
+    def handle_user_event(self, event: Any) -> None:
+        payload = PolymarketData._model_to_dict(event)
+        parsed = self.broker._parse_broker_order(payload, self.broker._strategy_name or self.broker.name)
+        status = parsed.status
+        if status == Order.OrderStatus.FILLED:
+            self.dispatch(self.broker.FILLED_ORDER, order=parsed, price=parsed.avg_fill_price, quantity=parsed.quantity)
+        elif status == Order.OrderStatus.PARTIALLY_FILLED:
+            self.dispatch(self.broker.PARTIALLY_FILLED_ORDER, order=parsed)
+        elif status == Order.OrderStatus.CANCELED:
+            self.dispatch(self.broker.CANCELED_ORDER, order=parsed)
+        elif status in (Order.OrderStatus.ERROR, Order.OrderStatus.REJECTED):
+            self.dispatch(self.broker.ERROR_ORDER, order=parsed)
+        else:
+            self.dispatch(self.broker.NEW_ORDER, order=parsed)
+
+    def _run(self):
+        # The SDK stream implementation is async-only. Until live credentials and SDK availability are verified, keep
+        # the stream thread useful as a reconciliation loop and route event handling through tested handler methods.
+        last_poll = 0.0
+        while not self._stop_event.is_set():
+            timeout = min(max(self.polling_interval, 0.1), 0.5)
+            try:
+                event, payload = self._queue.get(timeout=timeout)
+                self._process_queue_event(event, payload)
+                self._queue.task_done()
+                continue
+            except queue.Empty:
+                pass
+            except Exception:
+                self.broker.logger.exception("Polymarket stream event processing failed")
+
+            if time.monotonic() - last_poll < self.polling_interval:
+                continue
+            try:
+                self.broker.do_polling()
+                last_poll = time.monotonic()
+            except Exception:
+                self.broker.logger.exception("Polymarket stream reconciliation failed")
+
+
+class Polymarket(Broker):
+    NAME = "Polymarket"
+
+    def __init__(
+        self,
+        config: dict | None = None,
+        data_source: PolymarketData | None = None,
+        *,
+        polling_interval: float = 1.0,
+        use_websocket: bool = True,
+        connect_stream: bool = True,
+        max_workers: int = 20,
+        secure_client: Any | None = None,
+        data_api_client: Any | None = None,
+    ):
+        self.config = config or {}
+        self.credential_store = PolymarketCredentialStore(self.config)
+        self.credentials = self.credential_store.load()
+        self.polling_interval = polling_interval
+        self.use_websocket = use_websocket
+        self._secure_client = secure_client or self.config.get("secure_client")
+        self._data_api_client = data_api_client or httpx.Client(timeout=float(self.config.get("TIMEOUT", 10.0)))
+        self._owns_data_api_client = data_api_client is None
+        self._clients_initialized = secure_client is not None
+        self._trading_ready = False
+        self._recent_order_cache: dict[str, Any] = {}
+        self._recent_trade_cache: dict[str, Any] = {}
+
+        if data_source is None:
+            data_source = PolymarketData(config=self.config)
+
+        broker_config = dict(self.config)
+        broker_config.setdefault("MARKET", "24/7")
+        super().__init__(
+            name=self.NAME,
+            data_source=data_source,
+            config=broker_config,
+            connect_stream=connect_stream,
+            max_workers=max_workers,
+        )
+
+    def cleanup_streams(self):
+        try:
+            if self._owns_data_api_client and hasattr(self._data_api_client, "close"):
+                self._data_api_client.close()
+        finally:
+            super().cleanup_streams()
+
+    def _initialize_clients(self) -> Any:
+        if self._clients_initialized and self._secure_client is not None:
+            return self._secure_client
+
+        if not self.credentials.private_key:
+            raise LumibotBrokerAPIError(
+                "Missing POLYMARKET_PRIVATE_KEY. Authenticated Polymarket CLOB reads/trading require a local wallet "
+                "private key or session signer."
+            )
+
+        try:
+            from py_clob_client_v2.client import ClobClient
+            from py_clob_client_v2.clob_types import ApiCreds, BuilderConfig
+            from py_clob_client_v2.constants import POLYGON
+            from py_clob_client_v2.order_utils.model.signature_type_v2 import SignatureTypeV2
+        except Exception as exc:
+            raise LumibotBrokerAPIError(
+                "The Polymarket CLOB SDK is required for authenticated operations. Install `py-clob-client-v2` and "
+                "provide POLYMARKET_PRIVATE_KEY plus wallet/CLOB credentials."
+            ) from exc
+
+        creds = self._build_api_creds(ApiCreds)
+        builder_config = None
+        if self.credentials.builder_code:
+            builder_config = BuilderConfig(builder_code=self.credentials.builder_code)
+
+        signature_type = int(self.config.get("SIGNATURE_TYPE", SignatureTypeV2.POLY_1271))
+        self._secure_client = ClobClient(
+            self.config.get("CLOB_URL", PolymarketData.CLOB_URL),
+            chain_id=int(self.config.get("CHAIN_ID", POLYGON)),
+            key=self.credentials.private_key,
+            creds=creds,
+            signature_type=signature_type,
+            funder=self.credentials.wallet_address,
+            builder_config=builder_config,
+            retry_on_error=True,
+        )
+        if creds is None:
+            derived = self._secure_client.create_or_derive_api_key()
+            self._secure_client.set_api_creds(derived)
+            self._derived_api_creds = derived
+        self._clients_initialized = True
+        return self._secure_client
+
+    def _build_api_creds(self, api_creds_cls):
+        if self.credentials.api_credentials_json:
+            try:
+                raw = json.loads(self.credentials.api_credentials_json)
+            except json.JSONDecodeError as exc:
+                raise LumibotBrokerAPIError("POLYMARKET_API_CREDENTIALS_JSON is not valid JSON") from exc
+            return api_creds_cls(
+                api_key=raw.get("api_key") or raw.get("key"),
+                api_secret=raw.get("api_secret") or raw.get("secret"),
+                api_passphrase=raw.get("api_passphrase") or raw.get("passphrase"),
+            )
+        if (
+            self.credentials.clob_api_key
+            and self.credentials.clob_api_secret
+            and self.credentials.clob_api_passphrase
+        ):
+            return api_creds_cls(
+                api_key=self.credentials.clob_api_key,
+                api_secret=self.credentials.clob_api_secret,
+                api_passphrase=self.credentials.clob_api_passphrase,
+            )
+        return None
+
+    def _ensure_trading_ready(self) -> None:
+        if self._trading_ready:
+            return
+        secure_client = self._initialize_clients()
+        if self._truthy(self.config.get("AUTO_APPROVE") or os.environ.get("POLYMARKET_AUTO_APPROVE")):
+            try:
+                from py_clob_client_v2.clob_types import AssetType, BalanceAllowanceParams
+
+                secure_client.update_balance_allowance(BalanceAllowanceParams(asset_type=AssetType.COLLATERAL))
+            except Exception as exc:
+                raise LumibotBrokerAPIError(f"Polymarket trading approval setup failed: {exc}") from exc
+        self._trading_ready = True
+
+    def _get_balances_at_broker(self, quote_asset: Asset, strategy):
+        positions_value = self._get_positions_value()
+        cash = self._get_collateral_cash()
+        portfolio_value = cash + positions_value
+
+        secure_client = self._maybe_secure_client()
+        if secure_client is not None:
+            portfolio_values = self._call_if_exists(secure_client, "get_portfolio_values")
+            total = self._first_present(portfolio_values, "total", "portfolio_value", "portfolioValue", "value")
+            if total is not None:
+                portfolio_value = self._to_float(total)
+        return cash, positions_value, portfolio_value
+
+    def get_historical_account_value(self) -> dict:
+        secure_client = self._maybe_secure_client()
+        if secure_client is None:
+            return {}
+        values = self._call_if_exists(secure_client, "get_portfolio_values")
+        return PolymarketData._model_to_dict(values) if values is not None else {}
+
+    def _get_stream_object(self):
+        if self.use_websocket:
+            return PolymarketCLOBStream(self, polling_interval=self.polling_interval, use_websocket=True)
+        return PollingStream(self.polling_interval)
+
+    def _register_stream_events(self):
+        if isinstance(self.stream, PollingStream):
+            @self.stream.add_action(self.stream.POLL_EVENT)
+            def _poll_action():
+                self.do_polling()
+
+    def _run_stream(self):
+        self.stream.run(self.name)
+
+    def _pull_positions(self, strategy):
+        rows = self._get_positions_payload()
+        positions = []
+        for row in rows:
+            token_id = self._first_present(row, "asset", "token_id", "tokenId", "asset_id", "assetId")
+            if not token_id:
+                continue
+            asset = Asset(str(token_id), asset_type=Asset.AssetType.PREDICTION_CONTRACT, precision="0.000001")
+            quantity = self._to_float(self._first_present(row, "size", "quantity", "shares") or 0.0)
+            avg_price = self._optional_float(self._first_present(row, "avgPrice", "avg_price", "averagePrice"))
+            position = Position(strategy, asset, quantity, avg_fill_price=avg_price)
+            position.current_price = self._optional_float(self._first_present(row, "curPrice", "currentPrice", "price"))
+            position.market_value = self._optional_float(
+                self._first_present(row, "currentValue", "marketValue", "value")
+            )
+            position.pnl = self._optional_float(self._first_present(row, "cashPnl", "pnl"))
+            position.pnl_percent = self._optional_float(self._first_present(row, "percentPnl", "pnlPercent"))
+            position.outcome = self._first_present(row, "outcome")
+            position.condition_id = self._first_present(row, "conditionId", "condition_id")
+            position.slug = self._first_present(row, "slug", "marketSlug")
+            position._raw = row
+            positions.append(position)
+        return positions
+
+    def _pull_position(self, strategy, asset):
+        token_id = asset.symbol if isinstance(asset, Asset) else str(asset)
+        for position in self._pull_positions(strategy):
+            if str(position.asset.symbol) == str(token_id):
+                return position
+        return None
+
+    def _pull_broker_all_orders(self):
+        secure_client = self._initialize_clients()
+        orders = self._call_if_exists(secure_client, "get_open_orders")
+        return self._listify(orders)
+
+    def _pull_broker_order(self, identifier):
+        secure_client = self._initialize_clients()
+        order = self._call_if_exists(secure_client, "get_order", identifier)
+        if order is None:
+            return self._recent_order_cache.get(str(identifier)) or self._recent_trade_cache.get(str(identifier))
+        return order
+
+    def _parse_broker_order(self, response: dict, strategy_name: str, strategy_object=None):
+        payload = PolymarketData._model_to_dict(response) or {}
+        token_id = self._first_present(payload, "asset_id", "assetId", "token_id", "tokenId", "asset", "market")
+        asset = Asset(str(token_id or "UNKNOWN"), asset_type=Asset.AssetType.PREDICTION_CONTRACT, precision="0.000001")
+        side = self._map_side(self._first_present(payload, "side", "direction"))
+        price = self._optional_float(self._first_present(payload, "price", "limitPrice", "average_price", "avgPrice"))
+        quantity = self._optional_float(
+            self._first_present(payload, "size", "original_size", "originalSize", "shares", "quantity")
+        )
+        if quantity is None:
+            quantity = self._optional_float(self._first_present(payload, "matched_size", "matchedSize")) or 0.0
+
+        order_type = self._map_order_type(self._first_present(payload, "order_type", "orderType", "type"))
+        order = Order(
+            strategy_name,
+            asset=asset,
+            quantity=quantity,
+            side=side,
+            limit_price=price if order_type == Order.OrderType.LIMIT else None,
+            order_type=order_type,
+            identifier=str(self._first_present(payload, "id", "order_id", "orderId") or ""),
+            status=self._map_status(self._first_present(payload, "status", "state", "event_type", "eventType", "type")),
+            avg_fill_price=self._optional_float(self._first_present(payload, "average_price", "avgPrice", "price")),
+            time_in_force=str(self._first_present(payload, "time_in_force", "timeInForce", "tif") or "gtc").lower(),
+        )
+        order._raw = payload
+        order.broker_create_date = self._first_present(payload, "created_at", "createdAt", "created")
+        order.broker_update_date = self._first_present(payload, "updated_at", "updatedAt", "updated")
+        return order
+
+    def _submit_order(self, order):
+        self._validate_order(order)
+        if order.order_type == Order.OrderType.MARKET:
+            return self._submit_market_order(order)
+        if order.order_type == Order.OrderType.LIMIT:
+            return self._submit_limit_order(order)
+        raise ValueError(f"Unsupported Polymarket order type: {order.order_type}")
+
+    def _submit_market_order(self, order):
+        self._ensure_trading_ready()
+        token_id = self._token_id(order.asset)
+        side = str(order.side).upper()
+        params = order.custom_params or {}
+        explicit_tif = params.get("order_type") or params.get("time_in_force")
+        order_tif = str(order.time_in_force or "").upper()
+        tif = str(explicit_tif or (order_tif if order_tif in {"FAK", "FOK"} else "FAK")).upper()
+        if tif not in {"FAK", "FOK"}:
+            raise ValueError("Polymarket market orders require FAK or FOK time-in-force")
+
+        kwargs = {"token_id": token_id, "side": side, "order_type": tif}
+        if side == "BUY":
+            amount = params.get("amount")
+            if amount is None:
+                raise ValueError('Polymarket BUY market orders require custom_params["amount"] in dollars')
+            self._validate_notional_cap(amount)
+            kwargs["amount"] = str(amount)
+            max_spend = params.get("max_spend")
+            if max_spend is not None:
+                kwargs["max_spend"] = str(max_spend)
+            max_price = params.get("max_price") or params.get("price")
+            if max_price is not None:
+                kwargs["price"] = str(max_price)
+        else:
+            shares = params.get("shares") or order.quantity
+            if shares is None:
+                raise ValueError("Polymarket SELL market orders require shares or order.quantity")
+            kwargs["shares"] = str(shares)
+            min_price = params.get("min_price") or params.get("price")
+            if min_price is not None:
+                kwargs["price"] = str(min_price)
+
+        response = self._create_and_post_market_order(**kwargs)
+        return self._order_from_submit_response(response, order)
+
+    def _submit_limit_order(self, order):
+        self._ensure_trading_ready()
+        token_id = self._token_id(order.asset)
+        if order.limit_price is None:
+            raise ValueError("Polymarket limit orders require limit_price")
+        self._validate_tick_size(token_id, order.limit_price)
+        response = self._create_and_post_limit_order(
+            token_id=token_id,
+            side=str(order.side).upper(),
+            price=str(order.limit_price),
+            size=str(order.quantity),
+            time_in_force=str(order.time_in_force or "GTC").upper(),
+        )
+        return self._order_from_submit_response(response, order)
+
+    def cancel_order(self, order):
+        identifier = getattr(order, "identifier", order)
+        if not identifier:
+            raise ValueError("Cannot cancel Polymarket order without an identifier")
+        secure_client = self._initialize_clients()
+        try:
+            from py_clob_client_v2.clob_types import OrderPayload
+        except Exception as exc:
+            if hasattr(secure_client, "cancel_order"):
+                response = secure_client.cancel_order(str(identifier))
+                order.status = Order.OrderStatus.CANCELED
+                return response
+            raise LumibotBrokerAPIError("py-clob-client-v2 is required to cancel Polymarket orders") from exc
+        response = secure_client.cancel_order(OrderPayload(orderID=str(identifier)))
+        order.status = Order.OrderStatus.CANCELED
+        return response
+
+    def _modify_order(self, order, limit_price=None, stop_price=None):
+        raise NotImplementedError("Polymarket does not support native order modification yet; use cancel-replace.")
+
+    def do_polling(self):
+        try:
+            self._pull_positions(self._strategy_name or self.name)
+        except Exception:
+            self.logger.debug("Polymarket position polling failed", exc_info=True)
+        try:
+            for raw in self._pull_broker_all_orders():
+                parsed = self._parse_broker_order(raw, self._strategy_name or self.name)
+                if parsed.identifier:
+                    self._recent_order_cache[parsed.identifier] = raw
+        except Exception:
+            self.logger.debug("Polymarket order polling failed", exc_info=True)
+
+    def _get_positions_payload(self) -> list[dict]:
+        secure_client = self._maybe_secure_client()
+        if secure_client is not None:
+            rows = self._call_if_exists(secure_client, "list_positions")
+            if rows is not None:
+                return self._listify(rows)
+
+        wallet = self.credentials.wallet_address
+        if not wallet:
+            raise LumibotBrokerAPIError("Missing POLYMARKET_WALLET_ADDRESS for Polymarket position reads")
+        payload = self._data_api_get("/positions", params={"user": wallet})
+        return self._listify(payload)
+
+    def _get_positions_value(self) -> float:
+        secure_client = self._maybe_secure_client()
+        if secure_client is not None:
+            values = self._call_if_exists(secure_client, "get_portfolio_values")
+            value = self._first_present(values, "value", "positions_value", "positionsValue", "current_value")
+            if value is not None:
+                return self._to_float(value)
+
+        wallet = self.credentials.wallet_address
+        if not wallet:
+            return 0.0
+        try:
+            payload = self._data_api_get("/value", params={"user": wallet})
+        except Exception:
+            return 0.0
+        rows = self._listify(payload)
+        if not rows:
+            return 0.0
+        return self._to_float(self._first_present(rows[0], "value") or 0.0)
+
+    def _get_collateral_cash(self) -> float:
+        secure_client = self._maybe_secure_client()
+        if secure_client is not None:
+            for method_name in ("get_balance_allowance", "get_balance", "get_collateral_balance"):
+                if method_name == "get_balance_allowance":
+                    try:
+                        from py_clob_client_v2.clob_types import AssetType, BalanceAllowanceParams
+
+                        value = secure_client.get_balance_allowance(
+                            BalanceAllowanceParams(asset_type=AssetType.COLLATERAL)
+                        )
+                    except Exception:
+                        value = self._call_if_exists(secure_client, "get_balance_allowance")
+                else:
+                    value = self._call_if_exists(secure_client, method_name)
+                balance = self._first_present(value, "balance", "available", "cash", "collateral", "collateral_balance")
+                if balance is not None:
+                    return self._to_float(balance)
+        override = self.config.get("CASH_BALANCE") or self.config.get("POLYMARKET_CASH_BALANCE")
+        return self._to_float(override or 0.0)
+
+    def _data_api_get(self, path: str, params: dict | None = None) -> Any:
+        url = f"https://data-api.polymarket.com/{path.lstrip('/')}"
+        response = self._data_api_client.get(url, params=params or {})
+        if isinstance(response, (dict, list)):
+            return response
+        if hasattr(response, "raise_for_status"):
+            response.raise_for_status()
+        return response.json()
+
+    def _maybe_secure_client(self):
+        if self._secure_client is not None:
+            return self._secure_client
+        if self.credentials.private_key:
+            return self._initialize_clients()
+        return None
+
+    def _create_and_post_market_order(self, **kwargs):
+        secure_client = self._initialize_clients()
+        try:
+            from py_clob_client_v2.clob_types import MarketOrderArgs, OrderType
+        except Exception as exc:
+            if hasattr(secure_client, "create_and_post_market_order"):
+                return secure_client.create_and_post_market_order(kwargs)
+            raise LumibotBrokerAPIError("py-clob-client-v2 is required for Polymarket market orders") from exc
+
+        order_type = getattr(OrderType, str(kwargs.get("order_type") or "FOK").upper())
+        amount = kwargs.get("amount") if kwargs.get("side") == "BUY" else kwargs.get("shares")
+        order_kwargs = dict(
+            token_id=kwargs["token_id"],
+            amount=float(amount),
+            side=kwargs["side"],
+            price=float(kwargs.get("price") or 0),
+            order_type=order_type,
+        )
+        if self.credentials.builder_code:
+            order_kwargs["builder_code"] = self.credentials.builder_code
+        order_args = MarketOrderArgs(**order_kwargs)
+        return secure_client.create_and_post_market_order(order_args, order_type=order_type)
+
+    def _create_and_post_limit_order(self, **kwargs):
+        secure_client = self._initialize_clients()
+        try:
+            from py_clob_client_v2.clob_types import OrderArgs, OrderType
+        except Exception as exc:
+            if hasattr(secure_client, "create_and_post_order"):
+                return secure_client.create_and_post_order(kwargs)
+            raise LumibotBrokerAPIError("py-clob-client-v2 is required for Polymarket limit orders") from exc
+
+        tif = str(kwargs.get("time_in_force") or "GTC").upper()
+        if tif == "DAY":
+            tif = "GTC"
+        if tif not in {"GTC", "GTD"}:
+            raise ValueError("Polymarket limit orders support GTC or GTD")
+        order_kwargs = dict(
+            token_id=kwargs["token_id"],
+            price=float(kwargs["price"]),
+            size=float(kwargs["size"]),
+            side=kwargs["side"],
+        )
+        if self.credentials.builder_code:
+            order_kwargs["builder_code"] = self.credentials.builder_code
+        order_args = OrderArgs(**order_kwargs)
+        return secure_client.create_and_post_order(order_args, order_type=getattr(OrderType, tif))
+
+    @staticmethod
+    def _call_if_exists(obj: Any, method_name: str, *args, **kwargs):
+        if obj is None:
+            return None
+        method = getattr(obj, method_name, None)
+        if method is None:
+            return None
+        return method(*args, **kwargs)
+
+    def _order_from_submit_response(self, response: Any, original_order: Order) -> Order:
+        parsed = self._parse_broker_order(response, original_order.strategy)
+        if not parsed.identifier:
+            parsed.identifier = original_order.identifier
+        parsed.custom_params = original_order.custom_params
+        parsed.quote = original_order.quote
+        if parsed.asset.symbol == "UNKNOWN":
+            parsed.asset = original_order.asset
+        if parsed.quantity == 0:
+            parsed.quantity = original_order.quantity
+        if parsed.side == Order.OrderSide.UNKNOWN:
+            parsed.side = original_order.side
+        if parsed.order_type == Order.OrderType.UNKNOWN:
+            parsed.order_type = original_order.order_type
+        return parsed
+
+    def _validate_order(self, order: Order):
+        if order.asset is None or order.asset.asset_type != Asset.AssetType.PREDICTION_CONTRACT:
+            raise ValueError("Polymarket orders require asset_type='prediction_contract'")
+        if order.order_class not in (None, Order.OrderClass.SIMPLE, "simple"):
+            raise ValueError("Polymarket broker only supports simple orders")
+        if order.side not in (Order.OrderSide.BUY, Order.OrderSide.SELL, "buy", "sell"):
+            raise ValueError(f"Unsupported Polymarket side: {order.side}")
+
+    def _validate_notional_cap(self, amount: Any):
+        amount = self._decimal(amount)
+        cap = self._decimal(
+            self.config.get("MAX_MARKET_ORDER_NOTIONAL")
+            or self.config.get("POLYMARKET_MAX_MARKET_ORDER_NOTIONAL")
+            or os.environ.get("POLYMARKET_MAX_MARKET_ORDER_NOTIONAL")
+            or os.environ.get("POLYMARKET_TEST_MAX_NOTIONAL")
+            or "5"
+        )
+        if amount > cap:
+            raise ValueError(f"Polymarket market order amount {amount} exceeds configured cap {cap}")
+
+    def _validate_tick_size(self, token_id: str, price: Any):
+        tick_size = self.data_source.get_tick_size(token_id)
+        if tick_size is None:
+            return
+        price = self._decimal(price)
+        if price % tick_size != 0:
+            raise ValueError(f"Polymarket limit price {price} is not aligned to tick size {tick_size}")
+
+    @staticmethod
+    def _token_id(asset: Asset) -> str:
+        if asset.asset_type != Asset.AssetType.PREDICTION_CONTRACT:
+            raise ValueError("Polymarket orders require prediction_contract assets")
+        return str(asset.symbol)
+
+    @staticmethod
+    def _map_side(value: Any):
+        side = str(value or "").lower()
+        if side == "buy":
+            return Order.OrderSide.BUY
+        if side == "sell":
+            return Order.OrderSide.SELL
+        return Order.OrderSide.UNKNOWN
+
+    @staticmethod
+    def _map_order_type(value: Any):
+        order_type = str(value or "").lower()
+        if order_type in {"market", "fak", "fok"}:
+            return Order.OrderType.MARKET
+        if order_type in {"limit", "gtc", "gtd"}:
+            return Order.OrderType.LIMIT
+        return Order.OrderType.UNKNOWN
+
+    @staticmethod
+    def _map_status(value: Any):
+        status = str(value or "").lower()
+        if status in {"placement", "placed", "submitted", "live", "open", "matched"}:
+            return Order.OrderStatus.OPEN
+        if status in {"partially_filled", "partial_fill", "partially matched", "partial"}:
+            return Order.OrderStatus.PARTIALLY_FILLED
+        if status in {"filled", "fill", "mined", "confirmed"}:
+            return Order.OrderStatus.FILLED
+        if status in {"canceled", "cancelled", "cancellation"}:
+            return Order.OrderStatus.CANCELED
+        if status == "expired":
+            return Order.OrderStatus.EXPIRED
+        if status in {"failed", "error", "rejected"}:
+            return Order.OrderStatus.ERROR
+        return Order.OrderStatus.UNKNOWN
+
+    @staticmethod
+    def _first_present(mapping: Any, *keys: str) -> Any:
+        mapping = PolymarketData._model_to_dict(mapping)
+        if not isinstance(mapping, dict):
+            return None
+        for key in keys:
+            if key in mapping and mapping[key] is not None:
+                return mapping[key]
+        return None
+
+    @staticmethod
+    def _listify(value: Any) -> list:
+        value = PolymarketData._model_to_dict(value)
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, tuple):
+            return list(value)
+        if isinstance(value, dict):
+            for key in ("items", "data", "orders", "positions", "trades", "results"):
+                if key in value and isinstance(value[key], (list, tuple)):
+                    return list(value[key])
+            return [value]
+        return [value]
+
+    @staticmethod
+    def _decimal(value: Any) -> Decimal:
+        if isinstance(value, Decimal):
+            return value
+        try:
+            return Decimal(str(value))
+        except (InvalidOperation, TypeError) as exc:
+            raise ValueError(f"Invalid Polymarket numeric value: {value!r}") from exc
+
+    @classmethod
+    def _to_float(cls, value: Any) -> float:
+        return float(cls._decimal(value))
+
+    @classmethod
+    def _optional_float(cls, value: Any) -> float | None:
+        if value is None:
+            return None
+        return cls._to_float(value)
+
+    @staticmethod
+    def _truthy(value: Any) -> bool:
+        return str(value or "").strip().lower() in {"1", "true", "yes", "y", "on"}

--- a/lumibot/brokers/polymarket.py
+++ b/lumibot/brokers/polymarket.py
@@ -7,6 +7,7 @@ import queue
 import threading
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
@@ -114,6 +115,7 @@ class PolymarketCLOBStream(CustomStream):
         self.market_token_ids = {str(token_id) for token_id in (market_token_ids or []) if token_id}
         self.websocket_factory = websocket_factory
         self._websocket_threads: list[threading.Thread] = []
+        self._seen_user_event_keys: set[tuple[str, str, str]] = set()
 
     def subscribe_market_assets(self, token_ids: list[str] | tuple[str, ...] | set[str]) -> None:
         for token_id in token_ids or []:
@@ -125,7 +127,11 @@ class PolymarketCLOBStream(CustomStream):
 
     def handle_user_event(self, event: Any) -> None:
         payload = PolymarketData._model_to_dict(event)
-        parsed = self.broker._parse_broker_order(payload, self.broker._strategy_name or self.broker.name)
+        event_key = self._user_event_key(payload)
+        if event_key in self._seen_user_event_keys:
+            return
+        self._seen_user_event_keys.add(event_key)
+        parsed = self.broker._parse_broker_order(payload, self.broker._strategy_name or "")
         status = parsed.status
         if status == Order.OrderStatus.FILLED:
             self.dispatch(self.broker.FILLED_ORDER, order=parsed, price=parsed.avg_fill_price, quantity=parsed.quantity)
@@ -212,6 +218,8 @@ class PolymarketCLOBStream(CustomStream):
                     await asyncio.sleep(min(max(self.polling_interval, 0.5), 5.0))
 
     async def _user_websocket_loop(self) -> None:
+        while not self._stop_event.is_set() and not self._can_route_user_events():
+            await asyncio.sleep(0.1)
         auth = self.broker._websocket_auth_payload()
         if not auth:
             return
@@ -261,6 +269,34 @@ class PolymarketCLOBStream(CustomStream):
     @staticmethod
     def _user_subscription_payload(auth: dict) -> dict:
         return {"auth": auth, "type": "user"}
+
+    def _can_route_user_events(self) -> bool:
+        if self.broker._strategy_name:
+            return True
+        try:
+            return len(self.broker._subscribers) == 1
+        except Exception:
+            return False
+
+    @staticmethod
+    def _user_event_key(payload: dict) -> tuple[str, str, str]:
+        payload = PolymarketData._model_to_dict(payload) or {}
+        identifier = Polymarket._first_present(
+            payload,
+            "id",
+            "order_id",
+            "orderId",
+            "orderID",
+            "trade_id",
+            "tradeId",
+            "transactionHash",
+            "transaction_hash",
+        )
+        status = Polymarket._first_present(payload, "status", "state", "event_type", "eventType", "type")
+        if identifier is not None:
+            return str(identifier), str(status or ""), ""
+        updated = Polymarket._first_present(payload, "updated_at", "updatedAt", "timestamp", "created_at", "createdAt")
+        return str(identifier or ""), str(status or ""), str(updated or "")
 
 
 class Polymarket(Broker):
@@ -405,6 +441,20 @@ class Polymarket(Broker):
                 raise LumibotBrokerAPIError(f"Polymarket trading approval setup failed: {exc}") from exc
         self._trading_ready = True
 
+    def _ensure_sell_token_allowance(self, token_id: str) -> None:
+        """Sync conditional-token allowance before SELL orders."""
+        secure_client = self._initialize_clients()
+        try:
+            from py_clob_client_v2.clob_types import AssetType, BalanceAllowanceParams
+        except Exception as exc:
+            raise LumibotBrokerAPIError("py-clob-client-v2 is required to approve Polymarket sell tokens") from exc
+        try:
+            secure_client.update_balance_allowance(
+                BalanceAllowanceParams(asset_type=AssetType.CONDITIONAL, token_id=str(token_id))
+            )
+        except Exception as exc:
+            raise LumibotBrokerAPIError(f"Polymarket conditional-token sell approval failed: {exc}") from exc
+
     def _get_balances_at_broker(self, quote_asset: Asset, strategy):
         positions_value = self._get_positions_value()
         cash = self._get_collateral_cash()
@@ -437,10 +487,62 @@ class Polymarket(Broker):
         return PollingStream(self.polling_interval)
 
     def _register_stream_events(self):
-        if isinstance(self.stream, PollingStream):
-            @self.stream.add_action(self.stream.POLL_EVENT)
+        broker = self
+        stream = self.stream
+
+        if isinstance(stream, PollingStream):
+            @stream.add_action(stream.POLL_EVENT)
             def _poll_action():
                 self.do_polling()
+
+        @stream.add_action(broker.NEW_ORDER)
+        def _new_order_action(order):
+            try:
+                broker._process_trade_event(order, broker.NEW_ORDER)
+            except Exception:
+                broker.logger.exception("Polymarket NEW order stream event processing failed")
+
+        @stream.add_action(broker.FILLED_ORDER)
+        def _filled_order_action(order, price=None, quantity=None, filled_quantity=None):
+            try:
+                filled_quantity = filled_quantity if filled_quantity is not None else quantity
+                broker._process_trade_event(
+                    order,
+                    broker.FILLED_ORDER,
+                    price=price,
+                    filled_quantity=filled_quantity,
+                    multiplier=order.asset.multiplier if order.asset else 1,
+                )
+            except Exception:
+                broker.logger.exception("Polymarket FILLED order stream event processing failed")
+
+        @stream.add_action(broker.PARTIALLY_FILLED_ORDER)
+        def _partial_fill_action(order, price=None, quantity=None, filled_quantity=None):
+            try:
+                filled_quantity = filled_quantity if filled_quantity is not None else quantity
+                broker._process_trade_event(
+                    order,
+                    broker.PARTIALLY_FILLED_ORDER,
+                    price=price,
+                    filled_quantity=filled_quantity,
+                    multiplier=order.asset.multiplier if order.asset else 1,
+                )
+            except Exception:
+                broker.logger.exception("Polymarket PARTIAL order stream event processing failed")
+
+        @stream.add_action(broker.CANCELED_ORDER)
+        def _canceled_order_action(order):
+            try:
+                broker._process_trade_event(order, broker.CANCELED_ORDER)
+            except Exception:
+                broker.logger.exception("Polymarket CANCELED order stream event processing failed")
+
+        @stream.add_action(broker.ERROR_ORDER)
+        def _error_order_action(order, error=None):
+            try:
+                broker._process_trade_event(order, broker.ERROR_ORDER, error=error)
+            except Exception:
+                broker.logger.exception("Polymarket ERROR order stream event processing failed")
 
     def _run_stream(self):
         self.stream.run(self.name)
@@ -494,19 +596,8 @@ class Polymarket(Broker):
         asset = Asset(str(token_id or "UNKNOWN"), asset_type=Asset.AssetType.PREDICTION_CONTRACT, precision="0.000001")
         side = self._map_side(self._first_present(payload, "side", "direction"))
         price = self._optional_float(self._first_present(payload, "price", "limitPrice", "average_price", "avgPrice"))
-        avg_fill_price = self._average_fill_price(payload, fallback=price)
-        quantity = self._optional_float(
-            self._first_present(
-                payload,
-                "size",
-                "original_size",
-                "originalSize",
-                "shares",
-                "quantity",
-                "taking_amount",
-                "takingAmount",
-            )
-        )
+        avg_fill_price = self._average_fill_price(payload, side=side, fallback=price)
+        quantity = self._order_quantity(payload, side)
         if quantity is None:
             quantity = self._optional_float(self._first_present(payload, "matched_size", "matchedSize")) or 0.0
 
@@ -564,6 +655,7 @@ class Polymarket(Broker):
             shares = params.get("shares") or order.quantity
             if shares is None:
                 raise ValueError("Polymarket SELL market orders require shares or order.quantity")
+            self._ensure_sell_token_allowance(token_id)
             kwargs["shares"] = str(shares)
             min_price = params.get("min_price") or params.get("price")
             if min_price is not None:
@@ -578,12 +670,26 @@ class Polymarket(Broker):
         if order.limit_price is None:
             raise ValueError("Polymarket limit orders require limit_price")
         self._validate_tick_size(token_id, order.limit_price)
+        params = order.custom_params or {}
+        time_in_force = str(order.time_in_force or params.get("time_in_force") or "GTC").upper()
+        if time_in_force == "DAY":
+            time_in_force = "GTC"
+        if time_in_force not in {"GTC", "GTD"}:
+            raise ValueError("Polymarket limit orders support GTC or GTD")
+        expiration = self._resolve_gtd_expiration(order, params, time_in_force)
+        post_only = self._truthy(params.get("post_only"))
+        if post_only and time_in_force not in {"GTC", "GTD"}:
+            raise ValueError("Polymarket post-only orders only support GTC or GTD")
+        if str(order.side).upper() == "SELL":
+            self._ensure_sell_token_allowance(token_id)
         response = self._create_and_post_limit_order(
             token_id=token_id,
             side=str(order.side).upper(),
             price=str(order.limit_price),
             size=str(order.quantity),
-            time_in_force=str(order.time_in_force or "GTC").upper(),
+            time_in_force=time_in_force,
+            expiration=expiration,
+            post_only=post_only,
         )
         return self._order_from_submit_response(response, order)
 
@@ -604,6 +710,64 @@ class Polymarket(Broker):
         order.status = Order.OrderStatus.CANCELED
         return response
 
+    def cancel_orders(self, orders):
+        orders = orders or []
+        if len(orders) == 0:
+            return {"canceled": [], "not_canceled": {}}
+        secure_client = self._initialize_clients()
+        identifiers = [str(getattr(order, "identifier", order)) for order in orders if getattr(order, "identifier", order)]
+        if not identifiers:
+            raise ValueError("Cannot cancel Polymarket orders without identifiers")
+        cancel_orders = getattr(secure_client, "cancel_orders", None)
+        if cancel_orders is not None:
+            response = cancel_orders(identifiers)
+            for order in orders:
+                if hasattr(order, "status"):
+                    order.status = Order.OrderStatus.CANCELED
+            return response
+        results = []
+        for order in orders:
+            results.append(self.cancel_order(order))
+        return results
+
+    def cancel_all_orders(self):
+        secure_client = self._initialize_clients()
+        cancel_all = getattr(secure_client, "cancel_all", None)
+        if cancel_all is not None:
+            return cancel_all()
+        return self.cancel_orders([self._parse_broker_order(raw, self._strategy_name or self.name) for raw in self._pull_broker_all_orders()])
+
+    def cancel_market_orders(self, market: str | None = None, asset_id: str | Asset | None = None):
+        secure_client = self._initialize_clients()
+        asset_id = self._token_id(asset_id) if isinstance(asset_id, Asset) else asset_id
+        cancel_market_orders = getattr(secure_client, "cancel_market_orders", None)
+        if cancel_market_orders is not None:
+            try:
+                from py_clob_client_v2.clob_types import OrderMarketCancelParams
+            except Exception:
+                payload = {"market": market, "asset_id": asset_id}
+            else:
+                payload = OrderMarketCancelParams(market=market, asset_id=asset_id)
+            return cancel_market_orders(payload)
+
+        filtered = []
+        for raw in self._pull_broker_all_orders():
+            raw_market = self._first_present(raw, "market", "conditionId", "condition_id")
+            raw_asset = self._first_present(raw, "asset_id", "assetId", "token_id", "tokenId", "asset")
+            if market is not None and str(raw_market) != str(market):
+                continue
+            if asset_id is not None and str(raw_asset) != str(asset_id):
+                continue
+            filtered.append(self._parse_broker_order(raw, self._strategy_name or self.name))
+        return self.cancel_orders(filtered)
+
+    def submit_orders(self, orders, *args, **kwargs):
+        if not orders:
+            return []
+        if not self._truthy(kwargs.get("batch") or (orders[0].custom_params or {}).get("batch")):
+            return [self.submit_order(order) for order in orders]
+        return self._submit_batch_orders(orders)
+
     def _modify_order(self, order, limit_price=None, stop_price=None):
         raise NotImplementedError("Polymarket does not support native order modification yet; use cancel-replace.")
 
@@ -619,6 +783,34 @@ class Polymarket(Broker):
                     self._recent_order_cache[parsed.identifier] = raw
         except Exception:
             self.logger.debug("Polymarket order polling failed", exc_info=True)
+        try:
+            for raw in self.get_recent_trades(limit=50):
+                identifier = self._first_present(raw, "id", "trade_id", "tradeId", "transactionHash", "transaction_hash")
+                if identifier:
+                    self._recent_trade_cache[str(identifier)] = raw
+        except Exception:
+            self.logger.debug("Polymarket trade polling failed", exc_info=True)
+
+    def get_recent_trades(self, *, market: str | None = None, user: str | None = None, limit: int = 100, **params) -> list[dict]:
+        secure_client = self._maybe_secure_client()
+        if secure_client is not None:
+            try:
+                rows = self._call_if_exists(secure_client, "get_trades")
+            except TypeError:
+                rows = None
+            if rows is not None:
+                return self._listify(rows)
+
+        if user is None:
+            addresses = self._position_query_addresses()
+            user = addresses[0] if addresses else None
+        params = dict(params)
+        params.setdefault("limit", limit)
+        if user is not None:
+            params.setdefault("user", user)
+        if market is not None:
+            params.setdefault("market", market)
+        return self._listify(self._data_api_get("/trades", params=params))
 
     def _get_positions_payload(self) -> list[dict]:
         secure_client = self._maybe_secure_client()
@@ -744,14 +936,59 @@ class Polymarket(Broker):
             size=float(kwargs["size"]),
             side=kwargs["side"],
         )
+        if kwargs.get("expiration"):
+            order_kwargs["expiration"] = int(kwargs["expiration"])
         if self.credentials.builder_code:
             order_kwargs["builder_code"] = self.credentials.builder_code
         order_args = OrderArgs(**order_kwargs)
         options = self._create_order_options(kwargs["token_id"])
         try:
-            return secure_client.create_and_post_order(order_args, options=options, order_type=getattr(OrderType, tif))
+            return secure_client.create_and_post_order(
+                order_args,
+                options=options,
+                order_type=getattr(OrderType, tif),
+                post_only=bool(kwargs.get("post_only")),
+            )
         except Exception as exc:
             self._raise_order_error(exc)
+
+    def _submit_batch_orders(self, orders):
+        self._ensure_trading_ready()
+        secure_client = self._initialize_clients()
+        if len(orders) > 15:
+            raise ValueError("Polymarket batch order submission supports at most 15 orders")
+        try:
+            from py_clob_client_v2.clob_types import OrderArgs, OrderType, PostOrdersArgs
+        except Exception as exc:
+            raise LumibotBrokerAPIError("py-clob-client-v2 is required for Polymarket batch orders") from exc
+
+        post_args = []
+        for order in orders:
+            self._validate_order(order)
+            if order.order_type != Order.OrderType.LIMIT:
+                raise ValueError("Polymarket batch submission currently supports limit orders only")
+            token_id = self._token_id(order.asset)
+            self._validate_tick_size(token_id, order.limit_price)
+            params = order.custom_params or {}
+            tif = str(order.time_in_force or params.get("time_in_force") or "GTC").upper()
+            if tif == "DAY":
+                tif = "GTC"
+            expiration = self._resolve_gtd_expiration(order, params, tif)
+            order_kwargs = {
+                "token_id": token_id,
+                "price": float(order.limit_price),
+                "size": float(order.quantity),
+                "side": str(order.side).upper(),
+            }
+            if expiration:
+                order_kwargs["expiration"] = expiration
+            signed_order = secure_client.create_order(OrderArgs(**order_kwargs), options=self._create_order_options(token_id))
+            post_args.append(PostOrdersArgs(order=signed_order, order_type=getattr(OrderType, tif)))
+        response = secure_client.post_orders(
+            post_args,
+            post_only=any(self._truthy((order.custom_params or {}).get("post_only")) for order in orders),
+        )
+        return [self._order_from_submit_response(item, original) for item, original in zip(self._listify(response), orders)]
 
     def _create_order_options(self, token_id: str):
         try:
@@ -789,6 +1026,7 @@ class Polymarket(Broker):
         return method(*args, **kwargs)
 
     def _order_from_submit_response(self, response: Any, original_order: Order) -> Order:
+        payload = PolymarketData._model_to_dict(response) or {}
         parsed = self._parse_broker_order(response, original_order.strategy)
         if not parsed.identifier:
             parsed.identifier = original_order.identifier
@@ -804,6 +1042,17 @@ class Polymarket(Broker):
             parsed.order_type = original_order.order_type
         if parsed.limit_price is None:
             parsed.limit_price = original_order.limit_price
+        if parsed.side == Order.OrderSide.SELL:
+            corrected_quantity = self._order_quantity(payload, Order.OrderSide.SELL)
+            corrected_avg_fill_price = self._average_fill_price(
+                payload,
+                side=Order.OrderSide.SELL,
+                fallback=parsed.avg_fill_price,
+            )
+            if corrected_quantity is not None:
+                parsed.quantity = corrected_quantity
+            if corrected_avg_fill_price is not None:
+                parsed._avg_fill_price = corrected_avg_fill_price
         return parsed
 
     def _validate_order(self, order: Order):
@@ -833,6 +1082,36 @@ class Polymarket(Broker):
         price = self._decimal(price)
         if price % tick_size != 0:
             raise ValueError(f"Polymarket limit price {price} is not aligned to tick size {tick_size}")
+
+    def _resolve_gtd_expiration(self, order: Order, params: dict, time_in_force: str) -> int | None:
+        if time_in_force != "GTD":
+            return None
+        raw = (
+            params.get("expiration")
+            or params.get("expires_at")
+            or params.get("good_till_date")
+            or getattr(order, "good_till_date", None)
+        )
+        if raw is None:
+            raise ValueError("Polymarket GTD limit orders require good_till_date or custom_params['expiration']")
+        return self._to_epoch_seconds(raw)
+
+    @classmethod
+    def _to_epoch_seconds(cls, value: Any) -> int:
+        if isinstance(value, (int, float, Decimal)):
+            return int(value)
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped.isdigit():
+                return int(stripped)
+            dt = datetime.fromisoformat(stripped.replace("Z", "+00:00"))
+        elif isinstance(value, datetime):
+            dt = value
+        else:
+            raise ValueError(f"Unsupported Polymarket expiration value: {value!r}")
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp())
 
     def _configured_stream_token_ids(self) -> list[str]:
         values = []
@@ -924,6 +1203,17 @@ class Polymarket(Broker):
                 "but may need Polymarket's deposit-wallet flow, relayer/builder credentials, and regenerated CLOB L2 "
                 f"credentials before live order submission works. Raw Polymarket error: {message}"
             ) from exc
+        if "allowance is not enough" in lowered or "not enough balance / allowance" in lowered:
+            raise LumibotBrokerAPIError(
+                "Polymarket rejected the order because available balance or allowance was insufficient. BUY orders "
+                "need pUSD collateral approval; SELL orders need conditional-token approval for the exact outcome "
+                f"token. Raw Polymarket error: {message}"
+            ) from exc
+        if "invalid post-only order" in lowered or "order crosses book" in lowered:
+            raise LumibotBrokerAPIError(
+                "Polymarket rejected the post-only order because it would immediately cross the order book. Use a "
+                f"less marketable limit price or remove custom_params['post_only']. Raw Polymarket error: {message}"
+            ) from exc
         raise exc
 
     @staticmethod
@@ -978,7 +1268,7 @@ class Polymarket(Broker):
         return None
 
     @classmethod
-    def _average_fill_price(cls, payload: dict, *, fallback: float | None = None) -> float | None:
+    def _average_fill_price(cls, payload: dict, *, side: Any = None, fallback: float | None = None) -> float | None:
         explicit = cls._optional_float(cls._first_present(payload, "average_price", "avgPrice", "price"))
         if explicit is not None:
             return explicit
@@ -990,10 +1280,24 @@ class Polymarket(Broker):
             return fallback
         if isinstance(taking_amount, str) and not taking_amount.strip():
             return fallback
+        making_decimal = cls._decimal(making_amount)
         taking_decimal = cls._decimal(taking_amount)
-        if taking_decimal == 0:
+        if taking_decimal == 0 or making_decimal == 0:
             return fallback
-        return float(cls._decimal(making_amount) / taking_decimal)
+        if side == Order.OrderSide.SELL:
+            return float(taking_decimal / making_decimal)
+        return float(making_decimal / taking_decimal)
+
+    @classmethod
+    def _order_quantity(cls, payload: dict, side: Any) -> float | None:
+        quantity = cls._optional_float(
+            cls._first_present(payload, "size", "original_size", "originalSize", "shares", "quantity")
+        )
+        if quantity is not None:
+            return quantity
+        if side == Order.OrderSide.SELL:
+            return cls._optional_float(cls._first_present(payload, "making_amount", "makingAmount"))
+        return cls._optional_float(cls._first_present(payload, "taking_amount", "takingAmount"))
 
     @staticmethod
     def _listify(value: Any) -> list:

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -60,6 +60,19 @@ def _is_external_schwab_token_file_valid(token_path: Path) -> bool:
         return False
 
 
+def _strip_external_schwab_token(token: dict) -> dict:
+    """Return an access-token-only Schwab token payload for parent-managed refresh mode."""
+    sanitized = dict(token)
+    for secret_key in (
+        "refresh_token",
+        "refresh_token_issued_at",
+        "refresh_token_expires_in",
+        "id_token",
+    ):
+        sanitized.pop(secret_key, None)
+    return sanitized
+
+
 class SchwabTokenPersistenceError(RuntimeError):
     """Raised when a refreshed Schwab OAuth token cannot be durably written."""
 
@@ -316,6 +329,8 @@ class Schwab(Broker):
             token_dict_for_session = wrapped_token_data.get('token')
             if not token_dict_for_session or 'access_token' not in token_dict_for_session:
                 raise ValueError("Token file is missing the 'token' object or 'access_token' within it.")
+            if external_token_refresh:
+                token_dict_for_session = _strip_external_schwab_token(token_dict_for_session)
             token_file_state = {"signature": None}
 
             def _token_file_signature():
@@ -328,7 +343,9 @@ class Schwab(Broker):
                 latest_token = latest_wrapped.get("token") if isinstance(latest_wrapped, dict) else latest_wrapped
                 if not isinstance(latest_token, dict) or not latest_token.get("access_token"):
                     raise ValueError("Token file is missing a usable access_token.")
-                if not latest_token.get("refresh_token") and token_dict_for_session.get("refresh_token"):
+                if external_token_refresh:
+                    latest_token = _strip_external_schwab_token(latest_token)
+                elif not latest_token.get("refresh_token") and token_dict_for_session.get("refresh_token"):
                     latest_token["refresh_token"] = token_dict_for_session["refresh_token"]
                 if latest_token.get("issued_at") and latest_token.get("expires_in"):
                     latest_token["expires_at"] = int(
@@ -485,7 +502,7 @@ class Schwab(Broker):
             logger.info(f"[Schwab] Successfully initialized Schwab client from {token_path} (app_secret not used).")
             # Check if SCHWAB_APP_SECRET is available for auto-refresh warning
             app_secret_for_refresh = config.get("SCHWAB_APP_SECRET") or os.environ.get("SCHWAB_APP_SECRET")
-            if not app_secret_for_refresh:
+            if not external_token_refresh and not app_secret_for_refresh:
                 logger.warning(
                     "[Schwab] Token auto-refresh by this client may not work as SCHWAB_APP_SECRET is not configured. "
                     "You may need to re-authenticate by providing a new SCHWAB_TOKEN or deleting token.json when the current token expires."
@@ -493,7 +510,7 @@ class Schwab(Broker):
         except Exception as e:
             logger.error(colored(f"[Schwab] Error initializing Schwab client from token file {token_path}: {e}", "red"))
             logger.error(traceback.format_exc())
-            if token_path.exists() and not isinstance(e, SchwabTokenPersistenceError):
+            if token_path.exists() and not external_token_refresh and not isinstance(e, SchwabTokenPersistenceError):
                 logger.warning(f"[Schwab] Deleting potentially corrupt token file: {token_path}")
                 token_path.unlink(missing_ok=True)
             self.schwab_authorization_error = True

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -103,6 +103,19 @@ class Tradier(Broker):
         return payload
 
     @staticmethod
+    def _strip_external_oauth_token(token_json: dict) -> dict:
+        """Return an access-token-only OAuth payload for parent-managed refresh mode."""
+        sanitized = dict(token_json)
+        for secret_key in (
+            "refresh_token",
+            "refresh_token_issued_at",
+            "refresh_token_expires_in",
+            "id_token",
+        ):
+            sanitized.pop(secret_key, None)
+        return sanitized
+
+    @staticmethod
     def _write_json_file_atomic(path: str | os.PathLike[str], payload: dict) -> None:
         resolved = Path(path).expanduser().resolve()
         tmp_path = resolved.with_name(f".{resolved.name}.tmp.{os.getpid()}.{threading.get_ident()}")
@@ -156,11 +169,14 @@ class Tradier(Broker):
     def _apply_oauth_token_json(self, token_json: dict) -> bool:
         if not isinstance(token_json, dict):
             return False
+        if getattr(self, "_oauth_refresh_mode", None) == OAUTH_REFRESH_MODE_EXTERNAL:
+            token_json = self._strip_external_oauth_token(token_json)
+            self._oauth_refresh_token = None
         new_access_token = token_json.get("access_token") or token_json.get("AUTH_TOKEN")
         if not new_access_token:
             return False
         self._oauth_token_payload_b64 = self._encode_base64url_json(token_json)
-        if token_json.get("refresh_token"):
+        if getattr(self, "_oauth_refresh_mode", None) != OAUTH_REFRESH_MODE_EXTERNAL and token_json.get("refresh_token"):
             self._oauth_refresh_token = token_json.get("refresh_token")
         try:
             issued_at_ms = int(token_json.get("issued_at") or 0)
@@ -480,11 +496,18 @@ class Tradier(Broker):
             self._oauth_token_payload_b64 = payload_b64
 
         if token_json:
+            if self._oauth_refresh_mode == OAUTH_REFRESH_MODE_EXTERNAL:
+                token_json = self._strip_external_oauth_token(token_json)
+                self._oauth_token_payload_b64 = self._encode_base64url_json(token_json)
             # Prefer explicit access_token argument/config; fall back to decoded payload.
             if not access_token:
                 access_token = token_json.get("access_token") or token_json.get("AUTH_TOKEN")
 
-            self._oauth_refresh_token = os.environ.get("TRADIER_REFRESH_TOKEN") or token_json.get("refresh_token")
+            self._oauth_refresh_token = (
+                None
+                if self._oauth_refresh_mode == OAUTH_REFRESH_MODE_EXTERNAL
+                else os.environ.get("TRADIER_REFRESH_TOKEN") or token_json.get("refresh_token")
+            )
             self._oauth_client_id = os.environ.get("TRADIER_OAUTH_CLIENT_ID")
             self._oauth_client_secret = os.environ.get("TRADIER_OAUTH_CLIENT_SECRET")
 

--- a/lumibot/components/agents/builtins.py
+++ b/lumibot/components/agents/builtins.py
@@ -481,6 +481,17 @@ def _bind_alpaca_news(strategy: Any, manager: Any) -> BoundTool:
             warning(message)
 
     def _resolve_alpaca_news_headers() -> tuple[dict[str, str] | None, str | None]:
+        # Prefer news-only credentials when supplied. They are intentionally
+        # separate from generic Alpaca broker env vars so a Tradier/IBKR/etc.
+        # strategy can use Alpaca/Benzinga news without changing broker routing.
+        api_key = str(os.environ.get("ALPACA_NEWS_API_KEY") or "").strip()
+        api_secret = str(os.environ.get("ALPACA_NEWS_API_SECRET") or "").strip()
+        if api_key and api_secret:
+            return {
+                "APCA-API-KEY-ID": api_key,
+                "APCA-API-SECRET-KEY": api_secret,
+            }, "byok_alpaca_news_env"
+
         broker = getattr(strategy, "broker", None)
         if str(getattr(broker, "name", "") or "").lower() == "alpaca":
             oauth_token = str(getattr(broker, "oauth_token", "") or "").strip()
@@ -494,14 +505,6 @@ def _bind_alpaca_news(strategy: Any, manager: Any) -> BoundTool:
                     "APCA-API-KEY-ID": api_key,
                     "APCA-API-SECRET-KEY": api_secret,
                 }, "alpaca_broker_api_key"
-
-        api_key = str(os.environ.get("ALPACA_NEWS_API_KEY") or "").strip()
-        api_secret = str(os.environ.get("ALPACA_NEWS_API_SECRET") or "").strip()
-        if api_key and api_secret:
-            return {
-                "APCA-API-KEY-ID": api_key,
-                "APCA-API-SECRET-KEY": api_secret,
-            }, "byok_alpaca_news_env"
 
         return None, None
 

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -643,22 +643,61 @@ def _provider_prompt_cache_key(request: RuntimeRequest) -> str:
     return f"lumibot:{request.agent_name}:{digest[:32]}"
 
 
-def _model_context_limit_tokens(model: Any) -> int | None:
+DEFAULT_MODEL_CONTEXT_LIMIT_TOKENS = 1_000_000
+DEFAULT_MODEL_CONTEXT_STRING_LIMIT_CHARS = 20_000
+
+MODEL_CONTEXT_LIMIT_PREFIXES: tuple[tuple[str, int, int], ...] = (
+    ("anthropic/claude-", 200_000, DEFAULT_MODEL_CONTEXT_STRING_LIMIT_CHARS),
+    ("claude-", 200_000, DEFAULT_MODEL_CONTEXT_STRING_LIMIT_CHARS),
+    ("deepseek/deepseek-v4-", 1_048_576, DEFAULT_MODEL_CONTEXT_STRING_LIMIT_CHARS),
+    ("gemini-3.1", 1_048_576, DEFAULT_MODEL_CONTEXT_STRING_LIMIT_CHARS),
+    ("gemini-2.5", 1_048_576, DEFAULT_MODEL_CONTEXT_STRING_LIMIT_CHARS),
+    ("gemini-1.5", 1_048_576, DEFAULT_MODEL_CONTEXT_STRING_LIMIT_CHARS),
+    ("openai/gpt-4.1", 1_047_576, DEFAULT_MODEL_CONTEXT_STRING_LIMIT_CHARS),
+    ("gpt-4.1", 1_047_576, DEFAULT_MODEL_CONTEXT_STRING_LIMIT_CHARS),
+    ("xai/grok-4.20", 2_000_000, DEFAULT_MODEL_CONTEXT_STRING_LIMIT_CHARS),
+    ("grok-4.20", 2_000_000, DEFAULT_MODEL_CONTEXT_STRING_LIMIT_CHARS),
+)
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        parsed = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _model_context_limit_entry(model: Any) -> tuple[int, int] | None:
     if not isinstance(model, str):
         return None
     lower = model.strip().lower()
-    if lower.startswith("deepseek/deepseek-v4-"):
-        return 1_048_576
-    return None
+    if not lower:
+        return None
+    for prefix, token_limit, string_limit in MODEL_CONTEXT_LIMIT_PREFIXES:
+        if lower.startswith(prefix):
+            return token_limit, string_limit
+    return (
+        _positive_int_env("LUMIBOT_AGENT_DEFAULT_CONTEXT_LIMIT_TOKENS", DEFAULT_MODEL_CONTEXT_LIMIT_TOKENS),
+        _positive_int_env("LUMIBOT_AGENT_DEFAULT_CONTEXT_STRING_LIMIT_CHARS", DEFAULT_MODEL_CONTEXT_STRING_LIMIT_CHARS),
+    )
+
+
+def _model_context_limit_tokens(model: Any) -> int | None:
+    entry = _model_context_limit_entry(model)
+    if entry is None:
+        return None
+    return entry[0]
 
 
 def _model_context_string_limit_chars(model: Any) -> int | None:
-    if not isinstance(model, str):
+    entry = _model_context_limit_entry(model)
+    if entry is None:
         return None
-    lower = model.strip().lower()
-    if lower.startswith("deepseek/deepseek-v4-"):
-        return 20_000
-    return None
+    return entry[1]
 
 
 def _truncate_preserving_edges(text: str, max_chars: int, *, label: str) -> str:
@@ -762,7 +801,7 @@ def _prune_tool_response_for_context_window(tool_response: Any, *, tool_name: st
         "original_chars": response_chars,
         "excerpt": _truncate_preserving_edges(serialized, max_chars, label=f"tool_response.{tool_name or 'unknown'}"),
         "message": (
-            "Tool response was shortened by Lumibot before sending it back to this DeepSeek model "
+            "Tool response was shortened by Lumibot before sending it back to this model "
             "because the provider context window would otherwise be exceeded. Call a targeted tool "
             "again if more detail is required."
         ),

--- a/lumibot/credentials.py
+++ b/lumibot/credentials.py
@@ -53,6 +53,7 @@ _BROKER_CLASS_NAMES = {
     "Schwab",
     "Bitunix",
     "ProjectX",
+    "Polymarket",
 }
 
 
@@ -337,6 +338,25 @@ ALPACA_TEST_CONFIG = {  # Paper trading!
     "PAPER": True
 }
 
+# Polymarket International CLOB Configuration
+POLYMARKET_CONFIG = {
+    "PRIVATE_KEY": os.environ.get("POLYMARKET_PRIVATE_KEY"),
+    "WALLET_ADDRESS": os.environ.get("POLYMARKET_WALLET_ADDRESS"),
+    "CLOB_API_KEY": os.environ.get("POLYMARKET_CLOB_API_KEY"),
+    "CLOB_API_SECRET": os.environ.get("POLYMARKET_CLOB_API_SECRET"),
+    "CLOB_API_PASSPHRASE": os.environ.get("POLYMARKET_CLOB_API_PASSPHRASE"),
+    "RELAYER_API_KEY": os.environ.get("POLYMARKET_RELAYER_API_KEY"),
+    "RELAYER_API_KEY_ADDRESS": os.environ.get("POLYMARKET_RELAYER_API_KEY_ADDRESS"),
+    "API_CREDENTIALS_JSON": os.environ.get("POLYMARKET_API_CREDENTIALS_JSON"),
+    "BUILDER_CODE": os.environ.get("POLYMARKET_BUILDER_CODE"),
+    "CLOB_URL": os.environ.get("POLYMARKET_CLOB_URL", "https://clob.polymarket.com"),
+    "GAMMA_URL": os.environ.get("POLYMARKET_GAMMA_URL", "https://gamma-api.polymarket.com"),
+    "CHAIN_ID": os.environ.get("POLYMARKET_CHAIN_ID", "137"),
+    "SIGNATURE_TYPE": os.environ.get("POLYMARKET_SIGNATURE_TYPE"),
+    "AUTO_APPROVE": os.environ.get("POLYMARKET_AUTO_APPROVE"),
+    "MAX_MARKET_ORDER_NOTIONAL": os.environ.get("POLYMARKET_MAX_MARKET_ORDER_NOTIONAL"),
+}
+
 # Tradier Configuration
 TRADIER_CONFIG = {
     # Add TRADIER_ACCESS_TOKEN (or TRADIER_API_KEY), TRADIER_ACCOUNT_NUMBER, and TRADIER_IS_PAPER to your
@@ -571,6 +591,11 @@ if not is_backtesting or is_backtesting.lower() == "false":
             broker = _broker_class("Schwab")(SCHWAB_CONFIG)
         elif trading_broker_name.lower() == "bitunix":
             broker = _broker_class("Bitunix")(BITUNIX_CONFIG)
+        elif trading_broker_name.lower() in ("polymarket", "polymarket_clob"):
+            from .data_sources import PolymarketData
+
+            data_source = PolymarketData(POLYMARKET_CONFIG)
+            broker = _broker_class("Polymarket")(POLYMARKET_CONFIG, data_source=data_source)
         elif trading_broker_name.lower() == "projectx":
             try:
                 # Get specified firm or use auto-detection
@@ -743,6 +768,10 @@ if not is_backtesting or is_backtesting.lower() == "false":
                 # If broker is also Schwab, share the client
                 if broker and broker.name.lower() == "schwab" and hasattr(broker, "client"):
                     data_source.set_client(broker.client)
+            elif data_source_name.lower() in ("polymarket", "polymarket_clob"):
+                from .data_sources import PolymarketData
+
+                data_source = PolymarketData(POLYMARKET_CONFIG)
             elif data_source_name.lower() == "thetadata":
                 # Check if we have ThetaData configuration
                 if THETADATA_CONFIG["THETADATA_USERNAME"] and THETADATA_CONFIG["THETADATA_PASSWORD"]:

--- a/lumibot/credentials.py
+++ b/lumibot/credentials.py
@@ -341,6 +341,7 @@ ALPACA_TEST_CONFIG = {  # Paper trading!
 # Polymarket International CLOB Configuration
 POLYMARKET_CONFIG = {
     "PRIVATE_KEY": os.environ.get("POLYMARKET_PRIVATE_KEY"),
+    "OWNER_ADDRESS": os.environ.get("POLYMARKET_OWNER_ADDRESS"),
     "WALLET_ADDRESS": os.environ.get("POLYMARKET_WALLET_ADDRESS"),
     "CLOB_API_KEY": os.environ.get("POLYMARKET_CLOB_API_KEY"),
     "CLOB_API_SECRET": os.environ.get("POLYMARKET_CLOB_API_SECRET"),

--- a/lumibot/data_sources/__init__.py
+++ b/lumibot/data_sources/__init__.py
@@ -19,6 +19,7 @@ _NAME_TO_MODULE = {
     "NoDataFound": "exceptions",
     "PandasData": "pandas_data",
     "PolarsData": "polars_data",
+    "PolymarketData": "polymarket_data",
     "PolygonDataBacktesting": "polygon_backtesting",
     "ProjectXData": "projectx_data",
     "SchwabData": "schwab_data",

--- a/lumibot/data_sources/data_source.py
+++ b/lumibot/data_sources/data_source.py
@@ -919,14 +919,25 @@ class DataSource(ABC):
                 )
                 query_t = time.perf_counter()
                 option_symbol = create_options_symbol(opt_asset.symbol, expiry_dt, right, strike)
-                opt_price = self.get_last_price(opt_asset)
+                try:
+                    opt_price = self.get_last_price(opt_asset, allow_stale_option_last=False)
+                except TypeError:
+                    opt_price = self.get_last_price(opt_asset)
+                try:
+                    opt_price_float = float(opt_price)
+                except (TypeError, ValueError):
+                    continue
+                if not math.isfinite(opt_price_float) or opt_price_float <= 0:
+                    continue
                 greeks = self.calculate_greeks(opt_asset, opt_price, underlying_price, risk_free_rate)
+                if not isinstance(greeks, dict):
+                    continue
                 query_total += time.perf_counter() - query_t
 
                 # Build the row. Match the Tradier column naming conventions.
                 row = {
                     "symbol": option_symbol,
-                    "last": opt_price,
+                    "last": opt_price_float,
                     "expiration_date": expiry_dt,
                     "strike": strike,
                     "option_type": right,

--- a/lumibot/data_sources/data_source.py
+++ b/lumibot/data_sources/data_source.py
@@ -458,6 +458,92 @@ class DataSource(ABC):
         else:
             return AssetsMapping(result)
 
+    # ========Prediction-market metadata defaults======================
+    #
+    # These methods are intentionally safe no-ops on the base class. Prediction
+    # market data sources such as Polymarket can override them with provider
+    # implementations, while existing stock/options/crypto brokers continue to
+    # behave normally if strategy code probes for prediction-market metadata.
+
+    def search_markets(self, query: str | None = None, limit: int = 20, **kwargs) -> list:
+        """Search provider markets/events.
+
+        The default implementation returns an empty list because most data
+        sources do not expose prediction-market discovery.
+        """
+        return []
+
+    def get_event(self, event_id: str | int | None = None, slug: str | None = None, **kwargs) -> dict:
+        """Return event metadata if the provider supports event-level data."""
+        return {}
+
+    def get_market_metadata(self, market=None, **kwargs) -> dict:
+        """Return normalized market metadata if the provider supports it."""
+        return {}
+
+    def get_market_rules(self, market=None, **kwargs) -> dict:
+        """Return trading/resolution rules if the provider supports them."""
+        return {}
+
+    def get_resolution_status(self, market=None, **kwargs) -> dict:
+        """Return resolution state for a prediction contract.
+
+        Providers that do not support this surface return a stable unsupported
+        shape instead of raising.
+        """
+        return {"status": "unsupported", "resolved": None, "winner": None, "raw": None}
+
+    def get_spread(self, asset, quote=None, exchange=None) -> Union[float, Decimal, None]:
+        """Return bid/ask spread when available.
+
+        Generic fallback uses ``get_quote`` if the concrete data source has one.
+        """
+        get_quote = getattr(self, "get_quote", None)
+        if get_quote is None:
+            return None
+        try:
+            quote_obj = get_quote(asset, quote=quote, exchange=exchange)
+        except Exception:
+            return None
+        bid = getattr(quote_obj, "bid", None)
+        ask = getattr(quote_obj, "ask", None)
+        if bid is None or ask is None:
+            return None
+        return ask - bid
+
+    def get_midpoint(self, asset, quote=None, exchange=None) -> Union[float, Decimal, None]:
+        """Return midpoint/mark when available.
+
+        Generic fallback uses ``Quote.mid_price`` or bid/ask from ``get_quote``.
+        """
+        get_quote = getattr(self, "get_quote", None)
+        if get_quote is None:
+            return None
+        try:
+            quote_obj = get_quote(asset, quote=quote, exchange=exchange)
+        except Exception:
+            return None
+        mid_price = getattr(quote_obj, "mid_price", None)
+        if mid_price is not None:
+            return mid_price
+        bid = getattr(quote_obj, "bid", None)
+        ask = getattr(quote_obj, "ask", None)
+        if bid is not None and ask is not None:
+            return (bid + ask) / 2
+        return getattr(quote_obj, "price", None)
+
+    def get_recent_trades(self, market=None, limit: int = 100, **kwargs) -> list:
+        """Return recent trades/fills if the provider supports them."""
+        return []
+
+    def get_open_interest(self, market=None, **kwargs) -> Union[float, Decimal, None]:
+        """Return open interest if the provider supports it."""
+        return None
+
+    def get_holders(self, market=None, limit: int = 20, **kwargs) -> list:
+        """Return holder rows if the provider supports it."""
+        return []
+
     def get_strikes(self, asset) -> list:
         """Return a set of strikes for a given asset"""
         chains = self.get_chains(asset)

--- a/lumibot/data_sources/data_source.py
+++ b/lumibot/data_sources/data_source.py
@@ -1,4 +1,5 @@
 import os
+import math
 import time
 import traceback
 from abc import ABC, abstractmethod
@@ -23,6 +24,8 @@ logger = get_logger(__name__)
 class DataSource(ABC):
     SOURCE = ""
     IS_BACKTESTING_DATA_SOURCE = False
+    APPLY_BACKTEST_POSITION_SPLITS = True
+    AUTO_ADJUST_IMPLIES_SPLIT_ADJUSTED_PRICES = False
     MIN_TIMESTEP = "minute"
     TIMESTEP_MAPPING = []
     DEFAULT_TIMEZONE = LUMIBOT_DEFAULT_TIMEZONE
@@ -79,6 +82,7 @@ class DataSource(ABC):
         # Dividend cache for backtest performance
         self._dividend_cache = {}  # {asset: {date: dividend_value}}
         self._dividend_cache_enabled = kwargs.get('cache_dividends', True)
+        self._stock_split_cache = {}  # {asset: {date: split_ratio}}
 
         # Ensure the instance has an explicit attribute for fallback behaviour
         if not hasattr(self, "option_quote_fallback_allowed"):
@@ -470,6 +474,224 @@ class DataSource(ABC):
         bars = self.get_historical_prices(asset, 1, timestep="day")
         return bars.get_last_dividend()
 
+    def get_yesterday_stock_split(self, asset, quote=None):
+        """Return the stock split ratio for a given asset on the current backtest day."""
+        return self.get_yesterday_stock_splits([asset], quote=quote).get(asset, 0)
+
+    def _backtest_daily_corporate_action_length(self):
+        length = 2000
+        if (
+            hasattr(self, "datetime_start")
+            and hasattr(self, "datetime_end")
+            and getattr(self, "datetime_start", None) is not None
+            and getattr(self, "datetime_end", None) is not None
+        ):
+            try:
+                span_days = (self.datetime_end.date() - self.datetime_start.date()).days + 1
+                length = max(span_days + 10, 30)
+            except Exception:
+                length = 2000
+        return length
+
+    @staticmethod
+    def _normalize_stock_split_ratio(value):
+        try:
+            ratio = float(value)
+        except (TypeError, ValueError):
+            return 0.0
+        if not math.isfinite(ratio) or ratio <= 0:
+            return 0.0
+        if abs(ratio - 1.0) < 1e-12:
+            return 0.0
+        return ratio
+
+    @staticmethod
+    def _asset_values_match(left, right):
+        if left == right:
+            return True
+        try:
+            return (
+                str(getattr(left, "symbol", "")).upper() == str(getattr(right, "symbol", "")).upper()
+                and str(getattr(left, "asset_type", "")).lower() == str(getattr(right, "asset_type", "")).lower()
+            )
+        except Exception:
+            return False
+
+    @staticmethod
+    def _quote_values_match(data_quote, requested_quote):
+        if requested_quote is None:
+            if data_quote is None:
+                return True
+            try:
+                return (
+                    str(getattr(data_quote, "symbol", "")).upper() == "USD"
+                    and "forex" in str(getattr(data_quote, "asset_type", "")).lower()
+                )
+            except Exception:
+                return False
+        return DataSource._asset_values_match(data_quote, requested_quote)
+
+    def _get_backtest_daily_corporate_action_frame(self, asset, quote=None):
+        """Return the full preloaded daily frame for backtest corporate actions, when available.
+
+        Backtest data sources such as routed IBKR prefetch the complete native daily series. Split
+        events need that full daily frame because a split is effective before the market opens even
+        when the provider timestamps the daily row at the close.
+        """
+        store = getattr(self, "_data_store", None)
+        if not store:
+            return None
+
+        candidates = []
+        finder = getattr(self, "find_asset_in_data_store", None)
+        if callable(finder):
+            try:
+                key = finder(asset, quote, "day")
+            except TypeError:
+                try:
+                    key = finder(asset, quote)
+                except Exception:
+                    key = None
+            except Exception:
+                key = None
+            if key is not None:
+                candidates.append(key)
+
+        for key in candidates:
+            data = store.get(key) if hasattr(store, "get") else None
+            frame = self._daily_stock_split_frame_from_data(data, asset, quote)
+            if frame is not None:
+                return frame
+
+        try:
+            values = store.values()
+        except Exception:
+            values = []
+        for data in values:
+            frame = self._daily_stock_split_frame_from_data(data, asset, quote)
+            if frame is not None:
+                return frame
+        return None
+
+    def _daily_stock_split_frame_from_data(self, data, asset, quote=None):
+        if data is None:
+            return None
+        if str(getattr(data, "timestep", "") or "").strip().lower() != "day":
+            return None
+        data_asset = getattr(data, "asset", None)
+        data_quote = getattr(data, "quote", None)
+        if isinstance(data_asset, tuple):
+            if len(data_asset) >= 1:
+                data_quote = data_quote if data_quote is not None else (data_asset[1] if len(data_asset) > 1 else None)
+                data_asset = data_asset[0]
+        if not self._asset_values_match(data_asset, asset):
+            return None
+        if not self._quote_values_match(data_quote, quote):
+            return None
+        frame = getattr(data, "df", None)
+        if frame is None or not hasattr(frame, "columns") or "stock_splits" not in frame.columns:
+            return None
+        return frame
+
+    @staticmethod
+    def _frame_prices_are_split_adjusted(frame):
+        if frame is None or not hasattr(frame, "columns") or "_split_adjusted" not in frame.columns:
+            return False
+        try:
+            marker = frame["_split_adjusted"]
+            if hasattr(marker, "fillna"):
+                return bool(marker.fillna(False).astype(bool).any())
+            return bool(marker)
+        except Exception:
+            return False
+
+    def should_apply_stock_splits_to_positions(self, asset, quote=None):
+        """Return whether split events should update held share quantities.
+
+        Raw/unadjusted daily bars need position ledger adjustments on split dates. Split-adjusted
+        providers already express historical fills in current share units, so applying the ledger
+        split again would double-count the corporate action.
+        """
+        if not bool(getattr(self, "APPLY_BACKTEST_POSITION_SPLITS", True)):
+            return False
+
+        if bool(getattr(self, "AUTO_ADJUST_IMPLIES_SPLIT_ADJUSTED_PRICES", False)) and (
+            bool(getattr(self, "auto_adjust", False)) or bool(getattr(self, "_auto_adjust", False))
+        ):
+            return False
+
+        frame = self._get_backtest_daily_corporate_action_frame(asset, quote=quote)
+        if self._frame_prices_are_split_adjusted(frame):
+            return False
+
+        return True
+
+    def _stock_split_cache_from_frame(self, frame):
+        asset_splits = {}
+        if frame is None or not hasattr(frame, "iterrows") or "stock_splits" not in frame.columns:
+            return asset_splits
+        for idx, row in frame.iterrows():
+            date_key = idx.date() if hasattr(idx, 'date') else idx
+            ratio = self._normalize_stock_split_ratio(row.get('stock_splits', 0))
+            if ratio:
+                asset_splits[date_key] = ratio
+        return asset_splits
+
+    def _adjust_stale_daily_price_for_stock_split(self, data, price, dt):
+        """Adjust a previous daily price when the current date has a split before the daily row.
+
+        Native daily stock bars are commonly timestamped at the market close. On split effective
+        dates, the position quantity changes before the market opens, but a pre-close mark may
+        still resolve to the prior day's pre-split close. Dividing that stale price by the split
+        ratio keeps portfolio value continuous until the split-date daily bar is available.
+        """
+        if price is None:
+            return price
+        if data is None or str(getattr(data, "timestep", "") or "").strip().lower() != "day":
+            return price
+        frame = getattr(data, "df", None)
+        if frame is None or not hasattr(frame, "columns") or "stock_splits" not in frame.columns:
+            return price
+        if self._frame_prices_are_split_adjusted(frame):
+            return price
+        if bool(getattr(self, "AUTO_ADJUST_IMPLIES_SPLIT_ADJUSTED_PRICES", False)) and (
+            bool(getattr(self, "auto_adjust", False)) or bool(getattr(self, "_auto_adjust", False))
+        ):
+            return price
+        try:
+            dt_ts = pd.Timestamp(dt)
+            current_date = dt_ts.date()
+        except Exception:
+            return price
+
+        try:
+            matching_rows = frame.loc[[idx.date() == current_date for idx in frame.index]]
+        except Exception:
+            return price
+        if matching_rows.empty:
+            return price
+
+        for idx, row in matching_rows.iterrows():
+            ratio = self._normalize_stock_split_ratio(row.get("stock_splits", 0))
+            if not ratio:
+                continue
+            try:
+                event_ts = pd.Timestamp(idx)
+                compare_dt = dt_ts
+                if event_ts.tzinfo is not None:
+                    if compare_dt.tzinfo is None:
+                        compare_dt = compare_dt.tz_localize(event_ts.tzinfo)
+                    else:
+                        compare_dt = compare_dt.tz_convert(event_ts.tzinfo)
+                elif compare_dt.tzinfo is not None:
+                    compare_dt = compare_dt.tz_localize(None)
+                if compare_dt >= event_ts:
+                    continue
+                return float(price) / ratio
+            except Exception:
+                continue
+        return price
+
     def get_yesterday_dividends(self, assets, quote=None):
         """Return dividend per share for a list of assets for the day before.
 
@@ -559,6 +781,73 @@ class DataSource(ABC):
         for asset, bars in assets_bars.items():
             if bars is not None:
                 result[asset] = bars.get_last_dividend()
+
+        return AssetsMapping(result)
+
+    def get_yesterday_stock_splits(self, assets, quote=None):
+        """Return stock split ratios for a list of assets on the current backtest day.
+
+        Ratios use the data-source convention: 2.0 for a 2-for-1 split, 7.0 for
+        a 7-for-1 split, and 0.1 for a 1-for-10 reverse split. Missing, zero,
+        one, negative, and non-finite values are treated as no split.
+        """
+        result = {}
+
+        if hasattr(self, '_datetime') and self._datetime:
+            current_date = self._datetime.date() if hasattr(self._datetime, 'date') else self._datetime
+
+            for asset in assets:
+                if asset not in self._stock_split_cache:
+                    try:
+                        frame = self._get_backtest_daily_corporate_action_frame(asset, quote=quote)
+                        asset_splits = self._stock_split_cache_from_frame(frame)
+
+                        if not asset_splits:
+                            length = self._backtest_daily_corporate_action_length()
+                            bars = self.get_bars([asset], length, timestep="day", quote=quote).get(asset)
+                            if bars is not None and hasattr(bars, 'df'):
+                                asset_splits = self._stock_split_cache_from_frame(bars.df)
+
+                        self._stock_split_cache[asset] = asset_splits
+                        if asset_splits:
+                            logger.debug(
+                                "[SPLIT][CACHE] Cached %d entries for %s (%s -> %s)",
+                                len(asset_splits),
+                                getattr(asset, "symbol", asset),
+                                min(asset_splits.keys()),
+                                max(asset_splits.keys()),
+                            )
+                        else:
+                            logger.debug(
+                                "[SPLIT][CACHE] No split entries available for %s",
+                                getattr(asset, "symbol", asset),
+                            )
+                    except Exception:
+                        self._stock_split_cache[asset] = {}
+
+                asset_splits = self._stock_split_cache.get(asset, {})
+                split_ratio = asset_splits.get(current_date, 0)
+                if split_ratio:
+                    logger.debug(
+                        "[SPLIT][APPLY] %s -> %s split ratio %.6f on %s",
+                        getattr(asset, "symbol", asset),
+                        getattr(self, "_name", "strategy"),
+                        split_ratio,
+                        current_date,
+                    )
+                result[asset] = split_ratio
+
+            return AssetsMapping(result)
+
+        assets_bars = self.get_bars(assets, 1, timestep="day", quote=quote)
+        for asset, bars in assets_bars.items():
+            if bars is None:
+                continue
+            get_last_stock_split = getattr(bars, "get_last_stock_split", None)
+            if callable(get_last_stock_split):
+                result[asset] = self._normalize_stock_split_ratio(get_last_stock_split())
+            elif hasattr(bars, "df") and "stock_splits" in bars.df.columns:
+                result[asset] = self._normalize_stock_split_ratio(bars.df["stock_splits"].iloc[-1])
 
         return AssetsMapping(result)
 

--- a/lumibot/data_sources/pandas_data.py
+++ b/lumibot/data_sources/pandas_data.py
@@ -268,6 +268,7 @@ class PandasData(DataSourceBacktesting):
             try:
                 dt = self.get_datetime()
                 price = data.get_last_price(dt)
+                price = self._adjust_stale_daily_price_for_stock_split(data, price, dt)
 
                 # Check if price is NaN
                 if pd.isna(price):
@@ -343,6 +344,14 @@ class PandasData(DataSourceBacktesting):
             data = self._data_store[tuple_to_find]
             dt = self.get_datetime()
             ohlcv_bid_ask_dict = data.get_quote(dt)
+            if isinstance(ohlcv_bid_ask_dict, dict):
+                for price_key in ("open", "high", "low", "close", "bid", "ask"):
+                    if price_key in ohlcv_bid_ask_dict:
+                        ohlcv_bid_ask_dict[price_key] = self._adjust_stale_daily_price_for_stock_split(
+                            data,
+                            ohlcv_bid_ask_dict.get(price_key),
+                            dt,
+                        )
 
             # Check if ohlcv_bid_ask_dict is NaN
             if pd.isna(ohlcv_bid_ask_dict):

--- a/lumibot/data_sources/polymarket_data.py
+++ b/lumibot/data_sources/polymarket_data.py
@@ -20,6 +20,8 @@ class PolymarketData(DataSource):
     MIN_TIMESTEP = "minute"
     CLOB_URL = "https://clob.polymarket.com"
     GAMMA_URL = "https://gamma-api.polymarket.com"
+    MARKET_WS_URL = "wss://ws-subscriptions-clob.polymarket.com/ws/market"
+    USER_WS_URL = "wss://ws-subscriptions-clob.polymarket.com/ws/user"
 
     _HISTORY_INTERVALS = {
         "minute": "1m",
@@ -297,6 +299,18 @@ class PolymarketData(DataSource):
 
     def apply_market_event(self, event: Any) -> None:
         payload = self._model_to_dict(event)
+        if isinstance(payload, list):
+            for item in payload:
+                self.apply_market_event(item)
+            return
+        if isinstance(payload, dict) and isinstance(payload.get("price_changes"), list):
+            for item in payload["price_changes"]:
+                change = dict(item)
+                change.setdefault("event_type", "price_change")
+                change.setdefault("market", payload.get("market"))
+                change.setdefault("timestamp", payload.get("timestamp"))
+                self.apply_market_event(change)
+            return
         token_id = str(self._first_present(payload, "asset_id", "assetId", "token_id", "tokenId") or "")
         if not token_id:
             return

--- a/lumibot/data_sources/polymarket_data.py
+++ b/lumibot/data_sources/polymarket_data.py
@@ -20,6 +20,7 @@ class PolymarketData(DataSource):
     MIN_TIMESTEP = "minute"
     CLOB_URL = "https://clob.polymarket.com"
     GAMMA_URL = "https://gamma-api.polymarket.com"
+    DATA_API_URL = "https://data-api.polymarket.com"
     MARKET_WS_URL = "wss://ws-subscriptions-clob.polymarket.com/ws/market"
     USER_WS_URL = "wss://ws-subscriptions-clob.polymarket.com/ws/user"
 
@@ -43,6 +44,7 @@ class PolymarketData(DataSource):
         client: Any | None = None,
         clob_url: str | None = None,
         gamma_url: str | None = None,
+        data_api_url: str | None = None,
         timeout: float = 10.0,
         **kwargs,
     ):
@@ -51,6 +53,7 @@ class PolymarketData(DataSource):
         self.config = config or {}
         self.clob_url = (clob_url or self.config.get("CLOB_URL") or self.CLOB_URL).rstrip("/")
         self.gamma_url = (gamma_url or self.config.get("GAMMA_URL") or self.GAMMA_URL).rstrip("/")
+        self.data_api_url = (data_api_url or self.config.get("DATA_API_URL") or self.DATA_API_URL).rstrip("/")
         self.timeout = timeout
         self._client = client or httpx.Client(timeout=timeout)
         self._owns_client = client is None
@@ -83,11 +86,18 @@ class PolymarketData(DataSource):
         if interval is None:
             raise ValueError(f"Unsupported Polymarket history timestep: {timestep!r}")
 
+        start_arg = self._first_present(kwargs, "start", "start_dt", "start_date", "datetime_start")
+        end_arg = self._first_present(kwargs, "end", "end_dt", "end_date", "datetime_end")
+
         if interval == "1m":
-            end_dt = datetime.now(timezone.utc)
+            end_dt = self._parse_timestamp(end_arg) if end_arg is not None else datetime.now(timezone.utc)
             if timeshift is not None:
                 end_dt = end_dt - timeshift
-            start_dt = end_dt - timedelta(minutes=max(int(length or 1), 1))
+            start_dt = (
+                self._parse_timestamp(start_arg)
+                if start_arg is not None
+                else end_dt - timedelta(minutes=max(int(length or 1), 1))
+            )
             params = {
                 "market": token_id,
                 "fidelity": 1,
@@ -96,6 +106,10 @@ class PolymarketData(DataSource):
             }
         else:
             params = {"market": token_id, "interval": interval}
+            if start_arg is not None:
+                params["startTs"] = int(self._parse_timestamp(start_arg).timestamp())
+            if end_arg is not None:
+                params["endTs"] = int(self._parse_timestamp(end_arg).timestamp())
         payload = self._request_json(self.clob_url, "/prices-history", params=params)
         rows = payload.get("history") if isinstance(payload, dict) else payload
         rows = rows or []
@@ -175,6 +189,210 @@ class PolymarketData(DataSource):
         self._quote_cache[token_id] = quote_obj
         return quote_obj
 
+    def search_markets(self, query: str | None = None, limit: int = 20, **kwargs) -> list[dict]:
+        """Search Polymarket Gamma markets/events.
+
+        With ``query`` this uses Gamma public-search. Without ``query`` it falls
+        back to the markets list endpoint using any supplied filters.
+        """
+        if query:
+            params = dict(kwargs)
+            params.setdefault("q", query)
+            params.setdefault("limit_per_type", limit)
+            payload = self._request_json(self.gamma_url, "/public-search", params=self._clean_params(params))
+            markets = []
+            if isinstance(payload, dict):
+                markets.extend(self._listify(payload.get("markets")))
+                for event in self._listify(payload.get("events")):
+                    for market in self._listify(event.get("markets")):
+                        normalized = self._normalize_market(market)
+                        normalized.setdefault("eventSlug", event.get("slug"))
+                        normalized.setdefault("eventTitle", event.get("title"))
+                        markets.append(normalized)
+            return [self._normalize_market(item) for item in markets[:limit]]
+
+        params = dict(kwargs)
+        params.setdefault("limit", limit)
+        payload = self._request_json(self.gamma_url, "/markets", params=self._clean_params(params))
+        return [self._normalize_market(item) for item in self._listify(payload)[:limit]]
+
+    def get_event(self, event_id: str | int | None = None, slug: str | None = None, **kwargs) -> dict:
+        if slug is None:
+            slug = kwargs.get("event_slug")
+        if slug:
+            return self._model_to_dict(self._request_json(self.gamma_url, f"/events/slug/{slug}")) or {}
+        if event_id is None:
+            event_id = kwargs.get("id")
+        if event_id is None:
+            raise ValueError("event_id or slug is required")
+        return self._model_to_dict(self._request_json(self.gamma_url, f"/events/{event_id}")) or {}
+
+    def get_market_metadata(self, market=None, **kwargs) -> dict:
+        if isinstance(market, dict):
+            return self._normalize_market(market)
+        if isinstance(market, Asset):
+            attached = getattr(market, "polymarket_market", None)
+            if attached:
+                return self._normalize_market(attached)
+            kwargs.setdefault("token_id", market.symbol)
+        if isinstance(market, str) and not kwargs:
+            kwargs["slug"] = market
+
+        slug = kwargs.get("slug")
+        url = kwargs.get("url")
+        market_id = kwargs.get("market_id") or kwargs.get("id")
+        condition_id = kwargs.get("condition_id") or kwargs.get("conditionId")
+        token_id = kwargs.get("token_id") or kwargs.get("asset_id") or kwargs.get("assetId")
+
+        if token_id and not any([slug, url, market_id, condition_id]):
+            payload = self._request_json(self.gamma_url, f"/markets/token/{token_id}")
+            return self._normalize_market(payload)
+        return self.resolve_market(url=url, slug=slug, market_id=market_id, condition_id=condition_id)
+
+    def get_market_rules(self, market=None, **kwargs) -> dict:
+        metadata = self.get_market_metadata(market, **kwargs)
+        tick_size = self._first_present(
+            metadata,
+            "orderPriceMinTickSize",
+            "minimum_tick_size",
+            "minimumTickSize",
+            "tick_size",
+            "tickSize",
+        )
+        min_order_size = self._first_present(metadata, "orderMinSize", "min_order_size", "minOrderSize")
+        return {
+            "question": metadata.get("question"),
+            "description": metadata.get("description"),
+            "resolution_source": metadata.get("resolutionSource") or metadata.get("resolution_source"),
+            "end_date": self._first_present(metadata, "endDateIso", "endDate", "end_date"),
+            "uma_end_date": self._first_present(metadata, "umaEndDateIso", "umaEndDate", "uma_end_date"),
+            "outcomes": metadata.get("outcomes") or [],
+            "clob_token_ids": metadata.get("clobTokenIds") or metadata.get("clob_token_ids") or [],
+            "tick_size": tick_size,
+            "min_order_size": min_order_size,
+            "neg_risk": self._first_present(metadata, "negRisk", "neg_risk"),
+            "enable_order_book": self._first_present(metadata, "enableOrderBook", "enable_order_book"),
+            "accepting_orders": self._first_present(metadata, "acceptingOrders", "accepting_orders"),
+            "active": metadata.get("active"),
+            "closed": metadata.get("closed"),
+            "archived": metadata.get("archived"),
+            "category": metadata.get("category"),
+            "tags": metadata.get("tags") or [],
+            "raw": metadata,
+        }
+
+    def get_resolution_status(self, market=None, **kwargs) -> dict:
+        metadata = self.get_market_metadata(market, **kwargs)
+        status = self._first_present(metadata, "umaResolutionStatus", "resolutionStatus", "resolvedStatus")
+        closed = self._optional_bool(metadata.get("closed"))
+        resolved = bool(closed or (status and str(status).lower() not in {"", "pending", "unresolved", "not_started"}))
+        outcomes = metadata.get("outcomes") or []
+        tokens = metadata.get("tokens") or []
+        winner = self._first_present(metadata, "winner", "winningOutcome", "winning_outcome")
+        if winner is None:
+            winner = self._winning_outcome_from_tokens(tokens, outcomes)
+        return {
+            "status": status or ("resolved" if resolved else "open"),
+            "resolved": resolved,
+            "winner": winner,
+            "closed": closed,
+            "condition_id": self._first_present(metadata, "conditionId", "condition_id"),
+            "raw": metadata,
+        }
+
+    def get_spread(self, asset, quote=None, exchange=None):
+        token_id = self._token_id(asset)
+        try:
+            payload = self._request_json(self.clob_url, "/spread", params={"token_id": token_id})
+            value = self._first_present(payload, "spread")
+            if value is not None:
+                return float(self._decimal(value))
+        except Exception:
+            pass
+        return super().get_spread(asset, quote=quote, exchange=exchange)
+
+    def get_midpoint(self, asset, quote=None, exchange=None):
+        token_id = self._token_id(asset)
+        try:
+            payload = self._request_json(self.clob_url, "/midpoint", params={"token_id": token_id})
+            value = self._first_present(payload, "mid", "midpoint", "midpoint_price", "midpointPrice")
+            if value is not None:
+                return float(self._decimal(value))
+        except Exception:
+            pass
+        return super().get_midpoint(asset, quote=quote, exchange=exchange)
+
+    def get_recent_trades(self, market=None, limit: int = 100, **kwargs) -> list[dict]:
+        params = dict(kwargs)
+        params.setdefault("limit", limit)
+        if market is not None:
+            condition_id = self._condition_id(market)
+            if condition_id:
+                params.setdefault("market", condition_id)
+        payload = self._request_json(self.data_api_url, "/trades", params=self._clean_params(params))
+        return self._listify(payload)
+
+    def get_open_interest(self, market=None, **kwargs):
+        params = dict(kwargs)
+        if market is not None:
+            condition_id = self._condition_id(market)
+            if condition_id:
+                params.setdefault("market", condition_id)
+        payload = self._request_json(self.data_api_url, "/oi", params=self._clean_params(params))
+        if market is not None:
+            rows = self._listify(payload)
+            if not rows:
+                return None
+            value = self._first_present(rows[0], "value", "open_interest", "openInterest")
+            return float(self._decimal(value)) if value is not None else None
+        return payload
+
+    def get_holders(self, market=None, limit: int = 20, **kwargs) -> list[dict]:
+        params = dict(kwargs)
+        params.setdefault("limit", limit)
+        if market is not None:
+            condition_id = self._condition_id(market)
+            token_id = None if condition_id else self._safe_token_id(market)
+            if condition_id:
+                params.setdefault("market", condition_id)
+            elif token_id:
+                params.setdefault("token", token_id)
+        payload = self._request_json(self.data_api_url, "/holders", params=self._clean_params(params))
+        return self._listify(payload)
+
+    def get_market_close(self, market=None, **kwargs) -> datetime | None:
+        rules = self.get_market_rules(market, **kwargs)
+        value = rules.get("end_date") or rules.get("uma_end_date")
+        return self._parse_timestamp(value) if value else None
+
+    def get_resolution_source(self, market=None, **kwargs) -> str | None:
+        rules = self.get_market_rules(market, **kwargs)
+        return rules.get("resolution_source")
+
+    def get_min_order_size(self, market=None, **kwargs) -> Decimal | None:
+        rules = self.get_market_rules(market, **kwargs)
+        value = rules.get("min_order_size")
+        return self._decimal(value) if value is not None else None
+
+    def get_settlement_price(self, asset: Asset, market=None, **kwargs) -> float | None:
+        status = self.get_resolution_status(market or asset, **kwargs)
+        if not status.get("resolved"):
+            return None
+        winner = status.get("winner")
+        outcome = getattr(asset, "polymarket_outcome", None)
+        if outcome is not None and winner is not None:
+            return 1.0 if str(outcome).lower() == str(winner).lower() else 0.0
+        metadata = status.get("raw") or {}
+        token_ids = metadata.get("clobTokenIds") or metadata.get("clob_token_ids") or []
+        outcomes = metadata.get("outcomes") or []
+        try:
+            index = [str(token) for token in token_ids].index(str(asset.symbol))
+        except ValueError:
+            return None
+        if winner is None:
+            return None
+        return 1.0 if index < len(outcomes) and str(outcomes[index]).lower() == str(winner).lower() else 0.0
+
     def resolve_market(
         self,
         *,
@@ -194,11 +412,15 @@ class PolymarketData(DataSource):
                 )
             return self._market_cache[cache_key]
 
-        params = {}
         if slug:
-            params["slug"] = slug
             cache_key = f"slug:{slug}"
+            if cache_key not in self._market_cache:
+                self._market_cache[cache_key] = self._normalize_market(
+                    self._request_json(self.gamma_url, f"/markets/slug/{slug}")
+                )
+            return self._market_cache[cache_key]
         elif condition_id:
+            params = {}
             params["condition_ids"] = condition_id
             cache_key = f"condition:{condition_id}"
         else:
@@ -340,7 +562,7 @@ class PolymarketData(DataSource):
 
     def _request_json(self, base_url: str, path: str, params: dict | None = None) -> Any:
         url = f"{base_url.rstrip('/')}/{path.lstrip('/')}"
-        response = self._client.get(url, params=params or {})
+        response = self._client.get(url, params=self._clean_params(params or {}))
         if isinstance(response, (dict, list)):
             return response
         if hasattr(response, "raise_for_status"):
@@ -358,13 +580,29 @@ class PolymarketData(DataSource):
     @classmethod
     def _normalize_market(cls, payload: Any) -> dict:
         market = cls._model_to_dict(payload)
-        for key in ("outcomes", "clobTokenIds", "clob_token_ids"):
+        for key in ("outcomes", "outcomePrices", "clobTokenIds", "clob_token_ids", "shortOutcomes"):
             if isinstance(market.get(key), str):
                 try:
                     market[key] = json.loads(market[key])
                 except json.JSONDecodeError:
                     pass
         return market
+
+    @classmethod
+    def _listify(cls, value: Any) -> list:
+        value = cls._model_to_dict(value)
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, tuple):
+            return list(value)
+        if isinstance(value, dict):
+            for key in ("items", "data", "results", "markets", "events", "holders", "trades"):
+                if key in value and isinstance(value[key], (list, tuple)):
+                    return list(value[key])
+            return [value]
+        return [value]
 
     @staticmethod
     def _model_to_dict(value: Any) -> Any:
@@ -388,6 +626,65 @@ class PolymarketData(DataSource):
             if key in mapping and mapping[key] is not None:
                 return mapping[key]
         return None
+
+    @classmethod
+    def _condition_id(cls, market: Any) -> str | None:
+        if isinstance(market, Asset):
+            attached = getattr(market, "polymarket_market", None)
+            return cls._condition_id(attached) if attached else None
+        if isinstance(market, dict):
+            value = cls._first_present(market, "conditionId", "condition_id", "market")
+            return str(value) if value else None
+        text = str(market) if market is not None else ""
+        if text.startswith("0x") and len(text) >= 10:
+            return text
+        return None
+
+    @classmethod
+    def _safe_token_id(cls, value: Any) -> str | None:
+        try:
+            return cls._token_id(value)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _clean_params(params: dict | None) -> dict:
+        clean = {}
+        for key, value in (params or {}).items():
+            if value is None:
+                continue
+            if isinstance(value, (list, tuple, set)):
+                clean[key] = ",".join(str(item) for item in value)
+            else:
+                clean[key] = value
+        return clean
+
+    @classmethod
+    def _winning_outcome_from_tokens(cls, tokens: list, outcomes: list) -> str | None:
+        for token in tokens or []:
+            item = cls._model_to_dict(token)
+            if not isinstance(item, dict):
+                continue
+            winner = cls._first_present(item, "winner", "winning", "isWinner")
+            if cls._optional_bool(winner):
+                outcome = cls._first_present(item, "outcome", "name")
+                if outcome is not None:
+                    return str(outcome)
+                outcome_index = cls._first_present(item, "outcomeIndex", "outcome_index")
+                try:
+                    index = int(outcome_index)
+                    return str(outcomes[index]) if 0 <= index < len(outcomes) else None
+                except Exception:
+                    return None
+        return None
+
+    @staticmethod
+    def _optional_bool(value: Any) -> bool | None:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
 
     @staticmethod
     def _decimal(value: Any) -> Decimal:

--- a/lumibot/data_sources/polymarket_data.py
+++ b/lumibot/data_sources/polymarket_data.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import pandas as pd
+
+from lumibot.data_sources.data_source import DataSource
+from lumibot.entities import Asset, Bars, Quote
+
+
+class PolymarketData(DataSource):
+    """Public market-data source for Polymarket's international CLOB."""
+
+    SOURCE = "POLYMARKET"
+    MIN_TIMESTEP = "minute"
+    CLOB_URL = "https://clob.polymarket.com"
+    GAMMA_URL = "https://gamma-api.polymarket.com"
+
+    _HISTORY_INTERVALS = {
+        "minute": "1m",
+        "1m": "1m",
+        "hour": "1h",
+        "1h": "1h",
+        "day": "1d",
+        "1d": "1d",
+        "week": "1w",
+        "1w": "1w",
+        "all": "all",
+        "max": "max",
+    }
+
+    def __init__(
+        self,
+        config: dict | None = None,
+        *,
+        client: Any | None = None,
+        clob_url: str | None = None,
+        gamma_url: str | None = None,
+        timeout: float = 10.0,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.name = "polymarket"
+        self.config = config or {}
+        self.clob_url = (clob_url or self.config.get("CLOB_URL") or self.CLOB_URL).rstrip("/")
+        self.gamma_url = (gamma_url or self.config.get("GAMMA_URL") or self.GAMMA_URL).rstrip("/")
+        self.timeout = timeout
+        self._client = client or httpx.Client(timeout=timeout)
+        self._owns_client = client is None
+        self._market_cache: dict[str, dict] = {}
+        self._quote_cache: dict[str, Quote] = {}
+        self._tick_size_cache: dict[str, Decimal] = {}
+
+    def shutdown(self):
+        if self._owns_client and hasattr(self._client, "close"):
+            self._client.close()
+        super().shutdown()
+
+    def get_chains(self, asset: Asset, quote: Asset = None) -> dict:
+        """Prediction contracts are not option chains."""
+        return {}
+
+    def get_historical_prices(
+        self,
+        asset,
+        length,
+        timestep="",
+        timeshift=None,
+        quote=None,
+        exchange=None,
+        include_after_hours=True,
+        **kwargs,
+    ):
+        token_id = self._token_id(asset)
+        interval = self._HISTORY_INTERVALS.get((timestep or "minute").lower())
+        if interval is None:
+            raise ValueError(f"Unsupported Polymarket history timestep: {timestep!r}")
+
+        if interval == "1m":
+            end_dt = datetime.now(timezone.utc)
+            if timeshift is not None:
+                end_dt = end_dt - timeshift
+            start_dt = end_dt - timedelta(minutes=max(int(length or 1), 1))
+            params = {
+                "market": token_id,
+                "fidelity": 1,
+                "startTs": int(start_dt.timestamp()),
+                "endTs": int(end_dt.timestamp()),
+            }
+        else:
+            params = {"market": token_id, "interval": interval}
+        payload = self._request_json(self.clob_url, "/prices-history", params=params)
+        rows = payload.get("history") if isinstance(payload, dict) else payload
+        rows = rows or []
+
+        records = []
+        for row in rows:
+            ts = self._first_present(row, "t", "timestamp", "time")
+            price = self._first_present(row, "p", "price", "close")
+            if ts is None or price is None:
+                continue
+            timestamp = self._parse_timestamp(ts)
+            value = float(self._decimal(price))
+            records.append(
+                {
+                    "datetime": timestamp,
+                    "open": value,
+                    "high": value,
+                    "low": value,
+                    "close": value,
+                    "volume": float(self._first_present(row, "volume", "v") or 0.0),
+                }
+            )
+
+        if length:
+            records = records[-int(length):]
+
+        df = pd.DataFrame(records)
+        if df.empty:
+            df = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+            df.index = pd.DatetimeIndex([], tz=timezone.utc)
+        else:
+            df = df.set_index("datetime").sort_index()
+        return Bars(df, source=self.SOURCE, asset=asset, quote=quote, raw=payload)
+
+    def get_last_price(self, asset, quote=None, exchange=None):
+        token_id = self._token_id(asset)
+        try:
+            payload = self._request_json(self.clob_url, "/last-trade-price", params={"token_id": token_id})
+            price = self._first_present(payload, "price", "last_trade_price", "lastTradePrice")
+            if price is not None:
+                return float(self._decimal(price))
+        except Exception:
+            cached = self._quote_cache.get(token_id)
+            if cached and cached.price is not None:
+                return cached.price
+
+        quote_obj = self.get_quote(asset, quote=quote, exchange=exchange)
+        return quote_obj.price
+
+    def get_quote(self, asset: Asset, quote: Asset = None, exchange: str = None) -> Quote:
+        token_id = self._token_id(asset)
+        book = self.get_order_book(token_id)
+        bids = self._levels(book.get("bids", []))
+        asks = self._levels(book.get("asks", []))
+        best_bid = max(bids, key=lambda level: level[0]) if bids else None
+        best_ask = min(asks, key=lambda level: level[0]) if asks else None
+        bid = float(best_bid[0]) if best_bid else None
+        ask = float(best_ask[0]) if best_ask else None
+        bid_size = float(best_bid[1]) if best_bid else None
+        ask_size = float(best_ask[1]) if best_ask else None
+        midpoint = (bid + ask) / 2 if bid is not None and ask is not None else None
+        price = midpoint
+        if price is None:
+            cached = self._quote_cache.get(token_id)
+            price = cached.price if cached else None
+
+        quote_obj = Quote(
+            asset=asset,
+            price=price,
+            bid=bid,
+            ask=ask,
+            bid_size=bid_size,
+            ask_size=ask_size,
+            mid_price=midpoint,
+            raw_data=book,
+        )
+        self._quote_cache[token_id] = quote_obj
+        return quote_obj
+
+    def resolve_market(
+        self,
+        *,
+        url: str | None = None,
+        slug: str | None = None,
+        market_id: str | None = None,
+        condition_id: str | None = None,
+    ) -> dict:
+        if url and not slug:
+            slug = self._slug_from_url(url)
+
+        if market_id:
+            cache_key = f"id:{market_id}"
+            if cache_key not in self._market_cache:
+                self._market_cache[cache_key] = self._normalize_market(
+                    self._request_json(self.gamma_url, f"/markets/{market_id}")
+                )
+            return self._market_cache[cache_key]
+
+        params = {}
+        if slug:
+            params["slug"] = slug
+            cache_key = f"slug:{slug}"
+        elif condition_id:
+            params["condition_ids"] = condition_id
+            cache_key = f"condition:{condition_id}"
+        else:
+            raise ValueError("One of url, slug, market_id, or condition_id is required")
+
+        if cache_key not in self._market_cache:
+            payload = self._request_json(self.gamma_url, "/markets", params=params)
+            item = payload[0] if isinstance(payload, list) and payload else payload
+            self._market_cache[cache_key] = self._normalize_market(item)
+        return self._market_cache[cache_key]
+
+    def resolve_contract(self, market: dict, *, outcome: str | None = None, token_id: str | None = None) -> Asset:
+        market = self._normalize_market(market)
+        outcomes = market.get("outcomes") or []
+        token_ids = market.get("clobTokenIds") or market.get("clob_token_ids") or []
+
+        if token_id is None:
+            if outcome is None:
+                raise ValueError("outcome or token_id is required")
+            for idx, label in enumerate(outcomes):
+                if str(label).lower() == str(outcome).lower():
+                    if idx >= len(token_ids):
+                        raise ValueError(f"No Polymarket token id found for outcome {outcome!r}")
+                    token_id = str(token_ids[idx])
+                    break
+            if token_id is None:
+                raise ValueError(f"Outcome {outcome!r} was not found in market")
+
+        asset = Asset(str(token_id), asset_type=Asset.AssetType.PREDICTION_CONTRACT, precision="0.000001")
+        asset.polymarket_market = market
+        if outcome:
+            asset.polymarket_outcome = outcome
+        return asset
+
+    def get_order_book(self, token_id: str | Asset) -> dict:
+        token_id = self._token_id(token_id)
+        payload = self._request_json(self.clob_url, "/book", params={"token_id": token_id})
+        if not isinstance(payload, dict):
+            raise ValueError("Polymarket order book response was not an object")
+        return payload
+
+    def get_tick_size(self, token_id: str | Asset) -> Decimal | None:
+        token_id = self._token_id(token_id)
+        if token_id in self._tick_size_cache:
+            return self._tick_size_cache[token_id]
+        try:
+            payload = self._request_json(self.clob_url, "/tick-size", params={"token_id": token_id})
+            value = self._first_present(payload, "tick_size", "tickSize", "minimum_tick_size", "minimumTickSize")
+        except Exception:
+            value = None
+        if value is None:
+            return None
+        tick_size = self._decimal(value)
+        self._tick_size_cache[token_id] = tick_size
+        return tick_size
+
+    def calculate_market_price(self, token_id: str | Asset, side: str, amount: str | Decimal) -> dict:
+        """Return a lightweight pre-trade estimate from the current book."""
+        token_id = self._token_id(token_id)
+        amount = self._decimal(amount)
+        side = str(side).lower()
+        book = self.get_order_book(token_id)
+        levels = self._levels(book.get("asks" if side == "buy" else "bids", []))
+        levels = sorted(levels, key=lambda level: level[0], reverse=(side != "buy"))
+        remaining = amount
+        notional = Decimal("0")
+        shares = Decimal("0")
+        worst_price = None
+        for price, size in levels:
+            if side == "buy":
+                level_notional = price * size
+                take_notional = min(remaining, level_notional)
+                if take_notional <= 0:
+                    break
+                take_shares = take_notional / price
+                remaining -= take_notional
+            else:
+                take_shares = min(remaining, size)
+                take_notional = take_shares * price
+                remaining -= take_shares
+            notional += take_notional
+            shares += take_shares
+            worst_price = price
+            if remaining <= 0:
+                break
+        avg_price = notional / shares if shares else None
+        return {
+            "token_id": token_id,
+            "side": side,
+            "requested": float(amount),
+            "filled_shares_estimate": float(shares),
+            "notional_estimate": float(notional),
+            "avg_price_estimate": float(avg_price) if avg_price is not None else None,
+            "worst_price_estimate": float(worst_price) if worst_price is not None else None,
+            "fully_satisfied": remaining <= 0,
+            "raw_book": book,
+        }
+
+    def apply_market_event(self, event: Any) -> None:
+        payload = self._model_to_dict(event)
+        token_id = str(self._first_present(payload, "asset_id", "assetId", "token_id", "tokenId") or "")
+        if not token_id:
+            return
+        event_type = str(self._first_present(payload, "event_type", "eventType", "type") or "").lower()
+        if event_type in {"best_bid_ask", "book", "price_change", "last_trade_price"}:
+            quote = self._quote_cache.get(token_id)
+            bid = self._first_present(payload, "best_bid", "bestBid", "bid")
+            ask = self._first_present(payload, "best_ask", "bestAsk", "ask")
+            price = self._first_present(payload, "price", "last_trade_price", "lastTradePrice")
+            asset = quote.asset if quote else Asset(token_id, asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+            self._quote_cache[token_id] = Quote(
+                asset=asset,
+                price=float(self._decimal(price)) if price is not None else (quote.price if quote else None),
+                bid=float(self._decimal(bid)) if bid is not None else (quote.bid if quote else None),
+                ask=float(self._decimal(ask)) if ask is not None else (quote.ask if quote else None),
+                raw_data=payload,
+            )
+        if event_type == "tick_size_change":
+            tick_size = self._first_present(payload, "tick_size", "tickSize")
+            if tick_size is not None:
+                self._tick_size_cache[token_id] = self._decimal(tick_size)
+
+    @staticmethod
+    def _slug_from_url(url: str) -> str:
+        path = urlparse(url).path.rstrip("/")
+        return path.split("/")[-1]
+
+    def _request_json(self, base_url: str, path: str, params: dict | None = None) -> Any:
+        url = f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+        response = self._client.get(url, params=params or {})
+        if isinstance(response, (dict, list)):
+            return response
+        if hasattr(response, "raise_for_status"):
+            response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def _token_id(asset_or_token: str | Asset) -> str:
+        if isinstance(asset_or_token, Asset):
+            if asset_or_token.asset_type != Asset.AssetType.PREDICTION_CONTRACT:
+                raise ValueError("PolymarketData requires a prediction_contract asset")
+            return str(asset_or_token.symbol)
+        return str(asset_or_token)
+
+    @classmethod
+    def _normalize_market(cls, payload: Any) -> dict:
+        market = cls._model_to_dict(payload)
+        for key in ("outcomes", "clobTokenIds", "clob_token_ids"):
+            if isinstance(market.get(key), str):
+                try:
+                    market[key] = json.loads(market[key])
+                except json.JSONDecodeError:
+                    pass
+        return market
+
+    @staticmethod
+    def _model_to_dict(value: Any) -> Any:
+        if hasattr(value, "model_dump"):
+            return value.model_dump(mode="json")
+        if hasattr(value, "dict"):
+            return value.dict()
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, (list, tuple)):
+            return [PolymarketData._model_to_dict(item) for item in value]
+        if hasattr(value, "__dict__"):
+            return {k: v for k, v in vars(value).items() if not k.startswith("_")}
+        return value
+
+    @staticmethod
+    def _first_present(mapping: Any, *keys: str) -> Any:
+        if not isinstance(mapping, dict):
+            return None
+        for key in keys:
+            if key in mapping and mapping[key] is not None:
+                return mapping[key]
+        return None
+
+    @staticmethod
+    def _decimal(value: Any) -> Decimal:
+        if isinstance(value, Decimal):
+            return value
+        try:
+            return Decimal(str(value))
+        except (InvalidOperation, TypeError) as exc:
+            raise ValueError(f"Invalid Polymarket decimal value: {value!r}") from exc
+
+    @classmethod
+    def _levels(cls, values: list) -> list[tuple[Decimal, Decimal]]:
+        levels = []
+        for row in values or []:
+            if isinstance(row, dict):
+                price = cls._first_present(row, "price", "p")
+                size = cls._first_present(row, "size", "s")
+            else:
+                try:
+                    price, size = row[0], row[1]
+                except Exception:
+                    continue
+            levels.append((cls._decimal(price), cls._decimal(size)))
+        return levels
+
+    @staticmethod
+    def _parse_timestamp(value: Any) -> datetime:
+        if isinstance(value, datetime):
+            return value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        if isinstance(value, (int, float)):
+            ts = float(value)
+            if ts > 10_000_000_000:
+                ts = ts / 1000
+            return datetime.fromtimestamp(ts, tz=timezone.utc)
+        return pd.to_datetime(value, utc=True).to_pydatetime()

--- a/lumibot/data_sources/yahoo_data.py
+++ b/lumibot/data_sources/yahoo_data.py
@@ -15,6 +15,7 @@ logger = get_logger(__name__)
 
 class YahooData(DataSourceBacktesting):
     SOURCE = "YAHOO"
+    AUTO_ADJUST_IMPLIES_SPLIT_ADJUSTED_PRICES = True
     MIN_TIMESTEP = "day"
     TIMESTEP_MAPPING = [
         {"timestep": "day", "representations": ["1d", "day"]},

--- a/lumibot/entities/asset.py
+++ b/lumibot/entities/asset.py
@@ -164,6 +164,7 @@ class Asset:
         CONT_FUTURE = "cont_future" # Continuous future
         FOREX = "forex" # Forex or cash
         CRYPTO = "crypto" # Crypto
+        PREDICTION_CONTRACT = "prediction_contract" # Prediction market outcome contract
         INDEX = "index" # Index
         MULTILEG = "multileg" # Multileg option
         UNKNOWN = "unknown" # Broker object Lumibot cannot classify yet

--- a/lumibot/entities/bars.py
+++ b/lumibot/entities/bars.py
@@ -570,6 +570,19 @@ class Bars:
             logger.debug("Unable to find 'dividend' column in bars")
             return 0
 
+    def get_last_stock_split(self):
+        """Return the stock split ratio of the last bar.
+
+        Split ratios follow the market-data convention used by Yahoo/IBKR enrichment:
+        2.0 means a 2-for-1 split, 0.1 means a 1-for-10 reverse split, and 0 means
+        no split event on that bar.
+        """
+        if "stock_splits" in self.df.columns:
+            return self.df["stock_splits"][-1]
+        else:
+            logger.debug("Unable to find 'stock_splits' column in bars")
+            return 0
+
     def filter(self, start=None, end=None):
         """Return a Bars object with only the bars between start and end
 

--- a/lumibot/entities/data.py
+++ b/lumibot/entities/data.py
@@ -250,6 +250,7 @@ class Data:
         self._ohlc_has_nan = False
         self._volume_has_nan = False
         self._dividend_has_nan = False
+        self._stock_splits_has_nan = False
         try:
             required = [c for c in ("open", "high", "low", "close") if c in self.df.columns]
             if required:
@@ -262,10 +263,13 @@ class Data:
                 self._volume_has_nan = bool(pd.isna(self.df["volume"].to_numpy(copy=False)).any())
             if "dividend" in self.df.columns:
                 self._dividend_has_nan = bool(pd.isna(self.df["dividend"].to_numpy(copy=False)).any())
+            if "stock_splits" in self.df.columns:
+                self._stock_splits_has_nan = bool(pd.isna(self.df["stock_splits"].to_numpy(copy=False)).any())
         except Exception:
             self._ohlc_has_nan = True
             self._volume_has_nan = True
             self._dividend_has_nan = True
+            self._stock_splits_has_nan = True
 
         # PERF: `get_bars()` slices and then selects OHLCV columns on every call. Cache a stable
         # OHLCV view once (initialized lazily after `repair_times_and_fill()` so it reflects any
@@ -273,12 +277,15 @@ class Data:
         bars_cols = ["open", "high", "low", "close", "volume"]
         if "dividend" in self.df.columns:
             bars_cols.append("dividend")
+        if "stock_splits" in self.df.columns:
+            bars_cols.append("stock_splits")
         self._bars_cols = [c for c in bars_cols if c in self.df.columns]
         self._bars_df = None
         # PERF: `get_bars()` performs repeated `col in df.columns` membership checks which go
         # through `Index.__contains__` (hot in minute backtests). Cache the schema facts once.
         self._bars_has_volume = "volume" in self._bars_cols
         self._bars_has_dividend = "dividend" in self._bars_cols
+        self._bars_has_stock_splits = "stock_splits" in self._bars_cols
         self._bars_required_cols = [c for c in ("open", "high", "low", "close") if c in self._bars_cols]
 
     def set_times(self, trading_hours_start, trading_hours_end):
@@ -429,9 +436,22 @@ class Data:
         ohlc_cols = ["open", "high", "low"]
         # MODIFIED: Exclude bid/ask from standard ffill - handle them separately
         quote_cols_set = set(quote_cols)
-        non_ohlc_cols = [col for col in df.columns if col not in ohlc_cols and col not in quote_cols_set]
+        corporate_action_cols = {"dividend", "stock_splits"}
+        non_ohlc_cols = [
+            col
+            for col in df.columns
+            if col not in ohlc_cols
+            and col not in quote_cols_set
+            and col not in corporate_action_cols
+        ]
         if non_ohlc_cols:
             df[non_ohlc_cols] = df[non_ohlc_cols].ffill()
+
+        # Corporate actions are point-in-time events. Forward-filling a split ratio would make
+        # every later bar look like another split and can compound positions incorrectly.
+        for col in corporate_action_cols:
+            if col in df.columns:
+                df[col] = df[col].fillna(0)
 
         # For quote columns, do segment-wise ffill (don't fill across session boundaries)
         if apply_quote_session_boundaries and quote_cols_present and isinstance(df.index, pd.DatetimeIndex):
@@ -588,6 +608,8 @@ class Data:
             else:
                 if "return" in self.df.columns:
                     bars_cols.append("return")
+            if "stock_splits" in self.df.columns:
+                bars_cols.append("stock_splits")
 
             self._bars_cols = [c for c in bars_cols if c in self.df.columns]
             if self._bars_cols:
@@ -1316,6 +1338,10 @@ class Data:
             if has_dividend is _MISSING:
                 has_dividend = "dividend" in df.columns
                 self._bars_has_dividend = has_dividend
+            has_stock_splits = getattr(self, "_bars_has_stock_splits", _MISSING)
+            if has_stock_splits is _MISSING:
+                has_stock_splits = "stock_splits" in df.columns
+                self._bars_has_stock_splits = has_stock_splits
 
             # PERF: avoid fillna on every slice unless the dataset actually contains NaNs.
             needs_copy = False
@@ -1323,12 +1349,16 @@ class Data:
                 needs_copy = True
             if has_dividend and getattr(self, "_dividend_has_nan", False):
                 needs_copy = True
+            if has_stock_splits and getattr(self, "_stock_splits_has_nan", False):
+                needs_copy = True
             if needs_copy:
                 df = df.copy()
                 if has_volume and getattr(self, "_volume_has_nan", False):
                     df["volume"] = df["volume"].fillna(0)
                 if has_dividend and getattr(self, "_dividend_has_nan", False):
                     df["dividend"] = df["dividend"].fillna(0)
+                if has_stock_splits and getattr(self, "_stock_splits_has_nan", False):
+                    df["stock_splits"] = df["stock_splits"].fillna(0)
 
             required = getattr(self, "_bars_required_cols", None)
             if required is None:
@@ -1440,6 +1470,10 @@ class Data:
             if has_dividend is _MISSING:
                 has_dividend = "dividend" in df.columns
                 self._bars_has_dividend = has_dividend
+            has_stock_splits = getattr(self, "_bars_has_stock_splits", _MISSING)
+            if has_stock_splits is _MISSING:
+                has_stock_splits = "stock_splits" in df.columns
+                self._bars_has_stock_splits = has_stock_splits
 
             # PERF: avoid fillna on every slice unless the dataset actually contains NaNs.
             needs_copy = False
@@ -1447,12 +1481,16 @@ class Data:
                 needs_copy = True
             if has_dividend and getattr(self, "_dividend_has_nan", False):
                 needs_copy = True
+            if has_stock_splits and getattr(self, "_stock_splits_has_nan", False):
+                needs_copy = True
             if needs_copy:
                 df = df.copy()
                 if has_volume and getattr(self, "_volume_has_nan", False):
                     df["volume"] = df["volume"].fillna(0)
                 if has_dividend and getattr(self, "_dividend_has_nan", False):
                     df["dividend"] = df["dividend"].fillna(0)
+                if has_stock_splits and getattr(self, "_stock_splits_has_nan", False):
+                    df["stock_splits"] = df["stock_splits"].fillna(0)
 
             required = getattr(self, "_bars_required_cols", None)
             if required is None:
@@ -1521,6 +1559,8 @@ class Data:
         df = pd.DataFrame(data).assign(datetime=lambda df: pd.to_datetime(df['datetime'])).set_index('datetime')
         if "dividend" in df.columns:
             agg_column_map["dividend"] = "sum"
+        if "stock_splits" in df.columns:
+            agg_column_map["stock_splits"] = "max"
         df_result = df.resample(f"{quantity}{unit}").agg(agg_column_map)
 
         # Drop any rows that have NaN values (this can happen if the data is not complete, eg. weekends)
@@ -1601,6 +1641,8 @@ class Data:
         }
         if "dividend" in df.columns:
             agg["dividend"] = "sum"
+        if "stock_splits" in df.columns:
+            agg["stock_splits"] = "max"
 
         unit_code = "min" if timestep == "minute" else "h" if timestep == "hour" else "D"
         df_result = df.resample(f"{int(quantity)}{unit_code}").agg(agg).dropna()

--- a/lumibot/example_strategies/polymarket_prediction_contract.py
+++ b/lumibot/example_strategies/polymarket_prediction_contract.py
@@ -1,0 +1,93 @@
+import os
+from datetime import datetime, timezone
+
+from lumibot.backtesting import PolymarketBacktesting
+from lumibot.brokers import Polymarket
+from lumibot.entities import Asset, Order
+from lumibot.strategies.strategy import Strategy
+from lumibot.traders import Trader
+
+
+class PolymarketPredictionContractStrategy(Strategy):
+    """Polymarket prediction-contract strategy for live smoke tests and backtesting."""
+
+    def initialize(self, parameters=None):
+        parameters = parameters or {}
+        self.sleeptime = parameters.get("sleeptime", "1M")
+        token_id = parameters.get("token_id") or os.environ.get("POLYMARKET_TEST_TOKEN_ID")
+        if not token_id:
+            raise ValueError("Set POLYMARKET_TEST_TOKEN_ID or pass parameters={'token_id': ...}")
+        self.asset = Asset(token_id, asset_type=Asset.AssetType.PREDICTION_CONTRACT, precision="0.000001")
+        self.live_trade = str(parameters.get("live_trade", "false")).lower() in {"1", "true", "yes", "on"}
+        self.backtest_trade = str(parameters.get("backtest_trade", "false")).lower() in {"1", "true", "yes", "on"}
+        self.backtest_quantity = parameters.get("backtest_quantity", 10)
+        self.amount = str(parameters.get("amount", os.environ.get("POLYMARKET_TEST_ORDER_AMOUNT", "1.00")))
+        self.max_price = str(parameters.get("max_price", os.environ.get("POLYMARKET_TEST_MAX_PRICE", "0.99")))
+
+    def on_trading_iteration(self):
+        quote = self.get_quote(self.asset)
+        self.log_message(f"Polymarket quote bid={quote.bid} ask={quote.ask} mid={quote.mid_price}")
+
+        if self.is_backtesting and self.backtest_trade and self.first_iteration:
+            order = self.create_order(
+                self.asset,
+                quantity=self.backtest_quantity,
+                side=Order.OrderSide.BUY,
+                order_type=Order.OrderType.MARKET,
+            )
+            self.submit_order(order)
+            return
+
+        if not self.live_trade or not self.first_iteration:
+            return
+
+        order = self.create_order(
+            self.asset,
+            quantity=1,
+            side=Order.OrderSide.BUY,
+            order_type=Order.OrderType.MARKET,
+            time_in_force="fak",
+            custom_params={"amount": self.amount, "max_price": self.max_price, "order_type": "FAK"},
+        )
+        self.submit_order(order)
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+if __name__ == "__main__":
+    token_id = os.environ.get("POLYMARKET_TEST_TOKEN_ID")
+    if not token_id:
+        raise SystemExit("Set POLYMARKET_TEST_TOKEN_ID before running this example.")
+
+    if _env_flag("IS_BACKTESTING"):
+        os.environ["BACKTESTING_DATA_SOURCE"] = "polymarket"
+        start = datetime.fromisoformat(os.environ.get("BACKTESTING_START", "2026-06-01")).replace(tzinfo=timezone.utc)
+        end = datetime.fromisoformat(os.environ.get("BACKTESTING_END", "2026-06-02")).replace(tzinfo=timezone.utc)
+        PolymarketPredictionContractStrategy.backtest(
+            PolymarketBacktesting,
+            start,
+            end,
+            assets=[Asset(token_id, asset_type=Asset.AssetType.PREDICTION_CONTRACT, precision="0.000001")],
+            market="24/7",
+            timestep="minute",
+            parameters={"token_id": token_id, "backtest_trade": True},
+            benchmark_asset=None,
+            show_plot=False,
+            show_tearsheet=False,
+            save_tearsheet=False,
+            save_stats_file=False,
+            show_progress_bar=False,
+        )
+    else:
+        live_trade = _env_flag("POLYMARKET_LIVE_TRADING_ENABLED") and _env_flag("POLYMARKET_EXAMPLE_LIVE_TRADE")
+        broker = Polymarket()
+        strategy = PolymarketPredictionContractStrategy(
+            broker=broker,
+            budget=100000,
+            parameters={"token_id": token_id, "live_trade": live_trade},
+        )
+        trader = Trader()
+        trader.add_strategy(strategy)
+        trader.run_all()

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1149,6 +1149,16 @@ class _Strategy:
             if option_mark_time_local is not None:
                 t_local = option_mark_time_local.time()
                 option_marking_allowed = (t_local >= datetime.time(9, 30)) and (t_local <= datetime.time(16, 0))
+                if not option_marking_allowed and self.is_backtesting:
+                    try:
+                        cadence_seconds = self._get_sleeptime_seconds()
+                    except Exception:
+                        cadence_seconds = None
+                    if cadence_seconds is not None and cadence_seconds >= 20 * 3600:
+                        # Daily-cadence backtests commonly evaluate at midnight while using
+                        # daily/EOD bars. Treat those marks as valid for portfolio valuation;
+                        # intraday backtests still reject off-session option marks.
+                        option_marking_allowed = True
 
             def _asset_type_key(asset_obj):
                 cached_asset_type_key = getattr(asset_obj, "_cached_asset_type_key", None)
@@ -1426,9 +1436,37 @@ class _Strategy:
                             has_last_known_price = False
 
                         if day_quote_mark is not None:
-                            if has_last_known_price:
-                                return None
                             return day_quote_mark
+
+                        fallback_enabled = str(
+                            os.environ.get("THETADATA_OPTION_MTM_OHLC_FALLBACK", "true")
+                        ).strip().lower() not in {"0", "false", "no", "off"}
+                        if fallback_enabled:
+                            try:
+                                last_trade_mark = source.get_last_price(
+                                    base_asset,
+                                    timestep="day",
+                                    quote=quote_asset,
+                                    allow_stale_option_last=True,
+                                )
+                            except TypeError:
+                                try:
+                                    last_trade_mark = source.get_last_price(base_asset, quote=quote_asset)
+                                except Exception:
+                                    last_trade_mark = None
+                            except Exception:
+                                self.logger.debug(
+                                    "ThetaData daily option MTM fallback failed for %s",
+                                    base_asset,
+                                    exc_info=True,
+                                )
+                                last_trade_mark = None
+                            try:
+                                numeric_mark = float(last_trade_mark) if last_trade_mark is not None else None
+                            except (TypeError, ValueError):
+                                numeric_mark = None
+                            if numeric_mark is not None and math.isfinite(numeric_mark) and numeric_mark > 0:
+                                return numeric_mark
             except Exception as e:
                 self.logger.debug("ThetaData quote-mark lookup failed for %s: %s", base_asset, e)
             return None

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1772,6 +1772,145 @@ class _Strategy:
 
             return cash
 
+    def _update_positions_with_splits(self):
+        if not self.is_backtesting:
+            return 0
+
+        with self._executor.lock:
+            if not hasattr(self, '_stock_splits_applied_tracker'):
+                self._stock_splits_applied_tracker = set()
+
+            current_dt = self.get_datetime()
+            current_date = current_dt.date() if hasattr(current_dt, 'date') else current_dt
+            positions = self.broker.get_tracked_positions(self._name)
+
+            stock_positions = []
+            assets = []
+            for position in positions:
+                asset = position.asset
+                if asset == self._quote_asset:
+                    continue
+                asset_type = getattr(asset, "asset_type", "")
+                asset_type = getattr(asset_type, "value", asset_type)
+                if str(asset_type).lower() != "stock":
+                    continue
+                if not position.quantity:
+                    continue
+                stock_positions.append(position)
+                assets.append(asset)
+
+            if not assets:
+                return 0
+
+            data_source = getattr(getattr(self, "broker", None), "data_source", None)
+            get_splits = getattr(data_source, "get_yesterday_stock_splits", None)
+            if not callable(get_splits):
+                return 0
+
+            try:
+                split_ratios = get_splits(assets, quote=self._quote_asset)
+            except Exception:
+                self.logger.debug("Unable to read stock split ratios for %s", current_date, exc_info=True)
+                return 0
+
+            applied = 0
+            should_apply_splits = getattr(data_source, "should_apply_stock_splits_to_positions", None)
+            for position in stock_positions:
+                asset = position.asset
+                if callable(should_apply_splits):
+                    try:
+                        if not should_apply_splits(asset, quote=self._quote_asset):
+                            continue
+                    except Exception:
+                        self.logger.debug(
+                            "Unable to determine stock split accounting mode for %s on %s",
+                            getattr(asset, "symbol", asset),
+                            current_date,
+                            exc_info=True,
+                        )
+                        continue
+
+                raw_ratio = 0 if split_ratios is None else split_ratios.get(asset, 0)
+                try:
+                    split_ratio = float(raw_ratio)
+                except (TypeError, ValueError):
+                    continue
+                if not math.isfinite(split_ratio) or split_ratio <= 0 or abs(split_ratio - 1.0) < 1e-12:
+                    continue
+
+                symbol = getattr(asset, 'symbol', str(asset))
+                tracker_key = (current_date, symbol, f"{split_ratio:.12g}")
+                if tracker_key in self._stock_splits_applied_tracker:
+                    continue
+
+                try:
+                    old_quantity = getattr(position, "_quantity", Decimal(str(position.quantity)))
+                    split_ratio_decimal = Decimal(str(split_ratio))
+                    new_quantity = old_quantity * split_ratio_decimal
+                except Exception:
+                    self.logger.warning(
+                        "Skipping %s stock split ratio %.12g on %s because quantity %r could not be adjusted.",
+                        symbol,
+                        split_ratio,
+                        current_date,
+                        getattr(position, "quantity", None),
+                    )
+                    continue
+
+                old_quantity_float = float(old_quantity)
+                new_quantity_float = float(new_quantity)
+                position.quantity = new_quantity
+
+                avg_fill_price = getattr(position, "avg_fill_price", None)
+                if avg_fill_price is not None:
+                    try:
+                        position.avg_fill_price = float(Decimal(str(avg_fill_price)) / split_ratio_decimal)
+                    except Exception:
+                        pass
+
+                filled_positions = getattr(self.broker, "_filled_positions", None)
+                if hasattr(filled_positions, "revision"):
+                    filled_positions.revision += 1
+                for cache_name in (
+                    "_tracked_position_cache",
+                    "_tracked_positions_cache",
+                    "_asset_potential_total_cache",
+                ):
+                    cache = getattr(self.broker, cache_name, None)
+                    if hasattr(cache, "clear"):
+                        cache.clear()
+                self._portfolio_value_cache_key = None
+                self._portfolio_value_cache_value = None
+
+                record_event = getattr(self.broker, "record_corporate_action_event", None)
+                if callable(record_event):
+                    record_event(
+                        action_type="stock_split",
+                        asset=asset,
+                        strategy=getattr(self, "_name", None),
+                        ratio=split_ratio,
+                        quantity_before=old_quantity_float,
+                        quantity_after=new_quantity_float,
+                        occurred_at=current_dt,
+                        description=(
+                            f"{symbol} stock split ratio {split_ratio:.12g}: "
+                            f"quantity {old_quantity_float:.12g} -> {new_quantity_float:.12g}"
+                        ),
+                    )
+
+                self._stock_splits_applied_tracker.add(tracker_key)
+                applied += 1
+                self.logger.info(
+                    "Applied %s stock split ratio %.12g on %s: quantity %.12g -> %.12g",
+                    symbol,
+                    split_ratio,
+                    current_date,
+                    old_quantity_float,
+                    new_quantity_float,
+                )
+
+            return applied
+
     # =============Stats functions=====================
 
     def _append_row(self, row):

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -36,6 +36,7 @@ from ..backtesting import (
     CcxtBacktesting,
     DataBentoDataBacktesting,
     InteractiveBrokersRESTBacktesting,
+    PolymarketBacktesting,
     PolygonDataBacktesting,
     RoutedBacktestingPandas,
     ThetaDataBacktesting,
@@ -370,7 +371,13 @@ class _Strategy:
         # Handle data source initialization
         self._data_source = data_source
         if self._data_source is None:
-            self._data_source = DATA_SOURCE
+            # Live DATA_SOURCE overrides should not replace a backtesting broker's
+            # concrete data source. Backtests are selected through
+            # BACKTESTING_DATA_SOURCE or the explicit datasource_class argument.
+            if self.broker is not None and getattr(self.broker, "IS_BACKTESTING_BROKER", False):
+                self._data_source = None
+            else:
+                self._data_source = DATA_SOURCE
 
         # If we have a custom data source, attach it to the broker
         if self._data_source is not None and self.broker is not None:
@@ -2807,6 +2814,8 @@ class _Strategy:
                 "ibkr": InteractiveBrokersRESTBacktesting,
                 "interactivebrokersrest": InteractiveBrokersRESTBacktesting,
                 "interactive_brokers_rest": InteractiveBrokersRESTBacktesting,
+                "polymarket": PolymarketBacktesting,
+                "polymarket_clob": PolymarketBacktesting,
                 "router": RoutedBacktestingPandas,
                 "thetadata_ibkr": RoutedBacktestingPandas,
                 "theta_ibkr": RoutedBacktestingPandas,

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -4994,6 +4994,28 @@ class Strategy(_Strategy):
             self.log_message("Broker or data source is not available.")
             return None
 
+    def get_yesterday_stock_split(self, asset: Asset):
+        """Get the stock split ratio for the current backtest day."""
+        asset = self._sanitize_user_asset(asset)
+        if self.broker and self.broker.data_source:
+            return self.broker.data_source.get_yesterday_stock_split(asset, quote=self.quote_asset)
+        else:
+            self.log_message("Broker or data source is not available.")
+            return None
+
+    def get_yesterday_stock_splits(self, assets: List[Asset]):
+        """Get stock split ratios for the current backtest day.
+
+        A value of 2.0 means a 2-for-1 split, 0.1 means a 1-for-10 reverse split,
+        and 0 means no split event for that asset/date.
+        """
+        assets = [self._sanitize_user_asset(asset) for asset in assets]
+        if self.broker and self.broker.data_source:
+            return self.broker.data_source.get_yesterday_stock_splits(assets, quote=self.quote_asset)
+        else:
+            self.log_message("Broker or data source is not available.")
+            return None
+
     def update_parameters(self, parameters: dict):
         """Update the parameters of the strategy.
 

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -653,7 +653,12 @@ class StrategyExecutor(Thread):
 
             if (
                 update_cash
-                and asset_type not in (Asset.AssetType.CRYPTO, Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE)
+                and asset_type not in (
+                    Asset.AssetType.CRYPTO,
+                    Asset.AssetType.FUTURE,
+                    Asset.AssetType.CONT_FUTURE,
+                    Asset.AssetType.PREDICTION_CONTRACT,
+                )
                 and quantity is not None
                 and price is not None
             ):
@@ -688,7 +693,12 @@ class StrategyExecutor(Thread):
 
             if (
                 update_cash
-                and asset_type not in (Asset.AssetType.CRYPTO, Asset.AssetType.FUTURE, Asset.AssetType.CONT_FUTURE)
+                and asset_type not in (
+                    Asset.AssetType.CRYPTO,
+                    Asset.AssetType.FUTURE,
+                    Asset.AssetType.CONT_FUTURE,
+                    Asset.AssetType.PREDICTION_CONTRACT,
+                )
                 and quantity is not None
                 and price is not None
             ):

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -1717,6 +1717,9 @@ class StrategyExecutor(Thread):
         dt = self.broker.data_source._date_index[self.broker.data_source._iter_count]
         update_payload = self._build_backtest_progress_payload()
         self.broker._update_datetime(dt, **update_payload)
+        update_splits = getattr(self.strategy, "_update_positions_with_splits", None)
+        if callable(update_splits):
+            update_splits()
         self.strategy._update_cash_with_dividends()
 
         self._on_trading_iteration()
@@ -1831,9 +1834,13 @@ class StrategyExecutor(Thread):
         if not broker_continue:
             return False
 
-        # TODO: I think we should remove the OR. Pandas data can have dividends.
-        # Especially if it was saved from yahoo.
-        if not has_data_source or (has_data_source and self.broker.data_source.SOURCE != "PANDAS"):
+        # Pure pandas daily backtests process corporate actions on each dataframe row in
+        # `_process_pandas_daily_data`. Provider-routed pandas backtests still need this open-session
+        # path so split-adjusted positions are visible to pre-market lifecycle hooks.
+        if not has_data_source or not self._is_pandas_daily_data_source():
+            update_splits = getattr(self.strategy, "_update_positions_with_splits", None)
+            if callable(update_splits):
+                update_splits()
             self.strategy._update_cash_with_dividends()
 
         if not self.broker.is_market_open():
@@ -1885,6 +1892,9 @@ class StrategyExecutor(Thread):
                 break
 
             if not self._is_pandas_daily_data_source():
+                update_splits = getattr(self.strategy, "_update_positions_with_splits", None)
+                if callable(update_splits):
+                    update_splits()
                 self.strategy._update_cash_with_dividends()
 
             self._on_trading_iteration()

--- a/lumibot/tools/ibkr_helper.py
+++ b/lumibot/tools/ibkr_helper.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import time
 from dataclasses import dataclass
@@ -1000,9 +1001,10 @@ def get_price_data(
     # consistent with other providers. This is intentionally best-effort.
     if asset_type == "stock" and str(timestep_component).endswith("day"):
         enriched_cache, changed = _append_equity_corporate_actions_daily(df_cache, asset)
-        if changed:
-            _write_cache_frame(cache_file, enriched_cache)
-        df_cache = enriched_cache
+        normalized_cache, normalized_changed = _normalize_equity_daily_prices_for_splits(enriched_cache)
+        if changed or normalized_changed:
+            _write_cache_frame(cache_file, normalized_cache)
+        df_cache = normalized_cache
 
     # Remove placeholder rows from the returned frame (but keep them in cache).
     frame = df_cache.loc[(df_cache.index >= start_local) & (df_cache.index <= end_local)].copy()
@@ -1075,6 +1077,144 @@ def _align_stock_index_daily_to_session_close(df: pd.DataFrame) -> pd.DataFrame:
     frame.index = aligned_idx
     frame = frame[~frame.index.duplicated(keep="last")].sort_index()
     return frame
+
+
+def _normalize_split_ratio(value: Any) -> Optional[float]:
+    try:
+        ratio = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(ratio) or ratio <= 0 or math.isclose(ratio, 1.0):
+        return None
+    return ratio
+
+
+def _split_row_needs_price_adjustment(close: pd.Series, split_pos: int, ratio: float) -> bool:
+    """Return True when the local split window still has a raw split-level jump.
+
+    IBKR daily cache rows can be mixed: older rows may already be split-adjusted while
+    a newly appended tail around a fresh split is still raw. A per-split continuity test
+    prevents double-adjusting the already-normalized part of the cache.
+    """
+    if split_pos <= 0 or split_pos >= len(close):
+        return False
+
+    prev_close = close.iat[split_pos - 1]
+    split_close = close.iat[split_pos]
+    if (
+        pd.isna(prev_close)
+        or pd.isna(split_close)
+        or prev_close <= 0
+        or split_close <= 0
+    ):
+        return False
+
+    observed = float(prev_close) / float(split_close)
+    if observed <= 0:
+        return False
+
+    # In adjusted space, adjacent closes should be closer to 1x. In raw space,
+    # the adjacent ratio should be closer to the split ratio.
+    raw_score = abs(math.log(observed / ratio))
+    adjusted_score = abs(math.log(observed))
+    return raw_score < adjusted_score
+
+
+def _find_split_raw_segment_start(close: pd.Series, split_pos: int, ratio: float) -> int:
+    """Find where a mixed raw pre-split cache segment begins.
+
+    If a cache was partially refreshed after a split, the rows immediately before the split
+    can be raw while older rows are already adjusted. In that case there is usually a
+    persistent split-factor level jump at the cache splice point. Return that splice row;
+    if none is found, the whole history before the split is treated as raw.
+    """
+    for pos in range(split_pos - 1, 0, -1):
+        prev_close = close.iat[pos - 1]
+        cur_close = close.iat[pos]
+        if (
+            pd.isna(prev_close)
+            or pd.isna(cur_close)
+            or prev_close <= 0
+            or cur_close <= 0
+        ):
+            continue
+        observed = float(cur_close) / float(prev_close)
+        if observed <= 0:
+            continue
+        raw_boundary_score = abs(math.log(observed / ratio))
+        continuity_score = abs(math.log(observed))
+        if raw_boundary_score < continuity_score:
+            return pos
+    return 0
+
+
+def _normalize_equity_daily_prices_for_splits(frame: pd.DataFrame) -> tuple[pd.DataFrame, bool]:
+    """Normalize IBKR stock daily bars into split-adjusted price space.
+
+    LumiBot's stock backtesting providers generally expose Yahoo-style split-adjusted
+    OHLC to strategies. IBKR daily cache data can arrive raw for newly appended split
+    tails while older cached rows are already continuous. This function repairs only
+    the split dates whose local price jump still looks raw, marks the frame as
+    `_split_adjusted`, and lets the broker ledger skip share multiplication for the
+    adjusted frame.
+    """
+    if frame is None or frame.empty or "stock_splits" not in frame.columns or "close" not in frame.columns:
+        return frame, False
+
+    out = frame.sort_index().copy()
+    marker_all_adjusted = False
+    if "_split_adjusted" in out.columns:
+        marker = out["_split_adjusted"]
+        try:
+            marker_all_adjusted = bool(marker.fillna(False).astype(bool).all())
+        except Exception:
+            marker_all_adjusted = False
+
+    close = pd.to_numeric(out["close"], errors="coerce")
+    splits = pd.to_numeric(out["stock_splits"], errors="coerce").fillna(0.0)
+    split_positions = [i for i, value in enumerate(splits.to_numpy()) if _normalize_split_ratio(value) is not None]
+    if not split_positions:
+        if marker_all_adjusted:
+            return out, False
+        out["_split_adjusted"] = True
+        return out, True
+
+    price_cols = [
+        col
+        for col in ("open", "high", "low", "close", "bid", "ask", "last", "vwap")
+        if col in out.columns
+    ]
+    volume_cols = [col for col in ("volume",) if col in out.columns]
+    dividend_cols = [col for col in ("dividend",) if col in out.columns]
+
+    changed = False
+    adjusted_splits = 0
+    for split_pos in split_positions:
+        ratio = _normalize_split_ratio(splits.iat[split_pos])
+        if ratio is None:
+            continue
+        if not _split_row_needs_price_adjustment(close, split_pos, ratio):
+            continue
+
+        segment_start = _find_split_raw_segment_start(close, split_pos, ratio)
+        before_mask = pd.Series(False, index=out.index)
+        before_mask.iloc[segment_start:split_pos] = True
+        for col in price_cols + dividend_cols:
+            out.loc[before_mask, col] = pd.to_numeric(out.loc[before_mask, col], errors="coerce") / ratio
+        for col in volume_cols:
+            out.loc[before_mask, col] = pd.to_numeric(out.loc[before_mask, col], errors="coerce") * ratio
+
+        close = pd.to_numeric(out["close"], errors="coerce")
+        changed = True
+        adjusted_splits += 1
+
+    if not marker_all_adjusted or not out["_split_adjusted"].fillna(False).astype(bool).all():
+        out["_split_adjusted"] = True
+        changed = True
+
+    if adjusted_splits:
+        logger.warning("IBKR daily split normalization adjusted %s split boundary/boundaries.", adjusted_splits)
+    return out, changed
 
 
 def _repair_isolated_split_spikes_daily(df: pd.DataFrame) -> pd.DataFrame:

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ pyarrow>=15.0.0
 tqdm
 lumiwealth-tradier>=0.1.18
 py-clob-client-v2>=1.0.1
+websockets>=15.0.1
 pytz
 psycopg2-binary
 exchange_calendars>=4.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ appdirs
 pyarrow>=15.0.0
 tqdm
 lumiwealth-tradier>=0.1.18
+py-clob-client-v2>=1.0.1
 pytz
 psycopg2-binary
 exchange_calendars>=4.6.0

--- a/scripts/polymarket_deposit_wallet_setup.py
+++ b/scripts/polymarket_deposit_wallet_setup.py
@@ -24,6 +24,10 @@ ROOT = Path(__file__).resolve().parents[1]
 ENV_LOCAL = ROOT / ".env.local"
 RELAYER_URL = "https://relayer-v2.polymarket.com"
 PUSD_ADDRESS = "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB"
+CTF_ADDRESS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"
+CTF_EXCHANGE_ADDRESS = "0xE111180000d2663C0091e4f400237545B87B996B"
+NEG_RISK_CTF_EXCHANGE_ADDRESS = "0xe2222d279d744050d28e00520010520000310F59"
+NEG_RISK_ADAPTER_ADDRESS = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"
 
 
 def main() -> int:
@@ -49,6 +53,9 @@ def main() -> int:
     if args.approve:
         result["actions"].append(approve_deposit_wallet(relayer, deposit_wallet))
 
+    if args.approve_conditional:
+        result["actions"].append(approve_conditional_tokens(relayer, deposit_wallet))
+
     if args.activate:
         write_env(
             {
@@ -71,12 +78,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--deploy", action="store_true", help="Deploy the deterministic deposit wallet if needed.")
     parser.add_argument("--fund-amount", help="Transfer this many pUSD from the existing proxy wallet to deposit wallet.")
     parser.add_argument("--approve", action="store_true", help="Approve CLOB pUSD spenders from the deposit wallet.")
+    parser.add_argument("--approve-conditional", action="store_true", help="Approve CTF outcome-token spenders for sells.")
     parser.add_argument("--activate", action="store_true", help="Switch .env.local trading funder to the deposit wallet.")
     parser.add_argument("--all", action="store_true", help="Run deploy, fund, approve, and activate.")
     args = parser.parse_args()
     if args.all:
         args.deploy = True
         args.approve = True
+        args.approve_conditional = True
         args.activate = True
         args.fund_amount = args.fund_amount or os.environ.get("POLYMARKET_DEPOSIT_WALLET_FUND_AMOUNT", "5")
     return args
@@ -208,6 +217,41 @@ def approve_deposit_wallet(relayer, deposit_wallet: str) -> dict[str, Any]:
     return result
 
 
+def approve_conditional_tokens(relayer, deposit_wallet: str) -> dict[str, Any]:
+    from py_builder_relayer_client.models import DepositWalletCall, TransactionType
+
+    spenders = [
+        os.environ.get("POLYMARKET_CTF_EXCHANGE_ADDRESS", CTF_EXCHANGE_ADDRESS),
+        os.environ.get("POLYMARKET_NEG_RISK_CTF_EXCHANGE_ADDRESS", NEG_RISK_CTF_EXCHANGE_ADDRESS),
+        os.environ.get("POLYMARKET_NEG_RISK_ADAPTER_ADDRESS", NEG_RISK_ADAPTER_ADDRESS),
+    ]
+    nonce_payload = relayer.get_nonce(required_env("POLYMARKET_OWNER_ADDRESS"), TransactionType.WALLET.value)
+    calls = [
+        DepositWalletCall(
+            target=os.environ.get("POLYMARKET_CTF_ADDRESS", CTF_ADDRESS),
+            value="0",
+            data=erc1155_set_approval_for_all_calldata(spender, True),
+        )
+        for spender in spenders
+        if spender
+    ]
+    response = relayer.execute_deposit_wallet_batch(
+        calls=calls,
+        wallet_address=deposit_wallet,
+        nonce=str(nonce_payload["nonce"]),
+        deadline=str(int(time.time()) + 900),
+    )
+    return poll_transaction(
+        relayer,
+        response.transaction_id,
+        {
+            "approve_conditional": "submitted",
+            "ctf_contract": redact_address(os.environ.get("POLYMARKET_CTF_ADDRESS", CTF_ADDRESS)),
+            "approval_count": len(calls),
+        },
+    )
+
+
 def verify_deposit_wallet(deposit_wallet: str) -> dict[str, Any]:
     from py_clob_client_v2.clob_types import AssetType, BalanceAllowanceParams
     from py_clob_client_v2.order_utils.model.signature_type_v2 import SignatureTypeV2
@@ -274,6 +318,14 @@ def erc20_transfer_calldata(to_address: str, amount_units: int) -> str:
 
 def erc20_approve_calldata(spender: str, amount: int = 2**256 - 1) -> str:
     return "0x095ea7b3" + spender.lower().removeprefix("0x").rjust(64, "0") + hex(amount)[2:].rjust(64, "0")
+
+
+def erc1155_set_approval_for_all_calldata(operator: str, approved: bool = True) -> str:
+    return (
+        "0xa22cb465"
+        + operator.lower().removeprefix("0x").rjust(64, "0")
+        + ("1" if approved else "0").rjust(64, "0")
+    )
 
 
 def write_env(updates: dict[str, str]) -> None:

--- a/scripts/polymarket_deposit_wallet_setup.py
+++ b/scripts/polymarket_deposit_wallet_setup.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Polymarket deposit-wallet setup helper.
+
+This script performs the account plumbing required before LumiBot can trade
+through Polymarket's international CLOB deposit-wallet flow. It never prints raw
+keys or private addresses beyond redacted summaries.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import time
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENV_LOCAL = ROOT / ".env.local"
+RELAYER_URL = "https://relayer-v2.polymarket.com"
+PUSD_ADDRESS = "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB"
+
+
+def main() -> int:
+    args = parse_args()
+    load_dotenv(ENV_LOCAL, override=True)
+
+    result: dict[str, Any] = {"env_file": str(ENV_LOCAL), "actions": []}
+
+    if args.create_builder_key:
+        result["actions"].append(create_builder_key())
+
+    relayer = build_relayer(relay_tx_type=None)
+    deposit_wallet = relayer.get_expected_deposit_wallet()
+    result["deposit_wallet"] = redact_address(deposit_wallet)
+    write_env({"POLYMARKET_DEPOSIT_WALLET_ADDRESS": deposit_wallet})
+
+    if args.deploy:
+        result["actions"].append(deploy_deposit_wallet(relayer, deposit_wallet))
+
+    if args.fund_amount is not None:
+        result["actions"].append(fund_deposit_wallet(deposit_wallet, args.fund_amount))
+
+    if args.approve:
+        result["actions"].append(approve_deposit_wallet(relayer, deposit_wallet))
+
+    if args.activate:
+        write_env(
+            {
+                "POLYMARKET_PROXY_WALLET_ADDRESS": os.environ.get("POLYMARKET_WALLET_ADDRESS", ""),
+                "POLYMARKET_WALLET_ADDRESS": deposit_wallet,
+                "POLYMARKET_SIGNATURE_TYPE": "3",
+                "POLYMARKET_PUSD_ADDRESS": os.environ.get("POLYMARKET_PUSD_ADDRESS", PUSD_ADDRESS),
+            }
+        )
+        result["actions"].append({"activate": "updated POLYMARKET_WALLET_ADDRESS and POLYMARKET_SIGNATURE_TYPE"})
+
+    result["verification"] = verify_deposit_wallet(deposit_wallet)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Set up a Polymarket CLOB deposit wallet.")
+    parser.add_argument("--create-builder-key", action="store_true", help="Create/store builder HMAC credentials.")
+    parser.add_argument("--deploy", action="store_true", help="Deploy the deterministic deposit wallet if needed.")
+    parser.add_argument("--fund-amount", help="Transfer this many pUSD from the existing proxy wallet to deposit wallet.")
+    parser.add_argument("--approve", action="store_true", help="Approve CLOB pUSD spenders from the deposit wallet.")
+    parser.add_argument("--activate", action="store_true", help="Switch .env.local trading funder to the deposit wallet.")
+    parser.add_argument("--all", action="store_true", help="Run deploy, fund, approve, and activate.")
+    args = parser.parse_args()
+    if args.all:
+        args.deploy = True
+        args.approve = True
+        args.activate = True
+        args.fund_amount = args.fund_amount or os.environ.get("POLYMARKET_DEPOSIT_WALLET_FUND_AMOUNT", "5")
+    return args
+
+
+def create_builder_key() -> dict[str, Any]:
+    from py_clob_client_v2.client import ClobClient
+    from py_clob_client_v2.clob_types import ApiCreds
+    from py_clob_client_v2.constants import POLYGON
+
+    client = ClobClient(
+        os.environ.get("POLYMARKET_CLOB_URL", "https://clob.polymarket.com"),
+        chain_id=int(os.environ.get("POLYMARKET_CHAIN_ID", POLYGON)),
+        key=required_env("POLYMARKET_PRIVATE_KEY"),
+        creds=ApiCreds(
+            api_key=required_env("POLYMARKET_CLOB_API_KEY"),
+            api_secret=required_env("POLYMARKET_CLOB_API_SECRET"),
+            api_passphrase=required_env("POLYMARKET_CLOB_API_PASSPHRASE"),
+        ),
+        signature_type=int(os.environ.get("POLYMARKET_SIGNATURE_TYPE", "1")),
+        funder=os.environ.get("POLYMARKET_WALLET_ADDRESS"),
+        retry_on_error=True,
+    )
+    response = client.create_builder_api_key()
+    payload = to_plain(response)
+    key = payload.get("apiKey") or payload.get("key") or payload.get("api_key")
+    secret = payload.get("secret") or payload.get("apiSecret") or payload.get("api_secret")
+    passphrase = payload.get("passphrase") or payload.get("apiPassphrase") or payload.get("api_passphrase")
+    if not (key and secret and passphrase):
+        raise SystemExit(f"Builder key response missing expected fields: {sorted(payload)}")
+    write_env(
+        {
+            "POLYMARKET_BUILDER_API_KEY": key,
+            "POLYMARKET_BUILDER_SECRET": secret,
+            "POLYMARKET_BUILDER_PASSPHRASE": passphrase,
+            "BUILDER_API_KEY": key,
+            "BUILDER_SECRET": secret,
+            "BUILDER_PASS_PHRASE": passphrase,
+            "POLYMARKET_RELAYER_URL": os.environ.get("POLYMARKET_RELAYER_URL", RELAYER_URL),
+        }
+    )
+    return {"create_builder_key": "stored", "response_fields": sorted(payload)}
+
+
+def build_relayer(relay_tx_type):
+    from py_builder_relayer_client.client import RelayClient
+    from py_builder_signing_sdk.config import BuilderApiKeyCreds, BuilderConfig
+
+    builder_config = BuilderConfig(
+        local_builder_creds=BuilderApiKeyCreds(
+            key=required_env("POLYMARKET_BUILDER_API_KEY"),
+            secret=required_env("POLYMARKET_BUILDER_SECRET"),
+            passphrase=required_env("POLYMARKET_BUILDER_PASSPHRASE"),
+        )
+    )
+    return RelayClient(
+        os.environ.get("POLYMARKET_RELAYER_URL", RELAYER_URL),
+        int(os.environ.get("POLYMARKET_CHAIN_ID", "137")),
+        required_env("POLYMARKET_PRIVATE_KEY"),
+        builder_config,
+        relay_tx_type=relay_tx_type,
+    )
+
+
+def deploy_deposit_wallet(relayer, deposit_wallet: str) -> dict[str, Any]:
+    if relayer.get_deployed(deposit_wallet, "WALLET"):
+        return {"deploy": "already_deployed", "deposit_wallet": redact_address(deposit_wallet)}
+    response = relayer.deploy_deposit_wallet()
+    return poll_transaction(relayer, response.transaction_id, {"deploy": "submitted"})
+
+
+def fund_deposit_wallet(deposit_wallet: str, amount: str) -> dict[str, Any]:
+    from py_builder_relayer_client.client import RelayerTxType
+    from py_builder_relayer_client.models import Transaction
+
+    amount_units = int(Decimal(str(amount)) * Decimal("1000000"))
+    relayer = build_relayer(RelayerTxType.PROXY)
+    response = relayer.execute(
+        [
+            Transaction(
+                to=os.environ.get("POLYMARKET_PUSD_ADDRESS", PUSD_ADDRESS),
+                data=erc20_transfer_calldata(deposit_wallet, amount_units),
+                value="0",
+            )
+        ],
+        metadata="lumibot deposit wallet funding",
+    )
+    return poll_transaction(
+        relayer,
+        response.transaction_id,
+        {"fund": "submitted", "amount_usd": float(Decimal(str(amount)))},
+    )
+
+
+def approve_deposit_wallet(relayer, deposit_wallet: str) -> dict[str, Any]:
+    from py_builder_relayer_client.models import DepositWalletCall, TransactionType
+    from py_clob_client_v2.clob_types import AssetType, BalanceAllowanceParams
+    from py_clob_client_v2.order_utils.model.signature_type_v2 import SignatureTypeV2
+
+    client = clob_client(deposit_wallet)
+    balance = to_plain(
+        client.get_balance_allowance(
+            BalanceAllowanceParams(asset_type=AssetType.COLLATERAL, signature_type=SignatureTypeV2.POLY_1271)
+        )
+    )
+    spenders = [address for address, value in (balance.get("allowances") or {}).items() if str(value) in {"0", "0.0"}]
+    if not spenders:
+        return {"approve": "already_approved", "spender_count": len(balance.get("allowances") or {})}
+
+    nonce_payload = relayer.get_nonce(required_env("POLYMARKET_OWNER_ADDRESS"), TransactionType.WALLET.value)
+    calls = [
+        DepositWalletCall(
+            target=os.environ.get("POLYMARKET_PUSD_ADDRESS", PUSD_ADDRESS),
+            value="0",
+            data=erc20_approve_calldata(spender),
+        )
+        for spender in spenders
+    ]
+    response = relayer.execute_deposit_wallet_batch(
+        calls=calls,
+        wallet_address=deposit_wallet,
+        nonce=str(nonce_payload["nonce"]),
+        deadline=str(int(time.time()) + 900),
+    )
+    result = poll_transaction(relayer, response.transaction_id, {"approve": "submitted", "approval_count": len(calls)})
+    client.update_balance_allowance(
+        BalanceAllowanceParams(asset_type=AssetType.COLLATERAL, signature_type=SignatureTypeV2.POLY_1271)
+    )
+    return result
+
+
+def verify_deposit_wallet(deposit_wallet: str) -> dict[str, Any]:
+    from py_clob_client_v2.clob_types import AssetType, BalanceAllowanceParams
+    from py_clob_client_v2.order_utils.model.signature_type_v2 import SignatureTypeV2
+
+    client = clob_client(deposit_wallet)
+    balance = to_plain(
+        client.get_balance_allowance(
+            BalanceAllowanceParams(asset_type=AssetType.COLLATERAL, signature_type=SignatureTypeV2.POLY_1271)
+        )
+    )
+    return {
+        "deposit_wallet": redact_address(deposit_wallet),
+        "balance_raw_units": str(balance.get("balance")),
+        "allowance_count": len(balance.get("allowances") or {}),
+        "zero_allowance_count": sum(1 for value in (balance.get("allowances") or {}).values() if str(value) in {"0", "0.0"}),
+    }
+
+
+def clob_client(deposit_wallet: str):
+    from py_clob_client_v2.client import ClobClient
+    from py_clob_client_v2.clob_types import ApiCreds
+    from py_clob_client_v2.constants import POLYGON
+    from py_clob_client_v2.order_utils.model.signature_type_v2 import SignatureTypeV2
+
+    return ClobClient(
+        os.environ.get("POLYMARKET_CLOB_URL", "https://clob.polymarket.com"),
+        chain_id=int(os.environ.get("POLYMARKET_CHAIN_ID", POLYGON)),
+        key=required_env("POLYMARKET_PRIVATE_KEY"),
+        creds=ApiCreds(
+            api_key=required_env("POLYMARKET_CLOB_API_KEY"),
+            api_secret=required_env("POLYMARKET_CLOB_API_SECRET"),
+            api_passphrase=required_env("POLYMARKET_CLOB_API_PASSPHRASE"),
+        ),
+        signature_type=SignatureTypeV2.POLY_1271,
+        funder=deposit_wallet,
+        retry_on_error=True,
+    )
+
+
+def poll_transaction(relayer, transaction_id: str, base: dict[str, Any]) -> dict[str, Any]:
+    state = None
+    tx_hash = None
+    deadline = time.time() + 150
+    while time.time() < deadline:
+        try:
+            payload = relayer.get_transaction(transaction_id)
+            state = payload.get("state") if isinstance(payload, dict) else getattr(payload, "state", None)
+            tx_hash = (
+                payload.get("transactionHash") or payload.get("transaction_hash")
+                if isinstance(payload, dict)
+                else getattr(payload, "transaction_hash", None)
+            )
+            if state in {"STATE_CONFIRMED", "STATE_FAILED", "STATE_INVALID"}:
+                break
+        except Exception as exc:
+            state = f"poll_error:{type(exc).__name__}"
+        time.sleep(3)
+    return {**base, "transaction_id": transaction_id, "final_state": state, "transaction_hash_present": bool(tx_hash)}
+
+
+def erc20_transfer_calldata(to_address: str, amount_units: int) -> str:
+    return "0xa9059cbb" + to_address.lower().removeprefix("0x").rjust(64, "0") + hex(amount_units)[2:].rjust(64, "0")
+
+
+def erc20_approve_calldata(spender: str, amount: int = 2**256 - 1) -> str:
+    return "0x095ea7b3" + spender.lower().removeprefix("0x").rjust(64, "0") + hex(amount)[2:].rjust(64, "0")
+
+
+def write_env(updates: dict[str, str]) -> None:
+    existing = ENV_LOCAL.read_text() if ENV_LOCAL.exists() else ""
+    lines = existing.splitlines()
+    seen: set[str] = set()
+    output: list[str] = []
+    for line in lines:
+        if line.strip() and not line.lstrip().startswith("#") and "=" in line:
+            name = line.split("=", 1)[0].strip()
+            if name in updates:
+                if updates[name]:
+                    output.append(f"{name}={updates[name]}")
+                seen.add(name)
+            else:
+                output.append(line)
+        else:
+            output.append(line)
+    if output and output[-1].strip():
+        output.append("")
+    for name, value in updates.items():
+        if name not in seen and value:
+            output.append(f"{name}={value}")
+    ENV_LOCAL.write_text("\n".join(output) + "\n", encoding="utf-8")
+    os.chmod(ENV_LOCAL, stat.S_IRUSR | stat.S_IWUSR)
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing {name} in {ENV_LOCAL}")
+    return value
+
+
+def to_plain(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if hasattr(value, "dict"):
+        return value.dict()
+    if isinstance(value, dict):
+        return {key: to_plain(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [to_plain(item) for item in value]
+    return value
+
+
+def redact_address(value: str | None) -> str | None:
+    return f"{value[:6]}...{value[-4:]}" if value and len(value) > 12 else value
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/polymarket_lumibot_smoke.py
+++ b/scripts/polymarket_lumibot_smoke.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""LumiBot-level Polymarket live smoke checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENV_LOCAL = ROOT / ".env.local"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def main() -> int:
+    args = parse_args()
+    load_dotenv(ENV_LOCAL, override=True)
+
+    from lumibot.brokers.polymarket import Polymarket
+    from lumibot.entities import Asset, Order
+    from lumibot.strategies.strategy import Strategy
+
+    class PolymarketSmokeStrategy(Strategy):
+        def initialize(self):
+            self.sleeptime = "1S"
+
+    broker = Polymarket(connect_stream=False)
+    strategy = PolymarketSmokeStrategy(broker=broker, budget=100000)
+    asset = Asset(required_env("POLYMARKET_TEST_TOKEN_ID"), asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+
+    result: dict[str, Any] = {
+        "cash": strategy.get_cash(),
+        "portfolio_value": strategy.get_portfolio_value(),
+        "positions_count": len(strategy.get_positions()),
+        "open_orders_count": len(broker._pull_broker_all_orders()),
+    }
+
+    if args.market_order:
+        ensure_live_enabled()
+        amount = Decimal(str(args.amount))
+        enforce_notional_cap(amount)
+        order = strategy.create_order(
+            asset,
+            quantity=Decimal("1"),
+            side=Order.OrderSide.BUY,
+            order_type=Order.OrderType.MARKET,
+            time_in_force="fak",
+            custom_params={"amount": str(amount), "max_price": str(args.max_price)},
+        )
+        result["market_order"] = summarize_order(strategy.submit_order(order))
+
+    if args.limit_cancel:
+        ensure_live_enabled()
+        order = strategy.create_order(
+            asset,
+            quantity=Decimal(str(args.limit_size)),
+            side=Order.OrderSide.BUY,
+            limit_price=Decimal(str(args.limit_price)),
+            order_type=Order.OrderType.LIMIT,
+            time_in_force="gtc",
+        )
+        submitted = strategy.submit_order(order)
+        broker.cancel_order(submitted)
+        result["limit_cancel"] = {**summarize_order(submitted), "open_orders_after_cancel": len(broker._pull_broker_all_orders())}
+
+    print(json.dumps(result, indent=2, sort_keys=True, default=str))
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run LumiBot-level Polymarket smoke checks.")
+    parser.add_argument("--market-order", action="store_true", help="Submit one capped FAK market BUY.")
+    parser.add_argument("--amount", default=os.environ.get("POLYMARKET_TEST_ORDER_AMOUNT", "1.00"))
+    parser.add_argument("--max-price", default=os.environ.get("POLYMARKET_TEST_MAX_PRICE", "0.99"))
+    parser.add_argument("--limit-cancel", action="store_true", help="Submit and cancel one tiny GTC limit BUY.")
+    parser.add_argument("--limit-price", default=os.environ.get("POLYMARKET_TEST_LIMIT_PRICE", "0.01"))
+    parser.add_argument("--limit-size", default=os.environ.get("POLYMARKET_TEST_LIMIT_SIZE", "5"))
+    return parser.parse_args()
+
+
+def summarize_order(order) -> dict[str, Any]:
+    identifier = order.identifier or ""
+    return {
+        "identifier": f"{identifier[:8]}...{identifier[-8:]}" if len(identifier) > 16 else identifier,
+        "status": str(order.status),
+        "quantity": float(order.quantity or 0),
+        "avg_fill_price": order.avg_fill_price,
+        "limit_price": order.limit_price,
+    }
+
+
+def ensure_live_enabled() -> None:
+    if os.environ.get("POLYMARKET_LIVE_TRADING_ENABLED", "").strip().lower() not in {"1", "true", "yes", "on"}:
+        raise SystemExit("Refusing live order: set POLYMARKET_LIVE_TRADING_ENABLED=true first")
+
+
+def enforce_notional_cap(amount: Decimal) -> None:
+    cap = Decimal(os.environ.get("POLYMARKET_TEST_MAX_NOTIONAL") or os.environ.get("POLYMARKET_MAX_MARKET_ORDER_NOTIONAL") or "5")
+    if amount > cap:
+        raise SystemExit(f"Refusing live order: amount {amount} exceeds cap {cap}")
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing {name} in {ENV_LOCAL}")
+    return value
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/polymarket_lumibot_smoke.py
+++ b/scripts/polymarket_lumibot_smoke.py
@@ -7,6 +7,8 @@ import argparse
 import json
 import os
 import sys
+import time
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
@@ -32,47 +34,38 @@ def main() -> int:
         def initialize(self):
             self.sleeptime = "1S"
 
-    broker = Polymarket(connect_stream=False)
-    strategy = PolymarketSmokeStrategy(broker=broker, budget=100000)
-    asset = Asset(required_env("POLYMARKET_TEST_TOKEN_ID"), asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    broker = Polymarket(connect_stream=args.websocket, use_websocket=args.websocket, polling_interval=1.0)
+    try:
+        strategy = PolymarketSmokeStrategy(broker=broker, budget=100000)
+        broker.set_strategy_name(strategy._name)
+        asset = Asset(required_env("POLYMARKET_TEST_TOKEN_ID"), asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+        stream_capture = install_stream_capture(broker, asset.symbol) if args.websocket else None
 
-    result: dict[str, Any] = {
-        "cash": strategy.get_cash(),
-        "portfolio_value": strategy.get_portfolio_value(),
-        "positions_count": len(strategy.get_positions()),
-        "open_orders_count": len(broker._pull_broker_all_orders()),
-    }
+        result: dict[str, Any] = {
+            "cash": strategy.get_cash(),
+            "portfolio_value": strategy.get_portfolio_value(),
+            "positions_count": len(strategy.get_positions()),
+            "open_orders_count": len(broker._pull_broker_all_orders()),
+        }
 
-    if args.market_order:
-        ensure_live_enabled()
-        amount = Decimal(str(args.amount))
-        enforce_notional_cap(amount)
-        order = strategy.create_order(
-            asset,
-            quantity=Decimal("1"),
-            side=Order.OrderSide.BUY,
-            order_type=Order.OrderType.MARKET,
-            time_in_force="fak",
-            custom_params={"amount": str(amount), "max_price": str(args.max_price)},
-        )
-        result["market_order"] = summarize_order(strategy.submit_order(order))
+        if args.market_order:
+            args.order_kind = "fak-buy"
+        if args.limit_cancel:
+            args.order_kind = "cancel-single"
 
-    if args.limit_cancel:
-        ensure_live_enabled()
-        order = strategy.create_order(
-            asset,
-            quantity=Decimal(str(args.limit_size)),
-            side=Order.OrderSide.BUY,
-            limit_price=Decimal(str(args.limit_price)),
-            order_type=Order.OrderType.LIMIT,
-            time_in_force="gtc",
-        )
-        submitted = strategy.submit_order(order)
-        broker.cancel_order(submitted)
-        result["limit_cancel"] = {**summarize_order(submitted), "open_orders_after_cancel": len(broker._pull_broker_all_orders())}
+        if args.order_kind:
+            ensure_live_enabled()
+            result[args.order_kind] = run_live_order_kind(strategy, broker, asset, args)
 
-    print(json.dumps(result, indent=2, sort_keys=True, default=str))
-    return 0
+        if args.websocket:
+            time.sleep(max(args.stream_wait_seconds, 0.0))
+            broker.do_polling()
+            result["websocket"] = summarize_stream_capture(broker, asset.symbol, stream_capture)
+
+        print(json.dumps(result, indent=2, sort_keys=True, default=str))
+        return 0
+    finally:
+        broker.cleanup_streams()
 
 
 def parse_args() -> argparse.Namespace:
@@ -83,7 +76,120 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--limit-cancel", action="store_true", help="Submit and cancel one tiny GTC limit BUY.")
     parser.add_argument("--limit-price", default=os.environ.get("POLYMARKET_TEST_LIMIT_PRICE", "0.01"))
     parser.add_argument("--limit-size", default=os.environ.get("POLYMARKET_TEST_LIMIT_SIZE", "5"))
+    parser.add_argument(
+        "--order-kind",
+        choices=[
+            "fak-buy",
+            "fak-sell",
+            "fok-buy",
+            "fok-sell",
+            "gtc-buy",
+            "gtc-sell",
+            "gtd-buy",
+            "gtd-sell",
+            "post-only-buy",
+            "post-only-sell",
+            "cancel-single",
+            "cancel-multiple",
+            "cancel-all",
+            "cancel-market",
+        ],
+        help="Run one explicit LumiBot live order/cancel matrix case.",
+    )
+    parser.add_argument("--market-id", default=os.environ.get("POLYMARKET_TEST_CONDITION_ID"))
+    parser.add_argument("--gtd-seconds", type=int, default=int(os.environ.get("POLYMARKET_TEST_GTD_SECONDS", "300")))
+    parser.add_argument("--websocket", action="store_true", help="Enable public/private Polymarket WebSockets.")
+    parser.add_argument("--stream-wait-seconds", type=float, default=8.0)
     return parser.parse_args()
+
+
+def run_live_order_kind(strategy, broker, asset, args) -> dict[str, Any]:
+    from lumibot.entities import Order
+
+    order_kind = args.order_kind
+    if order_kind in {"fak-buy", "fok-buy"}:
+        tif = order_kind.split("-")[0].upper()
+        amount = Decimal(str(args.amount))
+        enforce_notional_cap(amount)
+        order = strategy.create_order(
+            asset,
+            quantity=Decimal("1"),
+            side=Order.OrderSide.BUY,
+            order_type=Order.OrderType.MARKET,
+            time_in_force=tif.lower(),
+            custom_params={"amount": str(amount), "max_price": str(args.max_price), "order_type": tif},
+        )
+        return summarize_order(strategy.submit_order(order))
+
+    if order_kind in {"fak-sell", "fok-sell"}:
+        tif = order_kind.split("-")[0].upper()
+        order = strategy.create_order(
+            asset,
+            quantity=Decimal(str(args.limit_size)),
+            side=Order.OrderSide.SELL,
+            order_type=Order.OrderType.MARKET,
+            time_in_force=tif.lower(),
+            custom_params={"min_price": str(args.limit_price), "order_type": tif},
+        )
+        return summarize_order(strategy.submit_order(order))
+
+    if order_kind in {"gtc-buy", "gtc-sell", "gtd-buy", "gtd-sell", "post-only-buy", "post-only-sell"}:
+        side = Order.OrderSide.SELL if order_kind.endswith("sell") else Order.OrderSide.BUY
+        time_in_force = "gtd" if order_kind.startswith("gtd") else "gtc"
+        custom_params = {}
+        if side == Order.OrderSide.BUY:
+            enforce_notional_cap(Decimal(str(args.limit_price)) * Decimal(str(args.limit_size)))
+        if time_in_force == "gtd":
+            custom_params["expiration"] = int((datetime.now(timezone.utc) + timedelta(seconds=args.gtd_seconds)).timestamp())
+        if order_kind.startswith("post-only"):
+            custom_params["post_only"] = True
+        order = strategy.create_order(
+            asset,
+            quantity=Decimal(str(args.limit_size)),
+            side=side,
+            limit_price=Decimal(str(args.limit_price)),
+            order_type=Order.OrderType.LIMIT,
+            time_in_force=time_in_force,
+            custom_params=custom_params,
+        )
+        return summarize_order(strategy.submit_order(order))
+
+    if order_kind == "cancel-single":
+        order = build_resting_buy_order(strategy, asset, args)
+        submitted = strategy.submit_order(order)
+        broker.cancel_order(submitted)
+        return {**summarize_order(submitted), "open_orders_after_cancel": len(broker._pull_broker_all_orders())}
+
+    if order_kind == "cancel-multiple":
+        orders = [strategy.submit_order(build_resting_buy_order(strategy, asset, args)) for _ in range(2)]
+        response = broker.cancel_orders(orders)
+        return {
+            "orders": [summarize_order(order) for order in orders],
+            "cancel_response": redact_identifiers(response),
+            "open_orders_after_cancel": len(broker._pull_broker_all_orders()),
+        }
+
+    if order_kind == "cancel-all":
+        return {"cancel_response": redact_identifiers(broker.cancel_all_orders())}
+
+    if order_kind == "cancel-market":
+        return {"cancel_response": redact_identifiers(broker.cancel_market_orders(market=args.market_id, asset_id=asset))}
+
+    raise SystemExit(f"Unsupported order kind: {order_kind}")
+
+
+def build_resting_buy_order(strategy, asset, args):
+    from lumibot.entities import Order
+
+    enforce_notional_cap(Decimal(str(args.limit_price)) * Decimal(str(args.limit_size)))
+    return strategy.create_order(
+        asset,
+        quantity=Decimal(str(args.limit_size)),
+        side=Order.OrderSide.BUY,
+        limit_price=Decimal(str(args.limit_price)),
+        order_type=Order.OrderType.LIMIT,
+        time_in_force="gtc",
+    )
 
 
 def summarize_order(order) -> dict[str, Any]:
@@ -95,6 +201,73 @@ def summarize_order(order) -> dict[str, Any]:
         "avg_fill_price": order.avg_fill_price,
         "limit_price": order.limit_price,
     }
+
+
+def install_stream_capture(broker, token_id: str) -> dict[str, list[Any]]:
+    capture: dict[str, list[Any]] = {"market_events": [], "user_events": []}
+    stream = getattr(broker, "stream", None)
+    if stream is None:
+        return capture
+    subscribe = getattr(stream, "subscribe_market_assets", None)
+    if subscribe is not None:
+        subscribe([token_id])
+
+    original_market_handler = getattr(stream, "handle_market_event", None)
+    original_user_handler = getattr(stream, "handle_user_event", None)
+
+    if original_market_handler is not None:
+        def capture_market_event(event):
+            capture["market_events"].append(event_summary(event))
+            return original_market_handler(event)
+
+        stream.handle_market_event = capture_market_event
+
+    if original_user_handler is not None:
+        def capture_user_event(event):
+            capture["user_events"].append(event_summary(event))
+            return original_user_handler(event)
+
+        stream.handle_user_event = capture_user_event
+
+    return capture
+
+
+def summarize_stream_capture(broker, token_id: str, capture: dict[str, list[Any]] | None) -> dict[str, Any]:
+    capture = capture or {"market_events": [], "user_events": []}
+    quote_cache = getattr(getattr(broker, "data_source", None), "_quote_cache", {})
+    return {
+        "market_event_count": len(capture["market_events"]),
+        "market_event_types": [item.get("type") for item in capture["market_events"][:5]],
+        "user_event_count": len(capture["user_events"]),
+        "user_event_types": [item.get("type") for item in capture["user_events"][:5]],
+        "trade_event_rows": len(getattr(broker, "_trade_event_log_rows", [])),
+        "recent_order_cache_count": len(getattr(broker, "_recent_order_cache", {})),
+        "recent_trade_cache_count": len(getattr(broker, "_recent_trade_cache", {})),
+        "quote_cache_has_test_token": str(token_id) in quote_cache,
+    }
+
+
+def event_summary(event: Any) -> dict[str, Any]:
+    if isinstance(event, list):
+        return {"type": "list", "count": len(event)}
+    if not isinstance(event, dict):
+        return {"type": type(event).__name__}
+    event_type = event.get("event_type") or event.get("eventType") or event.get("type") or event.get("status")
+    identifier = event.get("id") or event.get("orderID") or event.get("order_id") or event.get("trade_id")
+    return {
+        "type": event_type,
+        "identifier": redact_identifiers(str(identifier)) if identifier else None,
+    }
+
+
+def redact_identifiers(value):
+    if isinstance(value, dict):
+        return {key: redact_identifiers(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [redact_identifiers(item) for item in value]
+    if isinstance(value, str) and len(value) > 16:
+        return f"{value[:8]}...{value[-8:]}"
+    return value
 
 
 def ensure_live_enabled() -> None:

--- a/scripts/polymarket_smoke.py
+++ b/scripts/polymarket_smoke.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Direct Polymarket CLOB smoke proof for local development.
+
+This script is deliberately outside the LumiBot broker adapter. It verifies the raw
+Polymarket SDK, Data API, CLOB HTTP endpoints, and WebSockets before blaming or
+changing LumiBot mapping code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import httpx
+from dotenv import load_dotenv
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENV_LOCAL = ROOT / ".env.local"
+LOG_DIR = ROOT / "logs"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+CLOB_URL = "https://clob.polymarket.com"
+DATA_API_URL = "https://data-api.polymarket.com"
+MARKET_WS_URL = "wss://ws-subscriptions-clob.polymarket.com/ws/market"
+USER_WS_URL = "wss://ws-subscriptions-clob.polymarket.com/ws/user"
+
+KNOWN_ORDER_BLOCKERS = (
+    "maker address not allowed",
+    "deposit wallet flow",
+    "order signer address has to be the address of the api key",
+    "no deposit wallet found",
+)
+
+
+def main() -> int:
+    args = parse_args()
+    if ENV_LOCAL.exists():
+        load_dotenv(ENV_LOCAL)
+
+    result: dict[str, Any] = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "env_file": str(ENV_LOCAL),
+        "mode": {
+            "read_only": True,
+            "live_order": args.live_order,
+            "limit_cancel": args.limit_cancel,
+        },
+        "env_present": redacted_env_summary(),
+    }
+
+    client, derived = build_clob_client()
+    result["clob_credentials"] = {"derived_in_process": derived}
+
+    token_id = os.environ.get("POLYMARKET_TEST_TOKEN_ID")
+    if not token_id:
+        raise SystemExit("Missing POLYMARKET_TEST_TOKEN_ID in .env.local or environment")
+
+    result["account"] = prove_account(client)
+    result["market"] = prove_market(token_id)
+    result["websocket"] = asyncio.run(prove_websockets(token_id, timeout=args.ws_timeout))
+
+    if args.live_order:
+        result["live_market_order"] = prove_market_order(client, token_id, args.amount, args.max_price)
+
+    if args.limit_cancel:
+        result["limit_cancel"] = prove_limit_cancel(client, token_id, args.limit_price, args.limit_size)
+
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    output_path = LOG_DIR / f"polymarket_smoke_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}.json"
+    output_path.write_text(json.dumps(redact_for_log(result), indent=2, sort_keys=True), encoding="utf-8")
+
+    print(json.dumps(redact_for_console(result, output_path), indent=2, sort_keys=True))
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run direct Polymarket CLOB smoke checks with redacted output.")
+    parser.add_argument("--live-order", action="store_true", help="Attempt one tiny FAK market BUY order.")
+    parser.add_argument("--limit-cancel", action="store_true", help="Attempt one tiny GTC limit order and cancel it.")
+    parser.add_argument("--amount", default=os.environ.get("POLYMARKET_TEST_ORDER_AMOUNT", "1.00"))
+    parser.add_argument("--max-price", default=os.environ.get("POLYMARKET_TEST_MAX_PRICE", "0.99"))
+    parser.add_argument("--limit-price", default=os.environ.get("POLYMARKET_TEST_LIMIT_PRICE", "0.01"))
+    parser.add_argument("--limit-size", default=os.environ.get("POLYMARKET_TEST_LIMIT_SIZE", "5"))
+    parser.add_argument("--ws-timeout", type=float, default=8.0)
+    return parser.parse_args()
+
+
+def build_clob_client():
+    try:
+        from py_clob_client_v2.client import ClobClient
+        from py_clob_client_v2.clob_types import ApiCreds
+        from py_clob_client_v2.constants import POLYGON
+    except Exception as exc:
+        raise SystemExit("Install py-clob-client-v2 before running this script") from exc
+
+    private_key = required_env("POLYMARKET_PRIVATE_KEY")
+    signature_type = int(os.environ.get("POLYMARKET_SIGNATURE_TYPE", "3"))
+    chain_id = int(os.environ.get("POLYMARKET_CHAIN_ID", POLYGON))
+    funder = os.environ.get("POLYMARKET_WALLET_ADDRESS")
+
+    creds = None
+    if all(
+        os.environ.get(name)
+        for name in ("POLYMARKET_CLOB_API_KEY", "POLYMARKET_CLOB_API_SECRET", "POLYMARKET_CLOB_API_PASSPHRASE")
+    ):
+        creds = ApiCreds(
+            api_key=os.environ["POLYMARKET_CLOB_API_KEY"],
+            api_secret=os.environ["POLYMARKET_CLOB_API_SECRET"],
+            api_passphrase=os.environ["POLYMARKET_CLOB_API_PASSPHRASE"],
+        )
+
+    client = ClobClient(
+        os.environ.get("POLYMARKET_CLOB_URL", CLOB_URL),
+        chain_id=chain_id,
+        key=private_key,
+        creds=creds,
+        signature_type=signature_type,
+        funder=funder,
+        retry_on_error=True,
+    )
+    if creds is None:
+        derived = client.create_or_derive_api_key()
+        client.set_api_creds(derived)
+        return client, True
+    return client, False
+
+
+def prove_account(client) -> dict[str, Any]:
+    from py_clob_client_v2.clob_types import AssetType, BalanceAllowanceParams
+
+    balance_payload = client.get_balance_allowance(BalanceAllowanceParams(asset_type=AssetType.COLLATERAL))
+    open_orders = listify(client.get_open_orders())
+    trades = listify(client.get_trades())
+    addresses = query_addresses()
+    positions_by_address = {}
+    value_by_address = {}
+    with httpx.Client(timeout=10.0) as http:
+        for address in addresses:
+            positions_by_address[redact_address(address)] = len(
+                listify(http.get(f"{DATA_API_URL}/positions", params={"user": address}).json())
+            )
+            value_payload = http.get(f"{DATA_API_URL}/value", params={"user": address}).json()
+            value_by_address[redact_address(address)] = listify(value_payload)
+
+    balance_raw = first_present(balance_payload, "balance")
+    return {
+        "balance_raw_units": str(balance_raw),
+        "balance_usdc": float(raw_usdc_to_decimal(balance_raw)),
+        "allowance_present": first_present(balance_payload, "allowance") is not None,
+        "open_orders_count": len(open_orders),
+        "recent_trades_count": len(trades),
+        "positions_count_by_address": positions_by_address,
+        "value_by_address": value_by_address,
+    }
+
+
+def prove_market(token_id: str) -> dict[str, Any]:
+    from lumibot.data_sources.polymarket_data import PolymarketData
+    from lumibot.entities import Asset
+
+    data = PolymarketData()
+    asset = Asset(token_id, asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    book = data.get_order_book(token_id)
+    quote = data.get_quote(asset)
+    last_price = data.get_last_price(asset)
+    history = data.get_historical_prices(asset, 5, timestep="minute")
+    estimate = data.calculate_market_price(token_id, "buy", Decimal("1.00"))
+    return {
+        "token_id": redact_token(token_id),
+        "book_bid_count": len(book.get("bids") or []),
+        "book_ask_count": len(book.get("asks") or []),
+        "tick_size": str(first_present(book, "tick_size", "minimum_tick_size") or data.get_tick_size(token_id)),
+        "neg_risk": first_present(book, "neg_risk", "negRisk"),
+        "quote": {"bid": quote.bid, "ask": quote.ask, "mid": quote.mid_price},
+        "last_price": last_price,
+        "history_points": len(history.df),
+        "buy_one_dollar_estimate": {
+            "avg_price": estimate["avg_price_estimate"],
+            "shares": estimate["filled_shares_estimate"],
+            "fully_satisfied": estimate["fully_satisfied"],
+        },
+    }
+
+
+async def prove_websockets(token_id: str, timeout: float) -> dict[str, Any]:
+    try:
+        import websockets
+    except Exception as exc:
+        return {"error": f"websockets missing: {exc}"}
+
+    public_events: list[Any] = []
+    private_events: list[Any] = []
+
+    async def public_ws():
+        async with websockets.connect(MARKET_WS_URL, ping_interval=20, close_timeout=5) as ws:
+            await ws.send(json.dumps({"assets_ids": [token_id], "type": "market", "custom_feature_enabled": True}))
+            end = asyncio.get_running_loop().time() + timeout
+            while asyncio.get_running_loop().time() < end and len(public_events) < 3:
+                try:
+                    public_events.append(json.loads(await asyncio.wait_for(ws.recv(), timeout=1.0)))
+                except asyncio.TimeoutError:
+                    continue
+
+    async def private_ws():
+        auth = websocket_auth()
+        if not auth:
+            return
+        async with websockets.connect(USER_WS_URL, ping_interval=20, close_timeout=5) as ws:
+            await ws.send(json.dumps({"auth": auth, "type": "user"}))
+            end = asyncio.get_running_loop().time() + timeout
+            while asyncio.get_running_loop().time() < end and len(private_events) < 3:
+                try:
+                    private_events.append(json.loads(await asyncio.wait_for(ws.recv(), timeout=1.0)))
+                except asyncio.TimeoutError:
+                    continue
+
+    await asyncio.gather(public_ws(), private_ws(), return_exceptions=True)
+    return {
+        "public_event_count": len(public_events),
+        "public_event_types": [event_type(event) for event in public_events],
+        "private_event_count": len(private_events),
+        "private_stream_connected": websocket_auth() is not None,
+    }
+
+
+def prove_market_order(client, token_id: str, amount: str, max_price: str) -> dict[str, Any]:
+    ensure_live_enabled()
+    enforce_notional_cap(amount)
+    try:
+        from py_clob_client_v2.clob_types import MarketOrderArgs, OrderType
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)}
+
+    options = order_options(token_id)
+    order_args = MarketOrderArgs(
+        token_id=token_id,
+        amount=float(amount),
+        side="BUY",
+        price=float(max_price),
+        order_type=OrderType.FAK,
+    )
+    try:
+        response = client.create_and_post_market_order(order_args, options=options, order_type=OrderType.FAK)
+        return {"status": "submitted", "response": redact_for_log(to_plain(response))}
+    except Exception as exc:
+        return classify_order_exception(exc)
+
+
+def prove_limit_cancel(client, token_id: str, price: str, size: str) -> dict[str, Any]:
+    ensure_live_enabled()
+    try:
+        from py_clob_client_v2.clob_types import OrderArgs, OrderPayload, OrderType
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)}
+
+    options = order_options(token_id)
+    order_args = OrderArgs(token_id=token_id, price=float(price), size=float(size), side="BUY")
+    try:
+        response = client.create_and_post_order(order_args, options=options, order_type=OrderType.GTC)
+        order_id = first_present(response, "order_id", "orderID", "id")
+        cancel_response = None
+        if order_id:
+            cancel_response = client.cancel_order(OrderPayload(orderID=str(order_id)))
+        return {
+            "status": "submitted",
+            "order_response": redact_for_log(to_plain(response)),
+            "cancel_response": redact_for_log(to_plain(cancel_response)),
+        }
+    except Exception as exc:
+        return classify_order_exception(exc)
+
+
+def order_options(token_id: str):
+    from py_clob_client_v2.clob_types import PartialCreateOrderOptions
+    from lumibot.data_sources.polymarket_data import PolymarketData
+
+    data = PolymarketData()
+    book = data.get_order_book(token_id)
+    tick_size = first_present(book, "tick_size", "minimum_tick_size")
+    neg_risk = first_present(book, "neg_risk", "negRisk")
+    return PartialCreateOrderOptions(tick_size=str(tick_size) if tick_size else None, neg_risk=bool(neg_risk))
+
+
+def ensure_live_enabled() -> None:
+    enabled = os.environ.get("POLYMARKET_LIVE_TRADING_ENABLED", "").strip().lower()
+    if enabled not in {"1", "true", "yes", "on"}:
+        raise SystemExit("Refusing live order: set POLYMARKET_LIVE_TRADING_ENABLED=true first")
+
+
+def enforce_notional_cap(amount: str) -> None:
+    amount_value = Decimal(str(amount))
+    cap = Decimal(os.environ.get("POLYMARKET_TEST_MAX_NOTIONAL") or os.environ.get("POLYMARKET_MAX_MARKET_ORDER_NOTIONAL") or "5")
+    if amount_value > cap:
+        raise SystemExit(f"Refusing live order: amount {amount_value} exceeds cap {cap}")
+
+
+def classify_order_exception(exc: Exception) -> dict[str, Any]:
+    message = str(exc)
+    status = "blocked" if any(marker in message.lower() for marker in KNOWN_ORDER_BLOCKERS) else "error"
+    return {"status": status, "error": message}
+
+
+def websocket_auth() -> dict | None:
+    key = os.environ.get("POLYMARKET_CLOB_API_KEY")
+    secret = os.environ.get("POLYMARKET_CLOB_API_SECRET")
+    passphrase = os.environ.get("POLYMARKET_CLOB_API_PASSPHRASE")
+    if not (key and secret and passphrase):
+        return None
+    return {"apiKey": key, "secret": secret, "passphrase": passphrase}
+
+
+def query_addresses() -> list[str]:
+    addresses = []
+    for name in ("POLYMARKET_WALLET_ADDRESS", "POLYMARKET_OWNER_ADDRESS"):
+        value = os.environ.get(name)
+        if value and value.lower() not in {address.lower() for address in addresses}:
+            addresses.append(value)
+    return addresses
+
+
+def redacted_env_summary() -> dict[str, Any]:
+    names = [
+        "TRADING_BROKER",
+        "POLYMARKET_PRIVATE_KEY",
+        "POLYMARKET_OWNER_ADDRESS",
+        "POLYMARKET_WALLET_ADDRESS",
+        "POLYMARKET_SIGNATURE_TYPE",
+        "POLYMARKET_CLOB_API_KEY",
+        "POLYMARKET_CLOB_API_SECRET",
+        "POLYMARKET_CLOB_API_PASSPHRASE",
+        "POLYMARKET_TEST_TOKEN_ID",
+        "POLYMARKET_LIVE_TRADING_ENABLED",
+        "POLYMARKET_TEST_MAX_NOTIONAL",
+    ]
+    return {name: bool(os.environ.get(name)) for name in names}
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing {name} in .env.local or environment")
+    return value
+
+
+def listify(value: Any) -> list:
+    value = to_plain(value)
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        for key in ("items", "data", "orders", "positions", "trades", "results"):
+            if isinstance(value.get(key), list):
+                return value[key]
+        return [value]
+    return [value]
+
+
+def first_present(mapping: Any, *keys: str) -> Any:
+    mapping = to_plain(mapping)
+    if not isinstance(mapping, dict):
+        return None
+    for key in keys:
+        if key in mapping and mapping[key] is not None:
+            return mapping[key]
+    return None
+
+
+def raw_usdc_to_decimal(value: Any) -> Decimal:
+    if value is None:
+        return Decimal("0")
+    decimal_value = Decimal(str(value))
+    if decimal_value == decimal_value.to_integral_value():
+        return decimal_value / Decimal("1000000")
+    return decimal_value
+
+
+def event_type(event: Any) -> str:
+    if isinstance(event, list):
+        return "list"
+    return str(first_present(event, "event_type", "eventType", "type") or type(event).__name__)
+
+
+def to_plain(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if hasattr(value, "dict"):
+        return value.dict()
+    if isinstance(value, dict):
+        return {key: to_plain(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [to_plain(item) for item in value]
+    if hasattr(value, "__dict__"):
+        return {key: to_plain(item) for key, item in vars(value).items() if not key.startswith("_")}
+    return value
+
+
+def redact_for_console(result: dict[str, Any], output_path: Path) -> dict[str, Any]:
+    payload = redact_for_log(result)
+    payload["log_path"] = str(output_path)
+    return payload
+
+
+def redact_for_log(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: redact_for_log(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [redact_for_log(item) for item in value]
+    if isinstance(value, str):
+        if value.startswith("0x") and len(value) == 42:
+            return redact_address(value)
+        if value.isdigit() and len(value) > 20:
+            return redact_token(value)
+    return value
+
+
+def redact_address(value: str) -> str:
+    return f"{value[:6]}...{value[-4:]}" if value and len(value) > 12 else value
+
+
+def redact_token(value: str) -> str:
+    return f"{value[:8]}...{value[-8:]}" if value and len(value) > 20 else value
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,9 @@ markers =
     apitest: marks tests as API tests (deselect with '-m "not apitest"')
     smartlimit_matrix: larger SMART_LIMIT live matrix tests (run with '-m smartlimit_matrix')
     downloader: marks tests that require the shared Theta downloader service
+    polymarket: marks tests that require Polymarket CLOB credentials or live market data
+    polymarket_credentials: marks Polymarket tests that require authenticated CLOB credentials
+    polymarket_live_trading: marks Polymarket tests that can submit/cancel live orders when explicitly enabled
     acceptance_backtest: full Strategy Library acceptance backtests (ThetaData, prod-like flags)
 
 # Exclude the warnings issued by underlying library that we can't fix

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setuptools.setup(
         "pyarrow>=15.0.0",
         "tqdm",
         "lumiwealth-tradier>=0.1.18",
+        "py-clob-client-v2>=1.0.1",
         "pytz",
         "psycopg2-binary",
         # Exchange calendars 4.6.0+ supports NumPy 2.x
@@ -135,6 +136,7 @@ setuptools.setup(
         "alpaca",
         "interactive-brokers",
         "tradier",
+        "polymarket",
         "schwab",
         "trading-strategies",
         "paper-trading",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.63",
+    version="4.5.64",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/backtest/test_ibkr_equity_actions.py
+++ b/tests/backtest/test_ibkr_equity_actions.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from lumibot.entities import Asset
 from lumibot.tools import ibkr_helper
@@ -107,3 +108,162 @@ def test_append_equity_corporate_actions_daily_reuses_cached_actions_for_same_ne
     assert calls["count"] == 1
     assert float(first.loc[idx[1], "dividend"]) == 0.25
     assert float(second.loc[idx[1], "dividend"]) == 0.25
+
+
+def test_normalize_equity_daily_prices_for_raw_forward_split():
+    idx = pd.DatetimeIndex(
+        [
+            "2025-11-19 16:00:00-05:00",
+            "2025-11-20 16:00:00-05:00",
+            "2025-11-21 16:00:00-05:00",
+        ]
+    )
+    frame = pd.DataFrame(
+        {
+            "open": [98.0, 52.0, 47.0],
+            "high": [104.0, 54.0, 49.0],
+            "low": [97.0, 46.0, 45.0],
+            "close": [100.0, 46.5, 47.5],
+            "bid": [100.0, 46.5, 47.5],
+            "ask": [100.0, 46.5, 47.5],
+            "volume": [1000.0, 2000.0, 2100.0],
+            "dividend": [0.2, 0.0, 0.0],
+            "stock_splits": [0.0, 2.0, 0.0],
+        },
+        index=idx,
+    )
+
+    normalized, changed = ibkr_helper._normalize_equity_daily_prices_for_splits(frame)
+
+    assert changed is True
+    assert normalized["_split_adjusted"].all()
+    assert normalized.loc[idx[0], "close"] == pytest.approx(50.0)
+    assert normalized.loc[idx[0], "open"] == pytest.approx(49.0)
+    assert normalized.loc[idx[0], "volume"] == pytest.approx(2000.0)
+    assert normalized.loc[idx[0], "dividend"] == pytest.approx(0.1)
+    assert normalized.loc[idx[1], "close"] == pytest.approx(46.5)
+
+
+def test_normalize_equity_daily_prices_for_raw_reverse_split():
+    idx = pd.DatetimeIndex(
+        [
+            "2025-01-02 16:00:00-05:00",
+            "2025-01-03 16:00:00-05:00",
+        ]
+    )
+    frame = pd.DataFrame(
+        {
+            "open": [9.5, 95.0],
+            "high": [10.5, 105.0],
+            "low": [9.0, 90.0],
+            "close": [10.0, 100.0],
+            "volume": [10000.0, 1000.0],
+            "dividend": [1.0, 0.0],
+            "stock_splits": [0.0, 0.1],
+        },
+        index=idx,
+    )
+
+    normalized, changed = ibkr_helper._normalize_equity_daily_prices_for_splits(frame)
+
+    assert changed is True
+    assert normalized["_split_adjusted"].all()
+    assert normalized.loc[idx[0], "close"] == pytest.approx(100.0)
+    assert normalized.loc[idx[0], "volume"] == pytest.approx(1000.0)
+    assert normalized.loc[idx[0], "dividend"] == pytest.approx(10.0)
+
+
+def test_normalize_equity_daily_prices_marks_already_adjusted_split_without_double_adjusting():
+    idx = pd.DatetimeIndex(
+        [
+            "2025-11-19 16:00:00-05:00",
+            "2025-11-20 16:00:00-05:00",
+        ]
+    )
+    frame = pd.DataFrame(
+        {
+            "open": [49.0, 52.0],
+            "high": [52.0, 54.0],
+            "low": [48.5, 46.0],
+            "close": [50.0, 46.5],
+            "volume": [2000.0, 2000.0],
+            "dividend": [0.0, 0.0],
+            "stock_splits": [0.0, 2.0],
+        },
+        index=idx,
+    )
+
+    normalized, changed = ibkr_helper._normalize_equity_daily_prices_for_splits(frame)
+    normalized_again, changed_again = ibkr_helper._normalize_equity_daily_prices_for_splits(normalized)
+
+    assert changed is True
+    assert changed_again is False
+    assert normalized["_split_adjusted"].all()
+    assert normalized.loc[idx[0], "close"] == pytest.approx(50.0)
+    assert normalized_again.loc[idx[0], "close"] == pytest.approx(50.0)
+
+
+def test_normalize_equity_daily_prices_still_checks_marked_frame_after_late_split_enrichment():
+    idx = pd.DatetimeIndex(
+        [
+            "2025-11-19 16:00:00-05:00",
+            "2025-11-20 16:00:00-05:00",
+        ]
+    )
+    frame = pd.DataFrame(
+        {
+            "open": [98.0, 52.0],
+            "high": [104.0, 54.0],
+            "low": [97.0, 46.0],
+            "close": [100.0, 46.5],
+            "volume": [1000.0, 2000.0],
+            "dividend": [0.0, 0.0],
+            "stock_splits": [0.0, 2.0],
+            "_split_adjusted": [True, True],
+        },
+        index=idx,
+    )
+
+    normalized, changed = ibkr_helper._normalize_equity_daily_prices_for_splits(frame)
+
+    assert changed is True
+    assert normalized["_split_adjusted"].all()
+    assert normalized.loc[idx[0], "close"] == pytest.approx(50.0)
+    assert normalized.loc[idx[0], "volume"] == pytest.approx(2000.0)
+
+
+def test_normalize_equity_daily_prices_repairs_mixed_tqqq_cache_shape():
+    idx = pd.DatetimeIndex(
+        [
+            "2021-01-20 16:00:00-05:00",
+            "2021-01-21 16:00:00-05:00",
+            "2022-01-12 16:00:00-05:00",
+            "2022-01-13 16:00:00-05:00",
+            "2025-11-19 16:00:00-05:00",
+            "2025-11-20 16:00:00-05:00",
+        ]
+    )
+    frame = pd.DataFrame(
+        {
+            "open": [23.96, 25.08, 38.48, 38.57, 98.66, 52.92],
+            "high": [24.97, 25.54, 38.98, 38.78, 103.15, 53.54],
+            "low": [23.88, 24.75, 37.47, 35.01, 97.43, 46.23],
+            "close": [24.75, 25.36, 38.17, 35.40, 100.05, 46.45],
+            "volume": [1000.0, 1000.0, 1000.0, 1000.0, 768163.78, 1576329.68],
+            "dividend": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            "stock_splits": [0.0, 2.0, 0.0, 2.0, 0.0, 2.0],
+        },
+        index=idx,
+    )
+
+    normalized, changed = ibkr_helper._normalize_equity_daily_prices_for_splits(frame)
+
+    assert changed is True
+    assert normalized["_split_adjusted"].all()
+    # 2021 and 2022 were already continuous in the cache and must not be halved again.
+    assert normalized.loc[idx[0], "close"] == pytest.approx(24.75)
+    assert normalized.loc[idx[2], "close"] == pytest.approx(38.17)
+    # The 2025 tail was raw and must be brought into the same adjusted price space.
+    assert normalized.loc[idx[4], "close"] == pytest.approx(50.025)
+    assert normalized.loc[idx[4], "open"] == pytest.approx(49.33)
+    assert normalized.loc[idx[5], "close"] == pytest.approx(46.45)

--- a/tests/backtest/test_ibkr_equity_actions.py
+++ b/tests/backtest/test_ibkr_equity_actions.py
@@ -1,9 +1,34 @@
 import pandas as pd
 import pytest
 
+from lumibot.backtesting import BacktestingBroker, PandasDataBacktesting
 from lumibot.entities import Asset
+from lumibot.entities import Data
+from lumibot.strategies.strategy import Strategy
 from lumibot.tools import ibkr_helper
 from lumibot.tools.yahoo_helper import YahooHelper
+from lumibot.traders import Trader
+
+
+class _HoldTqqqThroughSplitStrategy(Strategy):
+    def initialize(self):
+        self.sleeptime = "1D"
+        self.asset = self.parameters["asset"]
+        self.observed_quantities = {}
+        self.did_buy = False
+        self.did_sell = False
+
+    def on_trading_iteration(self):
+        current_date = self.get_datetime().date()
+        position = self.get_position(self.asset)
+        self.observed_quantities[current_date] = 0 if position is None else float(position.quantity)
+
+        if not self.did_buy and position is None:
+            self.submit_order(self.create_order(self.asset, 10, "buy"))
+            self.did_buy = True
+        elif current_date >= pd.Timestamp("2025-11-21").date() and position is not None and not self.did_sell:
+            self.submit_order(self.create_order(self.asset, abs(position.quantity), "sell"))
+            self.did_sell = True
 
 
 def test_append_equity_corporate_actions_daily_populates_columns(monkeypatch):
@@ -267,3 +292,177 @@ def test_normalize_equity_daily_prices_repairs_mixed_tqqq_cache_shape():
     assert normalized.loc[idx[4], "close"] == pytest.approx(50.025)
     assert normalized.loc[idx[4], "open"] == pytest.approx(49.33)
     assert normalized.loc[idx[5], "close"] == pytest.approx(46.45)
+
+
+def test_normalize_equity_daily_prices_repairs_old_dev_tqqq_tail_only():
+    idx = pd.DatetimeIndex(
+        [
+            "2022-10-31 16:00:00",
+            "2022-11-01 16:00:00",
+            "2022-11-02 16:00:00",
+            "2024-01-30 16:00:00",
+            "2024-01-31 16:00:00",
+            "2024-02-01 16:00:00",
+            "2024-02-02 16:00:00",
+            "2024-02-05 16:00:00",
+        ],
+        tz="America/New_York",
+    )
+    frame = pd.DataFrame(
+        {
+            "open": [10.9, 20.9, 9.4, 28.4, 52.9, 52.8, 52.7, 26.7],
+            "high": [11.0, 21.1, 9.5, 28.5, 53.2, 53.1, 53.0, 27.0],
+            "low": [10.1, 19.8, 8.8, 27.2, 52.0, 52.2, 52.0, 26.0],
+            "close": [10.48, 20.30, 9.10, 27.97, 52.64, 52.80, 52.90, 26.45],
+            "volume": [1000.0, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0, 768163.78, 1576329.68],
+            "dividend": [0.0] * 8,
+            "stock_splits": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0],
+        },
+        index=idx,
+    )
+
+    normalized, changed = ibkr_helper._normalize_equity_daily_prices_for_splits(frame)
+
+    assert changed is True
+    assert normalized["_split_adjusted"].all()
+    # This known dev-cache jump was not on a split date. Keep it visible for cache-quality audits
+    # instead of masking arbitrary data anomalies as corporate actions.
+    assert normalized.loc[idx[1], "close"] == pytest.approx(20.30)
+    assert normalized.loc[idx[2], "close"] == pytest.approx(9.10)
+    # The later raw segment is exactly what created the false 2025 TQQQ split cliff.
+    assert normalized.loc[idx[4], "close"] == pytest.approx(26.32)
+    assert normalized.loc[idx[5], "close"] == pytest.approx(26.40)
+    assert normalized.loc[idx[6], "close"] == pytest.approx(26.45)
+    assert normalized.loc[idx[7], "close"] == pytest.approx(26.45)
+
+
+def test_get_price_data_normalizes_cached_ibkr_daily_stock_split_tail(tmp_path, monkeypatch):
+    class NoRemoteCache:
+        def ensure_local_file(self, *args, **kwargs):
+            return False
+
+        def on_local_update(self, *args, **kwargs):
+            return False
+
+    asset = Asset("TQQQ", Asset.AssetType.STOCK)
+    quote = Asset("USD", Asset.AssetType.FOREX)
+    cache_file = tmp_path / "stock_TQQQ_USD_day_AUTO_TRADES_RTH.parquet"
+    idx = pd.DatetimeIndex(
+        [
+            "2025-11-18 16:00:00-05:00",
+            "2025-11-19 16:00:00-05:00",
+            "2025-11-20 16:00:00-05:00",
+            "2025-11-21 16:00:00-05:00",
+        ]
+    )
+    raw_ibkr_frame = pd.DataFrame(
+        {
+            "open": [98.0, 98.66, 52.92, 47.05],
+            "high": [101.0, 103.15, 53.54, 48.0],
+            "low": [97.0, 97.43, 46.23, 46.2],
+            "close": [99.0, 100.05, 46.45, 46.85],
+            "volume": [720000.0, 768163.78, 1576329.68, 1500000.0],
+            "dividend": [0.0, 0.0, 0.0, 0.0],
+            "stock_splits": [0.0, 0.0, 2.0, 0.0],
+        },
+        index=idx,
+    )
+    raw_ibkr_frame.to_parquet(cache_file)
+
+    monkeypatch.setattr(ibkr_helper, "get_backtest_cache", lambda: NoRemoteCache())
+    monkeypatch.setattr(ibkr_helper, "_cache_file_for", lambda **kwargs: cache_file)
+    monkeypatch.setattr(
+        ibkr_helper,
+        "_append_equity_corporate_actions_daily",
+        lambda frame, stock_asset: (frame, False),
+    )
+
+    returned = ibkr_helper.get_price_data(
+        asset=asset,
+        quote=quote,
+        timestep="day",
+        start_dt=idx[0].to_pydatetime(),
+        end_dt=idx[-1].to_pydatetime(),
+        exchange="AUTO",
+        include_after_hours=False,
+        source="TRADES",
+    )
+
+    assert returned["_split_adjusted"].all()
+    assert returned.loc[idx[1], "close"] == pytest.approx(50.025)
+    assert returned.loc[idx[2], "close"] == pytest.approx(46.45)
+
+    persisted = pd.read_parquet(cache_file)
+    assert persisted["_split_adjusted"].all()
+    assert persisted.loc[idx[1], "close"] == pytest.approx(50.025)
+
+
+def test_tqqq_daily_backtest_uses_normalized_ibkr_split_data_without_false_cliff():
+    asset = Asset("TQQQ", Asset.AssetType.STOCK)
+    idx = pd.DatetimeIndex(
+        [
+            "2025-11-17 16:00:00-05:00",
+            "2025-11-18 16:00:00-05:00",
+            "2025-11-19 16:00:00-05:00",
+            "2025-11-20 16:00:00-05:00",
+            "2025-11-21 16:00:00-05:00",
+            "2025-11-24 16:00:00-05:00",
+        ]
+    )
+    raw_ibkr_frame = pd.DataFrame(
+        {
+            "open": [96.0, 98.0, 98.66, 52.92, 47.05, 47.4],
+            "high": [100.0, 101.0, 103.15, 53.54, 48.0, 48.2],
+            "low": [95.0, 97.0, 97.43, 46.23, 46.2, 46.9],
+            "close": [97.0, 99.0, 100.05, 46.45, 46.85, 47.3],
+            "volume": [700000.0, 720000.0, 768163.78, 1576329.68, 1500000.0, 1450000.0],
+            "dividend": [0.0] * 6,
+            "stock_splits": [0.0, 0.0, 0.0, 2.0, 0.0, 0.0],
+        },
+        index=idx,
+    )
+
+    normalized, changed = ibkr_helper._normalize_equity_daily_prices_for_splits(raw_ibkr_frame)
+    assert changed is True
+    assert normalized.loc[idx[2], "close"] == pytest.approx(50.025)
+    assert normalized.loc[idx[3], "close"] == pytest.approx(46.45)
+
+    data_source = PandasDataBacktesting(
+        pandas_data={asset: Data(asset, normalized, timestep="day")},
+        datetime_start=idx[0].to_pydatetime(),
+        datetime_end=idx[-1].to_pydatetime(),
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    broker = BacktestingBroker(data_source=data_source)
+    strategy = _HoldTqqqThroughSplitStrategy(
+        broker=broker,
+        data_source=data_source,
+        budget=1000.0,
+        risk_free_rate=0,
+        benchmark_asset=None,
+        analyze_backtest=False,
+        parameters={"asset": asset},
+    )
+
+    trader = Trader(backtest=True, logfile="")
+    trader.add_strategy(strategy)
+    trader.run_all(show_plot=False, show_tearsheet=False, save_tearsheet=False)
+
+    assert strategy.observed_quantities[pd.Timestamp("2025-11-20").date()] == pytest.approx(10)
+    assert strategy.observed_quantities[pd.Timestamp("2025-11-21").date()] == pytest.approx(10)
+
+    trade_log = broker._trade_event_log_df
+    split_events = trade_log.loc[trade_log["event_kind"] == "corporate_action"]
+    assert split_events.empty
+
+    fills = trade_log.loc[trade_log["status"] == "fill"]
+    sell_fills = fills.loc[fills["side"].astype(str).str.lower().str.startswith("sell")]
+    assert sell_fills.iloc[-1]["filled_quantity"] == pytest.approx(10)
+
+    stats = strategy.stats
+    split_eve_value = stats.loc[pd.Timestamp("2025-11-19 16:00:00-05:00"), "portfolio_value"]
+    split_day_value = stats.loc[pd.Timestamp("2025-11-20 16:00:00-05:00"), "portfolio_value"]
+    one_step_return = split_day_value / split_eve_value - 1
+    assert one_step_return == pytest.approx(-0.0358, abs=0.01)
+    assert one_step_return > -0.10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,9 @@ if os.getcwd() != str(project_root):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "ibkr: downloader-only IBKR tests that do not require Polygon or ThetaData credentials")
+    config.addinivalue_line("markers", "polymarket: Polymarket CLOB tests that do not require Polygon or ThetaData credentials")
+    config.addinivalue_line("markers", "polymarket_credentials: Polymarket CLOB tests that require authenticated credentials")
+    config.addinivalue_line("markers", "polymarket_live_trading: Polymarket CLOB tests that can submit/cancel live orders")
 
 
 class _PatchProxy:
@@ -321,6 +324,9 @@ def pytest_runtest_setup(item: pytest.Item):
       - polygon: requires Polygon credentials
       - thetadata: requires ThetaData credentials
       - ibkr: downloader-only IBKR tests; does not require Polygon/ThetaData creds
+      - polymarket: Polymarket CLOB tests; does not require Polygon/ThetaData creds
+      - polymarket_credentials: requires Polymarket wallet/CLOB credentials
+      - polymarket_live_trading: requires explicit live-trading enablement
 
     Behavior:
       - If a test is marked with ibkr, require neither Polygon nor ThetaData.
@@ -338,9 +344,12 @@ def pytest_runtest_setup(item: pytest.Item):
     requires_polygon = item.get_closest_marker("polygon") is not None
     requires_theta = item.get_closest_marker("thetadata") is not None
     requires_ibkr = item.get_closest_marker("ibkr") is not None
+    requires_polymarket = item.get_closest_marker("polymarket") is not None
+    requires_polymarket_credentials = item.get_closest_marker("polymarket_credentials") is not None
+    requires_polymarket_live_trading = item.get_closest_marker("polymarket_live_trading") is not None
 
     # Determine which providers are required
-    if requires_ibkr:
+    if requires_ibkr or requires_polymarket:
         need_polygon = False
         need_theta = False
     elif requires_polygon or requires_theta:
@@ -366,6 +375,18 @@ def pytest_runtest_setup(item: pytest.Item):
             missing.append("THETADATA_USERNAME")
         if _is_placeholder(theta_pass):
             missing.append("THETADATA_PASSWORD")
+
+    if requires_polymarket_credentials:
+        if _is_placeholder(os.environ.get("POLYMARKET_PRIVATE_KEY")):
+            missing.append("POLYMARKET_PRIVATE_KEY")
+        if _is_placeholder(os.environ.get("POLYMARKET_WALLET_ADDRESS")):
+            missing.append("POLYMARKET_WALLET_ADDRESS")
+
+    if requires_polymarket_live_trading:
+        if os.environ.get("POLYMARKET_LIVE_TRADING_ENABLED", "").strip().lower() not in {"1", "true", "yes", "on"}:
+            missing.append("POLYMARKET_LIVE_TRADING_ENABLED=true")
+        if _is_placeholder(os.environ.get("POLYMARKET_TEST_TOKEN_ID")):
+            missing.append("POLYMARKET_TEST_TOKEN_ID")
 
     # Downloader-specific requirement: shared downloader API key
     # Only enforce when tests are explicitly marked with `downloader`.

--- a/tests/test_agent_alpaca_news_builtin.py
+++ b/tests/test_agent_alpaca_news_builtin.py
@@ -54,15 +54,19 @@ class _Response:
         }
 
 
-def _install_fake_alpaca(monkeypatch):
+def _install_fake_alpaca(monkeypatch, *, set_news_env=True):
     calls = []
 
     def fake_get(url, *, headers, params, timeout):
         calls.append({"url": url, "headers": headers, "params": params, "timeout": timeout})
         return _Response()
 
-    monkeypatch.setenv("ALPACA_NEWS_API_KEY", "key")
-    monkeypatch.setenv("ALPACA_NEWS_API_SECRET", "secret")
+    if set_news_env:
+        monkeypatch.setenv("ALPACA_NEWS_API_KEY", "key")
+        monkeypatch.setenv("ALPACA_NEWS_API_SECRET", "secret")
+    else:
+        monkeypatch.delenv("ALPACA_NEWS_API_KEY", raising=False)
+        monkeypatch.delenv("ALPACA_NEWS_API_SECRET", raising=False)
     monkeypatch.setattr("lumibot.components.agents.builtins.requests.get", fake_get)
     return calls
 
@@ -105,8 +109,22 @@ def test_builtin_alpaca_news_does_not_use_standard_alpaca_env(monkeypatch):
     assert "alpaca_news is not configured" in strategy.log_messages[0][0]
 
 
-def test_builtin_alpaca_news_prefers_active_alpaca_broker_oauth(monkeypatch):
+def test_builtin_alpaca_news_prefers_news_env_over_active_alpaca_broker_oauth(monkeypatch):
     calls = _install_fake_alpaca(monkeypatch)
+
+    tool = BuiltinTools.news.alpaca_news().binder(
+        _StrategyWithBroker(_Broker(oauth_token="oauth-token", api_key="broker-key", api_secret="broker-secret")),
+        None,
+    )
+    result = tool.function(symbols="AAPL")
+
+    assert calls[0]["headers"]["APCA-API-KEY-ID"] == "key"
+    assert calls[0]["headers"]["APCA-API-SECRET-KEY"] == "secret"
+    assert result["credential_source"] == "byok_alpaca_news_env"
+
+
+def test_builtin_alpaca_news_falls_back_to_active_alpaca_broker_oauth(monkeypatch):
+    calls = _install_fake_alpaca(monkeypatch, set_news_env=False)
 
     tool = BuiltinTools.news.alpaca_news().binder(
         _StrategyWithBroker(_Broker(oauth_token="oauth-token", api_key="broker-key", api_secret="broker-secret")),
@@ -119,7 +137,7 @@ def test_builtin_alpaca_news_prefers_active_alpaca_broker_oauth(monkeypatch):
 
 
 def test_builtin_alpaca_news_uses_active_alpaca_broker_api_keys(monkeypatch):
-    calls = _install_fake_alpaca(monkeypatch)
+    calls = _install_fake_alpaca(monkeypatch, set_news_env=False)
 
     tool = BuiltinTools.news.alpaca_news().binder(
         _StrategyWithBroker(_Broker(api_key="broker-key", api_secret="broker-secret")),

--- a/tests/test_agent_runtime_provider_keys.py
+++ b/tests/test_agent_runtime_provider_keys.py
@@ -17,6 +17,8 @@ from lumibot.components.agents.runtime import (
     _sync_together_api_key_alias,
     _sync_xai_api_key_alias,
     _classify_agent_error,
+    _model_context_limit_tokens,
+    _model_context_string_limit_chars,
     _wrap_tool_callable,
 )
 from lumibot.components.agents.schemas import BoundTool
@@ -84,6 +86,32 @@ def test_together_litellm_key_wins_over_sdk_alias(monkeypatch):
 
     assert os.environ["TOGETHERAI_API_KEY"] == "togetherai-test-key"
     assert os.environ["TOGETHER_API_KEY"] == "together-test-key"
+
+
+def test_model_context_registry_has_conservative_default(monkeypatch):
+    monkeypatch.delenv("LUMIBOT_AGENT_DEFAULT_CONTEXT_LIMIT_TOKENS", raising=False)
+    monkeypatch.delenv("LUMIBOT_AGENT_DEFAULT_CONTEXT_STRING_LIMIT_CHARS", raising=False)
+
+    assert _model_context_limit_tokens("unknown-provider/future-model") == 1_000_000
+    assert _model_context_string_limit_chars("unknown-provider/future-model") == 20_000
+
+
+def test_model_context_registry_uses_known_provider_overrides(monkeypatch):
+    monkeypatch.delenv("LUMIBOT_AGENT_DEFAULT_CONTEXT_LIMIT_TOKENS", raising=False)
+
+    assert _model_context_limit_tokens("gemini-3.1-flash-lite") == 1_048_576
+    assert _model_context_limit_tokens("openai/gpt-4.1-mini") == 1_047_576
+    assert _model_context_limit_tokens("anthropic/claude-sonnet-4-6") == 200_000
+    assert _model_context_limit_tokens("xai/grok-4.20-0309-reasoning") == 2_000_000
+
+
+def test_model_context_registry_default_can_be_overridden(monkeypatch):
+    monkeypatch.setenv("LUMIBOT_AGENT_DEFAULT_CONTEXT_LIMIT_TOKENS", "750000")
+    monkeypatch.setenv("LUMIBOT_AGENT_DEFAULT_CONTEXT_STRING_LIMIT_CHARS", "12000")
+
+    assert _model_context_limit_tokens("unknown-provider/future-model") == 750_000
+    assert _model_context_string_limit_chars("unknown-provider/future-model") == 12_000
+    assert _model_context_limit_tokens("gemini-3.1-flash-lite") == 1_048_576
 
 
 def test_wrapped_tool_does_not_block_repeated_calls():

--- a/tests/test_backtesting_data_source_env.py
+++ b/tests/test_backtesting_data_source_env.py
@@ -36,6 +36,9 @@ class TestBacktestingDataSourceEnv:
     class _YahooSelected(_SelectedDataSource):
         pass
 
+    class _PolymarketSelected(_SelectedDataSource):
+        pass
+
     def test_auto_select_polygon_case_insensitive(self, monkeypatch, caplog):
         import logging
 
@@ -135,6 +138,39 @@ class TestBacktestingDataSourceEnv:
 
         assert any(
             "Using BACKTESTING_DATA_SOURCE setting for backtest data: Yahoo" in record.message
+            for record in caplog.records
+        )
+
+    def test_auto_select_polymarket_case_insensitive(self, monkeypatch, caplog):
+        import logging
+
+        caplog.set_level(logging.INFO, logger="lumibot.strategies._strategy")
+
+        class PolymarketBacktesting:
+            def __init__(self, *args, **kwargs):
+                raise TestBacktestingDataSourceEnv._PolymarketSelected()
+
+        import lumibot.strategies._strategy as strategy_module
+
+        monkeypatch.setattr(strategy_module, "PolymarketBacktesting", PolymarketBacktesting)
+        monkeypatch.setenv("BACKTESTING_DATA_SOURCE", "Polymarket")
+
+        with pytest.raises(self._PolymarketSelected):
+            SimpleTestStrategy.run_backtest(
+                None,
+                backtesting_start=datetime(2023, 1, 1),
+                backtesting_end=datetime(2023, 1, 10),
+                show_plot=False,
+                show_tearsheet=False,
+                show_indicators=False,
+                show_progress_bar=False,
+                save_tearsheet=False,
+                save_stats_file=False,
+                save_logfile=False,
+            )
+
+        assert any(
+            "Using BACKTESTING_DATA_SOURCE setting for backtest data: Polymarket" in record.message
             for record in caplog.records
         )
 

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -2,6 +2,7 @@
 Simple test cases for broker initialization error handling.
 """
 import json
+import os
 import time
 
 import pytest
@@ -342,6 +343,193 @@ def test_schwab_external_oauth_refresh_mode_skips_forced_refresh_and_uses_extern
     rewritten = json.loads(token_path.read_text(encoding="utf-8"))
     assert rewritten["token"]["access_token"] == "old-access"
     assert "refresh_token" not in rewritten["token"]
+
+
+def test_schwab_external_oauth_refresh_mode_reloads_access_only_file_without_refresh_token(monkeypatch, tmp_path):
+    from lumibot.brokers import broker as broker_module
+    from lumibot.brokers import schwab as schwab_module
+    import requests_oauthlib
+
+    token_path = tmp_path / "schwab_token.json"
+    token_path.write_text(
+        json.dumps(
+            {
+                "creation_timestamp": 1,
+                "token": {
+                    "access_token": "old-access",
+                    "refresh_token": "stale-refresh-must-not-survive",
+                    "issued_at": int(time.time() * 1000),
+                    "expires_in": 1800,
+                    "refresh_token_issued_at": int(time.time() * 1000),
+                    "refresh_token_expires_in": 7776000,
+                    "token_type": "Bearer",
+                    "scope": "api",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class TokenExpiredError(Exception):
+        pass
+
+    class _OAuth2Session:
+        def __init__(self, *, client_id, token, **kwargs):
+            self.client_id = client_id
+            self.token = token
+            self.kwargs = kwargs
+            self.request_calls = 0
+
+        def register_compliance_hook(self, hook_type, hook):
+            pytest.fail("External OAuth refresh mode must not install provider refresh hooks")
+
+        def refresh_token(self, *args, **kwargs):
+            pytest.fail("External OAuth refresh mode must not call Schwab refresh_token")
+
+        def request(self, *args, **kwargs):
+            self.request_calls += 1
+            if self.request_calls == 1:
+                token_path.write_text(
+                    json.dumps(
+                        {
+                            "creation_timestamp": 1,
+                            "token": {
+                                "access_token": "new-access",
+                                "issued_at": int(time.time() * 1000),
+                                "expires_in": 1800,
+                                "token_type": "Bearer",
+                                "scope": "api",
+                            },
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                raise TokenExpiredError("expired access token")
+            assert self.token["access_token"] == "new-access"
+            assert "refresh_token" not in self.token
+            return type("Response", (), {"status_code": 200})()
+
+    class _AccountResponse:
+        status_code = 200
+
+        def json(self):
+            return [{"accountNumber": "12345678", "hashValue": "hash-123"}]
+
+    class _Client:
+        def __init__(self, *, api_key, session):
+            self.api_key = api_key
+            self.session = session
+
+        def get_account_numbers(self):
+            return _AccountResponse()
+
+    monkeypatch.setenv("LUMIBOT_OAUTH_REFRESH_MODE", "external")
+    monkeypatch.setattr(requests_oauthlib, "OAuth2Session", _OAuth2Session)
+    monkeypatch.setattr(schwab_module, "Client", _Client)
+    monkeypatch.setattr(broker_module.Broker, "_start_orders_thread", lambda self: None)
+    monkeypatch.setattr(schwab_module.Schwab, "_finish_initialization", lambda self, *args, **kwargs: None)
+    monkeypatch.setattr(schwab_module.Schwab, "_get_stream_object", lambda self: None)
+
+    broker = schwab_module.Schwab(
+        config={
+            "SCHWAB_ACCOUNT_NUMBER": "5678",
+            "SCHWAB_APP_KEY": "app-key",
+            "SCHWAB_TOKEN_PATH": str(token_path),
+        }
+    )
+
+    assert broker.client.session.token["access_token"] == "old-access"
+    assert "refresh_token" not in broker.client.session.token
+    assert broker.client.session.request("https://api.schwab.test/accounts").status_code == 200
+    assert broker.client.session.request_calls == 2
+    assert broker.client.session.token["access_token"] == "new-access"
+    assert "refresh_token" not in broker.client.session.token
+
+
+def test_schwab_external_oauth_refresh_mode_multiple_brokers_reload_atomic_replacements(monkeypatch, tmp_path):
+    from lumibot.brokers import broker as broker_module
+    from lumibot.brokers import schwab as schwab_module
+    import requests_oauthlib
+
+    token_path = tmp_path / "schwab_token.json"
+
+    def write_token(access_token):
+        payload = {
+            "creation_timestamp": 1,
+            "token": {
+                "access_token": access_token,
+                "issued_at": int(time.time() * 1000),
+                "expires_in": 1800,
+                "token_type": "Bearer",
+                "scope": "api",
+            },
+        }
+        tmp_file = token_path.with_name(f".{token_path.name}.{access_token}.tmp")
+        tmp_file.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp_file, token_path)
+
+    write_token("access-0")
+
+    class _OAuth2Session:
+        def __init__(self, *, client_id, token, **kwargs):
+            self.client_id = client_id
+            self.token = token
+            self.kwargs = kwargs
+            self.request_calls = 0
+
+        def register_compliance_hook(self, hook_type, hook):
+            pytest.fail("External OAuth refresh mode must not install provider refresh hooks")
+
+        def refresh_token(self, *args, **kwargs):
+            pytest.fail("External OAuth refresh mode must not call Schwab refresh_token")
+
+        def request(self, *args, **kwargs):
+            self.request_calls += 1
+            assert "refresh_token" not in self.token
+            return type("Response", (), {"status_code": 200})()
+
+    class _AccountResponse:
+        status_code = 200
+
+        def json(self):
+            return [{"accountNumber": "12345678", "hashValue": "hash-123"}]
+
+    class _Client:
+        def __init__(self, *, api_key, session):
+            self.api_key = api_key
+            self.session = session
+
+        def get_account_numbers(self):
+            return _AccountResponse()
+
+    monkeypatch.setenv("LUMIBOT_OAUTH_REFRESH_MODE", "external")
+    monkeypatch.setattr(requests_oauthlib, "OAuth2Session", _OAuth2Session)
+    monkeypatch.setattr(schwab_module, "Client", _Client)
+    monkeypatch.setattr(broker_module.Broker, "_start_orders_thread", lambda self: None)
+    monkeypatch.setattr(schwab_module.Schwab, "_finish_initialization", lambda self, *args, **kwargs: None)
+    monkeypatch.setattr(schwab_module.Schwab, "_get_stream_object", lambda self: None)
+
+    brokers = [
+        schwab_module.Schwab(
+            config={
+                "SCHWAB_ACCOUNT_NUMBER": "5678",
+                "SCHWAB_APP_KEY": "app-key",
+                "SCHWAB_TOKEN_PATH": str(token_path),
+            }
+        )
+        for _ in range(3)
+    ]
+
+    for broker in brokers:
+        assert broker.client.session.token["access_token"] == "access-0"
+        assert "refresh_token" not in broker.client.session.token
+
+    for cycle in range(1, 4):
+        write_token(f"access-{cycle}")
+        for broker in brokers:
+            assert broker.client.session.request("https://api.schwab.test/accounts").status_code == 200
+            assert broker.client.session.token["access_token"] == f"access-{cycle}"
+            assert "refresh_token" not in broker.client.session.token
 
 
 def test_schwab_rejects_invalid_oauth_refresh_mode(monkeypatch, tmp_path):

--- a/tests/test_polymarket_apitest.py
+++ b/tests/test_polymarket_apitest.py
@@ -1,7 +1,10 @@
+import asyncio
+import json
 import os
 
 import pytest
 
+from lumibot.brokers.broker import LumibotBrokerAPIError
 from lumibot.brokers.polymarket import Polymarket
 from lumibot.data_sources.polymarket_data import PolymarketData
 from lumibot.entities import Asset, Order
@@ -28,6 +31,28 @@ def test_polymarket_public_quote_smoke():
     assert quote.bid is not None or quote.ask is not None or quote.price is not None
 
 
+def test_polymarket_public_websocket_smoke():
+    token_id = _token_or_skip()
+
+    async def _run():
+        import websockets
+
+        events = []
+        async with websockets.connect(PolymarketData.MARKET_WS_URL, ping_interval=20, close_timeout=5) as ws:
+            await ws.send(json.dumps({"assets_ids": [token_id], "type": "market", "custom_feature_enabled": True}))
+            deadline = asyncio.get_running_loop().time() + 8
+            while asyncio.get_running_loop().time() < deadline and not events:
+                try:
+                    events.append(json.loads(await asyncio.wait_for(ws.recv(), timeout=1.0)))
+                except asyncio.TimeoutError:
+                    continue
+        return events
+
+    events = asyncio.run(_run())
+
+    assert events
+
+
 @pytest.mark.polymarket_credentials
 def test_polymarket_account_snapshot_smoke(monkeypatch):
     monkeypatch.setattr("lumibot.brokers.broker.Broker._start_orders_thread", lambda self: None)
@@ -41,6 +66,7 @@ def test_polymarket_account_snapshot_smoke(monkeypatch):
         orders = broker._pull_broker_all_orders()
 
         assert isinstance(cash, float)
+        assert cash < 1_000_000
         assert isinstance(positions_value, float)
         assert isinstance(portfolio_value, float)
         assert isinstance(positions, list)
@@ -67,7 +93,17 @@ def test_polymarket_tiny_market_buy_smoke(monkeypatch):
         custom_params={"amount": amount, "price": max_price, "order_type": "FAK"},
     )
     try:
-        submitted = broker._submit_order(order)
+        try:
+            submitted = broker._submit_order(order)
+        except LumibotBrokerAPIError as exc:
+            message = str(exc).lower()
+            if (
+                "deposit wallet" in message
+                or "maker address not allowed" in message
+                or "order signer address" in message
+            ):
+                pytest.xfail(f"Current Polymarket account is blocked by deposit-wallet/API-key binding: {exc}")
+            raise
 
         assert submitted.identifier
         broker._get_balances_at_broker(Asset("USD", asset_type=Asset.AssetType.FOREX), None)

--- a/tests/test_polymarket_apitest.py
+++ b/tests/test_polymarket_apitest.py
@@ -1,0 +1,77 @@
+import os
+
+import pytest
+
+from lumibot.brokers.polymarket import Polymarket
+from lumibot.data_sources.polymarket_data import PolymarketData
+from lumibot.entities import Asset, Order
+
+
+pytestmark = [pytest.mark.apitest, pytest.mark.polymarket]
+
+
+def _token_or_skip():
+    token_id = os.environ.get("POLYMARKET_TEST_TOKEN_ID")
+    if not token_id:
+        pytest.skip("Missing POLYMARKET_TEST_TOKEN_ID")
+    return token_id
+
+
+def test_polymarket_public_quote_smoke():
+    token_id = _token_or_skip()
+    data = PolymarketData()
+    asset = Asset(token_id, asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+
+    quote = data.get_quote(asset)
+
+    assert quote.asset == asset
+    assert quote.bid is not None or quote.ask is not None or quote.price is not None
+
+
+@pytest.mark.polymarket_credentials
+def test_polymarket_account_snapshot_smoke(monkeypatch):
+    monkeypatch.setattr("lumibot.brokers.broker.Broker._start_orders_thread", lambda self: None)
+    broker = Polymarket(connect_stream=False)
+    try:
+        cash, positions_value, portfolio_value = broker._get_balances_at_broker(
+            Asset("USD", asset_type=Asset.AssetType.FOREX),
+            None,
+        )
+        positions = broker._pull_positions("apitest")
+        orders = broker._pull_broker_all_orders()
+
+        assert isinstance(cash, float)
+        assert isinstance(positions_value, float)
+        assert isinstance(portfolio_value, float)
+        assert isinstance(positions, list)
+        assert isinstance(orders, list)
+    finally:
+        broker.cleanup_streams()
+
+
+@pytest.mark.polymarket_credentials
+@pytest.mark.polymarket_live_trading
+def test_polymarket_tiny_market_buy_smoke(monkeypatch):
+    token_id = _token_or_skip()
+    amount = os.environ.get("POLYMARKET_TEST_ORDER_AMOUNT", "1.00")
+    max_price = os.environ.get("POLYMARKET_TEST_MAX_PRICE", "0.99")
+    monkeypatch.setattr("lumibot.brokers.broker.Broker._start_orders_thread", lambda self: None)
+    broker = Polymarket(connect_stream=False)
+    asset = Asset(token_id, asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    order = Order(
+        "apitest",
+        asset,
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.MARKET,
+        custom_params={"amount": amount, "price": max_price, "order_type": "FAK"},
+    )
+    try:
+        submitted = broker._submit_order(order)
+
+        assert submitted.identifier
+        broker._get_balances_at_broker(Asset("USD", asset_type=Asset.AssetType.FOREX), None)
+        broker._pull_positions("apitest")
+        broker._pull_broker_order(submitted.identifier)
+    finally:
+        broker.cleanup_streams()

--- a/tests/test_polymarket_asset.py
+++ b/tests/test_polymarket_asset.py
@@ -1,0 +1,20 @@
+import pytest
+
+from lumibot.entities import Asset
+
+
+def test_prediction_contract_asset_type_creation():
+    asset = Asset("1234567890", asset_type=Asset.AssetType.PREDICTION_CONTRACT, precision="0.000001")
+
+    assert asset.symbol == "1234567890"
+    assert asset.asset_type == Asset.AssetType.PREDICTION_CONTRACT
+    assert asset.precision == "0.000001"
+
+
+def test_prediction_contract_asset_type_enum_value():
+    assert Asset.AssetType.PREDICTION_CONTRACT == "prediction_contract"
+
+
+def test_invalid_asset_type_still_rejected():
+    with pytest.raises(Exception):
+        Asset("ABC", asset_type="not_prediction_contract")

--- a/tests/test_polymarket_backtesting.py
+++ b/tests/test_polymarket_backtesting.py
@@ -1,0 +1,295 @@
+from datetime import datetime
+from decimal import Decimal
+
+import pandas as pd
+
+from lumibot.backtesting import BacktestingBroker, PolymarketBacktesting
+from lumibot.data_sources.polymarket_data import PolymarketData
+from lumibot.entities import Asset
+from lumibot.entities.order import Order
+from lumibot.example_strategies.polymarket_prediction_contract import PolymarketPredictionContractStrategy
+from lumibot.strategies.strategy import Strategy
+
+
+class FakePolymarketHistoryClient:
+    def get(self, url, params=None):
+        if url.endswith("/prices-history"):
+            return {
+                "history": [
+                    {"t": 1_735_732_800, "p": "0.40"},
+                    {"t": 1_735_732_860, "p": "0.42"},
+                ]
+            }
+        if url.endswith("/markets/slug/test-market"):
+            return {
+                "id": "m1",
+                "slug": "test-market",
+                "conditionId": "0x" + "1" * 64,
+                "outcomes": '["Yes","No"]',
+                "clobTokenIds": '["111","222"]',
+                "orderPriceMinTickSize": "0.01",
+                "orderMinSize": "5",
+            }
+        if url.endswith("/markets/token/111"):
+            return {
+                "id": "m1",
+                "slug": "test-market",
+                "conditionId": "0x" + "1" * 64,
+                "outcomes": '["Yes","No"]',
+                "clobTokenIds": '["111","222"]',
+                "orderPriceMinTickSize": "0.01",
+                "orderMinSize": "5",
+            }
+        raise AssertionError(f"Unexpected URL: {url}")
+
+
+class FakeResolvedPolymarketClient(FakePolymarketHistoryClient):
+    def get(self, url, params=None):
+        if url.endswith("/prices-history"):
+            return {
+                "history": [
+                    {"t": 1_735_732_800, "p": "0.40"},
+                    {"t": 1_735_732_860, "p": "0.42"},
+                    {"t": 1_735_733_040, "p": "0.43"},
+                ]
+            }
+        if url.endswith("/markets/slug/resolved-market") or url.endswith("/markets/token/111"):
+            return {
+                "id": "m2",
+                "slug": "resolved-market",
+                "conditionId": "0x" + "2" * 64,
+                "outcomes": '["Yes","No"]',
+                "clobTokenIds": '["111","222"]',
+                "closed": True,
+                "winner": "Yes",
+                "endDate": "2025-01-01T12:02:00Z",
+                "orderPriceMinTickSize": "0.01",
+                "orderMinSize": "5",
+            }
+        return super().get(url, params=params)
+
+
+class PolymarketBacktestStrategy(Strategy):
+    def initialize(self, parameters=None):
+        self.sleeptime = "1M"
+
+    def on_trading_iteration(self):
+        return
+
+
+def _build_prediction_backtest():
+    start = pd.Timestamp("2025-01-01T12:00:00Z").to_pydatetime()
+    end = pd.Timestamp("2025-01-01T12:03:00Z").to_pydatetime()
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    quote = Asset("USD", asset_type=Asset.AssetType.FOREX)
+    polymarket_data = PolymarketData(client=FakePolymarketHistoryClient())
+    data_source = PolymarketBacktesting(
+        start,
+        end,
+        assets=[asset],
+        polymarket_data=polymarket_data,
+        show_progress_bar=False,
+        market="24/7",
+    )
+    data_source.load_data()
+    broker = BacktestingBroker(data_source=data_source)
+    broker.initialize_market_calendars(data_source.get_trading_days_pandas())
+    broker._first_iteration = False
+    strategy = PolymarketBacktestStrategy(
+        broker=broker,
+        data_source=data_source,
+        budget=100.0,
+        analyze_backtest=False,
+        parameters={},
+    )
+    strategy._first_iteration = False
+    return strategy, broker, asset, quote, data_source
+
+
+def test_polymarket_backtesting_loads_real_history_as_close_price_bars():
+    _, _, asset, _, data_source = _build_prediction_backtest()
+
+    stored_data = next(iter(data_source._data_store.values()))
+
+    assert list(stored_data.df["close"]) == [0.40, 0.42]
+    assert stored_data.asset.asset_type == Asset.AssetType.PREDICTION_CONTRACT
+
+
+def test_polymarket_backtesting_quote_and_last_price_use_loaded_bars_without_rounding():
+    strategy, _, asset, _, _ = _build_prediction_backtest()
+
+    quote = strategy.get_quote(asset)
+    last_price = strategy.get_last_price(asset)
+
+    assert quote.price == 0.40
+    assert quote.bid == 0.40
+    assert quote.ask == 0.40
+    assert quote.raw_data["source"] == "polymarket_backtesting"
+    assert last_price == 0.40
+
+
+def test_polymarket_backtesting_prediction_contract_cash_accounting():
+    strategy, broker, asset, quote, _ = _build_prediction_backtest()
+    buy = strategy.create_order(
+        asset,
+        Decimal("10"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.MARKET,
+        quote=quote,
+    )
+    sell = strategy.create_order(
+        asset,
+        Decimal("5"),
+        Order.OrderSide.SELL,
+        order_type=Order.OrderType.MARKET,
+        quote=quote,
+    )
+
+    broker._execute_filled_order(buy, price=0.40, filled_quantity=Decimal("10"), strategy=strategy)
+    strategy._executor.process_queue()
+    broker._execute_filled_order(sell, price=0.40, filled_quantity=Decimal("5"), strategy=strategy)
+    strategy._executor.process_queue()
+
+    assert strategy.cash == 98.0
+
+
+def test_polymarket_backtesting_market_and_limit_orders_fill_from_polymarket_bars():
+    strategy, broker, asset, quote, _ = _build_prediction_backtest()
+
+    market_buy = strategy.create_order(
+        asset,
+        Decimal("10"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.MARKET,
+        quote=quote,
+    )
+    strategy.submit_order(market_buy)
+    broker.process_pending_orders(strategy=strategy)
+    strategy._executor.process_queue()
+
+    assert market_buy.is_filled()
+    assert float(market_buy.avg_fill_price) == 0.40
+    assert strategy.cash == 96.0
+
+    limit_sell = strategy.create_order(
+        asset,
+        Decimal("5"),
+        Order.OrderSide.SELL,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=0.40,
+        quote=quote,
+    )
+    strategy.submit_order(limit_sell)
+    broker.process_pending_orders(strategy=strategy)
+    strategy._executor.process_queue()
+
+    assert limit_sell.is_filled()
+    assert strategy.cash == 98.0
+
+
+def test_polymarket_backtesting_validates_tick_size_and_min_order_size():
+    strategy, broker, asset, quote, _ = _build_prediction_backtest()
+    asset.polymarket_market = {
+        "outcomes": ["Yes", "No"],
+        "clobTokenIds": ["111", "222"],
+        "orderPriceMinTickSize": "0.01",
+        "orderMinSize": "5",
+    }
+
+    too_small = strategy.create_order(
+        asset,
+        Decimal("1"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=0.40,
+        quote=quote,
+    )
+    try:
+        broker.submit_order(too_small)
+    except ValueError as exc:
+        assert "minimum order size" in str(exc)
+    else:
+        raise AssertionError("Expected minimum order size validation to fail")
+
+    bad_tick = strategy.create_order(
+        asset,
+        Decimal("5"),
+        Order.OrderSide.BUY,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=0.405,
+        quote=quote,
+    )
+    try:
+        broker.submit_order(bad_tick)
+    except ValueError as exc:
+        assert "tick size" in str(exc)
+    else:
+        raise AssertionError("Expected tick-size validation to fail")
+
+
+def test_polymarket_backtesting_applies_market_close_and_resolution_settlement():
+    start = pd.Timestamp("2025-01-01T12:00:00Z").to_pydatetime()
+    end = pd.Timestamp("2025-01-01T12:05:00Z").to_pydatetime()
+    polymarket_data = PolymarketData(client=FakeResolvedPolymarketClient())
+    data_source = PolymarketBacktesting(
+        start,
+        end,
+        markets=[{"slug": "resolved-market", "outcome": "Yes"}],
+        polymarket_data=polymarket_data,
+        show_progress_bar=False,
+        market="24/7",
+    )
+    data_source.load_data()
+
+    stored_data = next(iter(data_source._data_store.values()))
+    assert stored_data.df.index.max() == pd.Timestamp("2025-01-01T12:02:00Z")
+    assert stored_data.df["close"].iloc[-1] == 1.0
+
+
+def test_polymarket_example_strategy_backtest_runs_with_mocked_history(monkeypatch):
+    monkeypatch.setenv("BACKTESTING_DATA_SOURCE", "none")
+    start = pd.Timestamp("2025-01-01T12:00:00Z").to_pydatetime()
+    end = pd.Timestamp("2025-01-01T12:03:00Z").to_pydatetime()
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+
+    results = PolymarketPredictionContractStrategy.backtest(
+        PolymarketBacktesting,
+        start,
+        end,
+        assets=[asset],
+        polymarket_data=PolymarketData(client=FakePolymarketHistoryClient()),
+        market="24/7",
+        timestep="minute",
+        parameters={"token_id": "111", "backtest_trade": True},
+        benchmark_asset=None,
+        show_plot=False,
+        show_tearsheet=False,
+        save_tearsheet=False,
+        save_stats_file=False,
+        show_progress_bar=False,
+    )
+
+    assert results is not None
+
+
+def test_polymarket_backtesting_rejects_out_of_range_prediction_prices():
+    start = datetime(2025, 1, 1)
+    end = datetime(2025, 1, 2)
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    bad_df = pd.DataFrame(
+        {
+            "open": [1.2],
+            "high": [1.2],
+            "low": [1.2],
+            "close": [1.2],
+            "volume": [0],
+        },
+        index=pd.date_range("2025-01-01", periods=1, freq="1min"),
+    )
+
+    try:
+        PolymarketBacktesting._validate_price_frame(bad_df, asset)
+    except ValueError as exc:
+        assert "between 0 and 1" in str(exc)
+    else:
+        raise AssertionError("Expected out-of-range prices to fail")

--- a/tests/test_polymarket_broker.py
+++ b/tests/test_polymarket_broker.py
@@ -29,14 +29,21 @@ class FakeMarketDataClient:
         if url.endswith("/tick-size"):
             return {"minimum_tick_size": "0.01"}
         if url.endswith("/book"):
-            return {"bids": [{"price": "0.40", "size": "10"}], "asks": [{"price": "0.45", "size": "10"}]}
+            return {
+                "bids": [{"price": "0.40", "size": "10"}],
+                "asks": [{"price": "0.45", "size": "10"}],
+                "tick_size": "0.01",
+                "neg_risk": True,
+            }
         raise AssertionError(f"Unexpected market-data URL: {url}")
 
 
 class FakeSecureClient:
     def __init__(self):
         self.market_orders = []
+        self.market_order_kwargs = []
         self.limit_orders = []
+        self.limit_order_kwargs = []
         self.canceled = []
 
     def get_balance_allowance(self, *args, **kwargs):
@@ -64,6 +71,7 @@ class FakeSecureClient:
 
     def create_and_post_market_order(self, payload, **kwargs):
         self.market_orders.append(payload)
+        self.market_order_kwargs.append(kwargs)
         if isinstance(payload, dict):
             return {
                 "id": "market-order",
@@ -86,6 +94,7 @@ class FakeSecureClient:
 
     def create_and_post_order(self, payload, **kwargs):
         self.limit_orders.append(payload)
+        self.limit_order_kwargs.append(kwargs)
         if isinstance(payload, dict):
             return {
                 "id": "limit-order",
@@ -154,6 +163,18 @@ def test_polymarket_balances_positions_orders(monkeypatch):
         broker.cleanup_streams()
 
 
+def test_polymarket_raw_collateral_balance_scales_from_usdc_units(monkeypatch):
+    broker = _broker(monkeypatch)
+    try:
+        broker._secure_client.get_balance_allowance = lambda *_, **__: {"balance": "29185517"}
+
+        cash = broker._get_collateral_cash()
+
+        assert cash == 29.185517
+    finally:
+        broker.cleanup_streams()
+
+
 def test_polymarket_parse_broker_order(monkeypatch):
     broker = _broker(monkeypatch)
     try:
@@ -200,7 +221,10 @@ def test_polymarket_market_buy_uses_custom_amount_not_quantity(monkeypatch):
         submitted = broker._submit_order(order)
 
         assert submitted.identifier == "market-order"
-        assert broker._secure_client.market_orders[0]["amount"] == "1.00"
+        assert broker._secure_client.market_orders[0].amount == 1.0
+        assert broker._secure_client.market_orders[0].token_id == "111"
+        assert broker._secure_client.market_order_kwargs[0]["options"].tick_size == "0.01"
+        assert broker._secure_client.market_order_kwargs[0]["options"].neg_risk is True
     finally:
         broker.cleanup_streams()
 
@@ -245,8 +269,36 @@ def test_polymarket_limit_order_and_cancel(monkeypatch):
 
         assert submitted.identifier == "limit-order"
         assert broker._secure_client.limit_orders
+        assert broker._secure_client.limit_order_kwargs[0]["options"].tick_size == "0.01"
+        assert broker._secure_client.limit_order_kwargs[0]["options"].neg_risk is True
         assert broker._secure_client.canceled
         assert submitted.status == Order.OrderStatus.CANCELED
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_wraps_known_deposit_wallet_order_blocker(monkeypatch):
+    broker = _broker(monkeypatch)
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    order = Order(
+        "unit",
+        asset,
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.MARKET,
+        custom_params={"amount": "1.00", "price": "0.45", "order_type": "FAK"},
+    )
+    broker._secure_client.create_and_post_market_order = lambda *_, **__: (_ for _ in ()).throw(
+        RuntimeError("maker address not allowed, please use the deposit wallet flow")
+    )
+    try:
+        try:
+            broker._submit_order(order)
+        except Exception as exc:
+            assert "deposit-wallet flow" in str(exc) or "deposit wallet" in str(exc)
+            assert "Raw Polymarket error" in str(exc)
+        else:
+            raise AssertionError("Expected platform order blocker to be surfaced")
     finally:
         broker.cleanup_streams()
 
@@ -261,3 +313,14 @@ def test_polymarket_stream_user_event_dispatch(monkeypatch):
 
     stream._process_queue_event(broker.FILLED_ORDER, {"order": broker._parse_broker_order({"id": "filled-1"}, "unit")})
     assert seen == ["filled-1"]
+
+
+def test_polymarket_stream_subscription_payloads():
+    market_payload = PolymarketCLOBStream._market_subscription_payload(["111", "222"])
+    user_payload = PolymarketCLOBStream._user_subscription_payload(
+        {"apiKey": "key", "secret": "secret", "passphrase": "passphrase"}
+    )
+
+    assert market_payload == {"assets_ids": ["111", "222"], "type": "market", "custom_feature_enabled": True}
+    assert user_payload["type"] == "user"
+    assert user_payload["auth"]["apiKey"] == "key"

--- a/tests/test_polymarket_broker.py
+++ b/tests/test_polymarket_broker.py
@@ -21,6 +21,8 @@ class FakeDataClient:
             ]
         if url.endswith("/value"):
             return [{"value": "1.26"}]
+        if url.endswith("/trades"):
+            return [{"id": "trade-1", "asset": "111", "price": "0.42", "size": "2"}]
         raise AssertionError(f"Unexpected data API URL: {url}")
 
 
@@ -45,9 +47,17 @@ class FakeSecureClient:
         self.limit_orders = []
         self.limit_order_kwargs = []
         self.canceled = []
+        self.cancel_many_payloads = []
+        self.cancel_all_called = False
+        self.cancel_market_payloads = []
+        self.balance_allowance_updates = []
 
     def get_balance_allowance(self, *args, **kwargs):
         return {"balance": "12.34"}
+
+    def update_balance_allowance(self, payload):
+        self.balance_allowance_updates.append(payload)
+        return {"updated": True}
 
     def get_portfolio_values(self):
         return {"portfolio_value": "13.60", "positions_value": "1.26"}
@@ -119,6 +129,18 @@ class FakeSecureClient:
         self.canceled.append(payload)
         return {"canceled": True}
 
+    def cancel_orders(self, payload):
+        self.cancel_many_payloads.append(payload)
+        return {"canceled": payload, "not_canceled": {}}
+
+    def cancel_all(self):
+        self.cancel_all_called = True
+        return {"canceled": ["all"], "not_canceled": {}}
+
+    def cancel_market_orders(self, payload):
+        self.cancel_market_payloads.append(payload)
+        return {"canceled": ["market"], "not_canceled": {}}
+
 
 def _broker(monkeypatch):
     monkeypatch.setattr(Broker, "_start_orders_thread", lambda self: None)
@@ -168,6 +190,7 @@ def test_polymarket_signature_type_honors_explicit_deposit_wallet_config(monkeyp
 
 def test_polymarket_signature_type_infers_proxy_when_no_explicit_value(monkeypatch):
     monkeypatch.setattr(Broker, "_start_orders_thread", lambda self: None)
+    monkeypatch.delenv("POLYMARKET_SIGNATURE_TYPE", raising=False)
 
     class SignatureTypes:
         POLY_PROXY = 1
@@ -259,6 +282,59 @@ def test_polymarket_parse_matched_market_order_response(monkeypatch):
         broker.cleanup_streams()
 
 
+def test_polymarket_parse_matched_sell_order_response(monkeypatch):
+    broker = _broker(monkeypatch)
+    try:
+        order = broker._parse_broker_order(
+            {
+                "orderID": "0xsell",
+                "side": "SELL",
+                "status": "matched",
+                "makingAmount": "5",
+                "takingAmount": "0.14",
+            },
+            "unit",
+        )
+
+        assert order.identifier == "0xsell"
+        assert order.status == Order.OrderStatus.FILLED
+        assert order.quantity == 5.0
+        assert round(order.avg_fill_price, 6) == 0.028
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_submit_response_uses_original_sell_side_for_matched_amounts(monkeypatch):
+    broker = _broker(monkeypatch)
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    original = Order(
+        "unit",
+        asset,
+        quantity=5,
+        side=Order.OrderSide.SELL,
+        order_type=Order.OrderType.MARKET,
+        custom_params={"order_type": "FOK", "price": "0.01"},
+    )
+    try:
+        parsed = broker._order_from_submit_response(
+            {
+                "orderID": "0xsell",
+                "status": "matched",
+                "makingAmount": "5",
+                "takingAmount": "0.14",
+            },
+            original,
+        )
+
+        assert parsed.identifier == "0xsell"
+        assert parsed.side == Order.OrderSide.SELL
+        assert parsed.status == Order.OrderStatus.FILLED
+        assert parsed.quantity == 5.0
+        assert round(parsed.avg_fill_price, 6) == 0.028
+    finally:
+        broker.cleanup_streams()
+
+
 def test_polymarket_parse_live_limit_order_response_with_empty_amounts(monkeypatch):
     broker = _broker(monkeypatch)
     try:
@@ -338,6 +414,40 @@ def test_polymarket_market_buy_uses_custom_amount_not_quantity(monkeypatch):
         broker.cleanup_streams()
 
 
+def test_polymarket_market_fok_buy_and_sell_semantics(monkeypatch):
+    broker = _broker(monkeypatch)
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    buy = Order(
+        "unit",
+        asset,
+        quantity=999,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.MARKET,
+        custom_params={"amount": "1.00", "price": "0.45", "order_type": "FOK"},
+    )
+    sell = Order(
+        "unit",
+        asset,
+        quantity=3,
+        side=Order.OrderSide.SELL,
+        order_type=Order.OrderType.MARKET,
+        custom_params={"price": "0.40", "order_type": "FOK"},
+    )
+    try:
+        broker._submit_order(buy)
+        broker._submit_order(sell)
+
+        assert broker._secure_client.market_orders[0].amount == 1.0
+        assert broker._secure_client.market_orders[0].side == "BUY"
+        assert broker._secure_client.market_orders[1].amount == 3.0
+        assert broker._secure_client.market_orders[1].side == "SELL"
+        assert str(broker._secure_client.market_order_kwargs[0]["order_type"]).upper().endswith("FOK")
+        assert broker._secure_client.balance_allowance_updates[-1].asset_type == "CONDITIONAL"
+        assert broker._secure_client.balance_allowance_updates[-1].token_id == "111"
+    finally:
+        broker.cleanup_streams()
+
+
 def test_polymarket_market_buy_notional_cap(monkeypatch):
     broker = _broker(monkeypatch)
     asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
@@ -386,6 +496,104 @@ def test_polymarket_limit_order_and_cancel(monkeypatch):
         broker.cleanup_streams()
 
 
+def test_polymarket_gtd_limit_order_passes_expiration(monkeypatch):
+    broker = _broker(monkeypatch)
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    order = Order(
+        "unit",
+        asset,
+        quantity=2,
+        side=Order.OrderSide.BUY,
+        limit_price=0.42,
+        order_type=Order.OrderType.LIMIT,
+        time_in_force="gtd",
+        custom_params={"expiration": 1_800_000_000},
+    )
+    try:
+        broker._submit_order(order)
+
+        assert broker._secure_client.limit_orders[0].expiration == 1_800_000_000
+        assert str(broker._secure_client.limit_order_kwargs[0]["order_type"]).upper().endswith("GTD")
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_gtd_limit_order_requires_expiration(monkeypatch):
+    broker = _broker(monkeypatch)
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    order = Order(
+        "unit",
+        asset,
+        quantity=2,
+        side=Order.OrderSide.BUY,
+        limit_price=0.42,
+        order_type=Order.OrderType.LIMIT,
+        time_in_force="gtd",
+    )
+    try:
+        try:
+            broker._submit_order(order)
+        except ValueError as exc:
+            assert "GTD" in str(exc)
+        else:
+            raise AssertionError("Expected GTD without expiration to fail")
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_limit_order_supports_post_only(monkeypatch):
+    broker = _broker(monkeypatch)
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    order = Order(
+        "unit",
+        asset,
+        quantity=2,
+        side=Order.OrderSide.BUY,
+        limit_price=0.42,
+        order_type=Order.OrderType.LIMIT,
+        time_in_force="gtc",
+        custom_params={"post_only": True},
+    )
+    try:
+        broker._submit_order(order)
+
+        assert broker._secure_client.limit_order_kwargs[0]["post_only"] is True
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_cancel_helpers_use_native_clob_methods(monkeypatch):
+    broker = _broker(monkeypatch)
+    order1 = Order("unit", Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT), 1, Order.OrderSide.BUY)
+    order1.identifier = "order-1"
+    order2 = Order("unit", Asset("222", asset_type=Asset.AssetType.PREDICTION_CONTRACT), 1, Order.OrderSide.SELL)
+    order2.identifier = "order-2"
+    try:
+        broker.cancel_orders([order1, order2])
+        broker.cancel_all_orders()
+        broker.cancel_market_orders(market="0x" + "1" * 64, asset_id="111")
+
+        assert broker._secure_client.cancel_many_payloads == [["order-1", "order-2"]]
+        assert broker._secure_client.cancel_all_called is True
+        assert broker._secure_client.cancel_market_payloads
+        assert order1.status == Order.OrderStatus.CANCELED
+        assert order2.status == Order.OrderStatus.CANCELED
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_recent_trades_from_data_api(monkeypatch):
+    broker = _broker(monkeypatch)
+    try:
+        broker._secure_client.get_trades = lambda: None
+
+        trades = broker.get_recent_trades(limit=5)
+
+        assert trades[0]["id"] == "trade-1"
+    finally:
+        broker.cleanup_streams()
+
+
 def test_polymarket_wraps_known_deposit_wallet_order_blocker(monkeypatch):
     broker = _broker(monkeypatch)
     asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
@@ -412,6 +620,35 @@ def test_polymarket_wraps_known_deposit_wallet_order_blocker(monkeypatch):
         broker.cleanup_streams()
 
 
+def test_polymarket_wraps_post_only_rejection(monkeypatch):
+    broker = _broker(monkeypatch)
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    order = Order(
+        "unit",
+        asset,
+        quantity=5,
+        side=Order.OrderSide.BUY,
+        limit_price=0.80,
+        order_type=Order.OrderType.LIMIT,
+        time_in_force="gtc",
+        custom_params={"post_only": True},
+    )
+    broker._secure_client.create_and_post_order = lambda *_, **__: (_ for _ in ()).throw(
+        RuntimeError("invalid post-only order: order crosses book")
+    )
+    try:
+        try:
+            broker._submit_order(order)
+        except Exception as exc:
+            assert "post-only" in str(exc)
+            assert "cross" in str(exc)
+            assert "Raw Polymarket error" in str(exc)
+        else:
+            raise AssertionError("Expected post-only rejection to be wrapped")
+    finally:
+        broker.cleanup_streams()
+
+
 def test_polymarket_stream_user_event_dispatch(monkeypatch):
     broker = _broker(monkeypatch)
     stream = PolymarketCLOBStream(broker, use_websocket=False)
@@ -422,6 +659,54 @@ def test_polymarket_stream_user_event_dispatch(monkeypatch):
 
     stream._process_queue_event(broker.FILLED_ORDER, {"order": broker._parse_broker_order({"id": "filled-1"}, "unit")})
     assert seen == ["filled-1"]
+
+
+def test_polymarket_stream_events_process_through_broker_lifecycle(monkeypatch):
+    broker = _broker(monkeypatch)
+    stream = PolymarketCLOBStream(broker, use_websocket=False)
+    broker.stream = stream
+    seen = []
+
+    def fake_process_trade_event(order, event, **kwargs):
+        seen.append((order.identifier, event, kwargs.get("price"), kwargs.get("filled_quantity")))
+
+    broker._process_trade_event = fake_process_trade_event
+    broker._register_stream_events()
+
+    event = {
+        "id": "filled-1",
+        "asset_id": "111",
+        "side": "BUY",
+        "status": "matched",
+        "price": "0.42",
+        "size": "2",
+        "updated_at": "2026-07-01T00:00:00Z",
+    }
+    stream.handle_user_event(event)
+    duplicate = dict(event)
+    duplicate["updated_at"] = "2026-07-01T00:00:01Z"
+    stream.handle_user_event(duplicate)
+
+    while not stream._queue.empty():
+        queued_event, payload = stream._queue.get_nowait()
+        stream._process_queue_event(queued_event, payload)
+        stream._queue.task_done()
+
+    assert seen == [("filled-1", broker.FILLED_ORDER, 0.42, 2.0)]
+
+
+def test_polymarket_user_stream_waits_until_events_can_route(monkeypatch):
+    broker = _broker(monkeypatch)
+    stream = PolymarketCLOBStream(broker, use_websocket=False)
+    try:
+        broker._subscribers = []
+        broker._strategy_name = ""
+        assert stream._can_route_user_events() is False
+
+        broker.set_strategy_name("unit")
+        assert stream._can_route_user_events() is True
+    finally:
+        broker.cleanup_streams()
 
 
 def test_polymarket_stream_subscription_payloads():

--- a/tests/test_polymarket_broker.py
+++ b/tests/test_polymarket_broker.py
@@ -1,0 +1,263 @@
+from lumibot.brokers.broker import Broker
+from lumibot.brokers.polymarket import Polymarket, PolymarketCLOBStream, PolymarketCredentialStore
+from lumibot.data_sources.polymarket_data import PolymarketData
+from lumibot.entities import Asset, Order, Position
+
+
+class FakeDataClient:
+    def get(self, url, params=None):
+        if url.endswith("/positions"):
+            return [
+                {
+                    "asset": "111",
+                    "size": "3",
+                    "avgPrice": "0.35",
+                    "currentValue": "1.26",
+                    "curPrice": "0.42",
+                    "cashPnl": "0.21",
+                    "outcome": "Yes",
+                    "slug": "test-market",
+                }
+            ]
+        if url.endswith("/value"):
+            return [{"value": "1.26"}]
+        raise AssertionError(f"Unexpected data API URL: {url}")
+
+
+class FakeMarketDataClient:
+    def get(self, url, params=None):
+        if url.endswith("/tick-size"):
+            return {"minimum_tick_size": "0.01"}
+        if url.endswith("/book"):
+            return {"bids": [{"price": "0.40", "size": "10"}], "asks": [{"price": "0.45", "size": "10"}]}
+        raise AssertionError(f"Unexpected market-data URL: {url}")
+
+
+class FakeSecureClient:
+    def __init__(self):
+        self.market_orders = []
+        self.limit_orders = []
+        self.canceled = []
+
+    def get_balance_allowance(self, *args, **kwargs):
+        return {"balance": "12.34"}
+
+    def get_portfolio_values(self):
+        return {"portfolio_value": "13.60", "positions_value": "1.26"}
+
+    def list_positions(self):
+        return [
+            {
+                "asset": "111",
+                "size": "3",
+                "avgPrice": "0.35",
+                "currentValue": "1.26",
+                "curPrice": "0.42",
+            }
+        ]
+
+    def get_open_orders(self):
+        return [{"id": "order-1", "asset_id": "111", "side": "BUY", "price": "0.42", "size": "2", "status": "live"}]
+
+    def get_order(self, identifier):
+        return {"id": identifier, "asset_id": "111", "side": "BUY", "price": "0.42", "size": "2", "status": "live"}
+
+    def create_and_post_market_order(self, payload, **kwargs):
+        self.market_orders.append(payload)
+        if isinstance(payload, dict):
+            return {
+                "id": "market-order",
+                "asset_id": payload["token_id"],
+                "side": payload["side"],
+                "type": "market",
+                "size": payload.get("amount") or payload.get("shares"),
+                "status": "filled",
+                "price": payload.get("price", "0.42"),
+            }
+        return {
+            "id": "market-order",
+            "asset_id": payload.token_id,
+            "side": payload.side,
+            "type": "market",
+            "size": payload.amount,
+            "status": "filled",
+            "price": payload.price,
+        }
+
+    def create_and_post_order(self, payload, **kwargs):
+        self.limit_orders.append(payload)
+        if isinstance(payload, dict):
+            return {
+                "id": "limit-order",
+                "asset_id": payload["token_id"],
+                "side": payload["side"],
+                "type": "limit",
+                "size": payload["size"],
+                "status": "live",
+                "price": payload["price"],
+            }
+        return {
+            "id": "limit-order",
+            "asset_id": payload.token_id,
+            "side": payload.side,
+            "type": "limit",
+            "size": payload.size,
+            "status": "live",
+            "price": payload.price,
+        }
+
+    def cancel_order(self, payload):
+        self.canceled.append(payload)
+        return {"canceled": True}
+
+
+def _broker(monkeypatch):
+    monkeypatch.setattr(Broker, "_start_orders_thread", lambda self: None)
+    data_source = PolymarketData(client=FakeMarketDataClient())
+    return Polymarket(
+        {
+            "WALLET_ADDRESS": "0xwallet",
+            "MAX_MARKET_ORDER_NOTIONAL": "5",
+        },
+        data_source=data_source,
+        secure_client=FakeSecureClient(),
+        data_api_client=FakeDataClient(),
+        connect_stream=False,
+    )
+
+
+def test_polymarket_credential_store_redacts_secrets():
+    store = PolymarketCredentialStore({"PRIVATE_KEY": "secret", "WALLET_ADDRESS": "0xwallet"})
+
+    assert store.redacted_config()["PRIVATE_KEY"] == "<redacted>"
+    assert store.redacted_config()["WALLET_ADDRESS"] == "0xwallet"
+
+
+def test_polymarket_balances_positions_orders(monkeypatch):
+    broker = _broker(monkeypatch)
+    try:
+        cash, positions_value, portfolio_value = broker._get_balances_at_broker(
+            Asset("USD", asset_type=Asset.AssetType.FOREX),
+            None,
+        )
+        positions = broker._pull_positions("unit")
+        orders = broker._pull_broker_all_orders()
+
+        assert cash == 12.34
+        assert positions_value == 1.26
+        assert portfolio_value == 13.60
+        assert isinstance(positions[0], Position)
+        assert positions[0].asset.asset_type == Asset.AssetType.PREDICTION_CONTRACT
+        assert positions[0].quantity == 3.0
+        assert orders[0]["id"] == "order-1"
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_parse_broker_order(monkeypatch):
+    broker = _broker(monkeypatch)
+    try:
+        order = broker._parse_broker_order(
+            {"id": "o1", "asset_id": "111", "side": "SELL", "price": "0.44", "size": "2", "status": "confirmed"},
+            "unit",
+        )
+
+        assert order.identifier == "o1"
+        assert order.side == Order.OrderSide.SELL
+        assert order.status == Order.OrderStatus.FILLED
+        assert order.asset.asset_type == Asset.AssetType.PREDICTION_CONTRACT
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_market_buy_requires_amount(monkeypatch):
+    broker = _broker(monkeypatch)
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    order = Order("unit", asset, quantity=1, side=Order.OrderSide.BUY, order_type=Order.OrderType.MARKET)
+    try:
+        try:
+            broker._submit_order(order)
+        except ValueError as exc:
+            assert 'custom_params["amount"]' in str(exc)
+        else:
+            raise AssertionError("Expected missing market amount to fail")
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_market_buy_uses_custom_amount_not_quantity(monkeypatch):
+    broker = _broker(monkeypatch)
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    order = Order(
+        "unit",
+        asset,
+        quantity=999,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.MARKET,
+        custom_params={"amount": "1.00", "price": "0.45", "order_type": "FAK"},
+    )
+    try:
+        submitted = broker._submit_order(order)
+
+        assert submitted.identifier == "market-order"
+        assert broker._secure_client.market_orders[0]["amount"] == "1.00"
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_market_buy_notional_cap(monkeypatch):
+    broker = _broker(monkeypatch)
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    order = Order(
+        "unit",
+        asset,
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.MARKET,
+        custom_params={"amount": "6.00", "price": "0.45", "order_type": "FAK"},
+    )
+    try:
+        try:
+            broker._submit_order(order)
+        except ValueError as exc:
+            assert "exceeds configured cap" in str(exc)
+        else:
+            raise AssertionError("Expected market order cap to fail")
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_limit_order_and_cancel(monkeypatch):
+    broker = _broker(monkeypatch)
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    order = Order(
+        "unit",
+        asset,
+        quantity=2,
+        side=Order.OrderSide.BUY,
+        limit_price=0.42,
+        order_type=Order.OrderType.LIMIT,
+        time_in_force="gtc",
+    )
+    try:
+        submitted = broker._submit_order(order)
+        broker.cancel_order(submitted)
+
+        assert submitted.identifier == "limit-order"
+        assert broker._secure_client.limit_orders
+        assert broker._secure_client.canceled
+        assert submitted.status == Order.OrderStatus.CANCELED
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_stream_user_event_dispatch(monkeypatch):
+    broker = _broker(monkeypatch)
+    stream = PolymarketCLOBStream(broker, use_websocket=False)
+    seen = []
+    stream.add_action(broker.FILLED_ORDER)(lambda order, **_: seen.append(order.identifier))
+
+    stream.handle_user_event({"id": "filled-1", "asset_id": "111", "side": "BUY", "status": "confirmed", "size": "1"})
+
+    stream._process_queue_event(broker.FILLED_ORDER, {"order": broker._parse_broker_order({"id": "filled-1"}, "unit")})
+    assert seen == ["filled-1"]

--- a/tests/test_polymarket_broker.py
+++ b/tests/test_polymarket_broker.py
@@ -142,6 +142,53 @@ def test_polymarket_credential_store_redacts_secrets():
     assert store.redacted_config()["WALLET_ADDRESS"] == "0xwallet"
 
 
+def test_polymarket_signature_type_honors_explicit_deposit_wallet_config(monkeypatch):
+    monkeypatch.setattr(Broker, "_start_orders_thread", lambda self: None)
+
+    class SignatureTypes:
+        POLY_PROXY = 1
+        POLY_1271 = 3
+
+    broker = Polymarket(
+        {
+            "OWNER_ADDRESS": "0xowner",
+            "WALLET_ADDRESS": "0xdepositwallet",
+            "SIGNATURE_TYPE": "3",
+        },
+        data_source=PolymarketData(client=FakeMarketDataClient()),
+        secure_client=FakeSecureClient(),
+        data_api_client=FakeDataClient(),
+        connect_stream=False,
+    )
+    try:
+        assert broker._configured_signature_type(SignatureTypes) == 3
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_signature_type_infers_proxy_when_no_explicit_value(monkeypatch):
+    monkeypatch.setattr(Broker, "_start_orders_thread", lambda self: None)
+
+    class SignatureTypes:
+        POLY_PROXY = 1
+        POLY_1271 = 3
+
+    broker = Polymarket(
+        {
+            "OWNER_ADDRESS": "0xowner",
+            "WALLET_ADDRESS": "0xproxywallet",
+        },
+        data_source=PolymarketData(client=FakeMarketDataClient()),
+        secure_client=FakeSecureClient(),
+        data_api_client=FakeDataClient(),
+        connect_stream=False,
+    )
+    try:
+        assert broker._configured_signature_type(SignatureTypes) == 1
+    finally:
+        broker.cleanup_streams()
+
+
 def test_polymarket_balances_positions_orders(monkeypatch):
     broker = _broker(monkeypatch)
     try:
@@ -187,6 +234,68 @@ def test_polymarket_parse_broker_order(monkeypatch):
         assert order.side == Order.OrderSide.SELL
         assert order.status == Order.OrderStatus.FILLED
         assert order.asset.asset_type == Asset.AssetType.PREDICTION_CONTRACT
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_parse_matched_market_order_response(monkeypatch):
+    broker = _broker(monkeypatch)
+    try:
+        order = broker._parse_broker_order(
+            {
+                "orderID": "0xabc",
+                "status": "matched",
+                "makingAmount": "0.999999",
+                "takingAmount": "35.714284",
+            },
+            "unit",
+        )
+
+        assert order.identifier == "0xabc"
+        assert order.status == Order.OrderStatus.FILLED
+        assert order.quantity == 35.714284
+        assert round(order.avg_fill_price, 6) == 0.028
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_parse_live_limit_order_response_with_empty_amounts(monkeypatch):
+    broker = _broker(monkeypatch)
+    try:
+        order = broker._parse_broker_order(
+            {
+                "orderID": "0xlimit",
+                "status": "live",
+                "makingAmount": "",
+                "takingAmount": "",
+            },
+            "unit",
+        )
+
+        assert order.identifier == "0xlimit"
+        assert order.status == Order.OrderStatus.OPEN
+        assert order.quantity == 0
+        assert order.avg_fill_price is None
+    finally:
+        broker.cleanup_streams()
+
+
+def test_polymarket_submit_response_preserves_original_limit_price(monkeypatch):
+    broker = _broker(monkeypatch)
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+    original = Order(
+        "unit",
+        asset,
+        quantity=5,
+        side=Order.OrderSide.BUY,
+        limit_price=0.01,
+        order_type=Order.OrderType.LIMIT,
+    )
+    try:
+        parsed = broker._order_from_submit_response({"orderID": "0xlimit", "status": "live"}, original)
+
+        assert parsed.limit_price == 0.01
+        assert parsed.order_type == Order.OrderType.LIMIT
     finally:
         broker.cleanup_streams()
 

--- a/tests/test_polymarket_data.py
+++ b/tests/test_polymarket_data.py
@@ -79,3 +79,48 @@ def test_polymarket_resolve_market_and_contract():
     assert market["outcomes"] == ["Yes", "No"]
     assert asset.symbol == "222"
     assert asset.asset_type == Asset.AssetType.PREDICTION_CONTRACT
+
+
+def test_polymarket_market_stream_list_event_updates_quote_cache():
+    data = PolymarketData(client=FakeHttpClient())
+
+    data.apply_market_event(
+        [
+            {
+                "event_type": "best_bid_ask",
+                "asset_id": "111",
+                "best_bid": "0.41",
+                "best_ask": "0.44",
+                "price": "0.425",
+            }
+        ]
+    )
+
+    cached = data._quote_cache["111"]
+    assert cached.bid == 0.41
+    assert cached.ask == 0.44
+    assert cached.price == 0.425
+
+
+def test_polymarket_market_stream_nested_price_changes_update_quote_cache():
+    data = PolymarketData(client=FakeHttpClient())
+
+    data.apply_market_event(
+        {
+            "event_type": "price_change",
+            "market": "0xmarket",
+            "price_changes": [
+                {
+                    "asset_id": "111",
+                    "price": "0.42",
+                    "best_bid": "0.42",
+                    "best_ask": "0.45",
+                }
+            ],
+        }
+    )
+
+    cached = data._quote_cache["111"]
+    assert cached.bid == 0.42
+    assert cached.ask == 0.45
+    assert cached.price == 0.42

--- a/tests/test_polymarket_data.py
+++ b/tests/test_polymarket_data.py
@@ -1,0 +1,81 @@
+from urllib.parse import parse_qs, urlparse
+
+from lumibot.data_sources.polymarket_data import PolymarketData
+from lumibot.entities import Asset, Bars, Quote
+
+
+class FakeHttpClient:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, params=None):
+        self.calls.append((url, params or {}))
+        path = urlparse(url).path
+        params = params or {}
+        if path == "/book":
+            return {
+                "bids": [{"price": "0.40", "size": "10"}, {"price": "0.42", "size": "5"}],
+                "asks": [{"price": "0.45", "size": "7"}, {"price": "0.47", "size": "9"}],
+                "tick_size": "0.01",
+                "min_order_size": "1",
+            }
+        if path == "/last-trade-price":
+            return {"price": "0.44"}
+        if path == "/prices-history":
+            return {"history": [{"t": 1_782_800_000, "p": "0.43"}, {"t": 1_782_800_060, "p": "0.44"}]}
+        if path == "/tick-size":
+            return {"minimum_tick_size": "0.01"}
+        if path == "/markets":
+            query = parse_qs(urlparse(url).query)
+            slug = params.get("slug") or query.get("slug", ["test-market"])[0]
+            return [
+                {
+                    "id": "m1",
+                    "slug": slug,
+                    "outcomes": '["Yes","No"]',
+                    "clobTokenIds": '["111","222"]',
+                }
+            ]
+        raise AssertionError(f"Unexpected URL: {url} params={params}")
+
+
+def test_polymarket_quote_from_order_book():
+    data = PolymarketData(client=FakeHttpClient())
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+
+    quote = data.get_quote(asset)
+
+    assert isinstance(quote, Quote)
+    assert quote.bid == 0.42
+    assert quote.ask == 0.45
+    assert quote.mid_price == 0.435
+    assert quote.bid_size == 5.0
+    assert quote.ask_size == 7.0
+
+
+def test_polymarket_last_price_uses_last_trade_endpoint():
+    data = PolymarketData(client=FakeHttpClient())
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+
+    assert data.get_last_price(asset) == 0.44
+
+
+def test_polymarket_history_returns_bars():
+    data = PolymarketData(client=FakeHttpClient())
+    asset = Asset("111", asset_type=Asset.AssetType.PREDICTION_CONTRACT)
+
+    bars = data.get_historical_prices(asset, 2, timestep="minute")
+
+    assert isinstance(bars, Bars)
+    assert list(bars.df["close"]) == [0.43, 0.44]
+
+
+def test_polymarket_resolve_market_and_contract():
+    data = PolymarketData(client=FakeHttpClient())
+
+    market = data.resolve_market(slug="test-market")
+    asset = data.resolve_contract(market, outcome="No")
+
+    assert market["outcomes"] == ["Yes", "No"]
+    assert asset.symbol == "222"
+    assert asset.asset_type == Asset.AssetType.PREDICTION_CONTRACT

--- a/tests/test_polymarket_data.py
+++ b/tests/test_polymarket_data.py
@@ -25,17 +25,67 @@ class FakeHttpClient:
             return {"history": [{"t": 1_782_800_000, "p": "0.43"}, {"t": 1_782_800_060, "p": "0.44"}]}
         if path == "/tick-size":
             return {"minimum_tick_size": "0.01"}
-        if path == "/markets":
+        if path == "/spread":
+            return {"spread": "0.03"}
+        if path == "/midpoint":
+            return {"mid": "0.435"}
+        if path in {"/markets", "/markets/slug/test-market", "/markets/token/111"}:
             query = parse_qs(urlparse(url).query)
             slug = params.get("slug") or query.get("slug", ["test-market"])[0]
-            return [
-                {
-                    "id": "m1",
-                    "slug": slug,
-                    "outcomes": '["Yes","No"]',
-                    "clobTokenIds": '["111","222"]',
-                }
-            ]
+            market = {
+                "id": "m1",
+                "slug": slug,
+                "question": "Will this test pass?",
+                "description": "Unit-test market",
+                "resolutionSource": "Unit test fixture",
+                "conditionId": "0x" + "1" * 64,
+                "outcomes": '["Yes","No"]',
+                "clobTokenIds": '["111","222"]',
+                "orderPriceMinTickSize": 0.01,
+                "orderMinSize": 5,
+                "umaResolutionStatus": "pending",
+                "acceptingOrders": True,
+                "enableOrderBook": True,
+                "closed": False,
+                "tokens": [{"token_id": "111", "outcome": "Yes", "winner": False}],
+            }
+            if path == "/markets":
+                return [market]
+            return market
+        if path == "/public-search":
+            return {
+                "markets": [
+                    {
+                        "id": "m1",
+                        "slug": "test-market",
+                        "outcomes": '["Yes","No"]',
+                        "clobTokenIds": '["111","222"]',
+                    }
+                ],
+                "events": [
+                    {
+                        "id": "e1",
+                        "slug": "event-slug",
+                        "title": "Event title",
+                        "markets": [
+                            {
+                                "id": "m2",
+                                "slug": "event-market",
+                                "outcomes": '["Up","Down"]',
+                                "clobTokenIds": '["333","444"]',
+                            }
+                        ],
+                    }
+                ],
+            }
+        if path == "/events/slug/event-slug":
+            return {"id": "e1", "slug": "event-slug", "title": "Event title", "markets": []}
+        if path == "/trades":
+            return [{"asset": "111", "conditionId": "0x" + "1" * 64, "price": "0.44", "size": "10"}]
+        if path == "/oi":
+            return [{"market": "0x" + "1" * 64, "value": 123.45}]
+        if path == "/holders":
+            return [{"token": "111", "holders": [{"proxyWallet": "0xwallet", "amount": 10}]}]
         raise AssertionError(f"Unexpected URL: {url} params={params}")
 
 
@@ -79,6 +129,33 @@ def test_polymarket_resolve_market_and_contract():
     assert market["outcomes"] == ["Yes", "No"]
     assert asset.symbol == "222"
     assert asset.asset_type == Asset.AssetType.PREDICTION_CONTRACT
+
+
+def test_polymarket_prediction_market_metadata_methods():
+    data = PolymarketData(client=FakeHttpClient())
+    market = data.get_market_metadata(slug="test-market")
+    asset = data.resolve_contract(market, outcome="Yes")
+
+    rules = data.get_market_rules(market)
+    resolution = data.get_resolution_status(market)
+    search = data.search_markets("test", limit=5)
+    event = data.get_event(slug="event-slug")
+    trades = data.get_recent_trades(market)
+    holders = data.get_holders(market)
+
+    assert rules["question"] == "Will this test pass?"
+    assert rules["tick_size"] == 0.01
+    assert rules["min_order_size"] == 5
+    assert rules["accepting_orders"] is True
+    assert resolution["status"] == "pending"
+    assert resolution["resolved"] is False
+    assert len(search) == 2
+    assert event["title"] == "Event title"
+    assert trades[0]["asset"] == "111"
+    assert holders[0]["token"] == "111"
+    assert data.get_open_interest(market) == 123.45
+    assert data.get_spread(asset) == 0.03
+    assert data.get_midpoint(asset) == 0.435
 
 
 def test_polymarket_market_stream_list_event_updates_quote_cache():

--- a/tests/test_prediction_market_data_source_defaults.py
+++ b/tests/test_prediction_market_data_source_defaults.py
@@ -1,0 +1,40 @@
+import pandas as pd
+
+from lumibot.data_sources.data_source import DataSource
+from lumibot.entities import Asset, Bars, Quote
+
+
+class DefaultPredictionMarketDataSource(DataSource):
+    SOURCE = "TEST"
+
+    def get_chains(self, asset, quote=None):
+        return {}
+
+    def get_historical_prices(self, asset, length, timestep="", timeshift=None, quote=None, exchange=None, **kwargs):
+        return Bars(
+            pd.DataFrame(columns=["open", "high", "low", "close", "volume"]),
+            source=self.SOURCE,
+            asset=asset,
+        )
+
+    def get_last_price(self, asset, quote=None, exchange=None):
+        return 1.0
+
+    def get_quote(self, asset, quote=None, exchange=None):
+        return Quote(asset=asset, bid=0.4, ask=0.6)
+
+
+def test_prediction_market_default_methods_do_not_break_regular_data_sources():
+    data = DefaultPredictionMarketDataSource()
+    asset = Asset("SPY")
+
+    assert data.search_markets("election") == []
+    assert data.get_event(slug="event") == {}
+    assert data.get_market_metadata(asset) == {}
+    assert data.get_market_rules(asset) == {}
+    assert data.get_resolution_status(asset)["status"] == "unsupported"
+    assert data.get_recent_trades(asset) == []
+    assert data.get_open_interest(asset) is None
+    assert data.get_holders(asset) == []
+    assert data.get_spread(asset) == 0.19999999999999996
+    assert data.get_midpoint(asset) == 0.5

--- a/tests/test_stock_split_accounting.py
+++ b/tests/test_stock_split_accounting.py
@@ -1,0 +1,460 @@
+from datetime import datetime
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+
+from lumibot.backtesting import BacktestingBroker, PandasDataBacktesting
+from lumibot.entities import Asset, Data, Position
+from lumibot.strategies.strategy import Strategy
+from lumibot.traders import Trader
+
+
+class _NoopSplitStrategy(Strategy):
+    def initialize(self):
+        self.sleeptime = "1D"
+
+    def on_trading_iteration(self):
+        pass
+
+
+def _strategy_with_position(quantity, avg_fill_price=100.0):
+    start = pd.Timestamp("2025-01-02 16:00:00-05:00").to_pydatetime()
+    end = pd.Timestamp("2025-01-07 16:00:00-05:00").to_pydatetime()
+    data_source = PandasDataBacktesting(
+        datetime_start=start,
+        datetime_end=end,
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    broker = BacktestingBroker(data_source=data_source)
+    broker._update_datetime(pd.Timestamp("2025-01-06 16:00:00-05:00").to_pydatetime())
+    strategy = _NoopSplitStrategy(broker=broker, data_source=data_source, budget=1000.0)
+
+    asset = Asset("SPLT", Asset.AssetType.STOCK)
+    broker._filled_positions.append(
+        Position(
+            strategy=strategy.name,
+            asset=asset,
+            quantity=Decimal(str(quantity)),
+            avg_fill_price=avg_fill_price,
+        )
+    )
+    return strategy, broker, asset
+
+
+@pytest.mark.parametrize(
+    "ratio,quantity,expected_quantity,avg_fill_price,expected_avg_fill_price",
+    [
+        (2.0, 100, 200, 80.0, 40.0),
+        (3.0, 100, 300, 90.0, 30.0),
+        (7.0, 5, 35, 70.0, 10.0),
+        (10.0, 8, 80, 100.0, 10.0),
+        (0.5, 100, 50, 20.0, 40.0),
+        (0.1, 100, 10, 10.0, 100.0),
+        (2.0, -100, -200, 80.0, 40.0),
+    ],
+)
+def test_update_positions_with_splits_adjusts_quantity_basis_and_records_event(
+    monkeypatch,
+    ratio,
+    quantity,
+    expected_quantity,
+    avg_fill_price,
+    expected_avg_fill_price,
+):
+    strategy, broker, asset = _strategy_with_position(quantity, avg_fill_price=avg_fill_price)
+    monkeypatch.setattr(
+        broker.data_source,
+        "get_yesterday_stock_splits",
+        lambda assets, quote=None: {asset: ratio},
+    )
+
+    revision_before = broker._filled_positions.revision
+
+    applied = strategy._update_positions_with_splits()
+    applied_again = strategy._update_positions_with_splits()
+
+    position = broker.get_tracked_position(strategy.name, asset)
+    assert applied == 1
+    assert applied_again == 0
+    assert position.quantity == pytest.approx(expected_quantity)
+    assert position.avg_fill_price == pytest.approx(expected_avg_fill_price)
+    assert broker._filled_positions.revision == revision_before + 1
+
+    split_events = broker._trade_event_log_df.loc[
+        broker._trade_event_log_df["event_kind"] == "corporate_action"
+    ]
+    assert len(split_events) == 1
+    row = split_events.iloc[0]
+    assert row["status"] == "stock_split"
+    assert row["symbol"] == "SPLT"
+    assert row["price"] == pytest.approx(ratio)
+    assert row["filled_quantity"] == pytest.approx(expected_quantity)
+    assert "quantity" in row["cash_event_description"]
+
+
+@pytest.mark.parametrize("ratio", [0, 1, -2, float("nan"), float("inf"), None, "not-a-ratio"])
+def test_update_positions_with_splits_ignores_non_action_ratios(monkeypatch, ratio):
+    strategy, broker, asset = _strategy_with_position(100, avg_fill_price=25.0)
+    monkeypatch.setattr(
+        broker.data_source,
+        "get_yesterday_stock_splits",
+        lambda assets, quote=None: {asset: ratio},
+    )
+
+    applied = strategy._update_positions_with_splits()
+
+    position = broker.get_tracked_position(strategy.name, asset)
+    assert applied == 0
+    assert position.quantity == pytest.approx(100)
+    assert position.avg_fill_price == pytest.approx(25.0)
+    assert broker._trade_event_log_df.empty
+
+
+def test_update_positions_with_splits_skips_split_adjusted_data():
+    strategy, broker, asset = _strategy_with_position(100, avg_fill_price=25.0)
+    quote = Asset("USD", Asset.AssetType.FOREX)
+    index = pd.DatetimeIndex(
+        [
+            "2025-01-03 16:00:00-05:00",
+            "2025-01-06 16:00:00-05:00",
+        ]
+    )
+    frame = pd.DataFrame(
+        {
+            "open": [50.0, 50.0],
+            "high": [50.0, 50.0],
+            "low": [50.0, 50.0],
+            "close": [50.0, 50.0],
+            "volume": [2000, 2000],
+            "stock_splits": [0.0, 2.0],
+            "_split_adjusted": [True, True],
+        },
+        index=index,
+    )
+    data = Data(asset, frame, timestep="day", quote=quote)
+    broker.data_source.pandas_data = {(asset, quote): data}
+    broker.data_source._data_store = {(asset, quote): data}
+
+    applied = strategy._update_positions_with_splits()
+
+    position = broker.get_tracked_position(strategy.name, asset)
+    assert applied == 0
+    assert position.quantity == pytest.approx(100)
+    assert position.avg_fill_price == pytest.approx(25.0)
+    assert broker._trade_event_log_df.empty
+
+
+def test_update_positions_with_splits_skips_auto_adjusted_data_source(monkeypatch):
+    strategy, broker, asset = _strategy_with_position(100, avg_fill_price=25.0)
+    broker.data_source.AUTO_ADJUST_IMPLIES_SPLIT_ADJUSTED_PRICES = True
+    broker.data_source.auto_adjust = True
+    monkeypatch.setattr(
+        broker.data_source,
+        "get_yesterday_stock_splits",
+        lambda assets, quote=None: {asset: 2.0},
+    )
+
+    applied = strategy._update_positions_with_splits()
+
+    position = broker.get_tracked_position(strategy.name, asset)
+    assert applied == 0
+    assert position.quantity == pytest.approx(100)
+    assert position.avg_fill_price == pytest.approx(25.0)
+    assert broker._trade_event_log_df.empty
+
+
+def test_update_positions_with_splits_only_adjusts_stock_positions(monkeypatch):
+    strategy, broker, stock = _strategy_with_position(100)
+    option = Asset("SPLT", Asset.AssetType.OPTION, expiration=datetime(2025, 1, 17).date(), strike=50, right="CALL")
+    broker._filled_positions.append(
+        Position(strategy=strategy.name, asset=option, quantity=Decimal("1"), avg_fill_price=2.0)
+    )
+    monkeypatch.setattr(
+        broker.data_source,
+        "get_yesterday_stock_splits",
+        lambda assets, quote=None: {stock: 2.0, option: 2.0},
+    )
+
+    applied = strategy._update_positions_with_splits()
+
+    assert applied == 1
+    assert broker.get_tracked_position(strategy.name, stock).quantity == pytest.approx(200)
+    assert broker.get_tracked_position(strategy.name, option).quantity == pytest.approx(1)
+
+
+def test_pandas_data_preserves_stock_splits_and_does_not_forward_fill_events():
+    asset = Asset("SPLT", Asset.AssetType.STOCK)
+    index = pd.DatetimeIndex(
+        [
+            "2025-01-02 16:00:00-05:00",
+            "2025-01-03 16:00:00-05:00",
+            "2025-01-06 16:00:00-05:00",
+        ]
+    )
+    frame = pd.DataFrame(
+        {
+            "open": [100.0, 50.0, 50.0],
+            "high": [100.0, 50.0, 50.0],
+            "low": [100.0, 50.0, 50.0],
+            "close": [100.0, 50.0, 50.0],
+            "volume": [1000, 1000, 1000],
+            "stock_splits": [2.0, None, 0.0],
+        },
+        index=index,
+    )
+    data = Data(asset, frame, timestep="day")
+    data.repair_times_and_fill(index)
+    assert data.df.loc[index[1], "stock_splits"] == 0
+
+    data_source = PandasDataBacktesting(
+        pandas_data={asset: Data(asset, frame, timestep="day")},
+        datetime_start=index[0].to_pydatetime(),
+        datetime_end=index[-1].to_pydatetime(),
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    data_source.load_data()
+    data_source._update_datetime(index[-1].to_pydatetime())
+    bars = data_source.get_historical_prices(asset, 3, timestep="day")
+
+    assert "stock_splits" in bars.df.columns
+    assert list(bars.df["stock_splits"]) == [2.0, 0.0, 0.0]
+
+
+@pytest.mark.parametrize("ratio", [2.0, 3.0, 7.0, 10.0, 0.5, 0.1])
+def test_data_source_reads_daily_stock_split_ratios(ratio):
+    asset = Asset("SPLT", Asset.AssetType.STOCK)
+    index = pd.DatetimeIndex(
+        [
+            "2025-01-02 16:00:00-05:00",
+            "2025-01-03 16:00:00-05:00",
+            "2025-01-06 16:00:00-05:00",
+        ]
+    )
+    frame = pd.DataFrame(
+        {
+            "open": [100.0, 100.0 / ratio, 100.0 / ratio],
+            "high": [100.0, 100.0 / ratio, 100.0 / ratio],
+            "low": [100.0, 100.0 / ratio, 100.0 / ratio],
+            "close": [100.0, 100.0 / ratio, 100.0 / ratio],
+            "volume": [1000, 1000, 1000],
+            "stock_splits": [0.0, ratio, 0.0],
+        },
+        index=index,
+    )
+    data_source = PandasDataBacktesting(
+        pandas_data={asset: Data(asset, frame, timestep="day")},
+        datetime_start=index[0].to_pydatetime(),
+        datetime_end=index[-1].to_pydatetime(),
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    data_source.load_data()
+    data_source._update_datetime(index[1].to_pydatetime())
+
+    splits = data_source.get_yesterday_stock_splits([asset])
+
+    assert splits[asset] == pytest.approx(ratio)
+    data_source._update_datetime(index[2].to_pydatetime())
+    assert data_source.get_yesterday_stock_splits([asset])[asset] == 0
+
+
+def test_data_source_reads_split_effective_before_daily_bar_timestamp():
+    asset = Asset("SPLT", Asset.AssetType.STOCK)
+    index = pd.DatetimeIndex(
+        [
+            "2025-01-02 16:00:00-05:00",
+            "2025-01-03 16:00:00-05:00",
+            "2025-01-06 16:00:00-05:00",
+        ]
+    )
+    frame = pd.DataFrame(
+        {
+            "open": [100.0, 50.0, 50.0],
+            "high": [100.0, 50.0, 50.0],
+            "low": [100.0, 50.0, 50.0],
+            "close": [100.0, 50.0, 50.0],
+            "volume": [1000, 1000, 1000],
+            "stock_splits": [0.0, 2.0, 0.0],
+        },
+        index=index,
+    )
+    data_source = PandasDataBacktesting(
+        pandas_data={asset: Data(asset, frame, timestep="day")},
+        datetime_start=index[0].to_pydatetime(),
+        datetime_end=index[-1].to_pydatetime(),
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    data_source.load_data()
+
+    data_source._update_datetime(pd.Timestamp("2025-01-03 09:30:00-05:00").to_pydatetime())
+    assert data_source.get_yesterday_stock_splits([asset])[asset] == pytest.approx(2.0)
+
+
+@pytest.mark.parametrize(
+    "ratio,previous_close,expected_preclose_mark,split_close",
+    [
+        (2.0, 100.0, 50.0, 48.0),
+        (3.0, 90.0, 30.0, 29.0),
+        (7.0, 70.0, 10.0, 9.5),
+        (10.0, 100.0, 10.0, 9.0),
+        (0.5, 20.0, 40.0, 42.0),
+        (0.1, 10.0, 100.0, 98.0),
+    ],
+)
+def test_daily_split_pre_close_mark_uses_split_adjusted_previous_close(
+    ratio,
+    previous_close,
+    expected_preclose_mark,
+    split_close,
+):
+    asset = Asset("SPLT", Asset.AssetType.STOCK)
+    index = pd.DatetimeIndex(
+        [
+            "2025-01-02 16:00:00-05:00",
+            "2025-01-03 16:00:00-05:00",
+        ]
+    )
+    frame = pd.DataFrame(
+        {
+            "open": [previous_close, expected_preclose_mark],
+            "high": [previous_close, max(expected_preclose_mark, split_close)],
+            "low": [previous_close, min(expected_preclose_mark, split_close)],
+            "close": [previous_close, split_close],
+            "volume": [1000, 1000],
+            "stock_splits": [0.0, ratio],
+        },
+        index=index,
+    )
+    data_source = PandasDataBacktesting(
+        pandas_data={asset: Data(asset, frame, timestep="day")},
+        datetime_start=index[0].to_pydatetime(),
+        datetime_end=index[-1].to_pydatetime(),
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    data_source.load_data()
+
+    data_source._update_datetime(pd.Timestamp("2025-01-03 09:30:00-05:00").to_pydatetime())
+    assert data_source.get_last_price(asset) == pytest.approx(expected_preclose_mark)
+
+    data_source._update_datetime(index[1].to_pydatetime())
+    assert data_source.get_last_price(asset) == pytest.approx(split_close)
+
+
+def test_daily_split_pre_close_mark_does_not_adjust_already_split_adjusted_frame():
+    asset = Asset("SPLT", Asset.AssetType.STOCK)
+    index = pd.DatetimeIndex(
+        [
+            "2025-01-02 16:00:00-05:00",
+            "2025-01-03 16:00:00-05:00",
+        ]
+    )
+    frame = pd.DataFrame(
+        {
+            "open": [50.0, 50.0],
+            "high": [50.0, 50.0],
+            "low": [50.0, 50.0],
+            "close": [50.0, 50.0],
+            "volume": [2000, 2000],
+            "stock_splits": [0.0, 2.0],
+            "_split_adjusted": [True, True],
+        },
+        index=index,
+    )
+    data_source = PandasDataBacktesting(
+        pandas_data={asset: Data(asset, frame, timestep="day")},
+        datetime_start=index[0].to_pydatetime(),
+        datetime_end=index[-1].to_pydatetime(),
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    data_source.load_data()
+
+    data_source._update_datetime(pd.Timestamp("2025-01-03 09:30:00-05:00").to_pydatetime())
+
+    assert data_source.get_last_price(asset) == pytest.approx(50.0)
+
+
+class _HoldThroughSplitStrategy(Strategy):
+    def initialize(self):
+        self.sleeptime = "1D"
+        self.asset = self.parameters["asset"]
+        self.observed_quantities = {}
+        self.did_buy = False
+        self.did_sell = False
+
+    def on_trading_iteration(self):
+        current_date = self.get_datetime().date()
+        position = self.get_position(self.asset)
+        self.observed_quantities[current_date] = 0 if position is None else float(position.quantity)
+
+        if not self.did_buy and position is None:
+            self.submit_order(self.create_order(self.asset, 10, "buy"))
+            self.did_buy = True
+        elif current_date >= datetime(2025, 1, 7).date() and position is not None and not self.did_sell:
+            self.submit_order(self.create_order(self.asset, abs(position.quantity), "sell"))
+            self.did_sell = True
+
+
+def test_daily_backtest_holding_through_split_sells_adjusted_quantity():
+    asset = Asset("SPLT", Asset.AssetType.STOCK)
+    index = pd.DatetimeIndex(
+        [
+            "2025-01-02 16:00:00-05:00",
+            "2025-01-03 16:00:00-05:00",
+            "2025-01-06 16:00:00-05:00",
+            "2025-01-07 16:00:00-05:00",
+        ]
+    )
+    frame = pd.DataFrame(
+        {
+            "open": [100.0, 100.0, 50.0, 50.0],
+            "high": [100.0, 100.0, 50.0, 50.0],
+            "low": [100.0, 100.0, 50.0, 50.0],
+            "close": [100.0, 100.0, 50.0, 50.0],
+            "volume": [1000, 1000, 1000, 1000],
+            "stock_splits": [0.0, 0.0, 2.0, 0.0],
+        },
+        index=index,
+    )
+    data_source = PandasDataBacktesting(
+        pandas_data={asset: Data(asset, frame, timestep="day")},
+        datetime_start=index[0].to_pydatetime(),
+        datetime_end=index[-1].to_pydatetime(),
+        show_progress_bar=False,
+        log_backtest_progress_to_file=False,
+    )
+    broker = BacktestingBroker(data_source=data_source)
+    strategy = _HoldThroughSplitStrategy(
+        broker=broker,
+        data_source=data_source,
+        budget=2000.0,
+        risk_free_rate=0,
+        benchmark_asset=None,
+        analyze_backtest=False,
+        parameters={"asset": asset},
+    )
+
+    trader = Trader(backtest=True, logfile="")
+    trader.add_strategy(strategy)
+    trader.run_all(show_plot=False, show_tearsheet=False, save_tearsheet=False)
+
+    assert strategy.observed_quantities[datetime(2025, 1, 6).date()] == pytest.approx(20)
+
+    trade_log = broker._trade_event_log_df
+    split_events = trade_log.loc[trade_log["event_kind"] == "corporate_action"]
+    assert len(split_events) == 1
+    assert split_events.iloc[0]["price"] == pytest.approx(2.0)
+    assert split_events.iloc[0]["filled_quantity"] == pytest.approx(20)
+
+    fills = trade_log.loc[trade_log["status"] == "fill"]
+    sell_fills = fills.loc[fills["side"].astype(str).str.lower().str.startswith("sell")]
+    assert sell_fills.iloc[-1]["filled_quantity"] == pytest.approx(20)
+
+    stats = strategy.stats
+    split_day_value = stats.loc[pd.Timestamp("2025-01-06 16:00:00-05:00"), "portfolio_value"]
+    assert split_day_value == pytest.approx(2000.0)

--- a/tests/test_tradier_oauth_refresh.py
+++ b/tests/test_tradier_oauth_refresh.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 import json
+import os
 
 import requests
 
@@ -132,6 +133,143 @@ def test_external_oauth_refresh_mode_reloads_token_file_and_retries_auth_error(t
     }
     assert attempts == 2
     assert broker._tradier_access_token == "new-access"
-    assert broker._oauth_refresh_token == "new-refresh"
+    assert broker._oauth_refresh_token is None
+    assert "refresh_token" not in broker._decode_base64url_json(broker._oauth_token_payload_b64)
     assert component.AUTH_TOKEN == "new-access"
     assert component.REQUESTS_HEADERS["Authorization"] == "Bearer new-access"
+
+
+def test_external_oauth_refresh_mode_strips_initial_refresh_token_and_never_calls_provider_refresh(tmp_path):
+    token_path = tmp_path / "tradier_token.json"
+    token_path.write_text(
+        json.dumps(
+            {
+                "access_token": "old-access",
+                "refresh_token": "stale-refresh-must-not-survive",
+                "expires_in": 86400,
+                "issued_at": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    component = SimpleNamespace(
+        AUTH_TOKEN="old-access",
+        REQUESTS_HEADERS={"Authorization": "Bearer old-access"},
+    )
+    attempts = 0
+
+    def request(endpoint):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            token_path.write_text(
+                json.dumps(
+                    {
+                        "access_token": "new-access",
+                        "expires_in": 86400,
+                        "issued_at": 2,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            raise requests.exceptions.RetryError("too many 401 error responses")
+        return {"ok": True, "endpoint": endpoint}
+
+    component.request = request
+
+    broker = Tradier.__new__(Tradier)
+    broker._oauth_token_payload_b64 = "present"
+    broker._oauth_refresh_mode = "external"
+    broker._oauth_token_path = str(token_path)
+    broker._oauth_token_path_signature = broker._oauth_token_file_signature()
+    broker._oauth_refresh_token = "stale-refresh-must-not-survive"
+    broker._oauth_token_expires_at = None
+    broker._tradier_access_token = "old-access"
+    broker.tradier = SimpleNamespace(account=component, orders=None, market=None)
+    broker.data_source = None
+
+    assert broker._apply_oauth_token_json(Tradier._load_token_json_from_path(token_path))
+    assert broker._oauth_refresh_token is None
+    assert "refresh_token" not in broker._decode_base64url_json(broker._oauth_token_payload_b64)
+
+    def fail_refresh(*, force=False):
+        raise AssertionError("External OAuth refresh mode must not call provider refresh")
+
+    broker._refresh_oauth_token = fail_refresh
+    broker._oauth_token_path_signature = broker._oauth_token_file_signature()
+    broker._install_oauth_refresh_hooks()
+
+    assert broker.tradier.account.request("v1/accounts/123/balances") == {
+        "ok": True,
+        "endpoint": "v1/accounts/123/balances",
+    }
+    assert attempts == 2
+    assert broker._tradier_access_token == "new-access"
+    assert broker._oauth_refresh_token is None
+    assert "refresh_token" not in broker._decode_base64url_json(broker._oauth_token_payload_b64)
+
+
+def test_external_oauth_refresh_mode_multiple_brokers_reload_atomic_replacements(tmp_path):
+    token_path = tmp_path / "tradier_token.json"
+
+    def write_token(access_token):
+        payload = {
+            "access_token": access_token,
+            "expires_in": 86400,
+            "issued_at": 1,
+        }
+        tmp_file = token_path.with_name(f".{token_path.name}.{access_token}.tmp")
+        tmp_file.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp_file, token_path)
+
+    write_token("access-0")
+
+    brokers = []
+    components = []
+    for _ in range(3):
+        component = SimpleNamespace(
+            AUTH_TOKEN="access-0",
+            REQUESTS_HEADERS={"Authorization": "Bearer access-0"},
+        )
+        component.request_calls = 0
+
+        def request(endpoint, *, _component=component):
+            _component.request_calls += 1
+            return {"ok": True, "endpoint": endpoint, "token": _component.AUTH_TOKEN}
+
+        component.request = request
+
+        broker = Tradier.__new__(Tradier)
+        broker._oauth_token_payload_b64 = "present"
+        broker._oauth_refresh_mode = "external"
+        broker._oauth_token_path = str(token_path)
+        broker._oauth_token_path_signature = broker._oauth_token_file_signature()
+        broker._oauth_refresh_token = "stale-refresh-must-not-survive"
+        broker._oauth_token_expires_at = None
+        broker._tradier_access_token = "access-0"
+        broker.tradier = SimpleNamespace(account=component, orders=None, market=None)
+        broker.data_source = None
+        assert broker._apply_oauth_token_json(Tradier._load_token_json_from_path(token_path))
+        broker._oauth_token_path_signature = broker._oauth_token_file_signature()
+
+        def fail_refresh(*, force=False):
+            raise AssertionError("External OAuth refresh mode must not call provider refresh")
+
+        broker._refresh_oauth_token = fail_refresh
+        broker._install_oauth_refresh_hooks()
+        brokers.append(broker)
+        components.append(component)
+
+    for cycle in range(1, 4):
+        write_token(f"access-{cycle}")
+        for broker, component in zip(brokers, components):
+            assert broker.tradier.account.request("v1/accounts/123/balances") == {
+                "ok": True,
+                "endpoint": "v1/accounts/123/balances",
+                "token": f"access-{cycle}",
+            }
+            assert broker._tradier_access_token == f"access-{cycle}"
+            assert broker._oauth_refresh_token is None
+            assert "refresh_token" not in broker._decode_base64url_json(broker._oauth_token_payload_b64)
+            assert component.REQUESTS_HEADERS["Authorization"] == f"Bearer access-{cycle}"


### PR DESCRIPTION
## Summary
- Document IBKR split-cache audit/delete-refill plan for the 2025 TQQQ split incident.
- Add Polymarket backtesting support, prediction-market data-source defaults, example strategy, and regression tests.
- Update `CHANGELOG.md` for the full 4.5.64 release range: Polymarket, ThetaData option valuation, OAuth refresh handling, IBKR split handling, docs/tests.

## Local validation
Passed focused release-scope tests earlier on this branch:
- Split/cache/Yahoo/Polymarket/Tradier OAuth/agent provider/data-source env focused set: `187 passed, 1 warning`.
- `python3 -m pytest tests/test_polymarket_backtesting.py tests/test_prediction_market_data_source_defaults.py`: `9 passed, 1 warning`.

Attempted release-doc quick suite:
- `python3 -m pytest -m "not apitest and not downloader" --tb=short -q --durations=30`
- Result: timed out after 30 minutes locally after acceptance backtests started failing/slowing due cold acceptance caches, not the TQQQ split path.
- Evidence: `test_acceptance_meli_deep_drawdown` submitted 15 downloader queue requests because local dev ThetaData option cache was not warm; `backdoor_smartlimit` then spent many minutes filling underfilled IBKR SPX minute cache slices through Data Downloader.
- These are local acceptance-cache hygiene issues; no source-code change was made to loosen acceptance gates.

Attempted broad non-acceptance suite:
- `python3 -m pytest -m "not apitest and not downloader and not acceptance_backtest" --tb=short -q --durations=30`
- Result: interrupted after progress stalled around 45%; observed failures before interruption were tracked in local pytest cache as existing/local env failures: Alpaca API last-price/history tests and the same `test_acceptance_meli_deep_drawdown` from the prior run cache. Generated performance-history rows were removed; working tree is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Polymarket prediction markets support for trading, backtesting, and documentation.
  * Introduced a new prediction-contract asset type and example strategy.
  * Added new smoke-test tools and setup guidance for Polymarket workflows.

* **Bug Fixes**
  * Improved split-adjusted backtesting and daily price handling for stock data.
  * Made external OAuth token handling more reliable for managed broker setups.
  * Strengthened option pricing and fallback behavior in backtests.

* **Documentation**
  * Updated release notes, setup docs, and site content to reflect new Polymarket support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->