### PR TITLE
Fix stats base handling for missing portfolio values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.71 - Unreleased
+
 ## 4.5.70 - 2026-07-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 4.5.71 - 2026-07-07
+
+### Fixed
+- **Narrowed the missing portfolio-value stats guard to avoid changing normal
+  backtest return math.** LumiBot still avoids crashing when live broker auth
+  failures leave portfolio value or cash-flow totals missing, but valid
+  first-row portfolio values now keep the existing cash-flow-adjusted return
+  behavior used by acceptance backtests.
+
 ## 4.5.70 - 2026-07-07
 
 ### Fixed

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -2350,9 +2350,10 @@ class _Strategy:
                 self._stats[period_col] = cumulative_to_period_flows(self._stats[total_col])
 
         if "portfolio_value" in self._stats.columns:
-            portfolio_values = pd.to_numeric(self._stats["portfolio_value"], errors="coerce")
+            portfolio_values = self._stats["portfolio_value"]
+            portfolio_values_numeric = pd.to_numeric(portfolio_values, errors="coerce")
             external_flow_totals = (
-                pd.to_numeric(self._stats["cash_adjustments_net_total"], errors="coerce").reindex(self._stats.index)
+                self._stats["cash_adjustments_net_total"]
                 if "cash_adjustments_net_total" in self._stats.columns
                 else None
             )
@@ -2360,14 +2361,22 @@ class _Strategy:
                 portfolio_values,
                 external_flow_totals,
             )
-            valid_portfolio_values = portfolio_values.dropna()
+            valid_portfolio_values = portfolio_values_numeric.dropna()
             if valid_portfolio_values.empty:
                 self._stats["cash_adjusted_portfolio_value"] = pd.NA
                 self._stats_dirty = False
                 return self._stats
-            adjusted_base = float(valid_portfolio_values.iloc[0])
+            base_index = portfolio_values_numeric.index[0]
+            base_value = portfolio_values_numeric.iloc[0]
+            if pd.isna(base_value):
+                base_index = valid_portfolio_values.index[0]
+                base_value = valid_portfolio_values.iloc[0]
+            adjusted_base = float(base_value)
             if external_flow_totals is not None:
-                base_external_flow = external_flow_totals.reindex(valid_portfolio_values.index).iloc[0]
+                try:
+                    base_external_flow = external_flow_totals.loc[base_index]
+                except Exception:
+                    base_external_flow = external_flow_totals.iloc[0]
                 if pd.notna(base_external_flow):
                     adjusted_base -= float(base_external_flow)
             self._stats["cash_adjusted_portfolio_value"] = (

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.70",
+    version="4.5.71",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_strategy_dump_stats_regression.py
+++ b/tests/test_strategy_dump_stats_regression.py
@@ -196,6 +196,37 @@ def test_format_stats_tolerates_missing_initial_portfolio_and_external_flows(mon
     assert float(stats["cash_adjusted_portfolio_value"].iloc[-1]) == 101_000.0
 
 
+def test_format_stats_preserves_valid_initial_portfolio_base(monkeypatch) -> None:
+    _stub_stats_flow_math(monkeypatch)
+    broker = PandasDataBacktesting(
+        datetime_start=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        datetime_end=datetime(2026, 1, 3, tzinfo=timezone.utc),
+    )
+    strat = _StatsOnlyStrategy(broker=BacktestingBroker(data_source=broker))
+    strat._benchmark_asset = None
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    strat._append_row({
+        "datetime": start,
+        "portfolio_value": 100_000.0,
+        "cash_adjustments_net_total": 0.0,
+    })
+    strat._append_row({
+        "datetime": start + timedelta(days=1),
+        "portfolio_value": None,
+        "cash_adjustments_net_total": None,
+    })
+    strat._append_row({
+        "datetime": start + timedelta(days=2),
+        "portfolio_value": 101_000.0,
+        "cash_adjustments_net_total": 0.0,
+    })
+
+    stats = strat._format_stats()
+
+    assert float(stats["cash_adjusted_portfolio_value"].iloc[0]) == 100_000.0
+    assert float(stats["cash_adjusted_portfolio_value"].iloc[-1]) == 100_000.0
+
+
 def test_format_stats_tolerates_no_valid_portfolio_values(monkeypatch) -> None:
     _stub_stats_flow_math(monkeypatch)
     broker = PandasDataBacktesting(


### PR DESCRIPTION
## Summary\n- narrow the missing portfolio-value guard so valid first-row portfolio values preserve existing return math\n- keep the live stats crash guard for missing broker values\n- add a regression for valid initial portfolio base with a missing later row\n\n## Local verification\n- python3 -m pytest tests/test_strategy_dump_stats_regression.py tests/test_broker_initialization.py::test_schwab_external_oauth_refresh_mode_reloads_access_only_file_without_refresh_token tests/test_broker_initialization.py::test_schwab_external_oauth_refresh_mode_force_reapplies_fresh_file_to_stale_client tests/test_broker_initialization.py::test_schwab_external_oauth_refresh_mode_multiple_brokers_reload_atomic_replacements tests/test_transient_network_logs_are_not_errors.py::test_tradier_transient_positions_failure_preserves_local_positions tests/test_transient_network_logs_are_not_errors.py::test_tradier_transient_orders_failure_skips_reconciliation -q\n\n## Note\n- The local backdoor_smartlimit acceptance mismatch also reproduces on clean v4.5.68 with identical metrics, so it is not introduced by this broker-token/stats patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved return/statistics handling so missing portfolio values no longer affect normal backtest return calculations.
  * Preserved the correct starting portfolio base when later values are unavailable or invalid.
  * Continued to prevent crashes when live broker auth issues leave portfolio or cash-flow data incomplete.

* **Tests**
  * Added regression coverage for stats formatting with an initial valid portfolio value followed by missing data.

* **Chores**
  * Bumped the release version to **4.5.71**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->