### PR TITLE
Release LumiBot 4.5.69 token reload fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ data/SRNE_Minute.csv
 *.tmp
 .env
 token.json
-schwab_token.json
+schwab_token*.json
 
 # AI assistant instruction files (contain local paths)
 CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 4.5.67 - Unreleased
 
+### Fixed
+- **Schwab stock market orders now use the normal session instead of seamless.**
+  Schwab's seamless/Day+Extended session is valid for eligible equity limit
+  orders, but live Schwab rejects seamless market orders with HTTP 400 invalid
+  request data. Stock limit orders continue to use `SEAMLESS`; stock market
+  orders, stop orders, options, and futures use `NORMAL`.
+
 ## 4.5.66 - Unreleased
 
 ## 4.5.65 - Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-## 4.5.68 - Unreleased
+## 4.5.68 - 2026-07-07
+
+### Fixed
+- **Schwab stock market orders now use the normal session instead of seamless.**
+  Schwab's seamless/Day+Extended session is valid for eligible equity limit
+  orders, but live Schwab rejects seamless market orders with HTTP 400 invalid
+  request data. Stock limit orders continue to use `SEAMLESS`; stock market
+  orders, stop orders, options, and futures use `NORMAL`.
+
+### Tests
+- **Alpaca-backed DriftRebalancer crypto tests are marked as API tests.** These
+  tests require authenticated access to Alpaca's live crypto data endpoint and
+  should not run in the normal release unit suite selected by
+  `-m "not apitest and not downloader"`.
 
 ## 4.5.67 - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.5.67 - Unreleased
+## 4.5.67 - 2026-07-07
 
 ### Fixed
 - **Schwab stock market orders now use the normal session instead of seamless.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.69 - Unreleased
+
 ## 4.5.68 - 2026-07-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,6 @@
 
 ## 4.5.66 - Unreleased
 
-### Fixed
-- **Tradier live polling now throttles repeated broker reads and backs off after
-  transient provider 5xx failures.** Account balances, positions, and orders
-  reuse recent good reads during short polling windows or transient-backoff
-  windows, reducing provider retry storms in managed live bots while preserving
-  auth failures as hard errors.
-
-### Tests
-- **Tradier transient-read regression coverage now proves cached balance,
-  position, and order behavior.** The focused tests cover cache reuse after
-  retry-exhausted 5xx responses and ensure OAuth/external-mode polling
-  regressions still pass.
-
 ## 4.5.65 - Unreleased
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.68 - Unreleased
+
 ## 4.5.67 - 2026-07-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.67 - Unreleased
+
 ## 4.5.66 - Unreleased
 
 ### Fixed

--- a/docs/BROKER_ORDER_SEMANTICS.md
+++ b/docs/BROKER_ORDER_SEMANTICS.md
@@ -2,7 +2,7 @@
 
 > Notes on live broker behavior that affect backtesting semantics (extended hours, order types, and “market closed / no data” handling).
 
-**Last Updated:** 2026-05-28
+**Last Updated:** 2026-07-07
 **Status:** Active
 **Audience:** Developers, AI Agents
 
@@ -99,15 +99,32 @@ Backtesting implications:
 ### Schwab (equities)
 
 Schwab supports extended hours trading; public docs emphasize:
-- extended-hours trades are typically **limit orders**
-- certain order types (e.g., stop orders) may not be eligible in extended sessions
+- regular-session stock orders can use market, limit, stop-limit, and other
+  order types depending on product/platform eligibility
+- extended-hours/pre-market/after-hours stock trading accepts **only limit
+  orders**
+- Day + Extended and GTC + Extended orders are known as seamless orders and are
+  available only for limit orders
+- certain order types (e.g., market and stop orders) are not eligible in
+  extended sessions
 
 Links (public):
 - https://www.schwab.com/content/how-to-place-trade-during-extended-hours
-- https://www.schwab.com/stocks/extended-hours-trading
+- https://international.schwab.com/content/stock-order-types-and-conditions-overview
+- https://www.schwab.com/learn/story/mastering-order-types-limit-orders
 
 Backtesting implications:
 - if we model Schwab extended sessions, order-type restrictions must be documented and tested.
+
+Live trading implications:
+- Schwab stock `LIMIT` orders may use `SEAMLESS` when extended-hours
+  participation is intended.
+- Schwab stock `MARKET` orders must use `NORMAL`; a live July 2026 production
+  customer run rejected `session=SEAMLESS`, `orderType=MARKET` with HTTP 400
+  `Invalid request data`.
+- Do not generalize "seamless spans all sessions" into "seamless works with all
+  order types." The session span and order type eligibility are separate broker
+  constraints.
 
 ### Tradier (equities/options)
 

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -2081,7 +2081,20 @@ class Schwab(Broker):
             logger.error(colored("Failed to import Schwab order enums. Make sure the schwab-py library is installed.", "red"))
             return None
 
-        if order and getattr(order, "asset", None) and order.asset.asset_type == Asset.AssetType.STOCK:
+        order_type = getattr(order, "order_type", None)
+        order_type_value = getattr(order_type, "value", order_type)
+        if isinstance(order_type_value, str):
+            order_type_value = order_type_value.lower()
+
+        if (
+            order
+            and getattr(order, "asset", None)
+            and order.asset.asset_type == Asset.AssetType.STOCK
+            and (
+                order_type == Order.OrderType.LIMIT
+                or order_type_value == "limit"
+            )
+        ):
             return Session.SEAMLESS
 
         return Session.NORMAL

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -130,6 +130,58 @@ def _strip_external_schwab_token(token: dict) -> dict:
     return sanitized
 
 
