### PR TITLE
v4.5.65 - Tradier transient 5xx polling safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.65 - Unreleased
+
 ## 4.5.64 - Unreleased
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 4.5.65 - Unreleased
 
+### Fixed
+- **Tradier live polling now treats transient provider 5xx reads as retryable
+  broker noise instead of fake empty broker state.** Position polling preserves
+  the current local LumiBot position snapshot for that poll, and order polling
+  skips reconciliation when Tradier returns retry-exhausted 5xx responses, so
+  managed live bots do not clear positions or orders just because Tradier had a
+  transient provider failure.
+
+### Docs
+- **Startup-optimization release risk review is documented for release
+  captains.** The note records the PR 1100 scope, clean-env local verification,
+  and why scheduled/live startup smoke remains required before treating that
+  optimization as low risk.
+
 ## 4.5.64 - Unreleased
 
 ### Added

--- a/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
+++ b/docs/investigations/2026-07-01_TQQQ_STOCK_SPLIT_POSITION_ACCOUNTING.md
@@ -337,3 +337,103 @@ Revised plan:
    - Follow `docs/DEPLOYMENT.md`: release LumiBot `4.5.64`, verify installability, then update Bot Manager.
    - Bot Manager currently pins `LUMIBOT_VERSION=4.5.63`; update after the LumiBot release is published.
    - Deploy Bot Manager dev first, run version/backtest canaries, then production.
