### PR TITLE
v4.5.66 - Tradier read throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.66 - Unreleased
+
 ## 4.5.65 - Unreleased
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 4.5.66 - Unreleased
 
+### Fixed
+- **Tradier live polling now throttles repeated broker reads and backs off after
+  transient provider 5xx failures.** Account balances, positions, and orders
+  reuse recent good reads during short polling windows or transient-backoff
+  windows, reducing provider retry storms in managed live bots while preserving
+  auth failures as hard errors.
+
+### Tests
+- **Tradier transient-read regression coverage now proves cached balance,
+  position, and order behavior.** The focused tests cover cache reuse after
+  retry-exhausted 5xx responses and ensure OAuth/external-mode polling
+  regressions still pass.
+
 ## 4.5.65 - Unreleased
 
 ### Fixed

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -80,10 +80,75 @@ class Tradier(Broker):
         r"(?:too many 5\d\d error responses|status(?: code)?[=: ]+5\d\d|\b5\d\d\b|internal server error)",
         re.IGNORECASE,
     )
+    _DEFAULT_READ_MIN_INTERVAL_SECONDS = 15.0
+    _DEFAULT_TRANSIENT_READ_BACKOFF_SECONDS = 30.0
 
     @classmethod
     def _is_transient_broker_read_error(cls, error: Exception) -> bool:
         return bool(cls._TRANSIENT_READ_ERROR_RE.search(str(error)))
+
+    @staticmethod
+    def _coerce_non_negative_seconds(value, default: float) -> float:
+        if value in (None, ""):
+            return float(default)
+        try:
+            coerced = float(value)
+        except (TypeError, ValueError):
+            return float(default)
+        return max(0.0, coerced)
+
+    @staticmethod
+    def _copy_tradier_read_value(value):
+        if isinstance(value, list):
+            copied = []
+            for item in value:
+                copied.append(dict(item) if isinstance(item, dict) else item)
+            return copied
+        if isinstance(value, dict):
+            return dict(value)
+        return value
+
+    def _ensure_tradier_read_control_state(self) -> None:
+        if not hasattr(self, "_tradier_read_cache"):
+            self._tradier_read_cache = {}
+        if not hasattr(self, "_tradier_read_backoff_until"):
+            self._tradier_read_backoff_until = {}
+        if not hasattr(self, "_tradier_read_min_interval_seconds"):
+            self._tradier_read_min_interval_seconds = self._DEFAULT_READ_MIN_INTERVAL_SECONDS
+        if not hasattr(self, "_tradier_transient_read_backoff_seconds"):
+            self._tradier_transient_read_backoff_seconds = self._DEFAULT_TRANSIENT_READ_BACKOFF_SECONDS
+
+    def _get_cached_tradier_read(self, endpoint: str):
+        self._ensure_tradier_read_control_state()
+        cached = self._tradier_read_cache.get(endpoint)
+        if not cached:
+            return None
+
+        now = time.monotonic()
+        cached_at = cached.get("monotonic_at", 0.0)
+        backoff_until = self._tradier_read_backoff_until.get(endpoint, 0.0)
+        min_interval = float(getattr(self, "_tradier_read_min_interval_seconds", 0.0) or 0.0)
+
+        if now < backoff_until or (min_interval and now - cached_at < min_interval):
+            return self._copy_tradier_read_value(cached.get("value"))
+        return None
+
+    def _tradier_read_is_in_backoff(self, endpoint: str) -> bool:
+        self._ensure_tradier_read_control_state()
+        return time.monotonic() < self._tradier_read_backoff_until.get(endpoint, 0.0)
+
+    def _cache_tradier_read(self, endpoint: str, value) -> None:
+        self._ensure_tradier_read_control_state()
+        self._tradier_read_cache[endpoint] = {
+            "monotonic_at": time.monotonic(),
+            "value": self._copy_tradier_read_value(value),
+        }
+
+    def _start_tradier_read_backoff(self, endpoint: str) -> None:
+        self._ensure_tradier_read_control_state()
+        backoff_seconds = float(getattr(self, "_tradier_transient_read_backoff_seconds", 0.0) or 0.0)
+        if backoff_seconds > 0:
+            self._tradier_read_backoff_until[endpoint] = time.monotonic() + backoff_seconds
 
     def _current_lumibot_positions_snapshot(self) -> list[Position]:
         filled_positions = getattr(self, "_filled_positions", None)
@@ -555,6 +620,25 @@ class Tradier(Broker):
         self._tradier_account_number = account_number
         self._tradier_paper = paper
         self.polling_interval = polling_interval