+def _schwab_token_issued_at_seconds(value):
+    if value is None:
+        return None
+    try:
+        raw = float(value)
+    except (TypeError, ValueError):
+        return None
+    return raw / 1000.0 if raw > 1_000_000_000_000 else raw
+
+
+def _normalize_schwab_token_expiry_metadata(token: dict) -> None:
+    if not isinstance(token, dict):
+        return
+    issued_at = _schwab_token_issued_at_seconds(token.get("issued_at") or token.get("creation_timestamp"))
+    try:
+        expires_in = float(token.get("expires_in"))
+    except (TypeError, ValueError):
+        expires_in = None
+    if issued_at is not None and expires_in is not None:
+        token["expires_at"] = int(issued_at + expires_in - 30)
+
+
+def _apply_external_schwab_token_to_session(oauth_session, token: dict) -> None:
+    """Synchronize requests-oauthlib's public token and oauthlib client cache."""
+    if not isinstance(token, dict):
+        return
+    oauth_session.token = dict(token)
+    client = getattr(oauth_session, "_client", None)
+    if client is None:
+        return
+    if token.get("access_token"):
+        try:
+            client.access_token = token.get("access_token")
+        except Exception:
+            pass
+    if token.get("token_type"):
+        try:
+            client.token_type = token.get("token_type")
+        except Exception:
+            pass
+    if token.get("scope"):
+        try:
+            client.scope = token.get("scope")
+        except Exception:
+            pass
+    if token.get("expires_at") is not None:
+        try:
+            client.expires_at = float(token.get("expires_at"))
+        except (TypeError, ValueError):
+            pass
+
+
 class SchwabTokenPersistenceError(RuntimeError):
     """Raised when a refreshed Schwab OAuth token cannot be durably written."""
 
@@ -411,10 +463,7 @@ class Schwab(Broker):
                     latest_token = _strip_external_schwab_token(latest_token)
                 elif not latest_token.get("refresh_token") and token_dict_for_session.get("refresh_token"):
                     latest_token["refresh_token"] = token_dict_for_session["refresh_token"]
-                if latest_token.get("issued_at") and latest_token.get("expires_in"):
-                    latest_token["expires_at"] = int(
-                        int(latest_token["issued_at"]) / 1000 + int(float(latest_token["expires_in"])) - 30
-                    )
+                _normalize_schwab_token_expiry_metadata(latest_token)
                 token_dict_for_session.clear()
                 token_dict_for_session.update(latest_token)
                 token_file_state["signature"] = _token_file_signature()
@@ -481,11 +530,12 @@ class Schwab(Broker):
             if client_secret_env:
                 refresh_kwargs["client_secret"] = client_secret_env
 
-            #add expires_at to token_dict_for_session. This is needed for the auto_refresh to work. Otherwise oauth2session always thinks it expires 30min from startup
-            token_dict_for_session['expires_at'] = int(token_dict_for_session['issued_at']/1000 + (token_dict_for_session['expires_in']) - 30) #30 second buffer
+            # Add expires_at so OAuth2Session sees externally issued tokens as current.
+            _normalize_schwab_token_expiry_metadata(token_dict_for_session)
 
             if external_token_refresh:
                 oauth_session = _OAS(client_id=api_key, token=token_dict_for_session)
+                _apply_external_schwab_token_to_session(oauth_session, token_dict_for_session)
             else:
                 oauth_session = _OAS(
                     client_id=api_key,
@@ -508,28 +558,31 @@ class Schwab(Broker):
             if external_token_refresh:
                 original_request = oauth_session.request
 
-                def _reload_if_token_file_changed():
+                def _reload_external_token_file(force=False):
                     try:
                         current_signature = _token_file_signature()
                     except Exception:
                         return False
-                    if current_signature == token_file_state.get("signature"):
+                    if not force and current_signature == token_file_state.get("signature"):
                         return False
                     try:
                         _load_token_file_for_session()
-                        oauth_session.token = token_dict_for_session
+                        _apply_external_schwab_token_to_session(oauth_session, token_dict_for_session)
                         logger.info(f"[Schwab] Reloaded externally managed token file from {token_path}")
                         return True
                     except Exception as reload_error:
                         logger.warning(f"[Schwab] Failed to reload externally managed token file: {reload_error}")
                         return False
 
+                def _reload_if_token_file_changed():
+                    return _reload_external_token_file(force=False)
+
                 def _request_with_external_token_reload(*args, **kwargs):
                     _reload_if_token_file_changed()
                     try:
                         response = original_request(*args, **kwargs)
                     except Exception as request_error:
-                        if request_error.__class__.__name__ == "TokenExpiredError" and _reload_if_token_file_changed():
+                        if request_error.__class__.__name__ == "TokenExpiredError" and _reload_external_token_file(force=True):
                             return original_request(*args, **kwargs)
                         raise
                     status_code = getattr(response, "status_code", None)

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -80,75 +80,10 @@ class Tradier(Broker):
         r"(?:too many 5\d\d error responses|status(?: code)?[=: ]+5\d\d|\b5\d\d\b|internal server error)",
         re.IGNORECASE,
     )
