### PR TITLE
Fix stats external flow base for duplicate timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 4.5.72 - 2026-07-07
+
+### Fixed
+- **Handle duplicate stats timestamps while avoiding missing portfolio-value
+  crashes.** Duplicate timestamp rows can make external-flow lookup return a
+  Series; LumiBot now normalizes that base flow to a scalar before building
+  cash-adjusted portfolio values.
+
 ## 4.5.71 - 2026-07-07
 
 ### Fixed

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -2377,6 +2377,8 @@ class _Strategy:
                     base_external_flow = external_flow_totals.loc[base_index]
                 except Exception:
                     base_external_flow = external_flow_totals.iloc[0]
+                if isinstance(base_external_flow, pd.Series):
+                    base_external_flow = base_external_flow.iloc[0] if not base_external_flow.empty else pd.NA
                 if pd.notna(base_external_flow):
                     adjusted_base -= float(base_external_flow)
             self._stats["cash_adjusted_portfolio_value"] = (

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.71",
+    version="4.5.72",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_strategy_dump_stats_regression.py
+++ b/tests/test_strategy_dump_stats_regression.py
@@ -227,6 +227,31 @@ def test_format_stats_preserves_valid_initial_portfolio_base(monkeypatch) -> Non
     assert float(stats["cash_adjusted_portfolio_value"].iloc[-1]) == 100_000.0
 
 
+def test_format_stats_handles_duplicate_datetime_external_flow_base(monkeypatch) -> None:
+    _stub_stats_flow_math(monkeypatch)
+    broker = PandasDataBacktesting(
+        datetime_start=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        datetime_end=datetime(2026, 1, 2, tzinfo=timezone.utc),
+    )
+    strat = _StatsOnlyStrategy(broker=BacktestingBroker(data_source=broker))
+    strat._benchmark_asset = None
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    strat._append_row({
+        "datetime": start,
+        "portfolio_value": 100_000.0,
+        "cash_adjustments_net_total": 0.0,
+    })
+    strat._append_row({
+        "datetime": start,
+        "portfolio_value": 100_000.0,
+        "cash_adjustments_net_total": 0.0,
+    })
+
+    stats = strat._format_stats()
+
+    assert float(stats["cash_adjusted_portfolio_value"].iloc[0]) == 100_000.0
+
+
 def test_format_stats_tolerates_no_valid_portfolio_values(monkeypatch) -> None:
     _stub_stats_flow_math(monkeypatch)
     broker = PandasDataBacktesting(


### PR DESCRIPTION
## Summary\n- bump release to 4.5.72 after failed 4.5.71 tag\n- normalize duplicate-timestamp external-flow base lookups to a scalar\n- add regression coverage for duplicate datetime stats rows\n\n## Local verification\n- python3 -m pytest tests/test_strategy_dump_stats_regression.py tests/test_broker_initialization.py::test_schwab_external_oauth_refresh_mode_reloads_access_only_file_without_refresh_token tests/test_broker_initialization.py::test_schwab_external_oauth_refresh_mode_force_reapplies_fresh_file_to_stale_client tests/test_broker_initialization.py::test_schwab_external_oauth_refresh_mode_multiple_brokers_reload_atomic_replacements tests/test_transient_network_logs_are_not_errors.py::test_tradier_transient_positions_failure_preserves_local_positions tests/test_transient_network_logs_are_not_errors.py::test_tradier_transient_orders_failure_skips_reconciliation tests/backtest/test_agent_runtime_backtest.py::test_agent_runtime_stock_backtest_replays_from_cache tests/backtest/test_agent_runtime_backtest.py::test_agent_runtime_option_backtest_executes_option_order tests/backtest/test_agent_runtime_backtest.py::test_agent_runtime_minute_duckdb_stress_binds_once tests/backtest/test_ai_committee_builtin_tools_backtest.py::test_ai_committee_builtin_tools_execute_inside_backtest tests/backtest/test_pandas_backtest.py::test_bracket_orders_apply_entry_and_exit_fees tests/backtest/test_pandas_backtest.py::test_bracket_positions_remain_bounded -q --tb=short --durations=20\n\n## Note\n- v4.5.71 tag failed release validation on duplicate datetime stats rows and was not published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where duplicate stats timestamps could cause portfolio calculations to use an unexpected multi-value result.
  * Cash-adjusted portfolio values and related returns now handle these cases consistently.
  * Added regression coverage for duplicate timestamp stats to prevent this issue from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->