+        self._tradier_read_cache = {}
+        self._tradier_read_backoff_until = {}
+        read_min_interval = None
+        transient_read_backoff = None
+        if isinstance(config, dict):
+            read_min_interval = config.get("TRADIER_READ_MIN_INTERVAL_SECONDS")
+            transient_read_backoff = config.get("TRADIER_TRANSIENT_READ_BACKOFF_SECONDS")
+        self._tradier_read_min_interval_seconds = self._coerce_non_negative_seconds(
+            os.environ.get("LUMIBOT_TRADIER_READ_MIN_INTERVAL_SECONDS")
+            or os.environ.get("TRADIER_READ_MIN_INTERVAL_SECONDS")
+            or read_min_interval,
+            self._DEFAULT_READ_MIN_INTERVAL_SECONDS,
+        )
+        self._tradier_transient_read_backoff_seconds = self._coerce_non_negative_seconds(
+            os.environ.get("LUMIBOT_TRADIER_TRANSIENT_READ_BACKOFF_SECONDS")
+            or os.environ.get("TRADIER_TRANSIENT_READ_BACKOFF_SECONDS")
+            or transient_read_backoff,
+            self._DEFAULT_TRANSIENT_READ_BACKOFF_SECONDS,
+        )
 
         # If this is an OAuth token, refresh before building API clients. Snapshot
         # runtimes can force this so BotSpot receives fresh token material to persist.
@@ -943,6 +1027,13 @@ class Tradier(Broker):
         return order
 
     def _get_balances_at_broker(self, quote_asset: Asset, strategy):
+        cached_balances = self._get_cached_tradier_read("balances")
+        if cached_balances is not None:
+            return cached_balances
+        if self._tradier_read_is_in_backoff("balances"):
+            logger.warning("Skipping Tradier balances read during transient broker backoff; no cached balances available")
+            return None
+
         try:
             df = self.tradier.account.get_account_balance()
         except TradierApiError as e:
@@ -962,8 +1053,34 @@ class Tradier(Broker):
                                           f"Your account number is: {self._tradier_account_number} and your "
                                           f"access token is: {access_token}", color="red")
                 raise ValueError(colored_message) from e
+            if self._is_transient_broker_read_error(e):
+                self._start_tradier_read_backoff("balances")
+                cached_balances = self._get_cached_tradier_read("balances")
+                if cached_balances is not None:
+                    logger.warning(
+                        "Transient Tradier balances read failure; reusing cached balances for this poll: %s",
+                        e,
+                        exc_info=True,
+                    )
+                    return cached_balances
             raise e
         except Exception as e:
+            if self._is_transient_broker_read_error(e):
+                self._start_tradier_read_backoff("balances")
+                cached_balances = self._get_cached_tradier_read("balances")
+                if cached_balances is not None:
+                    logger.warning(
+                        "Transient Tradier balances read failure; reusing cached balances for this poll: %s",
+                        e,
+                        exc_info=True,
+                    )
+                    return cached_balances
+                logger.warning(
+                    "Transient Tradier balances read failure without cached balances; skipping balance update: %s",
+                    e,
+                    exc_info=True,
+                )
+                return None
             logger.error(f"Error pulling balances from Tradier: {e}")
             # Add traceback to the error message
             logger.error(traceback.format_exc())
@@ -978,7 +1095,9 @@ class Tradier(Broker):
         # Calculate the gross positions value
         positions_value = portfolio_value - cash
 
-        return cash, positions_value, portfolio_value
+        balances = (cash, positions_value, portfolio_value)
+        self._cache_tradier_read("balances", balances)
+        return balances
 
     def get_historical_account_value(self):
         logger.error("The function get_historical_account_value is not implemented yet for Tradier.")
@@ -1306,6 +1425,12 @@ class Tradier(Broker):
         return normalized_events
 
     def _pull_positions(self, strategy):
+        cached_positions = self._get_cached_tradier_read("positions")
+        if cached_positions is not None:
+            return cached_positions
+        if self._tradier_read_is_in_backoff("positions"):
+            return self._current_lumibot_positions_snapshot()
+
         try:
             positions_df = self.tradier.account.get_positions()
         except TradierApiError as e:
@@ -1321,9 +1446,34 @@ class Tradier(Broker):
                 access_token = self._tradier_access_token[:7] + "*" * 7
                 colored_message = colored(f"Your TRADIER_ACCOUNT_NUMBER or TRADIER_ACCESS_TOKEN are invalid. Your account number is: {self._tradier_account_number} and your access token is: {access_token}", color="red")
                 raise ValueError(colored_message) from e
+            if self._is_transient_broker_read_error(e):
+                self._start_tradier_read_backoff("positions")
+                cached_positions = self._get_cached_tradier_read("positions")
+                if cached_positions is not None:
+                    logger.warning(
+                        "Transient Tradier positions read failure; reusing cached positions for this poll: %s",
+                        e,
+                        exc_info=True,
+                    )
+                    return cached_positions
+                logger.warning(
+                    "Transient Tradier positions read failure; preserving existing Lumibot positions for this poll: %s",
+                    e,
+                    exc_info=True,
+                )
+                return self._current_lumibot_positions_snapshot()
             raise e
         except Exception as e:
             if self._is_transient_broker_read_error(e):
