### PR TITLE
v4.5.73 - Tradier parser, agent pruning, and public hygiene

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,13 @@
 # review when someone opens a pull request
 
 * @grzesir
+
+# Public instruction and CI guardrails. These are high-risk because they can
+# accidentally publish local paths, credentials, or weaken repository gates.
+AGENTS.md @grzesir
+CLAUDE.md @grzesir
+SECURITY.md @grzesir
+.github/CODEOWNERS @grzesir
+.github/workflows/ @grzesir
+.github/copilot-instructions.md @grzesir
+tests/test_public_instruction_secret_hygiene.py @grzesir

--- a/.github/workflows/public-hygiene.yml
+++ b/.github/workflows/public-hygiene.yml
@@ -1,0 +1,30 @@
+name: Public Hygiene
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+      - main
+      - "version/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  public-hygiene:
+    name: Public repo hygiene
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check public instruction files
+        run: python tests/test_public_instruction_secret_hygiene.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,22 @@
+# Public Repo Secret Hygiene (CRITICAL)
+
+LumiBot is open source. Never put private, incriminating, account-specific, or
+machine-specific information in this file or any other tracked repo file.
+
+- Do not include usernames, passwords, API keys, tokens, account emails,
+  customer identifiers, broker credentials, paid vendor credentials, private
+  hostnames, private URLs, cookies, local profile paths, or absolute personal
+  filesystem paths.
+- Do not document real local `.env` locations, credential-file paths, secret
+  store values, or commands that write real credentials to disk.
+- Use placeholders such as `<your-vendor-username>`,
+  `<your-downloader-host>`, `<repo>`, and `$TMPDIR`, and point contributors to
+  the public environment variable names or their own secret manager.
+- If sensitive data is needed for private BotSpot/Lumiwealth operations, keep it
+  in the private repo/docs/secret store, not in this public LumiBot checkout.
+- If sensitive data is found in tracked files, remove it immediately, scan for
+  nearby leaks, and treat exposed credentials as needing rotation.
+
 # LumiBot Agent Instructions (Theta / Downloader Focus)
 
 These rules are mandatory whenever you work on ThetaData integrations.
@@ -53,9 +72,9 @@ call.
 ## Multi-Agent Collaboration (CRITICAL)
 This repo is frequently edited by **multiple AI sessions**. To avoid lost work:
 
-- **Canonical checkout (STRICT):** normal LumiBot work happens in
-  `/Users/robertgrzesik/Development/lumibot`. Keep that checkout on the active
-  `version/X.Y.Z` branch, clean, and deploy-ready. Do not create sibling
+- **Canonical checkout (STRICT):** normal LumiBot work happens in this repository
+  checkout. Keep it on the active `version/X.Y.Z` branch, clean, and
+  deploy-ready. Do not create sibling
   worktrees like `lumibot-version-X.Y.Z` for normal feature/doc/test work.
   Temporary worktrees outside this folder are allowed only for isolated review
   of unusually large or risky external PRs, and must not become the active
@@ -65,9 +84,9 @@ This repo is frequently edited by **multiple AI sessions**. To avoid lost work:
   - **Never push directly to `dev`.** All work must land via a PR (usually from `version/X.Y.Z` → `dev`).
   - **Stay on the current branch.** If you start on a `version/*` branch, keep all commits on that branch and push that branch.
   - **Never switch branches without explicit user instruction.** If you suspect you are on the wrong branch, stop and ask.
-  - **Post-release branch switch is a mandatory exception.** After a Lumibot release is tagged/published and the release workflow creates `version/X.Y.(Z+1)`, immediately move the canonical checkout to that next version branch with `git switch` and verify `git branch --show-current`, `setup.py`, and `git status`. Do this before reporting the release complete or triggering BotManager work. Never leave `/Users/robertgrzesik/Development/lumibot` on the just-released branch.
+  - **Post-release branch switch is a mandatory exception.** After a Lumibot release is tagged/published and the release workflow creates `version/X.Y.(Z+1)`, immediately move the canonical checkout to that next version branch with `git switch` and verify `git branch --show-current`, `setup.py`, and `git status`. Do this before reporting the release complete or triggering BotManager work. Never leave the canonical checkout on the just-released branch.
   - **Never update an old version branch to make a stale GitHub URL look current.** If Rob or a browser is viewing an older `version/X.Y.Z` branch, do not push current work to that old branch and do not switch to it. Give Rob the correct latest version branch URL instead. Historical version branches are release records, not redirect targets.
-  - **Always keep the canonical checkout on the latest active `version/X.Y.Z` branch.** If you discover `/Users/robertgrzesik/Development/lumibot` is on an older version branch, stop and report it unless Rob explicitly tells you to move it with `git switch` after verifying the tree is clean.
+  - **Always keep the canonical checkout on the latest active `version/X.Y.Z` branch.** If you discover this checkout is on an older version branch, stop and report it unless Rob explicitly tells you to move it with `git switch` after verifying the tree is clean.
   - **PRs must be version-scoped.** If a PR is needed for review/release, the PR head must be the existing `version/X.Y.Z` branch.
   - **PR title must be release-scoped.** Use `vX.Y.Z - <summary>` and include all notable changes shipped in that version (not just one feature).
 
@@ -98,41 +117,30 @@ This repo is frequently edited by **multiple AI sessions**. To avoid lost work:
 - **Test gating (STRICT):** do not introduce new environment variables just to skip/disable tests or to paper over CI failures.
   - Prefer existing pytest markers (`apitest`, `acceptance_backtest`, etc.) and normal test skips with clear reasons.
   - If a new env var is truly required for a user-facing feature, document it in `docsrc/environment_variables.rst` in the same PR.
+  - Hidden provider credential loading is an anti-pattern for user-facing
+    components. If LumiBot needs a provider key because a model, broker, data
+    tool, or component is selected, make the required env var explicit in docs,
+    examples, errors, and component metadata. Do not silently depend on an SDK
+    alias or behind-the-scenes env-var mutation that makes downstream products
+    unable to infer the required key.
 - **Full suite verification:** prefer pushing commits to GitHub on the shared `version/X.Y.Z` branch so sharded CI validates the full suite. Local runs should focus on targeted tests or marker-filtered subsets.
 
 1. **Never launch ThetaTerminal locally WITH PRODUCTION CREDENTIALS.** Production has the only licensed session for that account. Starting the jar with prod credentials (even briefly or via Docker) instantly terminates the prod connection and halts all customers.
 2. **Use the downloader for backtests.** All tests/backtests must set `DATADOWNLOADER_BASE_URL` and `DATADOWNLOADER_API_KEY` via the runtime environment. Do not short-cut by hitting Theta directly.
 3. **Never hardcode or share private downloader URLs.** Do not paste real downloader hostnames/URLs into code, docs, tests, logs, AGENTS, or CLAUDE; use placeholders (e.g., `http://localhost:8080` or `https://<your-downloader-host>:8080`) and refer to `DATADOWNLOADER_BASE_URL`.
 
-### Dev Credentials for Local ThetaTerminal Testing (SAFE)
+### Local ThetaTerminal Testing Credentials
 
-There is a **separate dev account** that CAN be used for local debugging without affecting production:
+Do not put ThetaData usernames, passwords, account emails, bundles, or local
+credential-file locations in this public repo. For rare local ThetaTerminal
+debugging, load credentials from your own secret manager or untracked local
+environment, use a disposable `$TMPDIR` file, and delete that file when the
+process exits. Do not use local ThetaTerminal credentials for backtests; use the
+configured Data Downloader path for consistent results.
 
-| Field | Value |
-|-------|-------|
-| Username | `rob-dev@lumiwealth.com` |
-| Password | `TestTestTest` |
-| Bundle | STOCK.PRO, OPTION.PRO, INDEX.PRO |
-| Location | `Strategy Library/Demos/.env` (commented out) |
-
-**Verified working:** Dec 7, 2025
-
-```bash
-# Quick test with dev credentials
-mkdir -p "/Users/robertgrzesik/Documents/Development/tmp/theta-dev-test"
-echo -e "rob-dev@lumiwealth.com\nTestTestTest" > "/Users/robertgrzesik/Documents/Development/tmp/theta-dev-test/creds.txt"
-java -jar $(python -c "import lumibot; import os; print(os.path.join(os.path.dirname(lumibot.__file__), 'tools', 'ThetaTerminal.jar'))") "/Users/robertgrzesik/Documents/Development/tmp/theta-dev-test/creds.txt" &
-sleep 10
-curl "http://127.0.0.1:25510/v2/status"  # Should show CONNECTED
-pkill -f "ThetaTerminal.jar"  # Clean up
-rm -rf "/Users/robertgrzesik/Documents/Development/tmp/theta-dev-test"
-```
-
-**Use dev credentials ONLY for:** Debugging ThetaTerminal itself, testing API endpoints, investigating data issues.
-**Do NOT use for:** Running backtests (always use prod Data Downloader for consistent results).
 3. **Respect the queue/backoff contract.** LumiBot no longer enforces a 30 s client timeout; instead it listens for the downloader’s `{"error":"queue_full"}` responses and retries with exponential backoff. If you add new downloader
    integrations, reuse that helper so we never DDoS the server.