+
+## 2026-07-02 Release, Deploy, And Cache-Refill Execution
+
+LumiBot `4.5.64` was released and verified.
+
+- Release PR: `https://github.com/Lumiwealth/lumibot/pull/1102`
+- Fix commit: `32ff0e14 Fix release-gate backtest regressions`
+- Dev merge/tag commit: `b6367dad2a69b5bdf940003bf984d0d66cce1367`
+- Tag: `v4.5.64`
+- GitHub release: `https://github.com/Lumiwealth/lumibot/releases/tag/v4.5.64`
+- PyPI install verification:
+  - `python3 -m pip install --no-deps --target /tmp/lumibot-pip-verify-4.5.64 lumibot==4.5.64`
+  - `PYTHONPATH=/tmp/lumibot-pip-verify-4.5.64 python3 -c "import lumibot; print(lumibot.__version__)"`
+  - Output: `4.5.64`
+- Local checkout was moved to `version/4.5.65` and `python3 scripts/verify_release_checkout_state.py --post-release-of 4.5.64` passed.
+
+Bot Manager dev and production were both deployed with a forced image rebuild.
+
+- Dev workflow run: `https://github.com/Lumiwealth/bot_manager/actions/runs/28577122393`
+  - Logs showed `LUMIBOT_VERSION: 4.5.64`.
+  - Build logs showed `uv pip install "lumibot==4.5.64"`.
+  - Runtime logs showed `LumiBot v4.5.64 starting`.
+- Production workflow run: `https://github.com/Lumiwealth/bot_manager/actions/runs/28580027661`
+  - Logs showed `FORCE_REBUILD_IMAGES: true`.
+  - Tests were enabled: `SKIP_UNIT_TESTS: false`, `SKIP_INTEGRATION_TESTS: false`, `RUN_INTEGRATION_TESTS: 1`.
+  - Backtest image build logs showed `uv pip install ... "lumibot==4.5.64"` and `+ lumibot==4.5.64`.
+  - Runtime logs showed `LumiBot v4.5.64 starting`.
+
+The production TQQQ canary on fixed `4.5.64` was sane and matched the prod/Yahoo range.
+
+- Bot ID: `direct-prod-tqqq-10k-4-5-64-s3-3e128f7c-ca20-425a-9a2a-2122cb9d9880`
+- Artifacts: `/Users/robertgrzesik/Development/bot_manager/logs/tqqq-split-release-2026-07-02/prod-canary-10k/`
+- `settings_json.lumibot_version`: `4.5.64`
+- Budget: `$10,000`
+- Remote cache: `s3://lumibot-cache-prod/prod/cache/v1`
+- Data route: `{"default":"ibkr","stock":"ibkr","index":"ibkr","option":"thetadata","crypto":"coinbase","crypto_future":"coinbase","future":"ibkr","cont_future":"ibkr"}`
+- Final PV: `$285,205.63`
+- Independent CAGR: `39.82%`
+- Independent max drawdown: `-48.22%`
+- Worst one-step EOD move: `-20.42%` on 2020-03-09
+- 2025 split window was sane. Quantity stayed `5622` through 2025-11-19/20/21; there was no false 50% portfolio cliff.
+
+Cache backup/delete/refill status is mixed and should not be represented as complete.
+
+Backups were made before deletion:
+
+- Local backup manifest: `/Users/robertgrzesik/Development/support-artifacts/tqqq-split-backtest-2026-07-01/cache-remediation-2026-07-02/local-backups/manifest.tsv`
+- S3 backup manifest: `/Users/robertgrzesik/Development/bot_manager/logs/tqqq-split-release-2026-07-02/cache-backup/s3-backup-allowed-prefix.tsv`
+- Live-delete manifest: `/Users/robertgrzesik/Development/bot_manager/logs/tqqq-split-release-2026-07-02/cache-delete/deleted-live-objects.tsv`
+
+Exact deleted targets were:
+
+- Production `prod/cache/v1`: `TECL`, `UPRO`, `SPXU`, `OUST` RTH daily stock bars.
+- Dev `dev/cache/v1`: `TQQQ`, `SQQQ`, `SPY` RTH daily stock bars.
+- Dev `dev/cache/v44`: non-RTH `TQQQ` daily `AUTO_BID_ASK`, `AUTO_MIDPOINT`, and `AUTO_TRADES`.
+
+Refill attempts did not successfully recreate the canonical cache objects:
+
+- Exact-window prod refill:
+  - Bot ID: `cache-refill-prod-v1-redo-4-5-64-0c9aec89-3f83-44e5-bb8a-93274fef055d`
+  - Result: failed on `TECL`.
+  - Relevant error: `IBKR history rebuild failed ... Chart data unavailable`, then `No daily bars returned for TECL`.
+  - Evidence showed 2026/2021/2016 TECL chunks completed, then the older `2011-03-09` chunk failed. This indicates a brittle exact-window rebuild path around older/inception-era IBKR data, not inability to fetch TECL generally.
+- Bounded prod refill:
+  - Bot ID: `cache-refill-prod-v1-bounded-4-5-64-787a712e-0aa2-4268-a8a0-be8a7a0226df`
+  - Window: `2026-03-03` to `2026-03-04`
+  - Lookback: `2700` daily bars.
+  - Result: failed on `OUST` with `No daily bars returned for OUST`.
+  - Logs showed `TECL`, `UPRO`, and `SPXU` chunks completed. SPXU also exercised the `IBKR daily split-spike repair adjusted 1 row(s)` path under `4.5.64`.
+  - Despite completed chunks, the four canonical production S3 objects were still missing after the failed run. That means this refill strategy path is not a reliable way to recreate the canonical S3 cache objects.
+
+Because refill failed, the live objects were restored from S3 backups. Verification after restore:
+
+- `prod/cache/v1/ibkr/stock/day/bars/stock_TECL_USD_day_AUTO_TRADES_RTH.parquet`: present, `142031` bytes.
+- `prod/cache/v1/ibkr/stock/day/bars/stock_UPRO_USD_day_AUTO_TRADES_RTH.parquet`: present, `144068` bytes.
+- `prod/cache/v1/ibkr/stock/day/bars/stock_SPXU_USD_day_AUTO_TRADES_RTH.parquet`: present, `85834` bytes.
+- `prod/cache/v1/ibkr/stock/day/bars/stock_OUST_USD_day_AUTO_TRADES_RTH.parquet`: present, `60597` bytes.
+- `dev/cache/v1/ibkr/stock/day/bars/stock_TQQQ_USD_day_AUTO_TRADES_RTH.parquet`: present, `130802` bytes.
+- `dev/cache/v1/ibkr/stock/day/bars/stock_SQQQ_USD_day_AUTO_TRADES_RTH.parquet`: present, `139224` bytes.
+- `dev/cache/v1/ibkr/stock/day/bars/stock_SPY_USD_day_AUTO_TRADES_RTH.parquet`: present, `151994` bytes.
+- `dev/cache/v44/ibkr/stock/day/bars/stock_TQQQ_USD_day_AUTO_BID_ASK.parquet`: present, `34755` bytes.
+- `dev/cache/v44/ibkr/stock/day/bars/stock_TQQQ_USD_day_AUTO_MIDPOINT.parquet`: present, `35008` bytes.
+- `dev/cache/v44/ibkr/stock/day/bars/stock_TQQQ_USD_day_AUTO_TRADES.parquet`: present, `203090` bytes.
+
+After cleanup:
+
+- No production refill ECS tasks remained running.
+- Data Downloader queue was clear: `pending_count=0`, `processing_count=0`, `failed_count=0`, `active_workers=0`.
+
+Updated cache conclusion:
+
+1. The LumiBot split normalization release and Bot Manager deployment are complete.
+2. The prod TQQQ canary proves the original chart cliff is fixed on the deployed `4.5.64` runtime.
+3. Cache deletion/refill is not complete. The deleted objects were restored because the refill path failed and did not recreate canonical S3 cache objects.
+4. The next cache fix should be a dedicated Data Downloader/LumiBot cache-hydration fix, not manual row repair and not broad cache deletion.
+5. The refill/hydration path needs tests proving:
+   - a symbol with limited/inception-era history does not collapse a partially valid multi-window rebuild into an empty frame;
+   - `Chart data unavailable` on an older no-data chunk is handled as an end-of-history condition when newer chunks succeeded;
+   - successful chunk fetches write or merge into the exact canonical S3 cache key expected by managed backtests;
+   - OUST-style short-history symbols produce usable recent-window daily bars instead of `No daily bars returned`.