-    _DEFAULT_READ_MIN_INTERVAL_SECONDS = 15.0
-    _DEFAULT_TRANSIENT_READ_BACKOFF_SECONDS = 30.0
 
     @classmethod
     def _is_transient_broker_read_error(cls, error: Exception) -> bool:
         return bool(cls._TRANSIENT_READ_ERROR_RE.search(str(error)))
-
-    @staticmethod
-    def _coerce_non_negative_seconds(value, default: float) -> float:
-        if value in (None, ""):
-            return float(default)
-        try:
-            coerced = float(value)
-        except (TypeError, ValueError):
-            return float(default)
-        return max(0.0, coerced)
-
-    @staticmethod
-    def _copy_tradier_read_value(value):
-        if isinstance(value, list):
-            copied = []
-            for item in value:
-                copied.append(dict(item) if isinstance(item, dict) else item)
-            return copied
-        if isinstance(value, dict):
-            return dict(value)
-        return value
-
-    def _ensure_tradier_read_control_state(self) -> None:
-        if not hasattr(self, "_tradier_read_cache"):
-            self._tradier_read_cache = {}
-        if not hasattr(self, "_tradier_read_backoff_until"):
-            self._tradier_read_backoff_until = {}
-        if not hasattr(self, "_tradier_read_min_interval_seconds"):
-            self._tradier_read_min_interval_seconds = self._DEFAULT_READ_MIN_INTERVAL_SECONDS
-        if not hasattr(self, "_tradier_transient_read_backoff_seconds"):
-            self._tradier_transient_read_backoff_seconds = self._DEFAULT_TRANSIENT_READ_BACKOFF_SECONDS
-
-    def _get_cached_tradier_read(self, endpoint: str):
-        self._ensure_tradier_read_control_state()
-        cached = self._tradier_read_cache.get(endpoint)
-        if not cached:
-            return None
-
-        now = time.monotonic()
-        cached_at = cached.get("monotonic_at", 0.0)
-        backoff_until = self._tradier_read_backoff_until.get(endpoint, 0.0)
-        min_interval = float(getattr(self, "_tradier_read_min_interval_seconds", 0.0) or 0.0)
-
-        if now < backoff_until or (min_interval and now - cached_at < min_interval):
-            return self._copy_tradier_read_value(cached.get("value"))
-        return None
-
-    def _tradier_read_is_in_backoff(self, endpoint: str) -> bool:
-        self._ensure_tradier_read_control_state()
-        return time.monotonic() < self._tradier_read_backoff_until.get(endpoint, 0.0)
-
-    def _cache_tradier_read(self, endpoint: str, value) -> None:
-        self._ensure_tradier_read_control_state()
-        self._tradier_read_cache[endpoint] = {
-            "monotonic_at": time.monotonic(),
-            "value": self._copy_tradier_read_value(value),
-        }
-
-    def _start_tradier_read_backoff(self, endpoint: str) -> None:
-        self._ensure_tradier_read_control_state()
-        backoff_seconds = float(getattr(self, "_tradier_transient_read_backoff_seconds", 0.0) or 0.0)
-        if backoff_seconds > 0:
-            self._tradier_read_backoff_until[endpoint] = time.monotonic() + backoff_seconds
 
     def _current_lumibot_positions_snapshot(self) -> list[Position]:
         filled_positions = getattr(self, "_filled_positions", None)
@@ -620,25 +555,6 @@ class Tradier(Broker):
         self._tradier_account_number = account_number
         self._tradier_paper = paper
         self.polling_interval = polling_interval
-        self._tradier_read_cache = {}
-        self._tradier_read_backoff_until = {}
-        read_min_interval = None
-        transient_read_backoff = None
-        if isinstance(config, dict):
-            read_min_interval = config.get("TRADIER_READ_MIN_INTERVAL_SECONDS")
-            transient_read_backoff = config.get("TRADIER_TRANSIENT_READ_BACKOFF_SECONDS")
-        self._tradier_read_min_interval_seconds = self._coerce_non_negative_seconds(
-            os.environ.get("LUMIBOT_TRADIER_READ_MIN_INTERVAL_SECONDS")
-            or os.environ.get("TRADIER_READ_MIN_INTERVAL_SECONDS")
-            or read_min_interval,
-            self._DEFAULT_READ_MIN_INTERVAL_SECONDS,
-        )
-        self._tradier_transient_read_backoff_seconds = self._coerce_non_negative_seconds(
-            os.environ.get("LUMIBOT_TRADIER_TRANSIENT_READ_BACKOFF_SECONDS")
-            or os.environ.get("TRADIER_TRANSIENT_READ_BACKOFF_SECONDS")
-            or transient_read_backoff,
-            self._DEFAULT_TRANSIENT_READ_BACKOFF_SECONDS,
-        )
 
         # If this is an OAuth token, refresh before building API clients. Snapshot
         # runtimes can force this so BotSpot receives fresh token material to persist.
@@ -1027,13 +943,6 @@ class Tradier(Broker):
         return order
 
     def _get_balances_at_broker(self, quote_asset: Asset, strategy):