-4. **Long commands = safe-timeout (20m default max).** Wrap backtests/pytest/stress jobs with `/Users/robertgrzesik/bin/safe-timeout 1200s …` and break work into smaller chunks if it would run longer. Only use longer timeouts when absolutely necessary (e.g., explicit full-window acceptance backtests).
+4. **Long commands = safe-timeout (20m default max).** Wrap backtests/pytest/stress jobs with `bin/safe-timeout 1200s ...` when available, or another timeout wrapper, and break work into smaller chunks if it would run longer. Only use longer timeouts when absolutely necessary (e.g., explicit full-window acceptance backtests).
 5. **Artifacts.** When demonstrating fixes, capture `Strategy\ Library/logs/*.log`, tear sheets, and downloader stress JSONs so the accuracy/dividend/resilience story stays reproducible.
 6. **Write Location Policy (no “code files” outside Development).** Do not create helper scripts (e.g., `*.py`) under `/tmp` or other non-Development locations. Put LumiBot helpers under `scripts/` in this repo.
 
@@ -428,4 +436,5 @@ This philosophy applies to ALL projects, not just LumiBot.
 
 - Track leading indicators weekly. Create dashboards and graphs to visualize progress.
 - When starting any task, check: does this move a North Star metric? If not, question its priority.
-- See `/Users/robertgrzesik/Documents/Development/CLAUDE.md` for the full framework.
+- See the private workspace operating instructions for the full framework when
+  working inside Rob's local BotSpot/Lumiwealth environment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.73 - Unreleased
+
 ## 4.5.72 - 2026-07-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 4.5.73 - Unreleased
 
+### Fixed
+- **Tradier order refresh now parses returned OTOCO bracket rows and preserves
+  unsupported asset rows during broker-state reads.** Tradier bracket submits are
+  sent as `otoco`; returned rows now map back to LumiBot bracket orders with
+  attached exit children, `combo` maps to multileg, and future-like or unknown
+  account rows are preserved instead of being forced through stock parsing.
+  Parser failures now log only sanitized row shapes.
+
 ## 4.5.72 - 2026-07-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@
   explicit public contract.** Native Gemini model resolution no longer mutates
   `GOOGLE_API_KEY` behind the scenes, and the bundled Alpaca news agent example
   only treats `GEMINI_API_KEY` as satisfying Gemini credential readiness.
+- **AI-agent context pruning no longer expands small tool results or prunes far
+  below the model's real context window.** Gemini 3.1 data-on BotSpot strategy
+  smokes exposed a pruning loop where compact tool payloads were replaced by
+  longer pruning notices and the serialized request grew past its own budget.
+  LumiBot now skips non-shrinking replacements, avoids repeatedly pruning
+  already-pruned function responses, and uses a realistic character budget from
+  the model context registry before pruning.
 
 ### Security
 - **Public-repo hygiene guardrails now block private local details and credential
@@ -45,15 +52,6 @@
   guards from 4.5.69 while satisfying the production CI Ruff gate.
 
 ## 4.5.69 - 2026-07-07
-
-### Fixed
-- **AI-agent context pruning no longer expands small tool results or prunes far
-  below the model's real context window.** Gemini 3.1 data-on BotSpot strategy
-  smokes exposed a pruning loop where compact tool payloads were replaced by
-  longer pruning notices and the serialized request grew past its own budget.
-  LumiBot now skips non-shrinking replacements, avoids repeatedly pruning
-  already-pruned function responses, and uses a realistic character budget from
-  the model context registry before pruning.
 
 ## 4.5.68 - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
   attached exit children, `combo` maps to multileg, and future-like or unknown
   account rows are preserved instead of being forced through stock parsing.
   Parser failures now log only sanitized row shapes.
+- **AI agent Gemini examples and runtime checks now use `GEMINI_API_KEY` as the
+  explicit public contract.** Native Gemini model resolution no longer mutates
+  `GOOGLE_API_KEY` behind the scenes, and the bundled Alpaca news agent example
+  only treats `GEMINI_API_KEY` as satisfying Gemini credential readiness.
+
+### Security
+- **Public-repo hygiene guardrails now block private local details and credential
+  leakage in tracked files.** Repo instructions, SECURITY guidance, CODEOWNERS,
+  and regression coverage now keep machine-specific/private operational details
+  out of public docs, tests, and examples.
 
 ## 4.5.72 - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@
 
 ## 4.5.69 - 2026-07-07
 
+### Fixed
+- **AI-agent context pruning no longer expands small tool results or prunes far
+  below the model's real context window.** Gemini 3.1 data-on BotSpot strategy
+  smokes exposed a pruning loop where compact tool payloads were replaced by
+  longer pruning notices and the serialized request grew past its own budget.
+  LumiBot now skips non-shrinking replacements, avoids repeatedly pruning
+  already-pruned function responses, and uses a realistic character budget from
+  the model context registry before pruning.
+
 ## 4.5.68 - 2026-07-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.73 - Unreleased
+## 4.5.73 - 2026-07-08
+
+Deploy marker: `deploy 4.5.73`
 
 ### Fixed
 - **Tradier order refresh now parses returned OTOCO bracket rows and preserves

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,22 @@
 # CLAUDE.md - AI Assistant Instructions for LumiBot
 
+## Public Repo Secret Hygiene (CRITICAL)
+
+LumiBot is open source. Never put private, account-specific, or
+machine-specific information in this file or any other tracked repo file.
+
+- Do not include usernames, passwords, API keys, tokens, account emails,
+  customer identifiers, broker credentials, paid vendor credentials, private
+  hostnames, private URLs, cookies, local profile paths, or absolute personal
+  filesystem paths.
+- Do not document real `.env` locations, credential-file paths, secret store
+  values, or commands that write real credentials to disk.
+- Use placeholders such as `<your-vendor-username>`,
+  `<your-downloader-host>`, `<repo>`, and `$TMPDIR`, and point contributors to
+  public environment variable names or their own secret manager.
+- If sensitive data is needed for private BotSpot/Lumiwealth operations, keep it
+  in private repos/docs/secret stores, not in this public LumiBot checkout.
+
 ## 🚨🚨🚨 RULE #1 — NEVER FABRICATE BACKTEST DATA 🚨🚨🚨
 
 **Fake / synthesized / default-filled market data is STRICTLY FORBIDDEN.**
@@ -34,9 +51,9 @@ Backtesting “accuracy” is measured against live broker behavior when possibl
 ## Multi-Agent Collaboration (CRITICAL)
 This repo is often worked on by **multiple AI sessions** at the same time.
 
-- Canonical checkout: normal LumiBot work must happen in
-  `/Users/robertgrzesik/Development/lumibot`. Keep that checkout on the active
-  `version/X.Y.Z` branch, clean, and ready for release. Do not create sibling
+- Canonical checkout: normal LumiBot work must happen in this repository
+  checkout. Keep that checkout on the active `version/X.Y.Z` branch, clean, and
+  ready for release. Do not create sibling
   worktrees like `lumibot-version-X.Y.Z` for normal development. Temporary
   worktrees outside this folder are acceptable only for isolated review of
   unusually large or risky external PRs, and must not become the active release
@@ -316,11 +333,11 @@ LumiBot is a trading and backtesting framework supporting multiple data sources 
 
 | What | Where |
 |------|-------|
-| LumiBot library | `/Users/robertgrzesik/Documents/Development/lumivest_bot_server/strategies/lumibot/` |
-| Strategy Library | `/Users/robertgrzesik/Documents/Development/Strategy Library/` |
-| Demo strategies | `/Users/robertgrzesik/Documents/Development/Strategy Library/Demos/` |
-| Environment config | `Demos/.env` for strategies, `lumibot/.env` for library |
-| Backtest logs | `/Users/robertgrzesik/Documents/Development/Strategy Library/logs/` |
+| LumiBot library | This repository checkout |
+| Strategy examples | `example_strategies/` and `tests/backtest/acceptance_strategies/` |
+| Demo strategies | Use your own untracked local strategy folder |
+| Environment config | Use untracked local `.env` files or your secret manager |
+| Backtest logs | Use `logs/` or another untracked local artifact folder |
 
 ## Critical Rules
 
@@ -329,11 +346,10 @@ LumiBot is a trading and backtesting framework supporting multiple data sources 
 1. **NEVER run ThetaTerminal locally WITH PRODUCTION CREDENTIALS** - It will kill production connections
 2. **Only use the Data Downloader** configured via `DATADOWNLOADER_BASE_URL` for backtests (avoid hard-coded IPs/hostnames—they can change on redeploy)
 3. **Always compare ThetaData vs Yahoo** - Yahoo is the gold standard for split-adjusted prices
-4. **Dev credentials available for local testing** - See `AGENTS.md` for details:
-   - Username: `rob-dev@lumiwealth.com` / Password: `TestTestTest`
-   - Safe to use locally without affecting production
-   - Verified working Dec 7, 2025 with STOCK.PRO, OPTION.PRO, INDEX.PRO bundle
-5. **Wrap long commands with safe-timeout (20m default max).** Use `/Users/robertgrzesik/bin/safe-timeout 1200s …` and split work into smaller chunks if it would run longer.
+4. **Do not publish local ThetaTerminal credentials** - See `AGENTS.md` for the
+   public-safe policy. Use your own secret manager or untracked local
+   environment for rare local ThetaTerminal debugging.
+5. **Wrap long commands with safe-timeout (20m default max).** Use `bin/safe-timeout 1200s ...` when available, or another timeout wrapper, and split work into smaller chunks if it would run longer.
 6. See `AGENTS.md` for complete rules
 
 ### Private endpoint hygiene (MUST FOLLOW)
