### PR TITLE
Fix 4.5.64 release-gate regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,15 @@
 ### Fixed
 - **ThetaData option valuation is more robust for option backtests.** The
   ThetaData backtesting path now avoids stale or missing option marks in the
-  relevant valuation path covered by the 4.5.64 release tests.
+  relevant valuation path covered by the 4.5.64 release tests. Daily option MTM
+  now forward-fills established positions when the intraday quote snapshot is
+  missing instead of forcing a stale day quote, and the strategy-level valuation
+  layer no longer reaches for stale option last trades after quote evidence is
+  unavailable.
+- **Polymarket example backtests now read strategy parameters correctly.** The
+  prediction-contract example strategy reads the normal `self.parameters` store
+  used by `Strategy.backtest()`, so local and release-gate backtests do not
+  require `POLYMARKET_TEST_TOKEN_ID` when a test supplies an explicit token id.
 - **Schwab and Tradier external OAuth mode now keeps managed child runtimes
   access-token-only.** When ``LUMIBOT_OAUTH_REFRESH_MODE=external`` is set,
   broker clients strip refresh-token material from in-memory token payloads,

--- a/lumibot/example_strategies/polymarket_prediction_contract.py
+++ b/lumibot/example_strategies/polymarket_prediction_contract.py
@@ -12,17 +12,19 @@ class PolymarketPredictionContractStrategy(Strategy):
     """Polymarket prediction-contract strategy for live smoke tests and backtesting."""
 
     def initialize(self, parameters=None):
-        parameters = parameters or {}
-        self.sleeptime = parameters.get("sleeptime", "1M")
-        token_id = parameters.get("token_id") or os.environ.get("POLYMARKET_TEST_TOKEN_ID")
+        strategy_parameters = dict(getattr(self, "parameters", {}) or {})
+        if isinstance(parameters, dict):
+            strategy_parameters.update(parameters)
+        self.sleeptime = strategy_parameters.get("sleeptime", "1M")
+        token_id = strategy_parameters.get("token_id") or os.environ.get("POLYMARKET_TEST_TOKEN_ID")
         if not token_id:
             raise ValueError("Set POLYMARKET_TEST_TOKEN_ID or pass parameters={'token_id': ...}")
         self.asset = Asset(token_id, asset_type=Asset.AssetType.PREDICTION_CONTRACT, precision="0.000001")
-        self.live_trade = str(parameters.get("live_trade", "false")).lower() in {"1", "true", "yes", "on"}
-        self.backtest_trade = str(parameters.get("backtest_trade", "false")).lower() in {"1", "true", "yes", "on"}
-        self.backtest_quantity = parameters.get("backtest_quantity", 10)
-        self.amount = str(parameters.get("amount", os.environ.get("POLYMARKET_TEST_ORDER_AMOUNT", "1.00")))
-        self.max_price = str(parameters.get("max_price", os.environ.get("POLYMARKET_TEST_MAX_PRICE", "0.99")))
+        self.live_trade = str(strategy_parameters.get("live_trade", "false")).lower() in {"1", "true", "yes", "on"}
+        self.backtest_trade = str(strategy_parameters.get("backtest_trade", "false")).lower() in {"1", "true", "yes", "on"}
+        self.backtest_quantity = strategy_parameters.get("backtest_quantity", 10)
+        self.amount = str(strategy_parameters.get("amount", os.environ.get("POLYMARKET_TEST_ORDER_AMOUNT", "1.00")))
+        self.max_price = str(strategy_parameters.get("max_price", os.environ.get("POLYMARKET_TEST_MAX_PRICE", "0.99")))
 
     def on_trading_iteration(self):
         quote = self.get_quote(self.asset)

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -1442,38 +1442,10 @@ class _Strategy:
                         except Exception:
                             has_last_known_price = False
 
+                        if has_last_known_price:
+                            return None
                         if day_quote_mark is not None:
                             return day_quote_mark
-
-                        fallback_enabled = str(
-                            os.environ.get("THETADATA_OPTION_MTM_OHLC_FALLBACK", "true")
-                        ).strip().lower() not in {"0", "false", "no", "off"}
-                        if fallback_enabled:
-                            try:
-                                last_trade_mark = source.get_last_price(
-                                    base_asset,
-                                    timestep="day",
-                                    quote=quote_asset,
-                                    allow_stale_option_last=True,
-                                )
-                            except TypeError:
-                                try:
-                                    last_trade_mark = source.get_last_price(base_asset, quote=quote_asset)
-                                except Exception:
-                                    last_trade_mark = None
-                            except Exception:
-                                self.logger.debug(
-                                    "ThetaData daily option MTM fallback failed for %s",
-                                    base_asset,
-                                    exc_info=True,
-                                )
-                                last_trade_mark = None
-                            try:
-                                numeric_mark = float(last_trade_mark) if last_trade_mark is not None else None
-                            except (TypeError, ValueError):
-                                numeric_mark = None
-                            if numeric_mark is not None and math.isfinite(numeric_mark) and numeric_mark > 0:
-                                return numeric_mark
             except Exception as e:
                 self.logger.debug("ThetaData quote-mark lookup failed for %s: %s", base_asset, e)
             return None


### PR DESCRIPTION
## Summary
- Fix Polymarket example strategy parameter loading for backtests
- Prevent ThetaData daily option MTM from forcing stale day quotes or stale option last trades after quote evidence is unavailable
- Update the 4.5.64 changelog with the release-gate fixes

## Local tests
- python3 -m pytest tests/test_polymarket_backtesting.py::test_polymarket_example_strategy_backtest_runs_with_mocked_history tests/test_thetadata_option_daily_mtm_snapshot.py::test_thetadata_daily_option_mtm_uses_forward_fill_when_snapshot_missing tests/test_thetadata_option_mtm_prefers_quote_mark.py::test_thetadata_option_mtm_returns_none_instead_of_stale_last_trade -q --tb=short
- python3 -m pytest tests/test_polymarket_backtesting.py tests/test_prediction_market_data_source_defaults.py tests/test_thetadata_option_daily_mtm_snapshot.py tests/test_thetadata_option_mtm_prefers_quote_mark.py -q --tb=short

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved option backtest pricing so missing intraday quotes no longer rely on stale fallback prices when prior pricing data already exists.
  * Clarified and corrected a prediction-contract example so backtests can use the configured token ID from strategy settings without requiring an extra environment variable in common cases.
  * Updated release notes to reflect the above fixes for the current unreleased version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->