-        cached_balances = self._get_cached_tradier_read("balances")
-        if cached_balances is not None:
-            return cached_balances
-        if self._tradier_read_is_in_backoff("balances"):
-            logger.warning("Skipping Tradier balances read during transient broker backoff; no cached balances available")
-            return None
-
         try:
             df = self.tradier.account.get_account_balance()
         except TradierApiError as e:
@@ -1053,34 +962,8 @@ class Tradier(Broker):
                                           f"Your account number is: {self._tradier_account_number} and your "
                                           f"access token is: {access_token}", color="red")
                 raise ValueError(colored_message) from e
-            if self._is_transient_broker_read_error(e):
-                self._start_tradier_read_backoff("balances")
-                cached_balances = self._get_cached_tradier_read("balances")
-                if cached_balances is not None:
-                    logger.warning(
-                        "Transient Tradier balances read failure; reusing cached balances for this poll: %s",
-                        e,
-                        exc_info=True,
-                    )
-                    return cached_balances
             raise e
         except Exception as e:
-            if self._is_transient_broker_read_error(e):
-                self._start_tradier_read_backoff("balances")
-                cached_balances = self._get_cached_tradier_read("balances")
-                if cached_balances is not None:
-                    logger.warning(
-                        "Transient Tradier balances read failure; reusing cached balances for this poll: %s",
-                        e,
-                        exc_info=True,
-                    )
-                    return cached_balances
-                logger.warning(
-                    "Transient Tradier balances read failure without cached balances; skipping balance update: %s",
-                    e,
-                    exc_info=True,
-                )
-                return None
             logger.error(f"Error pulling balances from Tradier: {e}")
             # Add traceback to the error message
             logger.error(traceback.format_exc())
@@ -1095,9 +978,7 @@ class Tradier(Broker):
         # Calculate the gross positions value
         positions_value = portfolio_value - cash
 
-        balances = (cash, positions_value, portfolio_value)
-        self._cache_tradier_read("balances", balances)
-        return balances
+        return cash, positions_value, portfolio_value
 
     def get_historical_account_value(self):
         logger.error("The function get_historical_account_value is not implemented yet for Tradier.")
@@ -1425,12 +1306,6 @@ class Tradier(Broker):
         return normalized_events
 
     def _pull_positions(self, strategy):
-        cached_positions = self._get_cached_tradier_read("positions")
-        if cached_positions is not None:
-            return cached_positions
-        if self._tradier_read_is_in_backoff("positions"):
-            return self._current_lumibot_positions_snapshot()
-
         try:
             positions_df = self.tradier.account.get_positions()
         except TradierApiError as e:
@@ -1446,34 +1321,9 @@ class Tradier(Broker):
                 access_token = self._tradier_access_token[:7] + "*" * 7
                 colored_message = colored(f"Your TRADIER_ACCOUNT_NUMBER or TRADIER_ACCESS_TOKEN are invalid. Your account number is: {self._tradier_account_number} and your access token is: {access_token}", color="red")
                 raise ValueError(colored_message) from e
-            if self._is_transient_broker_read_error(e):
-                self._start_tradier_read_backoff("positions")
-                cached_positions = self._get_cached_tradier_read("positions")
-                if cached_positions is not None:
-                    logger.warning(
-                        "Transient Tradier positions read failure; reusing cached positions for this poll: %s",
-                        e,
-                        exc_info=True,
-                    )
-                    return cached_positions
-                logger.warning(
-                    "Transient Tradier positions read failure; preserving existing Lumibot positions for this poll: %s",
-                    e,
-                    exc_info=True,
-                )
-                return self._current_lumibot_positions_snapshot()
             raise e
         except Exception as e:
             if self._is_transient_broker_read_error(e):
-                self._start_tradier_read_backoff("positions")
-                cached_positions = self._get_cached_tradier_read("positions")
-                if cached_positions is not None:
-                    logger.warning(
-                        "Transient Tradier positions read failure; reusing cached positions for this poll: %s",
-                        e,
-                        exc_info=True,
-                    )
-                    return cached_positions
                 logger.warning(
                     "Transient Tradier positions read failure; preserving existing Lumibot positions for this poll: %s",
                     e,
@@ -1507,7 +1357,6 @@ class Tradier(Broker):
             )
             positions_ret.append(position)  # Add the position to the list
 
-        self._cache_tradier_read("positions", positions_ret)
         return positions_ret
 
     def _pull_position(self, strategy, asset):