@@ -368,8 +384,8 @@ BACKTESTING_DATA_SOURCE=none       # Uses whatever class the code specifies
 ### Run a Backtest
 
 ```bash
-cd "/Users/robertgrzesik/Documents/Development/Strategy Library/Demos"
-python3 "TQQQ 200-Day MA.py"
+cd <your-untracked-strategy-folder>
+python3 "<your-strategy>.py"
 ```
 
 ### Compare Yahoo vs ThetaData
@@ -385,7 +401,7 @@ python3 "TQQQ 200-Day MA.py"
 ### Check Backtest Results
 
 ```bash
-ls -la "/Users/robertgrzesik/Documents/Development/Strategy Library/logs/" | grep TQQQ | tail -10
+ls -la logs/ | grep TQQQ | tail -10
 ```
 
 Look at `*_tearsheet.csv` for CAGR and metrics.
@@ -483,7 +499,7 @@ Two new test files provide comprehensive split adjustment coverage:
 ### Running Split Tests
 
 ```bash
-cd /Users/robertgrzesik/Documents/Development/lumivest_bot_server/strategies/lumibot
+cd <repo>
 
 # Run unit tests only (no API calls, fast)
 pytest tests/test_split_adjustment.py tests/test_thetadata_yahoo_parity.py -v -m "not apitest"
@@ -667,4 +683,5 @@ Without MCP tools, debugging these issues is slow and error-prone. With them, yo
 
 - Track leading indicators weekly. Create dashboards and graphs to visualize progress.
 - When starting any task, check: does this move a North Star metric? If not, question its priority.
-- See `/Users/robertgrzesik/Documents/Development/CLAUDE.md` for the full framework.
+- See the private workspace operating instructions for the full framework when
+  working inside Rob's local BotSpot/Lumiwealth environment.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected security issues privately instead of opening a public
+GitHub issue.
+
+- Use GitHub private vulnerability reporting if it is available for this
+  repository, or contact the repository maintainers privately.
+- Include the affected version or commit, reproduction steps, impact, and any
+  relevant logs with secrets redacted.
+- Do not include live credentials, account tokens, customer data, private local
+  paths, or production-only URLs in public issues, pull requests, docs, or
+  examples.
+
+## Public Repository Hygiene
+
+LumiBot is open source. Public files must not contain usernames, passwords, API
+keys, account emails, private URLs, local `.env` paths, credential-file paths,
+or absolute personal filesystem paths.
+
+The repository uses GitHub secret scanning with push protection plus a lightweight
+public-hygiene CI check for instruction files such as `AGENTS.md` and
+`CLAUDE.md`.

--- a/docs/BROKER_ORDER_SEMANTICS.md
+++ b/docs/BROKER_ORDER_SEMANTICS.md
@@ -2,7 +2,7 @@
 
 > Notes on live broker behavior that affect backtesting semantics (extended hours, order types, and “market closed / no data” handling).
 
-**Last Updated:** 2026-07-07
+**Last Updated:** 2026-07-08
 **Status:** Active
 **Audience:** Developers, AI Agents
 
@@ -137,6 +137,19 @@ Link (public):
 
 Backtesting implications:
 - for Tradier-style behavior, “order submitted outside session” likely means “accepted and held until open”.
+
+Live read-path implications:
+- Tradier's Brokerage REST advanced-order submit path uses `otoco` for bracket orders. Returned `otoco` rows must be
+  parsed back into LumiBot `OrderClass.BRACKET`, with the entry leg as the parent order and the take-profit/stop-loss
+  legs attached as children.
+- Tradier `combo` rows map to LumiBot `OrderClass.MULTILEG`.
+- Tradier account/order refresh may encounter future-like or unsupported broker asset rows. The read path should
+  preserve these as `future`, `cont_future`, or `unknown` assets instead of forcing every non-option row into stock
+  parsing. This is read-model preservation only; it does not mean Tradier Brokerage REST futures order execution is
+  supported.
+- If a Tradier order row cannot be parsed, logs must include only a sanitized row shape: class/type/status, field
+  presence, leg count, and per-leg field presence. Do not log raw symbols, account identifiers, tags, credentials, or
+  the full broker payload.
 
 ### IBKR (equities/options)
 

--- a/docs/investigations/2025-12-11_THETADATA_INVESTIGATION.md
+++ b/docs/investigations/2025-12-11_THETADATA_INVESTIGATION.md
@@ -182,9 +182,11 @@ This is NOT a data availability issue from ThetaData. The option contract `GOOG 
 
 **Local ThetaTerminal process (PID 41989) on your Mac was blocking production!**
 
-This process was running since Sunday 5AM:
+This process was running since Sunday 5AM. The original process command included
+a local username, absolute filesystem path, and credential-file path; those
+private details are intentionally redacted here because LumiBot is public:
 ```
-robertgrzesik    41989   0.1  2.0 449880816 1005520   ??  SN   Sun05AM  17:44.67 /usr/bin/java -XX:+IgnoreUnrecognizedVMOptions --sun-misc-unsafe-memory-access=allow --enable-native-access=ALL-UNNAMED -jar /Users/robertgrzesik/Documents/Development/botspot_data_downloader/resources/lib/202511141.jar --creds-file /tmp/theta-dev-test/creds.txt --config config.toml
+<local-user> 41989 ... /usr/bin/java ... -jar <theta-terminal-jar> --creds-file <redacted-local-creds-file> --config config.toml
 ```
 
 **Actions taken:**
@@ -241,7 +243,7 @@ BACKTESTING_DATA_SOURCE=thetadata
 
 ## Files Referenced
 
-- `/Users/robertgrzesik/Documents/Development/Strategy Library/Demos/.env` - Configuration
+- `<untracked-local-strategy-folder>/.env` - Local configuration
 - `botspot_data_downloader/src/botspot_data_downloader/supervisor.py` - ThetaTerminal process manager
 - CloudWatch Log Group: `/ecs/botspot-data-downloader`
 

--- a/docs/investigations/2026-07-08_AGENT_CONTEXT_PRUNING_SMOKE_FAILURE.md
+++ b/docs/investigations/2026-07-08_AGENT_CONTEXT_PRUNING_SMOKE_FAILURE.md
@@ -1,0 +1,70 @@
+# AI Agent Context Pruning Smoke Failure
+
+One-line description: Records the BotSpot Ray/Citadel data-on smoke blocker caused by LumiBot agent context pruning expanding request payloads.
+
+Last Updated: 2026-07-08
+
+Status: Fixed locally in LumiBot; requires deploy before BotSpot long backtests should resume.
+
+Audience: LumiBot release agents, BotSpot strategy/backtest agents, Bot Manager runtime investigators.
+
+## Overview
+
+BotSpot data-on strategy smokes for the Ray Dalio and Citadel AI trading teams were gated on proving that FRED and Alpaca News work before launching one-year backtests. The first fresh Ray regular data-on smoke proved both data integrations worked inside the ECS backtest runtime, but it stalled before the trader/order step because LumiBot's ADK context-pruning callback repeatedly expanded or failed to shrink the serialized model request.
+
+Do not treat this incident as an Alpaca credential failure. The credential path was separately verified locally and in ECS.
+
+## Evidence
+
+- Local Alpaca News credentials returned HTTP 200 against the Alpaca News API. Generic Alpaca broker environment variables were intentionally not used for news.
+- A temporary BotSpot diagnostic strategy verified runtime injection inside ECS: `ALPACA_NEWS_DIAGNOSTIC status=200 count=20`.
+- The Ray regular data-on smoke over `2026-05-26` to `2026-06-02` showed FRED tool results with `source=fred` and Alpaca News results with returned headlines.
+- The same smoke had no `401`, `Unauthorized`, `API_KEY_INVALID`, `ORDER_READINESS_REQUIRED`, `Traceback`, or `ContextWindowExceededError` matches at the time it was stopped.
+- Runtime logs showed repeated pruning warnings such as request chars growing from about `70072` to `75033` against a budget of `52428`, while the strategy remained before the trader/order step.
+
+The smoke was force-stopped to avoid wasting backtest runtime and model credits. The remaining Ray/Citadel smokes and all one-year promotions should wait until the LumiBot fix is deployed to the BotSpot backtest runtime.
+
+## Root Cause
+
+`lumibot/components/agents/runtime.py` had two related issues:
+
+1. The pruning helper replaced older function-response payloads without checking whether the replacement notice was actually shorter than the original payload. Compact tool results such as last-price responses could therefore be replaced with a larger pruning notice.
+2. The default serialized-character budget was calculated as `context_limit_tokens * 0.05`. For Gemini 3.1's roughly one-million-token registry entry, this produced a budget around `52k` JSON characters, causing pruning far below the real model window.
+
+Together, these made pruning fire too early and sometimes increase the request size, which can trap an agent before it reaches the final trader step.
+
+## Fix
+
+The local LumiBot fix:
+
+- skips pruning a function response when the replacement would not shrink the serialized payload;
+- skips function responses already marked as `lumibot_context_pruned`;
+- uses a realistic serialized-character budget derived from the model context registry instead of pruning at five percent of the token limit.
+
+Regression coverage was added in `tests/test_agent_deepseek_usage_accounting.py` for:
+
+- not expanding small tool results;
+- not repeatedly pruning already-pruned results;
+- not pruning moderate Gemini 3.1 request payloads far below the model's real context window.
+
+Focused verification run:
+
+```bash
+/Users/robertgrzesik/bin/safe-timeout 600s python3 -m pytest tests/test_agent_deepseek_usage_accounting.py tests/test_agent_runtime_provider_keys.py
+```
+
+Result: `38 passed`.
+
+## Follow-Up
+
+After this LumiBot version is deployed to the BotSpot backtest runtime:
+
+1. Rerun only the cheap Ray regular data-on smoke first over `2026-05-26` to `2026-06-02`.
+2. Confirm FRED and Alpaca News still work and that agent_detail/logs show the trader step and real filled orders.
+3. Only then smoke the other three separate strategies:
+   - Ray Dalio Idea Meritocracy - Leveraged Data-On
+   - Citadel Sector Pods - Regular Data-On
+   - Citadel Sector Pods - Leveraged Data-On
+4. Promote passing smokes to one-year backtests over `2025-06-24` to `2026-06-24`.
+
+No paper deployment should happen until a final strategy has a clean one-year result, acceptable drawdown, real fills, FRED success, Alpaca News success, and agent-detail evidence.