--- a/docs/investigations/2026-07-02_PR_1100_STARTUP_OPTIMIZATION_RISK_REVIEW.md
+++ b/docs/investigations/2026-07-02_PR_1100_STARTUP_OPTIMIZATION_RISK_REVIEW.md
@@ -1,0 +1,83 @@
+# PR 1100 Startup Optimization Risk Review
+
+One-line description: Merge-risk review for Martin Pelteshki's scheduled startup optimization PR.
+
+Last Updated: 2026-07-03
+
+Status: Review complete
+
+Audience: LumiBot maintainers, BotSpot deployment operators, release captain
+
+## Overview
+
+Reviewed <https://github.com/Lumiwealth/lumibot/pull/1100> without merging or switching the canonical checkout. The PR is titled `Optimize scheduled deployment startup paths` and targets `dev` from `perf/startup-optimization`.
+
+Current GitHub metadata at review time:
+
+- 56 changed files.
+- 6,150 additions and 1,124 deletions.
+- Mergeable, review required.
+- Visible checks were limited: GitHub Pages `build` passed, GitHub Pages `deploy` skipped, CodeRabbit passed. No full LumiBot test matrix was visible in the PR check rollup.
+
+## Scope Touched
+
+The PR is broad. It adds lazy import helpers and changes startup/materialization behavior across:
+
+- `lumibot._lazy_imports`, `lumibot._lazy_timezone`, package exports.
+- Broker constructors and provider modules for Alpaca, CCXT, Schwab, Tradier, Tradovate, Bitunix, ProjectX, and IBKR REST.
+- `lumibot.credentials` default broker/data-source resolution.
+- `Strategy`, `StrategyExecutor`, and `Trader` import/constructor/runtime paths.
+- Scheduled `run_once` market-open handling and stream/order-thread defaults.
+- Environment variable docs and startup optimization investigation notes.
+
+This is not a small or low-blast-radius patch even though the intended behavior is performance-oriented.
+
+## Local Verification
+
+Review was done from a temporary detached PR worktree at `/Users/robertgrzesik/Development/lumibot-pr1100-review.mYCiwe`; the canonical `/Users/robertgrzesik/Development/lumibot` checkout remained on `version/4.5.65`.
+
+Commands run:
+
+```bash
+git diff --check origin/dev...origin/pr/1100
+```
+
+Result: passed.
+
+```bash
+/Users/robertgrzesik/Development/lumibot/.venv/bin/python -m compileall -q lumibot
+```
+
+Result: passed.
+
+```bash
+env -u DATA_SOURCE -u TRADING_BROKER -u POLYMARKET_PRIVATE_KEY -u POLYMARKET_OWNER_ADDRESS -u POLYMARKET_WALLET_ADDRESS -u POLYMARKET_CLOB_API_KEY -u POLYMARKET_CLOB_API_SECRET -u POLYMARKET_CLOB_API_PASSPHRASE -u POLYMARKET_RELAYER_API_KEY -u POLYMARKET_RELAYER_API_KEY_ADDRESS LUMIBOT_DISABLE_DOTENV=1 LUMIBOT_DISABLE_DOTENV_LOCAL=1 /Users/robertgrzesik/Development/lumibot/.venv/bin/python -m pytest tests/test_lazy_exports.py tests/test_scheduled_run_once.py tests/test_strategy_methods.py tests/test_smart_limit_multileg_unit.py tests/test_smart_limit_single_leg_unit.py tests/test_backtesting_parameters.py tests/test_backtesting_data_source_env.py tests/test_backtesting_datetime_normalization.py tests/backtest/test_example_strategies.py::TestExampleStrategies::test_stock_diversified_leverage -q
+```
+
+Result: 110 passed.
+
+```bash
+env -u DATA_SOURCE -u TRADING_BROKER -u POLYMARKET_PRIVATE_KEY -u POLYMARKET_OWNER_ADDRESS -u POLYMARKET_WALLET_ADDRESS -u POLYMARKET_CLOB_API_KEY -u POLYMARKET_CLOB_API_SECRET -u POLYMARKET_CLOB_API_PASSPHRASE -u POLYMARKET_RELAYER_API_KEY -u POLYMARKET_RELAYER_API_KEY_ADDRESS LUMIBOT_DISABLE_DOTENV=1 LUMIBOT_DISABLE_DOTENV_LOCAL=1 /Users/robertgrzesik/Development/lumibot/.venv/bin/python -m pytest -m 'not apitest' tests/test_broker_initialization.py tests/test_alpaca.py tests/test_broker_bitunix.py tests/test_ccxt.py tests/test_tradier.py tests/test_projectx.py tests/test_projectx_data.py tests/test_tradovate.py -q
+```
+
+Result: 150 passed, 4 skipped, 7 deselected.
+
+Initial runs without clearing the local shell's broker/data-source environment failed because local `DATA_SOURCE`/`TRADING_BROKER` style state polluted tests and caused explicit Alpaca/CCXT strategies to attach `PolymarketData`; Alpaca API tests also attempted real credentials and returned 401. Clean-env reruns passed and are the relevant signal for this PR review.
+
+## Risk Call
+
+Recommendation: cautiously merge only after the normal full LumiBot gate and one BotSpot scheduled paper-deployment smoke. Do not treat this as a trivial safe merge based only on the visible GitHub checks.
+
+Backtesting risk: medium-low for ordinary backtests based on the diff and local checks. The patch does not intentionally change market-data fabrication, fill logic, cash accounting, or order simulation semantics. The representative stock backtest and backtesting env/datetime tests passed. Remaining backtesting risk is coverage breadth: this review did not run the full acceptance backtest suite, Theta/IBKR/options/futures parity, or live-replay baselines.
+
+Deployment risk: medium to medium-high. This is the main blast radius. The PR changes when live brokers authenticate, start streams, start order workers, materialize data sources, and decide pre-open scheduled exits. The intended scheduled path is sensible and covered by unit tests, and the IB queue-worker CodeRabbit concern appears addressed with `REQUIRES_ORDERS_THREAD`. Still, failures could move from constructor time to first real broker/data/order call, and that matters for BotSpot scheduled deployments.
+
+Safe-to-merge conditions:
+
+- Full LumiBot CI/test gate is green on the current PR head or post-merge release branch.
+- A clean-env local or CI run includes the focused startup/scheduled tests.
+- At least one BotSpot scheduled paper deployment smoke proves startup, market-open/closed behavior, first data access, order submission path, and clean exit with the intended broker.
+
+## Bottom Line
+
+This looks directionally good and probably worth merging for scheduled startup performance, but it is not a low-risk patch. The file count, constructor deferral, broker/data-source lazy materialization, and scheduled `run_once` changes make it a controlled medium-risk merge. Backtesting is less concerning than live/scheduled deployment startup, provided the full backtest gate still passes.

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -43,6 +43,10 @@ class TradierTokenPersistenceError(RuntimeError):
     """Raised when a refreshed Tradier OAuth token cannot be durably written."""
 
 