+                self._start_tradier_read_backoff("positions")
+                cached_positions = self._get_cached_tradier_read("positions")
+                if cached_positions is not None:
+                    logger.warning(
+                        "Transient Tradier positions read failure; reusing cached positions for this poll: %s",
+                        e,
+                        exc_info=True,
+                    )
+                    return cached_positions
                 logger.warning(
                     "Transient Tradier positions read failure; preserving existing Lumibot positions for this poll: %s",
                     e,
@@ -1357,6 +1507,7 @@ class Tradier(Broker):
             )
             positions_ret.append(position)  # Add the position to the list
 
+        self._cache_tradier_read("positions", positions_ret)
         return positions_ret
 
     def _pull_position(self, strategy, asset):
@@ -1532,10 +1683,25 @@ class Tradier(Broker):
         and then returned. It is expected that the caller will convert each dictionary to an Order object by
         calling parse_broker_order() on the dictionary.
         """
+        cached_orders = self._get_cached_tradier_read("orders")
+        if cached_orders is not None:
+            return cached_orders
+        if self._tradier_read_is_in_backoff("orders"):
+            raise TradierTransientBrokerReadError("Tradier orders read is in transient backoff")
+
         try:
             df = self.tradier.orders.get_orders()
         except Exception as e:
             if self._is_transient_broker_read_error(e):
+                self._start_tradier_read_backoff("orders")
+                cached_orders = self._get_cached_tradier_read("orders")
+                if cached_orders is not None:
+                    logger.warning(
+                        "Transient Tradier orders read failure; reusing cached orders for this poll: %s",
+                        e,
+                        exc_info=True,
+                    )
+                    return cached_orders
                 logger.warning(
                     "Transient Tradier orders read failure; skipping order reconciliation for this poll: %s",
                     e,
@@ -1547,9 +1713,12 @@ class Tradier(Broker):
 
         # Check if the dataframe is empty or None
         if df is None or df.empty:
+            self._cache_tradier_read("orders", [])
             return []
 
-        return self._clean_order_records(df)
+        orders = self._clean_order_records(df)
+        self._cache_tradier_read("orders", orders)
+        return orders
 
     @staticmethod
     def _clean_order_records(df):

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.65",
+    version="4.5.66",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_transient_network_logs_are_not_errors.py
+++ b/tests/test_transient_network_logs_are_not_errors.py
@@ -1,19 +1,43 @@
 import logging
 from types import SimpleNamespace
 
+import pandas as pd
 import pytest
 
 from lumibot.brokers.tradier import Tradier, TradierTransientBrokerReadError
 from lumibot.strategies._strategy import _Strategy
 
 
+class _TradierReadStub(SimpleNamespace):
+    _DEFAULT_READ_MIN_INTERVAL_SECONDS = Tradier._DEFAULT_READ_MIN_INTERVAL_SECONDS
+    _DEFAULT_TRANSIENT_READ_BACKOFF_SECONDS = Tradier._DEFAULT_TRANSIENT_READ_BACKOFF_SECONDS
+    _ensure_tradier_read_control_state = Tradier._ensure_tradier_read_control_state
+    _get_cached_tradier_read = Tradier._get_cached_tradier_read
+    _tradier_read_is_in_backoff = Tradier._tradier_read_is_in_backoff
+    _cache_tradier_read = Tradier._cache_tradier_read
+    _start_tradier_read_backoff = Tradier._start_tradier_read_backoff
+    _copy_tradier_read_value = staticmethod(Tradier._copy_tradier_read_value)
+    _clean_order_records = staticmethod(Tradier._clean_order_records)
+
+    def _is_transient_broker_read_error(self, error: Exception) -> bool:
+        return Tradier._is_transient_broker_read_error(error)
+
+    def _current_lumibot_positions_snapshot(self):
+        return []
+
+    def _normalize_symbol_for_internal(self, symbol, asset_type=None):
+        return str(symbol)
+
+
 def _tradier_read_stub(**kwargs):
     values = {
-        "_is_transient_broker_read_error": Tradier._is_transient_broker_read_error,
-        "_current_lumibot_positions_snapshot": lambda: [],
+        "_tradier_read_cache": {},
+        "_tradier_read_backoff_until": {},
+        "_tradier_read_min_interval_seconds": 0.0,
+        "_tradier_transient_read_backoff_seconds": 30.0,
     }
     values.update(kwargs)
-    return SimpleNamespace(**values)
+    return _TradierReadStub(**values)
 
 
 def test_update_broker_balances_exception_logs_info(monkeypatch, caplog):
@@ -110,3 +134,74 @@ def test_tradier_transient_orders_failure_skips_reconciliation(monkeypatch):
 
     with pytest.raises(TradierTransientBrokerReadError):
         Tradier._pull_broker_all_orders(dummy)
+
+
+def test_tradier_transient_balances_failure_reuses_cache_and_backs_off(monkeypatch):
+    calls = {"count": 0}
+
+    def get_balance():
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return pd.DataFrame([{"total_equity": 1200.0, "total_cash": 1000.0}])
+        raise ConnectionError("HTTPSConnectionPool: too many 500 error responses")
+
+    dummy = _tradier_read_stub(
+        tradier=SimpleNamespace(account=SimpleNamespace(get_account_balance=get_balance)),
+        _tradier_read_min_interval_seconds=0.0,
+        _tradier_transient_read_backoff_seconds=60.0,
+    )
+
+    first_result = Tradier._get_balances_at_broker(dummy, None, None)
+    second_result = Tradier._get_balances_at_broker(dummy, None, None)
+    third_result = Tradier._get_balances_at_broker(dummy, None, None)
+
+    assert first_result == (1000.0, 200.0, 1200.0)
+    assert second_result == first_result
+    assert third_result == first_result
+    assert calls["count"] == 2
+
+
+def test_tradier_cached_position_read_avoids_provider_call_during_min_interval(monkeypatch):
+    calls = {"count": 0}
+
+    def get_positions():
+        calls["count"] += 1
+        return pd.DataFrame([{"symbol": "SPY", "quantity": 3}])
+
+    dummy = _tradier_read_stub(
+        tradier=SimpleNamespace(account=SimpleNamespace(get_positions=get_positions)),
+        _tradier_read_min_interval_seconds=60.0,
+    )
+
+    first_result = Tradier._pull_positions(dummy, "unit-test")
+    second_result = Tradier._pull_positions(dummy, "unit-test")
+
+    assert calls["count"] == 1
+    assert len(first_result) == 1
+    assert len(second_result) == 1
+    assert first_result[0].asset.symbol == second_result[0].asset.symbol == "SPY"
+
+
+def test_tradier_orders_backoff_uses_cache_without_provider_call(monkeypatch):
+    calls = {"count": 0}
+
+    def get_orders():
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return pd.DataFrame([{"id": "abc", "status": "open"}])
+        raise ConnectionError("HTTPSConnectionPool: too many 500 error responses")
+
+    dummy = _tradier_read_stub(
+        tradier=SimpleNamespace(orders=SimpleNamespace(get_orders=get_orders)),
+        _tradier_read_min_interval_seconds=0.0,
+        _tradier_transient_read_backoff_seconds=60.0,
+    )
+
+    first_result = Tradier._pull_broker_all_orders(dummy)
+    second_result = Tradier._pull_broker_all_orders(dummy)
+    third_result = Tradier._pull_broker_all_orders(dummy)
+
+    assert first_result == [{"id": "abc", "status": "open"}]
+    assert second_result == first_result
+    assert third_result == first_result
+    assert calls["count"] == 2


### PR DESCRIPTION
## What
Release LumiBot 4.5.66 with Tradier broker-read throttling and transient 5xx backoff for balances, positions, and orders.

## Why
Bot Manager dev canaries on LumiBot 4.5.65 still hit retry-exhausted Tradier provider 500s even at one managed live bot. This release reduces per-bot Tradier read pressure and reuses recent good reads during short polling/backoff windows while preserving auth failures as hard failures.

## Risk
Tradier live polling may observe broker-side position/order changes up to the configured read minimum interval later than before. Defaults are conservative and overrideable through `LUMIBOT_TRADIER_READ_MIN_INTERVAL_SECONDS` / `LUMIBOT_TRADIER_TRANSIENT_READ_BACKOFF_SECONDS` or matching config keys.

## Tests run
- `/Users/robertgrzesik/Development/bin/safe-timeout 180s pytest tests/test_transient_network_logs_are_not_errors.py tests/test_tradier_oauth_refresh.py tests/test_tradier_polling_large_orders_no_growth.py`
- `/Users/robertgrzesik/Development/bin/safe-timeout 240s pytest tests/test_tradier.py tests/test_tradier_force_refresh.py`
- `git diff --check`

## Docs
- `CHANGELOG.md` updated for 4.5.66.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter live polling for broker data, helping the app keep recent account, position, and order information available during short-lived provider issues.
* **Bug Fixes**
  * Reduced repeated broker requests during transient failures.
  * Improved handling of temporary service errors by reusing recent successful data and continuing to treat authentication failures as hard errors.
  * Added regression coverage for balance, position, and order polling stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->