--- a/docsrc/brokers.tradier.rst
+++ b/docsrc/brokers.tradier.rst
@@ -175,5 +175,8 @@ Tradier-specific limitations
 * Tradier sandbox/paper accounts do not provide account history, so the cash-event read path cannot be fully smoke
   tested against paper credentials.
 * Tradier history is updated on a delayed/nightly basis, so new cash events are not expected to appear intraday.
+* LumiBot's Tradier broker path is for Tradier Brokerage REST stocks/options order routing. LumiBot may preserve
+  future-like or unsupported account rows during broker-state refreshes so a read does not crash, but that preservation
+  is not futures execution support through Tradier Brokerage REST.
 
 See also: :doc:`cash_accounting`

--- a/docsrc/environment_variables.rst
+++ b/docsrc/environment_variables.rst
@@ -852,6 +852,9 @@ GEMINI_API_KEY
 - Purpose: Auth for Gemini models (the default provider).
 - Values: Obtain from https://aistudio.google.com/apikey.
 - Required when ``default_model`` starts with ``gemini-`` (e.g. ``gemini-3.1-flash-lite-preview``).
+- LumiBot's public contract is ``GEMINI_API_KEY``. Do not rely on Google SDK
+  alias names in strategy examples or downstream products that infer required
+  runtime secrets.
 
 OPENAI_API_KEY
 ^^^^^^^^^^^^^^

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -1419,15 +1419,28 @@ class Tradier(Broker):
         # Loop through each row in the dataframe
         for _, row in positions_df.iterrows():
             # Get the symbol/quantity and create the position asset
-            symbol = self._normalize_symbol_for_internal(row["symbol"], asset_type=Asset.AssetType.STOCK)
+            symbol = row.get("symbol") if hasattr(row, "get") else row["symbol"]
             quantity = row["quantity"]
-            asset = Asset.symbol2asset(symbol)  # Parse the symbol. Handles 'stock' and 'option' types
+            asset = self._asset_from_tradier_row(row, symbol=symbol, context="position")
+            if asset is None:
+                logger.warning(
+                    "Skipping Tradier position with no usable symbol; shape=%s",
+                    self._tradier_position_shape_for_log(row),
+                )
+                continue
 
             # Create the position
             position = Position(
                 strategy=strategy_name,
                 asset=asset,
                 quantity=quantity,
+            )
+            self._attach_tradier_parse_metadata(
+                position,
+                raw_asset_type=getattr(asset, "raw_asset_type", None),
+                raw_symbol=getattr(asset, "raw_symbol", None),
+                broker_parse_warning=getattr(asset, "broker_parse_warning", None),
+                broker_parse_degraded=getattr(asset, "broker_parse_degraded", False),
             )
             positions_ret.append(position)  # Add the position to the list
 
@@ -1480,26 +1493,93 @@ class Tradier(Broker):
             The Lumibot order object created from the response. For multileg orders, the parent order will be returned
             with child orders internally attached.
         """
-        # First try to parse the parent order
-        parent_order = self._parse_broker_order(response, strategy_name, strategy_object)
+        try:
+            order_class = self._tradier_class2lumi(response.get("class"))
+            legs = response["leg"] if "leg" in response and isinstance(response["leg"], list) else []
+            if order_class is Order.OrderClass.BRACKET and legs:
+                return self._parse_tradier_bracket_order_dict(response, legs, strategy_name, strategy_object)
 
-        # Check if the order is a multileg order
-        if "leg" in response and isinstance(response["leg"], list):
-            # Reset child orders and replace them with the parsed child orders from broker
-            parent_order.child_orders = []
+            # First try to parse the parent order
+            parent_order = self._parse_broker_order(response, strategy_name, strategy_object)
 
-            # Loop through each leg in the response
-            for leg in response["leg"]:
-                # Create the order object
-                child_order = self._parse_broker_order(leg, strategy_name, strategy_object)
-                child_order.parent_identifier = parent_order.identifier
+            # Check if the order is a multileg order
+            if "leg" in response and isinstance(response["leg"], list):
+                # Reset child orders and replace them with the parsed child orders from broker
+                parent_order.child_orders = []
 
-                # Add the order to the list
-                parent_order.add_child_order(child_order)
+                # Loop through each leg in the response
+                for leg in response["leg"]:
+                    # Create the order object
+                    child_order = self._parse_broker_order(leg, strategy_name, strategy_object)
+                    child_order.parent_identifier = parent_order.identifier
 
+                    # Add the order to the list
+                    parent_order.add_child_order(child_order)
+
+            return parent_order
+        except Exception:
+            self._log_tradier_order_parse_failure(response)
+            raise
+
+    def _parse_tradier_bracket_order_dict(self, response: dict, legs: list, strategy_name: str, strategy_object=None):
+        """
+        Tradier returns bracket orders as OTOCO: the entry leg first, then the limit/stop exits.
+        LumiBot represents that as one BRACKET parent with the exit legs attached as children.
+        """
+        entry_leg = self._select_tradier_bracket_entry_leg(legs)
+        exit_legs = [leg for leg in legs if leg is not entry_leg]
+        child_orders = []
+        for leg in exit_legs:
+            child_order = self._parse_broker_order(
+                leg,
+                strategy_name,
+                strategy_object,
+                order_class_override=Order.OrderClass.SIMPLE,
+            )
+            child_orders.append(child_order)
+
+        parent_response = self._merge_tradier_parent_with_entry_leg(response, entry_leg)
+        parent_order = self._parse_broker_order(
+            parent_response,
+            strategy_name,
+            strategy_object,
+            child_orders=child_orders,
+            order_class_override=Order.OrderClass.BRACKET,
+        )
+        for child_order in parent_order.child_orders:
+            child_order.parent_identifier = parent_order.identifier
         return parent_order
 
-    def _parse_broker_order(self, response: dict, strategy_name: str, strategy_object=None):
+    @staticmethod
+    def _select_tradier_bracket_entry_leg(legs: list):
+        if not legs:
+            return {}
+        for leg in legs:
+            leg_type = str(leg.get("type") or "").strip().lower() if isinstance(leg, dict) else ""
+            if leg_type not in {"limit", "stop", "stop_limit"}:
+                return leg
+        return legs[0]
+
+    @classmethod
+    def _merge_tradier_parent_with_entry_leg(cls, response: dict, entry_leg: dict):
+        parent_response = dict(response)
+        parent_response.pop("leg", None)
+        for key in ("symbol", "option_symbol", "side", "type", "quantity", "duration", "price", "stop_price"):
+            if key in entry_leg and not cls._is_missing_broker_value(entry_leg.get(key)):
+                parent_response[key] = entry_leg.get(key)
+        for key in ("status", "create_date", "transaction_date", "avg_fill_price"):
+            if cls._is_missing_broker_value(parent_response.get(key)) and key in entry_leg:
+                parent_response[key] = entry_leg.get(key)
+        return parent_response
+
+    def _parse_broker_order(
+        self,
+        response: dict,
+        strategy_name: str,
+        strategy_object=None,
+        child_orders: list | None = None,
+        order_class_override=None,
+    ):
         """
         Parse a broker order representation to a Lumi order object. Once the Lumi order has been created, it will
         be dispatched to our "stream" queue for processing until a time when Live Streaming can be implemented.
@@ -1515,20 +1595,29 @@ class Tradier(Broker):
             strategy_name if strategy_name else strategy_object.name if strategy_object else None
         )
 
-        # For OCO orders, tradier leaves lots of fields empty (float nan). Pull values from the children if needed
+        order_class = order_class_override or self._tradier_class2lumi(response.get("class")) or Order.OrderClass.SIMPLE
+
+        # For OCO/OTOCO orders, Tradier leaves many parent fields empty. Pull values from legs where needed.
         legs = response["leg"] if "leg" in response and isinstance(response["leg"], list) else []
