### PR TITLE
Release LumiBot 4.5.70 lint fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 4.5.69 - Unreleased
+## 4.5.70 - 2026-07-07
+
+### Fixed
+- **Release lint cleanup for Schwab token reload and stats crash fixes.**
+  Keeps the externally managed Schwab token reload and missing portfolio-value
+  guards from 4.5.69 while satisfying the production CI Ruff gate.
+
+## 4.5.69 - 2026-07-07
 
 ## 4.5.68 - 2026-07-07
 

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -9,6 +9,7 @@ from importlib import import_module
 
 from lumibot._lazy_imports import LazyClassMeta, LazyModule, LazyStrategyLogger, lazy_class, lazy_typing
 
+
 def _env_flag_enabled(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "y", "on")
 
@@ -81,7 +82,6 @@ else:
         DISCORD_WEBHOOK_URL,
         HIDE_POSITIONS,
         HIDE_TRADES,
-        IS_BACKTESTING,
         LIVE_CONFIG,
         LOG_BACKTEST_PROGRESS_TO_FILE,
         LUMIWEALTH_API_KEY,
@@ -95,6 +95,9 @@ else:
         THETADATA_CONFIG,
         get_default_broker,
         get_default_data_source,
+    )
+    from ..credentials import (
+        IS_BACKTESTING as IS_BACKTESTING,
     )
 
 mdates = LazyModule("matplotlib.dates")
@@ -121,7 +124,7 @@ BROKER = None
 DATA_SOURCE = None
 
 if TYPE_CHECKING:
-    from ..entities import CashEvent, Data, Position
+    from ..entities import CashEvent, Data
 
 
 def colored(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.69",
+    version="4.5.70",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",


### PR DESCRIPTION
## Summary
- bump LumiBot to 4.5.70 after the 4.5.69 token reload release
- keep the Schwab external token reload and stats crash fixes from 4.5.69
- satisfy the Ruff CI scope for lumibot/strategies/_strategy.py without changing runtime behavior

## Local checks
- python3 -m ruff check --select F,I lumibot/tools/thetadata_helper.py lumibot/tools/data_downloader_queue_client.py lumibot/backtesting/thetadata_backtesting_pandas.py lumibot/components/options_helper.py lumibot/strategies/_strategy.py tests/backtest/test_acceptance_backtests_ci.py tests/test_thetadata_day_timestamp_alignment.py tests/test_thetadata_get_last_price_trade_only.py tests/test_options_helper_thetadata_actionable_strikes.py tests/test_thetadata_queue_client.py
- python3 -m pytest tests/test_broker_initialization.py::test_schwab_external_oauth_refresh_mode_reloads_access_only_file_without_refresh_token tests/test_broker_initialization.py::test_schwab_external_oauth_refresh_mode_force_reapplies_fresh_file_to_stale_client tests/test_broker_initialization.py::test_schwab_external_oauth_refresh_mode_multiple_brokers_reload_atomic_replacements tests/test_strategy_dump_stats_regression.py::test_format_stats_tolerates_missing_initial_portfolio_and_external_flows tests/test_strategy_dump_stats_regression.py::test_format_stats_tolerates_no_valid_portfolio_values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Included fixes for token reloading and a stats-related crash.
* **Documentation**
  * Updated the changelog with the latest release entry and dated the previous version.
* **Chores**
  * Bumped the application version to 4.5.70.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->