+class TradierTransientBrokerReadError(RuntimeError):
+    """Raised when a Tradier read endpoint returns a transient provider failure."""
+
+
 class Tradier(Broker):
     """
     Broker that connects to Tradier API to place orders and retrieve data. Tradier API only supports Order streaming
@@ -72,6 +76,23 @@ class Tradier(Broker):
     # OAuth refresh endpoint (only available for approved Tradier partner apps).
     _OAUTH_REFRESH_URL = "https://api.tradier.com/v1/oauth/refreshtoken"
     _OAUTH_REFRESH_SKEW_SECONDS = 60  # Refresh a bit early to avoid edge-of-expiry failures.
+    _TRANSIENT_READ_ERROR_RE = re.compile(
+        r"(?:too many 5\d\d error responses|status(?: code)?[=: ]+5\d\d|\b5\d\d\b|internal server error)",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def _is_transient_broker_read_error(cls, error: Exception) -> bool:
+        return bool(cls._TRANSIENT_READ_ERROR_RE.search(str(error)))
+
+    def _current_lumibot_positions_snapshot(self) -> list[Position]:
+        filled_positions = getattr(self, "_filled_positions", None)
+        if filled_positions is None:
+            return []
+        try:
+            return list(filled_positions.get_list())
+        except Exception:
+            return []
 
     @staticmethod
     def _decode_base64url_json(payload_str: str) -> dict:
@@ -1302,6 +1323,13 @@ class Tradier(Broker):
                 raise ValueError(colored_message) from e
             raise e
         except Exception as e:
+            if self._is_transient_broker_read_error(e):
+                logger.warning(
+                    "Transient Tradier positions read failure; preserving existing Lumibot positions for this poll: %s",
+                    e,
+                    exc_info=True,
+                )
+                return self._current_lumibot_positions_snapshot()
             logger.error(f"Error pulling positions from Tradier: {e}")
             return []
 
@@ -1507,6 +1535,13 @@ class Tradier(Broker):
         try:
             df = self.tradier.orders.get_orders()
         except Exception as e:
+            if self._is_transient_broker_read_error(e):
+                logger.warning(
+                    "Transient Tradier orders read failure; skipping order reconciliation for this poll: %s",
+                    e,
+                    exc_info=True,
+                )
+                raise TradierTransientBrokerReadError(str(e)) from e
             logger.info(f"Error pulling orders from Tradier: {e}", exc_info=True)
             return []
 
@@ -1667,7 +1702,11 @@ class Tradier(Broker):
         # lumi orders (not just active "tracked" ones) to catch any orders that might have changed final
         # status in Tradier.
         # df_orders = self.tradier.orders.get_orders()
-        raw_orders = self._pull_broker_all_orders()
+        try:
+            raw_orders = self._pull_broker_all_orders()
+        except TradierTransientBrokerReadError:
+            logger.info("Skipping Tradier polling reconciliation after transient broker read failure")
+            return
         try:
             self._telemetry_polls_total += 1
             self._telemetry_orders_seen_max = max(int(self._telemetry_orders_seen_max), len(raw_orders or []))

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.64",
+    version="4.5.65",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_transient_network_logs_are_not_errors.py
+++ b/tests/test_transient_network_logs_are_not_errors.py
@@ -1,8 +1,19 @@
 import logging
 from types import SimpleNamespace
 
-from lumibot.brokers.tradier import Tradier
+import pytest
+
+from lumibot.brokers.tradier import Tradier, TradierTransientBrokerReadError
 from lumibot.strategies._strategy import _Strategy
+
+
+def _tradier_read_stub(**kwargs):
+    values = {
+        "_is_transient_broker_read_error": Tradier._is_transient_broker_read_error,
+        "_current_lumibot_positions_snapshot": lambda: [],
+    }
+    values.update(kwargs)
+    return SimpleNamespace(**values)
 
 
 def test_update_broker_balances_exception_logs_info(monkeypatch, caplog):
@@ -38,7 +49,7 @@ def test_tradier_pull_orders_exception_logs_info(monkeypatch):
     def raise_orders_error():
         raise ConnectionError("Max retries exceeded")
 
-    dummy = SimpleNamespace(
+    dummy = _tradier_read_stub(
         tradier=SimpleNamespace(
             orders=SimpleNamespace(get_orders=raise_orders_error),
         )
@@ -67,3 +78,35 @@ def test_tradier_pull_orders_exception_logs_info(monkeypatch):
     assert any(
         "Error pulling orders from Tradier" in msg and kwargs.get("exc_info") for msg, kwargs in info_calls
     )
+
+
+def test_tradier_transient_positions_failure_preserves_local_positions(monkeypatch):
+    local_position = object()
+
+    def raise_positions_error():
+        raise ConnectionError("HTTPSConnectionPool: too many 500 error responses")
+
+    dummy = _tradier_read_stub(
+        tradier=SimpleNamespace(
+            account=SimpleNamespace(get_positions=raise_positions_error),
+        ),
+        _current_lumibot_positions_snapshot=lambda: [local_position],
+    )
+
+    result = Tradier._pull_positions(dummy, "unit-test")
+
+    assert result == [local_position]
+
+
+def test_tradier_transient_orders_failure_skips_reconciliation(monkeypatch):
+    def raise_orders_error():
+        raise ConnectionError("HTTPSConnectionPool: too many 500 error responses")
+
+    dummy = _tradier_read_stub(
+        tradier=SimpleNamespace(
+            orders=SimpleNamespace(get_orders=raise_orders_error),
+        )
+    )
+
+    with pytest.raises(TradierTransientBrokerReadError):
+        Tradier._pull_broker_all_orders(dummy)


### PR DESCRIPTION
## What
Release LumiBot 4.5.65 with a focused Tradier live-polling safety fix and release documentation.

## Why
Bot Manager dev staged broker OAuth validation reproduced Tradier provider 500 retry exhaustion with two concurrent managed live polling loops. The old Tradier adapter could turn transient provider read failures into empty positions/orders, which is unsafe for managed live bots.

## Changes
- Preserve current local LumiBot positions when Tradier positions reads fail with transient provider 5xx retry exhaustion.
- Skip order reconciliation for that poll when Tradier order reads fail with transient provider 5xx retry exhaustion.
- Keep existing non-transient generic order read fallback behavior unchanged.
- Document PR 1100 startup optimization risk review for release captains.
- Add 4.5.65 changelog notes.

## Risk
Medium for Tradier live polling behavior, but the patch is defensive: it avoids reconciling against fake empty provider state on transient 5xx. Main risk is over-classifying a provider error as transient and preserving state for one poll; this is safer than clearing live state on a provider outage.

## Tests run
```bash
/Users/robertgrzesik/Development/bin/safe-timeout 120 /Users/robertgrzesik/Development/lumibot/.venv/bin/python -m pytest tests/test_transient_network_logs_are_not_errors.py -q --tb=short
/Users/robertgrzesik/Development/bin/safe-timeout 180 /Users/robertgrzesik/Development/lumibot/.venv/bin/python -m pytest tests/test_transient_network_logs_are_not_errors.py tests/test_symbol_normalization.py tests/test_tradier_stream_optional_unit.py tests/test_tradier_oauth_refresh.py -q --tb=short
/Users/robertgrzesik/Development/bin/safe-timeout 180 /Users/robertgrzesik/Development/lumibot/.venv/bin/python -m pytest tests/test_broker_sync_positions.py tests/test_transient_network_logs_are_not_errors.py -q --tb=short
git diff --check
```

## Docs
- `docs/investigations/2026-07-02_PR_1100_STARTUP_OPTIMIZATION_RISK_REVIEW.md`
- Bot Manager evidence doc: `/Users/robertgrzesik/Development/bot_manager/docs/investigations/2026-07-03_broker_oauth_dev_stress_validation.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broker polling resilience during temporary provider outages.
  * Position updates now continue using the last known snapshot instead of clearing data on transient failures.
  * Order reconciliation is skipped for a polling cycle when provider reads fail briefly, reducing unnecessary interruptions.

* **Documentation**
  * Added release notes and investigation records covering rollout verification, cache recovery findings, and startup-risk review guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->