-        limit_order = next((o for o in legs if o["type"] == "limit"), {})
-        stop_order = next((o for o in legs if o["type"] == "stop"), {})
+        entry_order = self._select_tradier_bracket_entry_leg(legs) if order_class in {
+            Order.OrderClass.BRACKET,
+            Order.OrderClass.OTO,
+        } else {}
+        exit_legs = [leg for leg in legs if leg is not entry_order] if entry_order else legs
+        limit_order = next((o for o in exit_legs if o.get("type") == "limit"), {})
+        stop_order = next((o for o in exit_legs if o.get("type") in {"stop", "stop_limit"}), {})
+        value_order = limit_order if order_class is Order.OrderClass.OCO else entry_order
+        stop_value_order = stop_order if order_class is Order.OrderClass.OCO else entry_order
 
         # Parse the symbol & side
-        symbol = self._extract_order_value(response, limit_order, "symbol")
-        option_symbol = self._extract_order_value(response, limit_order, "option_symbol")
-        side = self._extract_order_value(response, limit_order, "side")
-
-        asset = (
-            Asset.symbol2asset(option_symbol)
-            if option_symbol and not pd.isna(option_symbol)
-            else Asset.symbol2asset(self._normalize_symbol_for_internal(symbol, asset_type=Asset.AssetType.STOCK))
+        symbol = self._extract_order_value(response, value_order, "symbol")
+        option_symbol = self._extract_order_value(response, value_order, "option_symbol")
+        side = self._extract_order_value(response, value_order, "side")
+        asset = self._asset_from_tradier_row(
+            response,
+            symbol=symbol,
+            option_symbol=option_symbol,
+            context="order row",
         )
 
         # Get the reason_description if it exists
@@ -1545,7 +1634,7 @@ class Tradier(Broker):
             avg_fill_price = None
 
         # Map Tradier order types to Lumi order types
-        lumi_order_type = self._tradier_type2lumi(self._extract_order_value(response, {}, "type"))
+        lumi_order_type = self._tradier_type2lumi(self._extract_order_value(response, value_order, "type"))
 
         # Create the order object
         order = Order(
@@ -1554,22 +1643,184 @@ class Tradier(Broker):
             status=response["status"],  # Status conversion happens automatically in Order
             asset=asset,
             side=self._tradier_side2lumi(side),
-            quantity=self._extract_order_value(response, limit_order, "quantity"),
+            quantity=self._extract_order_value(response, value_order, "quantity"),
             order_type=lumi_order_type,
-            time_in_force=self._extract_order_value(response, limit_order, "duration"),
-            limit_price=self._extract_order_value(response, limit_order, "price"),
-            stop_price=self._extract_order_value(response, stop_order, "stop_price"),
+            time_in_force=self._extract_order_value(response, value_order, "duration"),
+            limit_price=self._extract_order_value(response, value_order, "price"),
+            stop_price=self._extract_order_value(response, stop_value_order, "stop_price"),
+            secondary_limit_price=limit_order.get("price") if not child_orders else None,
+            secondary_stop_price=stop_order.get("stop_price") if not child_orders else None,
             tag=response["tag"] if "tag" in response and response["tag"] else None,
             date_created=response["create_date"],
             avg_fill_price=avg_fill_price,
             error_message=reason_description,
-            order_class=self._tradier_class2lumi(response["class"] if "class" in response else None) or Order.OrderClass.SIMPLE,
+            child_orders=child_orders,
+            order_class=order_class,
+        )
+        self._attach_tradier_parse_metadata(
+            order,
+            raw_asset_type=getattr(asset, "raw_asset_type", None),
+            raw_symbol=getattr(asset, "raw_symbol", None),
+            broker_parse_warning=getattr(asset, "broker_parse_warning", None),
+            broker_parse_degraded=getattr(asset, "broker_parse_degraded", False),
         )
         # Example Tradier Date Value: '2024-10-04T15:46:14.946Z'
         order.broker_create_date = response["create_date"] if "create_date" in response else None
         order.broker_update_date = response["transaction_date"] if "transaction_date" in response else None
         order.update_raw(response)  # This marks order as 'transmitted'
         return order
+
+    @staticmethod
+    def _attach_tradier_parse_metadata(entity, **metadata):
+        entity.broker_parse_warning = metadata.pop("broker_parse_warning", None)
+        entity.broker_parse_degraded = metadata.pop("broker_parse_degraded", False)
+        for key, value in metadata.items():
+            if value is not None:
+                setattr(entity, key, value)
+        return entity
+
+    def _asset_from_tradier_row(self, row, *, symbol=None, option_symbol=None, context: str = "broker row"):
+        raw_symbol = self._clean_tradier_symbol(symbol if symbol is not None else row.get("symbol"))
+        raw_option_symbol = self._clean_tradier_symbol(
+            option_symbol if option_symbol is not None else row.get("option_symbol")
+        )
+        raw_asset_type = self._extract_tradier_asset_type(row)
+        raw_asset_type_key = str(raw_asset_type or "").strip().lower().replace(" ", "_")
+
+        if raw_option_symbol:
+            try:
+                asset = Asset.symbol2asset(raw_option_symbol)
+            except Exception:
+                asset = Asset(raw_symbol or raw_option_symbol, asset_type=Asset.AssetType.UNKNOWN)
+                self._attach_tradier_parse_metadata(
+                    asset,
+                    raw_asset_type=raw_asset_type or "option",
+                    raw_symbol=raw_symbol or raw_option_symbol,
+                    broker_parse_warning=f"Could not parse Tradier option symbol for {context}",
+                    broker_parse_degraded=True,
+                )
+            else:
+                self._attach_tradier_parse_metadata(
+                    asset,
+                    raw_asset_type=raw_asset_type or "option",
+                    raw_symbol=raw_symbol or raw_option_symbol,
+                )
+            return asset
+
+        if not raw_symbol:
+            return None
+
+        if raw_asset_type_key == "option":
+            try:
+                asset = Asset.symbol2asset(raw_symbol)
+            except Exception:
+                logger.warning(
+                    "Could not parse Tradier option symbol for %s; preserving broker row as unknown.",
+                    context,
+                )
+                return self._attach_tradier_parse_metadata(
+                    Asset(raw_symbol, asset_type=Asset.AssetType.UNKNOWN),
+                    raw_asset_type=raw_asset_type,
+                    raw_symbol=raw_symbol,
+                    broker_parse_warning=f"Could not parse Tradier option symbol: {raw_symbol}",
+                    broker_parse_degraded=True,
+                )
+            return self._attach_tradier_parse_metadata(
+                asset,
+                raw_asset_type=raw_asset_type,
+                raw_symbol=raw_symbol,
+            )
+
+        future_asset_types = {"future", "futures", "cont_future", "continuous_future", "future_contract"}
+        if raw_asset_type_key in future_asset_types or raw_symbol.startswith("/"):
+            future_symbol = raw_symbol[1:] if raw_symbol.startswith("/") else raw_symbol
+            is_continuous = raw_asset_type_key in {"cont_future", "continuous_future"}
+            if not is_continuous:
+                try:
+                    from lumibot.tools.futures_symbols import parse_contract_symbol
+
+                    is_continuous = parse_contract_symbol(future_symbol) is None
+                except Exception:
+                    is_continuous = True
+            asset_type = Asset.AssetType.CONT_FUTURE if is_continuous else Asset.AssetType.FUTURE
+            return self._attach_tradier_parse_metadata(
+                Asset(future_symbol, asset_type=asset_type),
+                raw_asset_type=raw_asset_type or "future",
+                raw_symbol=raw_symbol,
+            )
+
+        known_asset_types = {
+            "equity": Asset.AssetType.STOCK,
+            "stock": Asset.AssetType.STOCK,
+            "option": Asset.AssetType.OPTION,
+            "index": Asset.AssetType.INDEX,
+            "forex": Asset.AssetType.FOREX,
+            "cash": Asset.AssetType.FOREX,
+            "crypto": Asset.AssetType.CRYPTO,
+        }
+        if (
+            raw_asset_type_key in known_asset_types
+            and known_asset_types[raw_asset_type_key] is not Asset.AssetType.OPTION
+        ):
+            asset_type = known_asset_types[raw_asset_type_key]
+            normalized_symbol = (
+                self._normalize_symbol_for_internal(raw_symbol, asset_type=asset_type)
+                if asset_type in {Asset.AssetType.STOCK, Asset.AssetType.INDEX}
+                else raw_symbol
+            )
+            return self._attach_tradier_parse_metadata(
+                Asset(normalized_symbol, asset_type=asset_type),
+                raw_asset_type=raw_asset_type,
+                raw_symbol=raw_symbol,
+            )
+
+        if raw_asset_type_key and raw_asset_type_key not in {"equity", "stock"}:
+            logger.warning(
+                "Unknown Tradier asset type %r for %s; preserving broker row as unknown.",
+                raw_asset_type,
+                context,
+            )
+            return self._attach_tradier_parse_metadata(
+                Asset(raw_symbol, asset_type=Asset.AssetType.UNKNOWN),
+                raw_asset_type=raw_asset_type,
+                raw_symbol=raw_symbol,
+                broker_parse_warning=f"Unknown Tradier asset type: {raw_asset_type}",
+                broker_parse_degraded=True,
+            )
+
+        normalized_symbol = self._normalize_symbol_for_internal(raw_symbol, asset_type=Asset.AssetType.STOCK)
+        asset = Asset.symbol2asset(normalized_symbol)
+        return self._attach_tradier_parse_metadata(
+            asset,
+            raw_asset_type=raw_asset_type,
+            raw_symbol=raw_symbol,
+        )
+
+    @classmethod
+    def _extract_tradier_asset_type(cls, row):
+        for key in (
+            "asset_type",
+            "assetType",
+            "asset_class",
+            "assetClass",
+            "security_type",
+            "securityType",
+            "instrument_type",
+            "instrumentType",
+        ):
+            value = row.get(key) if hasattr(row, "get") else None
+            if not cls._is_missing_broker_value(value):
+                return str(value).strip()
+        broker_class = row.get("class") if hasattr(row, "get") else None
+        if isinstance(broker_class, str) and broker_class.strip().lower() in {"equity", "option"}:
+            return broker_class.strip()
+        return None
+
+    @classmethod
+    def _clean_tradier_symbol(cls, value):
+        if cls._is_missing_broker_value(value):
+            return None
+        return str(value).strip().upper() or None
 
     @staticmethod
     def _tradier_type2lumi(order_type):
@@ -1581,14 +1832,68 @@ class Tradier(Broker):
             return "limit"
         return order_type
 
-    @staticmethod
-    def _extract_order_value(response, child_response, key):
+    @classmethod
+    def _extract_order_value(cls, response, child_response, key):
         """
         OCO orders have empty values for many fields. This function will pull the value from the child order if
         the value is empty in the parent order.
         """
-        is_oco = response["class"] == "oco"
-        return response[key] if key in response and not is_oco else child_response.get(key, None)
+        order_class = response.get("class")
+        is_oco = isinstance(order_class, str) and order_class.strip().lower() == "oco"
+        value = response.get(key)
+        if not is_oco and not cls._is_missing_broker_value(value):
+            return value
+        return child_response.get(key, None)
+
+    @staticmethod
+    def _is_missing_broker_value(value):
+        if value is None:
+            return True
+        if isinstance(value, (dict, list, tuple)):
+            return False
+        try:
+            return bool(pd.isna(value))
+        except Exception:
+            return False
+
+    @classmethod
+    def _tradier_position_shape_for_log(cls, row):
+        return {
+            "symbol_present": not cls._is_missing_broker_value(row.get("symbol") if hasattr(row, "get") else None),
+            "asset_type": cls._extract_tradier_asset_type(row),
+            "quantity_present": not cls._is_missing_broker_value(row.get("quantity") if hasattr(row, "get") else None),
+        }
+
+    @classmethod
+    def _tradier_order_shape_for_log(cls, row):
+        legs = row.get("leg") if isinstance(row, dict) and isinstance(row.get("leg"), list) else []
+
+        def one_shape(order_row):
+            return {
+                "class": order_row.get("class"),
+                "type": order_row.get("type"),
+                "status": order_row.get("status"),
+                "symbol_present": not cls._is_missing_broker_value(order_row.get("symbol")),
+                "option_symbol_present": not cls._is_missing_broker_value(order_row.get("option_symbol")),
+                "side_present": not cls._is_missing_broker_value(order_row.get("side")),
+                "duration_present": not cls._is_missing_broker_value(order_row.get("duration")),
+                "price_present": not cls._is_missing_broker_value(order_row.get("price")),
+                "stop_price_present": not cls._is_missing_broker_value(order_row.get("stop_price")),
+            }
+
+        return {
+            **one_shape(row),
+            "leg_count": len(legs),
+            "legs": [one_shape(leg) for leg in legs if isinstance(leg, dict)],
+        }
+
+    @classmethod
+    def _log_tradier_order_parse_failure(cls, response):
+        logger.warning(
+            "Failed to parse Tradier order row; sanitized_shape=%s",
+            cls._tradier_order_shape_for_log(response),
+            exc_info=True,
+        )
 
     def _pull_broker_order(self, identifier):
         """
@@ -1732,8 +2037,13 @@ class Tradier(Broker):
         if order_class is None or not isinstance(order_class, str):
             return None
 
+        order_class = order_class.strip().lower()
         if order_class in ['equity', 'option']:
             return Order.OrderClass.SIMPLE
+        if order_class == "otoco":
+            return Order.OrderClass.BRACKET
+        if order_class == "combo":
+            return Order.OrderClass.MULTILEG
 
         # Check if the order class is a valid Lumi order class
         try:

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -775,14 +775,28 @@ def _function_response_payload_length(part: Any) -> int:
     return _serialized_content_length(getattr(function_response, "response", None))
 
 
+def _function_response_payload_is_pruned(part: Any) -> bool:
+    function_response = getattr(part, "function_response", None)
+    if function_response is None:
+        return False
+    response = getattr(function_response, "response", None)
+    if isinstance(response, dict):
+        return response.get("lumibot_context_pruned") is True
+    return False
+
+
 def _replace_function_response_payload(part: Any, message: str) -> bool:
     function_response = getattr(part, "function_response", None)
     if function_response is None:
         return False
+    original_response = getattr(function_response, "response", None)
+    original_chars = _serialized_content_length(original_response)
     replacement = {
         "lumibot_context_pruned": True,
         "message": message,
     }
+    if _serialized_content_length(replacement) >= original_chars:
+        return False
     try:
         function_response.response = replacement
         return True
@@ -812,7 +826,7 @@ def _prune_request_contents_for_context_window(
     contents: list[Any],
     *,
     context_limit_tokens: int,
-    reserve_ratio: float = 0.05,
+    reserve_ratio: float = 3.0,
     preserve_recent_tool_results: int = 4,
     always_prune_older_tool_results: bool = False,
 ) -> dict[str, Any] | None:
@@ -827,6 +841,9 @@ def _prune_request_contents_for_context_window(
     if not contents:
         return None
 
+    # The registry stores provider limits in tokens while this guard only has a
+    # cheap serialized-character estimate. Use a conservative character budget
+    # instead of pruning at a tiny percentage of the true token window.
     max_chars = int(context_limit_tokens * reserve_ratio)
     before_chars = _request_contents_length(contents)
 
@@ -851,7 +868,11 @@ def _prune_request_contents_for_context_window(
         "recent visible tool results or call a targeted tool again if this older "
         "detail is still required."
     )
-    candidates = tool_response_parts[: -preserve_recent_tool_results]
+    candidates = [
+        part
+        for part in tool_response_parts[: -preserve_recent_tool_results]
+        if not _function_response_payload_is_pruned(part)
+    ]
     candidates.sort(key=_function_response_payload_length, reverse=True)
     for part in candidates:
         if should_prune_for_size and _request_contents_length(contents) <= max_chars:

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -595,16 +595,6 @@ def _sync_xai_api_key_alias() -> None:
         os.environ["XAI_API_KEY"] = os.environ["GROK_API_KEY"]
 
 
-def _sync_gemini_api_key_alias() -> None:
-    """Allow product-facing GEMINI_API_KEY with Google SDK internals.
-
-    Google examples and some SDK paths use GOOGLE_API_KEY. LumiBot's public
-    docs use GEMINI_API_KEY, so mirror it when the Google name is absent.
-    """
-    if not os.environ.get("GOOGLE_API_KEY") and os.environ.get("GEMINI_API_KEY"):
-        os.environ["GOOGLE_API_KEY"] = os.environ["GEMINI_API_KEY"]
-
-
 def _sync_together_api_key_alias() -> None:
     """Allow either Together's SDK key name or LiteLLM's provider key name.
 
@@ -943,7 +933,6 @@ def _resolve_model_for_adk(
         return model
     lower = model.strip().lower()
     if _is_native_gemini_model(model):
-        _sync_gemini_api_key_alias()
         return model
     if lower.startswith("xai/"):
         _sync_xai_api_key_alias()

--- a/lumibot/example_strategies/agent_alpaca_news_builtin.py
+++ b/lumibot/example_strategies/agent_alpaca_news_builtin.py
@@ -74,7 +74,7 @@ class AlpacaNewsBuiltinStrategy(Strategy):
 def _has_model_key(model_id: str) -> bool:
     lower = model_id.lower()
     if lower.startswith("gemini-") or lower.startswith("models/gemini"):
-        return bool(os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"))
+        return bool(os.environ.get("GEMINI_API_KEY"))
     if lower.startswith("openai/"):
         return bool(os.environ.get("OPENAI_API_KEY"))
     if lower.startswith("xai/"):

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.72",
+    version="4.5.73",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_agent_deepseek_usage_accounting.py
+++ b/tests/test_agent_deepseek_usage_accounting.py
@@ -4,6 +4,7 @@ from lumibot.components.agents.runtime import (
     _prune_large_context_strings,
     _prune_request_contents_for_context_window,
     _prune_tool_response_for_context_window,
+    _request_contents_length,
 )
 
 from scripts.run_ai_committee_provider_benchmark import _estimate_cost as estimate_benchmark_cost
@@ -115,6 +116,126 @@ def test_deepseek_context_pruning_replaces_only_older_tool_results():
     recent_response = contents[-1].parts[0].function_response.response
     assert older_response["lumibot_context_pruned"] is True
     assert recent_response["payload"] == "x" * 2_000
+
+
+def test_context_pruning_does_not_expand_small_tool_results():
+    from google.genai import types
+
+    contents = [
+        types.Content(
+            role="user",
+            parts=[types.Part(text="Use compact tool results without expanding them.")],
+        )
+    ]
+    for idx in range(12):
+        contents.append(
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part(
+                        functionResponse=types.FunctionResponse(
+                            name=f"tool_{idx}",
+                            response={"value": idx},
+                        )
+                    )
+                ],
+            )
+        )
+
+    before = _request_contents_length(contents)
+    result = _prune_request_contents_for_context_window(
+        contents,
+        context_limit_tokens=1_000,
+        reserve_ratio=0.01,
+        preserve_recent_tool_results=4,
+        always_prune_older_tool_results=True,
+    )
+    after = _request_contents_length(contents)
+
+    assert result is None
+    assert after == before
+    assert contents[1].parts[0].function_response.response == {"value": 0}
+
+
+def test_context_pruning_does_not_repeat_prune_already_pruned_results():
+    from google.genai import types
+
+    contents = [
+        types.Content(
+            role="user",
+            parts=[types.Part(text="Keep task text.")],
+        )
+    ]
+    for idx in range(8):
+        contents.append(
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part(
+                        functionResponse=types.FunctionResponse(
+                            name=f"tool_{idx}",
+                            response={"payload": "x" * 2_000, "idx": idx},
+                        )
+                    )
+                ],
+            )
+        )
+
+    first = _prune_request_contents_for_context_window(
+        contents,
+        context_limit_tokens=10_000,
+        reserve_ratio=0.30,
+        preserve_recent_tool_results=4,
+    )
+    assert first is not None
+
+    before_second = _request_contents_length(contents)
+    second = _prune_request_contents_for_context_window(
+        contents,
+        context_limit_tokens=10_000,
+        reserve_ratio=0.30,
+        preserve_recent_tool_results=4,
+        always_prune_older_tool_results=True,
+    )
+    after_second = _request_contents_length(contents)
+
+    assert second is None
+    assert after_second == before_second
+
+
+def test_gemini_context_pruning_uses_realistic_default_char_budget():
+    from google.genai import types
+
+    contents = [
+        types.Content(
+            role="user",
+            parts=[types.Part(text="Gemini 3.1 has a large context window.")],
+        )
+    ]
+    for idx in range(5):
+        contents.append(
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part(
+                        functionResponse=types.FunctionResponse(
+                            name=f"tool_{idx}",
+                            response={"payload": "x" * 15_000, "idx": idx},
+                        )
+                    )
+                ],
+            )
+        )
+
+    before = _request_contents_length(contents)
+    result = _prune_request_contents_for_context_window(
+        contents,
+        context_limit_tokens=1_048_576,
+        preserve_recent_tool_results=4,
+    )
+
+    assert result is None
+    assert _request_contents_length(contents) == before
 
 
 def test_deepseek_context_string_pruning_preserves_edges():