@@ -1683,25 +1532,10 @@ class Tradier(Broker):
         and then returned. It is expected that the caller will convert each dictionary to an Order object by
         calling parse_broker_order() on the dictionary.
         """
-        cached_orders = self._get_cached_tradier_read("orders")
-        if cached_orders is not None:
-            return cached_orders
-        if self._tradier_read_is_in_backoff("orders"):
-            raise TradierTransientBrokerReadError("Tradier orders read is in transient backoff")
-
         try:
             df = self.tradier.orders.get_orders()
         except Exception as e:
             if self._is_transient_broker_read_error(e):
-                self._start_tradier_read_backoff("orders")
-                cached_orders = self._get_cached_tradier_read("orders")
-                if cached_orders is not None:
-                    logger.warning(
-                        "Transient Tradier orders read failure; reusing cached orders for this poll: %s",
-                        e,
-                        exc_info=True,
-                    )
-                    return cached_orders
                 logger.warning(
                     "Transient Tradier orders read failure; skipping order reconciliation for this poll: %s",
                     e,
@@ -1713,12 +1547,9 @@ class Tradier(Broker):
 
         # Check if the dataframe is empty or None
         if df is None or df.empty:
-            self._cache_tradier_read("orders", [])
             return []
 
-        orders = self._clean_order_records(df)
-        self._cache_tradier_read("orders", orders)
-        return orders
+        return self._clean_order_records(df)
 
     @staticmethod
     def _clean_order_records(df):

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -2346,19 +2346,27 @@ class _Strategy:
             if total_col in self._stats.columns:
                 self._stats[period_col] = cumulative_to_period_flows(self._stats[total_col])
 
-        external_flow_totals = (
-            self._stats["cash_adjustments_net_total"]
-            if "cash_adjustments_net_total" in self._stats.columns
-            else None
-        )
-        self._stats["return"] = cash_flow_adjusted_returns(
-            self._stats["portfolio_value"],
-            external_flow_totals,
-        )
         if "portfolio_value" in self._stats.columns:
-            adjusted_base = float(self._stats["portfolio_value"].iloc[0])
+            portfolio_values = pd.to_numeric(self._stats["portfolio_value"], errors="coerce")
+            external_flow_totals = (
+                pd.to_numeric(self._stats["cash_adjustments_net_total"], errors="coerce").reindex(self._stats.index)
+                if "cash_adjustments_net_total" in self._stats.columns
+                else None
+            )
+            self._stats["return"] = cash_flow_adjusted_returns(
+                portfolio_values,
+                external_flow_totals,
+            )
+            valid_portfolio_values = portfolio_values.dropna()
+            if valid_portfolio_values.empty:
+                self._stats["cash_adjusted_portfolio_value"] = pd.NA
+                self._stats_dirty = False
+                return self._stats
+            adjusted_base = float(valid_portfolio_values.iloc[0])
             if external_flow_totals is not None:
-                adjusted_base -= float(external_flow_totals.iloc[0])
+                base_external_flow = external_flow_totals.reindex(valid_portfolio_values.index).iloc[0]
+                if pd.notna(base_external_flow):
+                    adjusted_base -= float(base_external_flow)
             self._stats["cash_adjusted_portfolio_value"] = (
                 (1.0 + self._stats["return"].fillna(0.0)).cumprod() * adjusted_base
             )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.68",
+    version="4.5.69",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.67",
+    version="4.5.68",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.66",
+    version="4.5.67",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -632,6 +632,93 @@ def test_schwab_external_oauth_refresh_mode_reloads_access_only_file_without_ref
     assert "refresh_token" not in broker.client.session.token
 
 
+def test_schwab_external_oauth_refresh_mode_force_reapplies_fresh_file_to_stale_client(monkeypatch, tmp_path):
+    from lumibot.brokers import broker as broker_module
+    from lumibot.brokers import schwab as schwab_module
+    import requests_oauthlib
+
+    token_path = tmp_path / "schwab_token.json"
+    issued_at = int(time.time() * 1000)
+    token_path.write_text(
+        json.dumps(
+            {
+                "creation_timestamp": 1,
+                "token": {
+                    "access_token": "fresh-access",
+                    "issued_at": issued_at,
+                    "expires_in": 1800,
+                    "token_type": "Bearer",
+                    "scope": "api",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class TokenExpiredError(Exception):
+        pass
+
+    class _OAuth2Session:
+        def __init__(self, *, client_id, token, **kwargs):
+            self.client_id = client_id
+            self.token = token
+            self.kwargs = kwargs
+            self.request_calls = 0
+            self._client = SimpleNamespace(access_token=token.get("access_token"), expires_at=0)
+
+        def register_compliance_hook(self, hook_type, hook):
+            pytest.fail("External OAuth refresh mode must not install provider refresh hooks")
+
+        def refresh_token(self, *args, **kwargs):
+            pytest.fail("External OAuth refresh mode must not call Schwab refresh_token")
+
+        def request(self, *args, **kwargs):
+            self.request_calls += 1
+            if self.request_calls == 1:
+                self._client.expires_at = 0
+                raise TokenExpiredError("oauthlib stale client state")
+            assert self.token["access_token"] == "fresh-access"
+            assert "refresh_token" not in self.token
+            assert self._client.access_token == "fresh-access"
+            assert self._client.expires_at > time.time()
+            return type("Response", (), {"status_code": 200})()
+
+    class _AccountResponse:
+        status_code = 200
+
+        def json(self):
+            return [{"accountNumber": "12345678", "hashValue": "hash-123"}]
+
+    class _Client:
+        def __init__(self, *, api_key, session):
+            self.api_key = api_key
+            self.session = session
+
+        def get_account_numbers(self):
+            return _AccountResponse()
+
+    monkeypatch.setenv("LUMIBOT_OAUTH_REFRESH_MODE", "external")
+    monkeypatch.setattr(requests_oauthlib, "OAuth2Session", _OAuth2Session)
+    monkeypatch.setattr(schwab_module, "Client", _Client)
+    monkeypatch.setattr(broker_module.Broker, "_start_orders_thread", lambda self: None)
+    monkeypatch.setattr(schwab_module.Schwab, "_finish_initialization", lambda self, *args, **kwargs: None)
+    monkeypatch.setattr(schwab_module.Schwab, "_get_stream_object", lambda self: None)
+
+    broker = schwab_module.Schwab(
+        config={
+            "SCHWAB_ACCOUNT_NUMBER": "5678",
+            "SCHWAB_APP_KEY": "app-key",
+            "SCHWAB_TOKEN_PATH": str(token_path),
+        }
+    )
+
+    assert broker.client.session.request("https://api.schwab.test/accounts").status_code == 200
+    assert broker.client.session.request_calls == 2
+    rewritten = json.loads(token_path.read_text(encoding="utf-8"))
+    assert rewritten["token"]["access_token"] == "fresh-access"
+    assert "refresh_token" not in rewritten["token"]
+
+
 def test_schwab_external_oauth_refresh_mode_multiple_brokers_reload_atomic_replacements(monkeypatch, tmp_path):
     from lumibot.brokers import broker as broker_module
     from lumibot.brokers import schwab as schwab_module

--- a/tests/test_drift_rebalancer.py
+++ b/tests/test_drift_rebalancer.py
@@ -2002,6 +2002,7 @@ class TestDriftRebalancer:
         assert filled_orders.iloc[1]["side"] == "buy"
         assert filled_orders.iloc[1]["symbol"] == "ETH"
 
+    @pytest.mark.apitest
     @pytest.mark.skipif(
         not ALPACA_TEST_CONFIG['API_KEY'] or ALPACA_TEST_CONFIG['API_KEY'] == '<your key here>',
         reason="This test requires an alpaca API key"
@@ -2072,6 +2073,7 @@ class TestDriftRebalancer:
         assert filled_orders.iloc[1]["side"] == "buy"
         assert filled_orders.iloc[1]["symbol"] == "ETH"
 
+    @pytest.mark.apitest
     @pytest.mark.skipif(
         not ALPACA_TEST_CONFIG['API_KEY'] or ALPACA_TEST_CONFIG['API_KEY'] == '<your key here>',
         reason="This test requires an alpaca API key"
@@ -2153,6 +2155,7 @@ class TestDriftRebalancer:
         assert strat_obj.cash > 0
         assert strat_obj.cash / final_value < 0.01
 
+    @pytest.mark.apitest
     @pytest.mark.skipif(
         not ALPACA_TEST_CONFIG['API_KEY'] or ALPACA_TEST_CONFIG['API_KEY'] == '<your key here>',
         reason="This test requires an alpaca API key"

--- a/tests/test_schwab_positions_unit.py
+++ b/tests/test_schwab_positions_unit.py
@@ -408,7 +408,31 @@ def test_schwab_option_replacement_uses_option_builder_and_updates_identifier():
     assert order.limit_price == 4.75
 
 
-def test_schwab_stock_submit_uses_seamless_session():
+def test_schwab_stock_market_submit_uses_normal_session():
+    client = _PlaceClient()
+    stream = _Stream()
+    broker = Schwab.__new__(Schwab)
+    broker.name = "Schwab"
+    broker.schwab_authorization_error = False
+    broker.client = client
+    broker.hash_value = "account-hash"
+    broker.stream = stream
+    broker._unprocessed_orders = SafeList(RLock())
+    order = _stock_market_order(side=Order.OrderSide.BUY, quantity=12)
+
+    submitted = broker._submit_order(order)
+
+    assert submitted is order
+    assert client.place_calls[0][0] == "account-hash"
+    order_spec = client.place_calls[0][1]
+    assert order_spec["session"] == "NORMAL"
+    assert order_spec["duration"] == "DAY"
+    assert order_spec["orderType"] == "MARKET"
+    assert order.identifier == "submitted-123"
+    assert stream.dispatched[-1][0] == broker.NEW_ORDER
+
+
+def test_schwab_stock_limit_submit_uses_seamless_session():
     client = _PlaceClient()
     stream = _Stream()
     broker = Schwab.__new__(Schwab)
@@ -431,7 +455,19 @@ def test_schwab_stock_submit_uses_seamless_session():
     assert stream.dispatched[-1][0] == broker.NEW_ORDER
 
 
-def test_schwab_stock_replacement_spec_uses_seamless_session():
+def test_schwab_stock_market_replacement_spec_uses_normal_session():
+    broker = Schwab.__new__(Schwab)
+    broker.name = "Schwab"
+    order = _stock_market_order(side=Order.OrderSide.SELL, quantity=1)
+
+    order_spec = broker._prepare_stock_order_spec(order)
+
+    assert order_spec["session"] == "NORMAL"
+    assert order_spec["duration"] == "DAY"
+    assert order_spec["orderType"] == "MARKET"
+
+
+def test_schwab_stock_limit_replacement_spec_uses_seamless_session():
     broker = Schwab.__new__(Schwab)
     broker.name = "Schwab"
     order = _stock_limit_order(side=Order.OrderSide.SELL, limit_price=20.0)

--- a/tests/test_strategy_dump_stats_regression.py
+++ b/tests/test_strategy_dump_stats_regression.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from lumibot.backtesting import BacktestingBroker, PandasDataBacktesting
 from lumibot.entities import Asset
+from lumibot.strategies import _strategy as strategy_module
 from lumibot.strategies.strategy import Strategy
 
 
@@ -18,6 +19,24 @@ class _StatsOnlyStrategy(Strategy):
 
     def on_trading_iteration(self):
         raise AssertionError("This regression test should not run the trading loop.")
+
+
+def _stub_stats_flow_math(monkeypatch) -> None:
+    def cumulative_to_period_flows(values):
+        return pd.to_numeric(values, errors="coerce").diff().fillna(0.0)
+
+    def cash_flow_adjusted_returns(values, cumulative_external_flows=None):
+        numeric_values = pd.to_numeric(values, errors="coerce")
+        previous_values = numeric_values.shift(1)
+        if cumulative_external_flows is None:
+            external_period = pd.Series(0.0, index=numeric_values.index, dtype=float)
+        else:
+            external_period = cumulative_to_period_flows(cumulative_external_flows).reindex(numeric_values.index).fillna(0.0)
+        returns = (numeric_values - previous_values - external_period) / previous_values
+        return returns.where(previous_values.notna()).astype(float)
+
+    monkeypatch.setattr(strategy_module, "cumulative_to_period_flows", cumulative_to_period_flows)
+    monkeypatch.setattr(strategy_module, "cash_flow_adjusted_returns", cash_flow_adjusted_returns)
 
 
 def test_dump_stats_end_to_end_regression_for_datetime_indexes():
@@ -141,3 +160,57 @@ def test_dump_stats_parquet_is_resilient_to_object_positions(tmp_path) -> None:
     parquet_df = pd.read_parquet(stats_parquet)
     assert "positions" in parquet_df.columns
     assert isinstance(parquet_df["positions"].iloc[0], str)
+
+
+def test_format_stats_tolerates_missing_initial_portfolio_and_external_flows(monkeypatch) -> None:
+    _stub_stats_flow_math(monkeypatch)
+    broker = PandasDataBacktesting(
+        datetime_start=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        datetime_end=datetime(2026, 1, 3, tzinfo=timezone.utc),
+    )
+    strat = _StatsOnlyStrategy(broker=BacktestingBroker(data_source=broker))
+    strat._benchmark_asset = None
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    strat._append_row({
+        "datetime": start,
+        "portfolio_value": None,
+        "cash_adjustments_net_total": None,
+    })
+    strat._append_row({
+        "datetime": start + timedelta(days=1),
+        "portfolio_value": 100_000.0,
+        "cash_adjustments_net_total": None,
+    })
+    strat._append_row({
+        "datetime": start + timedelta(days=2),
+        "portfolio_value": 101_000.0,
+        "cash_adjustments_net_total": 0.0,
+    })
+
+    stats = strat._format_stats()
+
+    assert "return" in stats.columns
+    assert "cash_adjusted_portfolio_value" in stats.columns
+    assert pd.isna(stats["return"].iloc[0])
+    assert float(stats["cash_adjusted_portfolio_value"].iloc[0]) == 100_000.0
+    assert float(stats["cash_adjusted_portfolio_value"].iloc[-1]) == 101_000.0
+
+
+def test_format_stats_tolerates_no_valid_portfolio_values(monkeypatch) -> None:
+    _stub_stats_flow_math(monkeypatch)
+    broker = PandasDataBacktesting(
+        datetime_start=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        datetime_end=datetime(2026, 1, 2, tzinfo=timezone.utc),
+    )
+    strat = _StatsOnlyStrategy(broker=BacktestingBroker(data_source=broker))
+    strat._benchmark_asset = None
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    strat._append_row({"datetime": start, "portfolio_value": None})
+    strat._append_row({"datetime": start + timedelta(days=1), "portfolio_value": None})
+
+    stats = strat._format_stats()
+
+    assert "return" in stats.columns
+    assert "cash_adjusted_portfolio_value" in stats.columns
+    assert stats["return"].isna().all()
+    assert stats["cash_adjusted_portfolio_value"].isna().all()

--- a/tests/test_transient_network_logs_are_not_errors.py
+++ b/tests/test_transient_network_logs_are_not_errors.py
@@ -1,43 +1,19 @@
 import logging
 from types import SimpleNamespace
 
-import pandas as pd
 import pytest
 
 from lumibot.brokers.tradier import Tradier, TradierTransientBrokerReadError
 from lumibot.strategies._strategy import _Strategy
 
 
-class _TradierReadStub(SimpleNamespace):
-    _DEFAULT_READ_MIN_INTERVAL_SECONDS = Tradier._DEFAULT_READ_MIN_INTERVAL_SECONDS
-    _DEFAULT_TRANSIENT_READ_BACKOFF_SECONDS = Tradier._DEFAULT_TRANSIENT_READ_BACKOFF_SECONDS
-    _ensure_tradier_read_control_state = Tradier._ensure_tradier_read_control_state
-    _get_cached_tradier_read = Tradier._get_cached_tradier_read
-    _tradier_read_is_in_backoff = Tradier._tradier_read_is_in_backoff
-    _cache_tradier_read = Tradier._cache_tradier_read
-    _start_tradier_read_backoff = Tradier._start_tradier_read_backoff
-    _copy_tradier_read_value = staticmethod(Tradier._copy_tradier_read_value)
-    _clean_order_records = staticmethod(Tradier._clean_order_records)
-
-    def _is_transient_broker_read_error(self, error: Exception) -> bool:
-        return Tradier._is_transient_broker_read_error(error)
-
-    def _current_lumibot_positions_snapshot(self):
-        return []
-
-    def _normalize_symbol_for_internal(self, symbol, asset_type=None):
-        return str(symbol)
-
-
 def _tradier_read_stub(**kwargs):
     values = {
-        "_tradier_read_cache": {},
-        "_tradier_read_backoff_until": {},
-        "_tradier_read_min_interval_seconds": 0.0,
-        "_tradier_transient_read_backoff_seconds": 30.0,
+        "_is_transient_broker_read_error": Tradier._is_transient_broker_read_error,
+        "_current_lumibot_positions_snapshot": lambda: [],
     }
     values.update(kwargs)
-    return _TradierReadStub(**values)
+    return SimpleNamespace(**values)
 
 
 def test_update_broker_balances_exception_logs_info(monkeypatch, caplog):
@@ -134,74 +110,3 @@ def test_tradier_transient_orders_failure_skips_reconciliation(monkeypatch):
 
     with pytest.raises(TradierTransientBrokerReadError):
         Tradier._pull_broker_all_orders(dummy)
-
-
-def test_tradier_transient_balances_failure_reuses_cache_and_backs_off(monkeypatch):
-    calls = {"count": 0}
-
-    def get_balance():
-        calls["count"] += 1
-        if calls["count"] == 1:
-            return pd.DataFrame([{"total_equity": 1200.0, "total_cash": 1000.0}])
-        raise ConnectionError("HTTPSConnectionPool: too many 500 error responses")
-
-    dummy = _tradier_read_stub(
-        tradier=SimpleNamespace(account=SimpleNamespace(get_account_balance=get_balance)),
-        _tradier_read_min_interval_seconds=0.0,
-        _tradier_transient_read_backoff_seconds=60.0,
-    )
-
-    first_result = Tradier._get_balances_at_broker(dummy, None, None)
-    second_result = Tradier._get_balances_at_broker(dummy, None, None)
-    third_result = Tradier._get_balances_at_broker(dummy, None, None)
-
-    assert first_result == (1000.0, 200.0, 1200.0)
-    assert second_result == first_result
-    assert third_result == first_result
-    assert calls["count"] == 2
-
-
-def test_tradier_cached_position_read_avoids_provider_call_during_min_interval(monkeypatch):
-    calls = {"count": 0}
-
-    def get_positions():
-        calls["count"] += 1
-        return pd.DataFrame([{"symbol": "SPY", "quantity": 3}])
-
-    dummy = _tradier_read_stub(
-        tradier=SimpleNamespace(account=SimpleNamespace(get_positions=get_positions)),
-        _tradier_read_min_interval_seconds=60.0,
-    )
-
-    first_result = Tradier._pull_positions(dummy, "unit-test")
-    second_result = Tradier._pull_positions(dummy, "unit-test")
-
-    assert calls["count"] == 1
-    assert len(first_result) == 1
-    assert len(second_result) == 1
-    assert first_result[0].asset.symbol == second_result[0].asset.symbol == "SPY"
-
-
-def test_tradier_orders_backoff_uses_cache_without_provider_call(monkeypatch):
-    calls = {"count": 0}
-
-    def get_orders():
-        calls["count"] += 1
-        if calls["count"] == 1:
-            return pd.DataFrame([{"id": "abc", "status": "open"}])
-        raise ConnectionError("HTTPSConnectionPool: too many 500 error responses")
-
-    dummy = _tradier_read_stub(
-        tradier=SimpleNamespace(orders=SimpleNamespace(get_orders=get_orders)),
-        _tradier_read_min_interval_seconds=0.0,
-        _tradier_transient_read_backoff_seconds=60.0,
-    )
-
-    first_result = Tradier._pull_broker_all_orders(dummy)
-    second_result = Tradier._pull_broker_all_orders(dummy)
-    third_result = Tradier._pull_broker_all_orders(dummy)
-
-    assert first_result == [{"id": "abc", "status": "open"}]
-    assert second_result == first_result
-    assert third_result == first_result
-    assert calls["count"] == 2


### PR DESCRIPTION
## Summary
- Fix Schwab external OAuth token reload when oauthlib session state remains expired after Bot Manager reissues an access-only token file.
- Make stats formatting tolerate missing portfolio values and missing external flow totals instead of crashing with float(None).

## Tests
- python3 -m pytest tests/test_broker_initialization.py::test_schwab_external_oauth_refresh_mode_reloads_access_only_file_without_refresh_token tests/test_broker_initialization.py::test_schwab_external_oauth_refresh_mode_force_reapplies_fresh_file_to_stale_client tests/test_broker_initialization.py::test_schwab_external_oauth_refresh_mode_multiple_brokers_reload_atomic_replacements tests/test_strategy_dump_stats_regression.py::test_format_stats_tolerates_missing_initial_portfolio_and_external_flows tests/test_strategy_dump_stats_regression.py::test_format_stats_tolerates_no_valid_portfolio_values

No refresh tokens are introduced into child token files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Schwab order handling so stock market orders now use the normal session, while limit orders continue to use seamless session.
  * Made Schwab token refresh more reliable when using externally managed OAuth tokens.
  * Reduced issues in portfolio stats when some values are missing or invalid.
  * Simplified handling of temporary Tradier read failures to avoid stale cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->