--- a/tests/test_agent_runtime_provider_keys.py
+++ b/tests/test_agent_runtime_provider_keys.py
@@ -13,7 +13,6 @@ from lumibot.components.agents.runtime import (
     _resolve_model_for_adk,
     _strip_thought_parts_from_litellm_request,
     _supports_explicit_temperature_for_adk_model,
-    _sync_gemini_api_key_alias,
     _sync_together_api_key_alias,
     _sync_xai_api_key_alias,
     _classify_agent_error,
@@ -42,22 +41,14 @@ def test_xai_api_key_wins_over_grok_alias(monkeypatch):
     assert os.environ["XAI_API_KEY"] == "xai-test-key"
 
 
-def test_gemini_api_key_alias_populates_google_api_key(monkeypatch):
+def test_native_gemini_model_does_not_mutate_google_api_key(monkeypatch):
     monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
     monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
 
-    _sync_gemini_api_key_alias()
+    resolved = _resolve_model_for_adk("gemini-3.1-flash-lite-preview")
 
-    assert os.environ["GOOGLE_API_KEY"] == "gemini-test-key"
-
-
-def test_google_api_key_wins_over_gemini_alias(monkeypatch):
-    monkeypatch.setenv("GOOGLE_API_KEY", "google-test-key")
-    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
-
-    _sync_gemini_api_key_alias()
-
-    assert os.environ["GOOGLE_API_KEY"] == "google-test-key"
+    assert resolved == "gemini-3.1-flash-lite-preview"
+    assert "GOOGLE_API_KEY" not in os.environ
 
 
 def test_together_api_key_alias_populates_litellm_key(monkeypatch):

--- a/tests/test_options_helper.py
+++ b/tests/test_options_helper.py
@@ -4,12 +4,8 @@
 import unittest
 from unittest.mock import Mock, MagicMock
 from datetime import date, timedelta, datetime
-import sys
 import os
 import pytest
-
-# Add the lumibot path
-sys.path.insert(0, '/Users/robertgrzesik/Documents/Development/lumivest_bot_server/strategies/lumibot')
 
 from lumibot.components.options_helper import OptionsHelper, OptionMarketEvaluation
 from lumibot.entities import Asset
@@ -443,7 +439,7 @@ class TestOptionsHelper(unittest.TestCase):
 
     @pytest.mark.skipif(
         os.environ.get("RUN_THETADATA_TERMINAL_TESTS") != "true",
-        reason="Disabled by default: requires local ThetaTerminal; set RUN_THETADATA_TERMINAL_TESTS=true to enable.",
+        reason="Disabled by default: requires local ThetaTerminal and non-production credentials.",
     )
     def test_find_next_valid_option_checks_quote_first(self):
         """Test that find_next_valid_option checks quote before last_price using REAL ThetaData"""
@@ -463,8 +459,8 @@ class TestOptionsHelper(unittest.TestCase):
             self.skipTest("ThetaData username not configured")
         if not password or password.lower() in {"", "pwd"}:
             self.skipTest("ThetaData password not configured")
-        if username != "rob-dev@lumiwealth.com":
-            self.skipTest("Safety: integration test only runs with dev ThetaData credentials (rob-dev@lumiwealth.com)")
+        if os.environ.get("THETADATA_NON_PRODUCTION_ACCOUNT") != "true":
+            self.skipTest("Safety: confirm these are non-production ThetaData credentials before running")
 
         # Create a simple strategy that uses OptionsHelper with REAL data
         class TestStrategy(Strategy):
@@ -525,7 +521,7 @@ class TestOptionsHelper(unittest.TestCase):
 
     @pytest.mark.skipif(
         os.environ.get("RUN_THETADATA_TERMINAL_TESTS") != "true",
-        reason="Disabled by default: requires local ThetaTerminal; set RUN_THETADATA_TERMINAL_TESTS=true to enable.",
+        reason="Disabled by default: requires local ThetaTerminal and non-production credentials.",
     )
     def test_find_next_valid_option_falls_back_to_last_price(self):
         """Test fallback to last_price when quote has no bid/ask using REAL ThetaData"""
@@ -545,8 +541,8 @@ class TestOptionsHelper(unittest.TestCase):
             self.skipTest("ThetaData username not configured")
         if not password or password.lower() in {"", "pwd"}:
             self.skipTest("ThetaData password not configured")
-        if username != "rob-dev@lumiwealth.com":
-            self.skipTest("Safety: integration test only runs with dev ThetaData credentials (rob-dev@lumiwealth.com)")
+        if os.environ.get("THETADATA_NON_PRODUCTION_ACCOUNT") != "true":
+            self.skipTest("Safety: confirm these are non-production ThetaData credentials before running")
 
         # Create a simple strategy that uses OptionsHelper with REAL data
         class TestStrategy(Strategy):

--- a/tests/test_public_instruction_secret_hygiene.py
+++ b/tests/test_public_instruction_secret_hygiene.py
@@ -1,0 +1,53 @@
+"""Regression checks for public AI instruction files.
+
+These files are tracked in the open-source LumiBot repo, so they must not carry
+private local paths or real credential/account material.
+"""
+
+from pathlib import Path
+import re
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_INSTRUCTION_FILES = [
+    REPO_ROOT / "AGENTS.md",
+    REPO_ROOT / "CLAUDE.md",
+    REPO_ROOT / "SECURITY.md",
+]
+
+FORBIDDEN_PATTERNS = [
+    re.compile(r"/Users/[^`\s)]+"),
+    re.compile(r"Documents/Development"),
+    re.compile(r"\bDev Credentials\b", re.IGNORECASE),
+    re.compile(r"\bUsername\s*\|", re.IGNORECASE),
+    re.compile(r"\bPassword\s*\|", re.IGNORECASE),
+    re.compile(r"\b[A-Z0-9._%+-]+@(lumiwealth|botspot)\.", re.IGNORECASE),
+]
+
+
+def collect_public_instruction_hygiene_violations():
+    violations = []
+
+    for path in PUBLIC_INSTRUCTION_FILES:
+        text = path.read_text(encoding="utf-8")
+        for pattern in FORBIDDEN_PATTERNS:
+            for match in pattern.finditer(text):
+                line_number = text.count("\n", 0, match.start()) + 1
+                violations.append(f"{path.relative_to(REPO_ROOT)}:{line_number}: {pattern.pattern}")
+
+    return violations
+
+
+def test_public_instruction_files_do_not_publish_private_paths_or_credentials():
+    violations = collect_public_instruction_hygiene_violations()
+
+    assert violations == []
+
+
+if __name__ == "__main__":
+    violations = collect_public_instruction_hygiene_violations()
+    if violations:
+        print("Public instruction hygiene violations found:")
+        for violation in violations:
+            print(f"  {violation}")
+        raise SystemExit(1)

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -632,6 +632,136 @@ class TestTradierBroker:
         assert stop_order.side == "sell_to_close"
         assert stop_order.order_type == Order.OrderType.STOP
 
+    def test_otoco_bracket_parse_broker_order_dict(self):
+        broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True, connect_stream=False)
+        strategy = "strat_unittest"
+        response = {
+            "avg_fill_price": None,
+            "class": "otoco",
+            "create_date": "2026-07-08T13:30:00.000Z",
+            "duration": None,
+            "id": 20000001,
+            "quantity": None,
+            "side": None,
+            "status": "submitted",
+            "symbol": None,
+            "tag": "BracketStrat",
+            "type": None,
+            "leg": [
+                {
+                    "avg_fill_price": None,
+                    "class": "equity",
+                    "create_date": "2026-07-08T13:30:00.000Z",
+                    "duration": "day",
+                    "id": 20000002,
+                    "price": 500.0,
+                    "quantity": 1,
+                    "side": "buy",
+                    "status": "submitted",
+                    "symbol": "SPY",
+                    "type": "limit",
+                },
+                {
+                    "avg_fill_price": None,
+                    "class": "equity",
+                    "create_date": "2026-07-08T13:30:00.000Z",
+                    "duration": "gtc",
+                    "id": 20000003,
+                    "price": 510.0,
+                    "quantity": 1,
+                    "side": "sell",
+                    "status": "pending",
+                    "symbol": "SPY",
+                    "type": "limit",
+                },
+                {
+                    "avg_fill_price": None,
+                    "class": "equity",
+                    "create_date": "2026-07-08T13:30:00.000Z",
+                    "duration": "gtc",
+                    "id": 20000004,
+                    "quantity": 1,
+                    "side": "sell",
+                    "status": "pending",
+                    "stop_price": 490.0,
+                    "symbol": "SPY",
+                    "type": "stop",
+                },
+            ],
+        }
+
+        order = broker._parse_broker_order_dict(response, strategy)
+
+        assert order.identifier == 20000001
+        assert order.strategy == strategy
+        assert order.asset.symbol == "SPY"
+        assert order.order_class == Order.OrderClass.BRACKET
+        assert order.order_type == Order.OrderType.LIMIT
+        assert order.limit_price == 500.0
+        assert order.quantity == 1
+        assert len(order.child_orders) == 2
+
+        take_profit, stop_loss = order.child_orders
+        assert take_profit.identifier == 20000003
+        assert take_profit.parent_identifier == order.identifier
+        assert take_profit.order_type == Order.OrderType.LIMIT
+        assert take_profit.limit_price == 510.0
+        assert stop_loss.identifier == 20000004
+        assert stop_loss.parent_identifier == order.identifier
+        assert stop_loss.order_type == Order.OrderType.STOP
+        assert stop_loss.stop_price == 490.0
+
+    def test_tradier_class2lumi_maps_otoco_and_combo(self):
+        assert Tradier._tradier_class2lumi("otoco") == Order.OrderClass.BRACKET
+        assert Tradier._tradier_class2lumi("OTOCO") == Order.OrderClass.BRACKET
+        assert Tradier._tradier_class2lumi("combo") == Order.OrderClass.MULTILEG
+        assert Tradier._tradier_class2lumi("multileg") == Order.OrderClass.MULTILEG
+        assert Tradier._tradier_class2lumi("oco") == Order.OrderClass.OCO
+
+    def test_extract_order_value_handles_missing_class_defensively(self):
+        assert Tradier._extract_order_value({"symbol": "SPY"}, {}, "symbol") == "SPY"
+        assert Tradier._extract_order_value({"symbol": None}, {"symbol": "QQQ"}, "symbol") == "QQQ"
+
+    def test_pull_positions_preserves_future_and_unknown_asset_rows(self):
+        broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True, connect_stream=False)
+        broker.tradier.account.get_positions = lambda: pd.DataFrame(
+            [
+                {"symbol": "AAPL", "quantity": 3},
+                {"symbol": "/ES", "quantity": 1, "asset_type": "future"},
+                {"symbol": "MYSTERY", "quantity": 2, "asset_type": "new_asset_class"},
+            ]
+        )
+
+        positions = broker._pull_positions(SimpleNamespace(name="unit-test"))
+
+        by_symbol_and_type = {(position.asset.symbol, position.asset.asset_type): position for position in positions}
+        assert ("AAPL", Asset.AssetType.STOCK) in by_symbol_and_type
+        assert ("ES", Asset.AssetType.CONT_FUTURE) in by_symbol_and_type
+        assert ("MYSTERY", Asset.AssetType.UNKNOWN) in by_symbol_and_type
+        assert by_symbol_and_type[("ES", Asset.AssetType.CONT_FUTURE)].raw_asset_type == "future"
+        assert by_symbol_and_type[("ES", Asset.AssetType.CONT_FUTURE)].raw_symbol == "/ES"
+        assert by_symbol_and_type[("MYSTERY", Asset.AssetType.UNKNOWN)].raw_asset_type == "new_asset_class"
+        assert by_symbol_and_type[("MYSTERY", Asset.AssetType.UNKNOWN)].broker_parse_degraded is True
+
+    def test_tradier_parse_failure_logs_sanitized_shape_without_raw_symbols(self, caplog):
+        broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True, connect_stream=False)
+        response = {
+            "class": "equity",
+            "type": "market",
+            "status": "submitted",
+            "symbol": "PRIVATE_SYMBOL",
+            "side": "buy",
+            "duration": "day",
+        }
+
+        with caplog.at_level("WARNING"):
+            with pytest.raises(KeyError):
+                broker._parse_broker_order_dict(response, "strat_unittest")
+
+        assert "Failed to parse Tradier order row" in caplog.text
+        assert "symbol_present" in caplog.text
+        assert "PRIVATE_SYMBOL" not in caplog.text
+
     @pytest.mark.skip(reason="Complex test that requires proper stream setup - skipping to fix CI timeout")
     def test_do_polling(self, mocker):
         broker = Tradier(account_number="1234", access_token="a1b2c3", paper=True, polling_interval=None, connect_stream=False)


### PR DESCRIPTION
## What / Why
Release LumiBot 4.5.73 with three fixes that are safe to ship together:

- Harden Tradier returned-order parsing so OTOCO bracket rows, combo/multileg rows, missing-class rows, and future-like or unknown account assets do not crash broker-state reads. Parser diagnostics log sanitized shape only.
- Fix AI-agent context pruning so compact tool results are not replaced by larger pruning notices and Gemini 3.1 budgets use the model context registry instead of pruning far too early.
- Tighten public-repo hygiene guardrails so private local details and credential-like material are blocked from tracked instructions/docs/tests.
- Make GEMINI_API_KEY the explicit public contract for native Gemini agent examples/runtime checks instead of mutating GOOGLE_API_KEY behind the scenes.

## Risk
Moderate. The Tradier change is broker parser behavior but is defensive and covered by focused regression tests. The agent pruning change affects request shaping for large agent histories. Public hygiene changes add CI/tests and documentation guardrails.

## Tests run
- `python3 -m pytest -q -m "not apitest" tests/test_tradier.py tests/test_tradier_clean_order_records.py tests/test_tradier_polling_large_orders_no_growth.py tests/test_tradier_polling_skips_historical_closed_orders.py tests/test_tradier_stream_optional_unit.py --tb=short` -> 32 passed, 1 skipped, 2 deselected.
- `python3 -m pytest -q tests/test_agent_runtime_provider_keys.py --tb=short` -> 28 passed.
- `python3 -m pytest -m "not apitest and not downloader" --tb=short -q --durations=30` -> attempted locally; timed out after 20m after emitting a failure marker.
- `python3 -m pytest -m "not apitest and not downloader" --tb=short -x -vv --durations=20` -> first failure was `test_acceptance_aapl_deep_dip_calls` wall-clock guard only: 457.7s actual vs 300s max. No Tradier or provider-key assertion failure surfaced before the local run stopped. Release should still gate on GitHub PR CI before merge/tag.

## Docs / Prompts
- Updated `CHANGELOG.md`, `docs/BROKER_ORDER_SEMANTICS.md`, `docsrc/brokers.tradier.rst`, `docsrc/environment_variables.rst`, `SECURITY.md`, `AGENTS.md`, `CLAUDE.md`, and `docs/investigations/2026-07-08_AGENT_CONTEXT_PRUNING_SMOKE_FAILURE.md`.
- No BotSpot agent prompt change was needed for Tradier returned-order parsing; this is broker-state normalization, not strategy-generation behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent context pruning to avoid expanding small tool results, prevent repeated pruning, use a more realistic pruning budget, and reduce failure logging noise.
  * Fixed Tradier order refresh by rebuilding bracket/multileg structures (including exit legs), mapping order classes, and preserving unsupported broker rows.
  * Tightened Gemini key handling to require `GEMINI_API_KEY` (no implicit aliasing).
* **Documentation**
  * Updated Tradier semantics and added clearer security/public hygiene guidance, including `SECURITY.md`.
* **Tests**
  * Added context-pruning and Tradier parsing regression coverage, plus public instruction/secret hygiene checks and CI workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->