### PR TITLE
v4.5.74 - Live market calendar startup fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 4.5.74 - Unreleased
 
+### Fixed
+- **Live strategies no longer sleep through an already-open market because of
+  stale startup calendars.** Live startup now initializes a bounded market
+  calendar around the current session instead of defaulting to a calendar that
+  ends before today, and broker market-open checks fall back to direct calendar
+  logic when a preloaded calendar does not cover the current date.
+
 ## 4.5.73 - 2026-07-08
 
 Deploy marker: `deploy 4.5.73`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Changelog
 
-## 4.5.74 - Unreleased
+## 4.5.74 - 2026-07-08
+
+Deploy marker: `deploy 4.5.74`
 
 ### Fixed
 - **Live strategies no longer sleep through an already-open market because of
   stale startup calendars.** Live startup now initializes a bounded market
   calendar around the current session instead of defaulting to a calendar that
   ends before today, and broker market-open checks fall back to direct calendar
-  logic when a preloaded calendar does not cover the current date.
+  logic when a preloaded calendar does not cover the current date. Regression
+  coverage now includes `NASDAQ`, `NYSE`, `24/5`, `24/7`, `us_futures`,
+  weekends, premarket/after-hours, overnight sessions, extended trading minutes,
+  and an Alpaca-shaped no-order broker path.
 
 ## 4.5.73 - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.74 - Unreleased
+
 ## 4.5.73 - 2026-07-08
 
 Deploy marker: `deploy 4.5.73`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ Deploy marker: `deploy 4.5.74`
   ends before today, and broker market-open checks fall back to direct calendar
   logic when a preloaded calendar does not cover the current date. Regression
   coverage now includes `NASDAQ`, `NYSE`, `24/5`, `24/7`, `us_futures`,
-  weekends, premarket/after-hours, overnight sessions, extended trading minutes,
-  and an Alpaca-shaped no-order broker path.
+  futures Saturday-night versus Monday-night sessions, equity holidays,
+  weekend behavior, premarket/after-hours, overnight sessions, extended trading
+  minutes, and an Alpaca-shaped no-order broker path. A read-only Alpaca paper
+  broker smoke verified authentication, balance reads, position reads, order
+  reads, and the fixed initialized-calendar path without submitting orders.
 
 ## 4.5.73 - 2026-07-08
 

--- a/docs/investigations/2026-07-08_LIVE_MARKET_CALENDAR_STARTUP.md
+++ b/docs/investigations/2026-07-08_LIVE_MARKET_CALENDAR_STARTUP.md
@@ -1,0 +1,68 @@
+# Live Market Calendar Startup
+
+One-line description: Investigation note for live strategies waiting for market open after the market is already open.
+
+Last Updated: 2026-07-08
+Status: Fixed in 4.5.74
+Audience: LumiBot maintainers and release operators
+
+## Overview
+
+Live startup could preload a broker market calendar that ended before the current
+trading day. When the strategy reached the market-open wait path, the broker's
+initialized-calendar fast path treated the stale calendar as an authoritative
+closed-market result. The strategy then logged that it was sleeping until market
+open even when the market was already open.
+
+This was a framework startup issue, not a strategy `sleeptime` issue. It could
+affect normal equity markets such as `NASDAQ` and `NYSE`, and it was especially
+confusing for `24/5` strategies because those strategies still need current
+calendar rows to distinguish weekday sessions from weekend gaps.
+
+## Fix
+
+- Live startup now initializes market calendars around the current session using
+  an explicit bounded window.
+- The broker initialized-calendar fast path now returns `None` when the calendar
+  does not cover the current date, allowing normal broker/calendar logic to
+  answer instead of forcing `False`.
+- If the initialized calendar spans the current date but no session is open
+  because of premarket, after-hours, weekends, holidays, or maintenance gaps, the
+  fast path returns `False`.
+- Base broker continuous-market detection now samples a multi-day window so
+  `24/5` and `us_futures` weekend gaps are not misclassified as `24/7`.
+
+## Regression Coverage
+
+The 4.5.74 regression coverage includes:
+
+- stale calendars before and after the current date,
+- premarket and after-hours closed sessions,
+- overnight sessions,
+- extended trading minutes,
+- weekend gaps inside a loaded calendar window,
+- generated calendar rows for `NASDAQ`, `NYSE`, `24/5`, `us_futures`, and
+  `24/7`,
+- an Alpaca-shaped no-order broker path where a stale initialized calendar falls
+  through to normal market-hours logic.
+
+The focused local verification command used for this fix was:
+
+```bash
+.venv/bin/python -m pytest \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_is_market_open_uses_initialized_calendar \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_initialized_calendar_returns_none_when_current_date_not_covered \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_initialized_calendar_returns_none_when_current_date_before_calendar_window \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_initialized_calendar_returns_false_for_covered_closed_session \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_initialized_calendar_returns_false_for_weekend_inside_calendar_window \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_initialized_calendar_handles_overnight_sessions \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_initialized_calendar_applies_extended_trading_minutes \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_is_market_open_falls_back_when_initialized_calendar_is_stale \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_is_market_open_does_not_fall_back_for_weekend_inside_calendar_window \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_base_broker_continuous_market_detection_respects_weekend_gaps \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_real_market_calendars_cover_open_and_other_times \
+  tests/test_alpaca.py::TestAlpacaBroker::test_market_open_falls_back_when_initialized_calendar_is_stale \
+  tests/test_market_type_detection.py \
+  tests/test_scheduled_run_once.py \
+  -q
+```

--- a/docs/investigations/2026-07-08_LIVE_MARKET_CALENDAR_STARTUP.md
+++ b/docs/investigations/2026-07-08_LIVE_MARKET_CALENDAR_STARTUP.md
@@ -43,8 +43,15 @@ The 4.5.74 regression coverage includes:
 - weekend gaps inside a loaded calendar window,
 - generated calendar rows for `NASDAQ`, `NYSE`, `24/5`, `us_futures`, and
   `24/7`,
+- U.S. futures Saturday-night closed behavior versus Monday-night open behavior,
+- equity market holidays such as observed Independence Day,
+- `24/7` behavior on weekends and holidays,
 - an Alpaca-shaped no-order broker path where a stale initialized calendar falls
   through to normal market-hours logic.
+
+A read-only Alpaca paper broker smoke also verified that a real broker can
+authenticate, read balances, read positions, read orders, and use the fixed
+initialized-calendar path without submitting orders.
 
 The focused local verification command used for this fix was:
 
@@ -61,6 +68,10 @@ The focused local verification command used for this fix was:
   tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_is_market_open_does_not_fall_back_for_weekend_inside_calendar_window \
   tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_base_broker_continuous_market_detection_respects_weekend_gaps \
   tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_real_market_calendars_cover_open_and_other_times \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_us_futures_real_calendar_weekend_closed_and_monday_night_open \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_24_5_real_calendar_weekend_closed_and_weeknight_open \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_equity_real_calendar_market_hours_weekend_and_holiday \
+  tests/test_broker_initialization.py::TestBrokerInitializationSimple::test_24_7_real_calendar_ignores_weekends_and_holidays \
   tests/test_alpaca.py::TestAlpacaBroker::test_market_open_falls_back_when_initialized_calendar_is_stale \
   tests/test_market_type_detection.py \
   tests/test_scheduled_run_once.py \

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -2177,6 +2177,7 @@ class Broker(ABC):
             if "market_close" not in getattr(rows, "columns", ()):
                 rows = rows.reset_index()
 
+            covers_current_date = False
             for row in rows.itertuples(index=False):
                 market_open = getattr(row, "market_open", None)
                 market_close = getattr(row, "market_close", None)
@@ -2198,10 +2199,14 @@ class Broker(ABC):
                     market_close = market_close.astimezone(timezone.utc)
 
                 market_close = market_close + timedelta(minutes=self.extended_trading_minutes)
+                if market_open.date() <= now_utc.date() <= market_close.date():
+                    covers_current_date = True
                 if market_open <= now_utc <= market_close:
                     return True
 
-            return False
+            if covers_current_date:
+                return False
+            return None
         except Exception:
             return None
 

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -2177,7 +2177,8 @@ class Broker(ABC):
             if "market_close" not in getattr(rows, "columns", ()):
                 rows = rows.reset_index()
 
-            covers_current_date = False
+            earliest_calendar_date = None
+            latest_calendar_date = None
             for row in rows.itertuples(index=False):
                 market_open = getattr(row, "market_open", None)
                 market_close = getattr(row, "market_close", None)
@@ -2199,12 +2200,25 @@ class Broker(ABC):
                     market_close = market_close.astimezone(timezone.utc)
 
                 market_close = market_close + timedelta(minutes=self.extended_trading_minutes)
-                if market_open.date() <= now_utc.date() <= market_close.date():
-                    covers_current_date = True
+                open_date = market_open.date()
+                close_date = market_close.date()
+                earliest_calendar_date = (
+                    open_date
+                    if earliest_calendar_date is None
+                    else min(earliest_calendar_date, open_date)
+                )
+                latest_calendar_date = (
+                    close_date
+                    if latest_calendar_date is None
+                    else max(latest_calendar_date, close_date)
+                )
                 if market_open <= now_utc <= market_close:
                     return True
 
-            if covers_current_date:
+            if (
+                earliest_calendar_date is not None
+                and earliest_calendar_date <= now_utc.date() <= latest_calendar_date
+            ):
                 return False
             return None
         except Exception:
@@ -2251,14 +2265,14 @@ class Broker(ABC):
                 
                 return True
                 
-            # Get market calendar
-            import pandas as pd
-            import pandas_market_calendars as mcal
             cal = mcal.get_calendar(market_name)
-            
-            # Test with a recent Monday (typical trading day)
-            test_date = pd.Timestamp('2025-01-13', tz='UTC')  # Monday
-            schedule = cal.schedule(start_date=test_date, end_date=test_date)
+
+            # Sample ~1.5 weeks so weekend/maintenance gaps are not misclassified as always-open.
+            reference_day = pd.Timestamp('2025-01-13', tz='UTC')  # Monday
+            schedule = cal.schedule(
+                start_date=(reference_day - timedelta(days=3)),
+                end_date=(reference_day + timedelta(days=7)),
+            )
             
             if schedule.empty:
                 # No trading on this date, assume it's not continuous
@@ -2266,14 +2280,20 @@ class Broker(ABC):
                 
                 return False
                 
-            # Calculate trading hours duration
-            market_open = schedule.iloc[0, 0]
-            market_close = schedule.iloc[0, 1]
-            duration_hours = (market_close - market_open).total_seconds() / 3600
+            durations = schedule["market_close"] - schedule["market_open"]
+            avg_duration = durations.mean()
+            duration_hours = avg_duration.total_seconds() / 3600 if avg_duration is not pd.NaT else 0
+
+            if len(schedule) >= 2:
+                next_opens = schedule["market_open"].iloc[1:].reset_index(drop=True)
+                prev_closes = schedule["market_close"].iloc[:-1].reset_index(drop=True)
+                gaps = next_opens - prev_closes
+                max_gap = gaps.max()
+                gap_hours = max_gap.total_seconds() / 3600 if isinstance(max_gap, pd.Timedelta) else 0
+            else:
+                gap_hours = 0
             
-            # Consider markets with 20+ hours per day as continuous
-            # This catches futures markets that trade ~22-24 hours
-            is_continuous = duration_hours >= 20.0
+            is_continuous = (duration_hours >= 20.0) and (gap_hours < 6.0)
             
             self._market_type_cache[market_name] = is_continuous
             

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -290,18 +290,28 @@ class StrategyExecutor(Thread):
                 self._run_once_market_open_override = False
                 return
         try:
-            now = self._scheduled_now_utc()
-            buffer = timedelta(days=14)
-            self.broker.initialize_market_calendars(
-                get_trading_days(
-                    market=market,
-                    start_date=now - buffer,
-                    end_date=now + buffer + timedelta(days=1),
-                    tzinfo=_default_pytz(),
-                )
+            self._initialize_live_market_calendars(market, now_utc=self._scheduled_now_utc())
+        except Exception as e:
+            if hasattr(self.strategy, "logger"):
+                self.strategy.logger.warning(f"Could not initialize live market calendar: {e}")
+
+    def _initialize_live_market_calendars(self, market, now_utc=None):
+        """Initialize a bounded live calendar that covers the current session."""
+        now = now_utc or datetime.now(timezone.utc)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        else:
+            now = now.astimezone(timezone.utc)
+
+        buffer = timedelta(days=14)
+        self.broker.initialize_market_calendars(
+            get_trading_days(
+                market=market,
+                start_date=now - buffer,
+                end_date=now + buffer + timedelta(days=1),
+                tzinfo=_default_pytz(),
             )
-        except Exception:
-            self.broker.initialize_market_calendars(get_trading_days(market))
+        )
 
     def _is_continuous_market(self, market_name):
         """
@@ -2422,7 +2432,7 @@ class StrategyExecutor(Thread):
                     except Exception:
                         self.broker.initialize_market_calendars(get_trading_days(market))
                 else:
-                    self.broker.initialize_market_calendars(get_trading_days(market))
+                    self._initialize_live_market_calendars(market)
 
             #####
             # Main strategy execution loop

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.73",
+    version="4.5.74",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_alpaca.py
+++ b/tests/test_alpaca.py
@@ -8,7 +8,7 @@ from lumibot.data_sources.alpaca_data import AlpacaData
 from lumibot.example_strategies.stock_buy_and_hold import BuyAndHold
 from lumibot.credentials import ALPACA_TEST_CONFIG
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import math
 
@@ -99,6 +99,37 @@ class TestAlpacaBroker:
         order = Order(asset=Asset("SPY"), quantity=10, side=Order.OrderSide.BUY, limit_price=0.12345, strategy='abc')
         broker._conform_order(order)
         assert order.limit_price == 0.1235
+
+    def test_market_open_falls_back_when_initialized_calendar_is_stale(self, mocker):
+        broker = Alpaca(ALPACA_UNIT_CONFIG, connect_stream=False)
+        broker.market = "NASDAQ"
+        broker.initialize_market_calendars(
+            pd.DataFrame(
+                {
+                    "market_open": [datetime(2026, 7, 7, 13, 30, tzinfo=timezone.utc)],
+                    "market_close": [datetime(2026, 7, 7, 20, 0, tzinfo=timezone.utc)],
+                }
+            )
+        )
+
+        class FixedDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                value = datetime(2026, 7, 8, 14, 7, 54, tzinfo=timezone.utc)
+                return value.astimezone(tz) if tz else value.replace(tzinfo=None)
+
+        def fake_market_hours(close=False, next=False):
+            if close:
+                return datetime(2026, 7, 8, 20, 0, tzinfo=timezone.utc)
+            return datetime(2026, 7, 8, 13, 30, tzinfo=timezone.utc)
+
+        mocker.patch("lumibot.brokers.alpaca.datetime.datetime", FixedDatetime)
+        mocker.patch.object(broker, "market_hours", side_effect=fake_market_hours)
+
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 8, 14, 7, 54, tzinfo=timezone.utc)
+        ) is None
+        assert broker.is_market_open() is True
 
     # The tests below exist to make sure the BROKER calls pass through the data source correctly.
     # Testing that the DATA is CORRECT (vs just existing) happens in test_alpaca_data.

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -11,6 +11,31 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 
+class _CalendarTestBroker:
+    @staticmethod
+    def create():
+        from lumibot.brokers.broker import Broker
+
+        class TestBroker(Broker):
+            IS_BACKTESTING_BROKER = True
+
+            def cancel_order(self, order): pass
+            def _modify_order(self, order, limit_price=None, stop_price=None): pass
+            def _submit_order(self, order): return order
+            def _get_balances_at_broker(self, quote_asset, strategy): return (0, 0, 0)
+            def get_historical_account_value(self): return {}
+            def _get_stream_object(self): return None
+            def _register_stream_events(self): pass
+            def _run_stream(self): pass
+            def _pull_positions(self, strategy): return []
+            def _pull_position(self, strategy, asset): return None
+            def _parse_broker_order(self, response, strategy_name, strategy_object=None): return response
+            def _pull_broker_order(self, identifier): return None
+            def _pull_broker_all_orders(self): return []
+
+        return TestBroker(name="test", connect_stream=False, data_source=object())
+
+
 class TestBrokerInitializationSimple:
     """Test cases for broker initialization and error handling."""
     
@@ -117,6 +142,57 @@ class TestBrokerInitializationSimple:
         assert broker._is_market_open_from_initialized_calendar(
             datetime(2026, 5, 11, 21, 0, tzinfo=timezone.utc)
         ) is False
+
+    def test_initialized_calendar_returns_none_when_current_date_not_covered(self):
+        import pandas as pd
+
+        broker = _CalendarTestBroker.create()
+        broker.initialize_market_calendars(
+            pd.DataFrame(
+                {
+                    "market_open": [datetime(2026, 7, 7, 13, 30, tzinfo=timezone.utc)],
+                    "market_close": [datetime(2026, 7, 7, 20, 0, tzinfo=timezone.utc)],
+                }
+            )
+        )
+
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 8, 14, 7, tzinfo=timezone.utc)
+        ) is None
+
+    def test_initialized_calendar_returns_false_for_covered_closed_session(self):
+        import pandas as pd
+
+        broker = _CalendarTestBroker.create()
+        broker.initialize_market_calendars(
+            pd.DataFrame(
+                {
+                    "market_open": [datetime(2026, 7, 8, 13, 30, tzinfo=timezone.utc)],
+                    "market_close": [datetime(2026, 7, 8, 20, 0, tzinfo=timezone.utc)],
+                }
+            )
+        )
+
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
+        ) is False
+
+    def test_is_market_open_falls_back_when_initialized_calendar_is_stale(self, mocker):
+        import pandas as pd
+
+        broker = _CalendarTestBroker.create()
+        broker.market = "24/5"
+        broker.initialize_market_calendars(
+            pd.DataFrame(
+                {
+                    "market_open": [datetime(2026, 7, 7, 13, 30, tzinfo=timezone.utc)],
+                    "market_close": [datetime(2026, 7, 7, 20, 0, tzinfo=timezone.utc)],
+                }
+            )
+        )
+        mocker.patch.object(broker, "_is_continuous_market", return_value=True)
+
+        assert broker.is_market_open() is True
 
     def test_utc_to_local_converts_aware_datetime_before_localizing(self):
         from dateutil import tz

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -7,6 +7,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
+import pandas as pd
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -144,8 +145,6 @@ class TestBrokerInitializationSimple:
         ) is False
 
     def test_initialized_calendar_returns_none_when_current_date_not_covered(self):
-        import pandas as pd
-
         broker = _CalendarTestBroker.create()
         broker.initialize_market_calendars(
             pd.DataFrame(
@@ -160,9 +159,22 @@ class TestBrokerInitializationSimple:
             datetime(2026, 7, 8, 14, 7, tzinfo=timezone.utc)
         ) is None
 
-    def test_initialized_calendar_returns_false_for_covered_closed_session(self):
-        import pandas as pd
+    def test_initialized_calendar_returns_none_when_current_date_before_calendar_window(self):
+        broker = _CalendarTestBroker.create()
+        broker.initialize_market_calendars(
+            pd.DataFrame(
+                {
+                    "market_open": [datetime(2026, 7, 9, 13, 30, tzinfo=timezone.utc)],
+                    "market_close": [datetime(2026, 7, 9, 20, 0, tzinfo=timezone.utc)],
+                }
+            )
+        )
 
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 8, 14, 7, tzinfo=timezone.utc)
+        ) is None
+
+    def test_initialized_calendar_returns_false_for_covered_closed_session(self):
         broker = _CalendarTestBroker.create()
         broker.initialize_market_calendars(
             pd.DataFrame(
@@ -177,9 +189,62 @@ class TestBrokerInitializationSimple:
             datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
         ) is False
 
-    def test_is_market_open_falls_back_when_initialized_calendar_is_stale(self, mocker):
-        import pandas as pd
+    def test_initialized_calendar_returns_false_for_weekend_inside_calendar_window(self):
+        broker = _CalendarTestBroker.create()
+        broker.initialize_market_calendars(
+            pd.DataFrame(
+                {
+                    "market_open": [
+                        datetime(2026, 7, 10, 13, 30, tzinfo=timezone.utc),
+                        datetime(2026, 7, 13, 13, 30, tzinfo=timezone.utc),
+                    ],
+                    "market_close": [
+                        datetime(2026, 7, 10, 20, 0, tzinfo=timezone.utc),
+                        datetime(2026, 7, 13, 20, 0, tzinfo=timezone.utc),
+                    ],
+                }
+            )
+        )
 
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 11, 14, 0, tzinfo=timezone.utc)
+        ) is False
+
+    def test_initialized_calendar_handles_overnight_sessions(self):
+        broker = _CalendarTestBroker.create()
+        broker.initialize_market_calendars(
+            pd.DataFrame(
+                {
+                    "market_open": [datetime(2026, 7, 8, 22, 0, tzinfo=timezone.utc)],
+                    "market_close": [datetime(2026, 7, 9, 21, 0, tzinfo=timezone.utc)],
+                }
+            )
+        )
+
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 9, 2, 0, tzinfo=timezone.utc)
+        ) is True
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 9, 21, 30, tzinfo=timezone.utc)
+        ) is False
+
+    def test_initialized_calendar_applies_extended_trading_minutes(self):
+        broker = _CalendarTestBroker.create()
+        broker.extended_trading_minutes = 15
+        broker.initialize_market_calendars(
+            pd.DataFrame(
+                {
+                    "market_open": [datetime(2026, 7, 8, 13, 30, tzinfo=timezone.utc)],
+                    "market_close": [datetime(2026, 7, 8, 20, 0, tzinfo=timezone.utc)],
+                }
+            )
+        )
+
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 8, 20, 10, tzinfo=timezone.utc)
+        ) is True
+
+    def test_is_market_open_falls_back_when_initialized_calendar_is_stale(self, mocker):
         broker = _CalendarTestBroker.create()
         broker.market = "24/5"
         broker.initialize_market_calendars(
@@ -193,6 +258,92 @@ class TestBrokerInitializationSimple:
         mocker.patch.object(broker, "_is_continuous_market", return_value=True)
 
         assert broker.is_market_open() is True
+
+    def test_is_market_open_does_not_fall_back_for_weekend_inside_calendar_window(self, mocker):
+        broker = _CalendarTestBroker.create()
+        broker.market = "24/5"
+        broker.initialize_market_calendars(
+            pd.DataFrame(
+                {
+                    "market_open": [
+                        datetime(2026, 7, 10, 0, 0, tzinfo=timezone.utc),
+                        datetime(2026, 7, 13, 0, 0, tzinfo=timezone.utc),
+                    ],
+                    "market_close": [
+                        datetime(2026, 7, 10, 21, 0, tzinfo=timezone.utc),
+                        datetime(2026, 7, 13, 21, 0, tzinfo=timezone.utc),
+                    ],
+                }
+            )
+        )
+        mocker.patch.object(broker, "_is_continuous_market", side_effect=AssertionError("should not fall back"))
+
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 11, 14, 0, tzinfo=timezone.utc)
+        ) is False
+
+    def test_base_broker_continuous_market_detection_respects_weekend_gaps(self):
+        broker = _CalendarTestBroker.create()
+
+        assert broker._is_continuous_market("24/7") is True
+        assert broker._is_continuous_market("24/5") is False
+        assert broker._is_continuous_market("us_futures") is False
+
+    @pytest.mark.parametrize(
+        ("market", "open_dt", "other_dt", "expected_other_open"),
+        [
+            (
+                "NASDAQ",
+                datetime(2026, 7, 8, 14, 7, 54, tzinfo=timezone.utc),
+                datetime(2026, 7, 11, 14, 0, tzinfo=timezone.utc),
+                False,
+            ),
+            (
+                "NYSE",
+                datetime(2026, 7, 8, 14, 7, 54, tzinfo=timezone.utc),
+                datetime(2026, 7, 11, 14, 0, tzinfo=timezone.utc),
+                False,
+            ),
+            (
+                "24/5",
+                datetime(2026, 7, 8, 14, 7, 54, tzinfo=timezone.utc),
+                datetime(2026, 7, 11, 14, 0, tzinfo=timezone.utc),
+                False,
+            ),
+            (
+                "us_futures",
+                datetime(2026, 7, 8, 14, 7, 54, tzinfo=timezone.utc),
+                datetime(2026, 7, 11, 14, 0, tzinfo=timezone.utc),
+                False,
+            ),
+            (
+                "24/7",
+                datetime(2026, 7, 8, 14, 7, 54, tzinfo=timezone.utc),
+                datetime(2026, 7, 11, 14, 0, tzinfo=timezone.utc),
+                True,
+            ),
+        ],
+    )
+    def test_real_market_calendars_cover_open_and_other_times(
+        self,
+        market,
+        open_dt,
+        other_dt,
+        expected_other_open,
+    ):
+        from lumibot.tools import get_trading_days
+
+        broker = _CalendarTestBroker.create()
+        broker.initialize_market_calendars(
+            get_trading_days(
+                market=market,
+                start_date=open_dt - timedelta(days=14),
+                end_date=open_dt + timedelta(days=15),
+            )
+        )
+
+        assert broker._is_market_open_from_initialized_calendar(open_dt) is True
+        assert broker._is_market_open_from_initialized_calendar(other_dt) is expected_other_open
 
     def test_utc_to_local_converts_aware_datetime_before_localizing(self):
         from dateutil import tz

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -345,6 +345,99 @@ class TestBrokerInitializationSimple:
         assert broker._is_market_open_from_initialized_calendar(open_dt) is True
         assert broker._is_market_open_from_initialized_calendar(other_dt) is expected_other_open
 
+    def test_us_futures_real_calendar_weekend_closed_and_monday_night_open(self):
+        from lumibot.tools import get_trading_days
+
+        broker = _CalendarTestBroker.create()
+        broker.initialize_market_calendars(
+            get_trading_days(
+                market="us_futures",
+                start_date=datetime(2026, 7, 1, tzinfo=timezone.utc),
+                end_date=datetime(2026, 7, 22, tzinfo=timezone.utc),
+            )
+        )
+
+        # Saturday night in New York is still the CME weekend gap.
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 12, 2, 0, tzinfo=timezone.utc)
+        ) is False
+        # Monday night in New York is inside the regular Globex session.
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 14, 2, 0, tzinfo=timezone.utc)
+        ) is True
+
+    def test_24_5_real_calendar_weekend_closed_and_weeknight_open(self):
+        from lumibot.tools import get_trading_days
+
+        broker = _CalendarTestBroker.create()
+        broker.initialize_market_calendars(
+            get_trading_days(
+                market="24/5",
+                start_date=datetime(2026, 7, 1, tzinfo=timezone.utc),
+                end_date=datetime(2026, 7, 22, tzinfo=timezone.utc),
+            )
+        )
+
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 12, 2, 0, tzinfo=timezone.utc)
+        ) is False
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 14, 2, 0, tzinfo=timezone.utc)
+        ) is True
+
+    @pytest.mark.parametrize("market", ["NASDAQ", "NYSE"])
+    def test_equity_real_calendar_market_hours_weekend_and_holiday(self, market):
+        from lumibot.tools import get_trading_days
+
+        broker = _CalendarTestBroker.create()
+        broker.initialize_market_calendars(
+            get_trading_days(
+                market=market,
+                start_date=datetime(2026, 7, 1, tzinfo=timezone.utc),
+                end_date=datetime(2026, 7, 22, tzinfo=timezone.utc),
+            )
+        )
+
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 8, 14, 7, 54, tzinfo=timezone.utc)
+        ) is True
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
+        ) is False
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 8, 21, 0, tzinfo=timezone.utc)
+        ) is False
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 11, 14, 0, tzinfo=timezone.utc)
+        ) is False
+        # Independence Day is observed on Friday July 3 in 2026.
+        assert broker._is_market_open_from_initialized_calendar(
+            datetime(2026, 7, 3, 14, 0, tzinfo=timezone.utc)
+        ) is False
+
+    @pytest.mark.parametrize(
+        "timestamp",
+        [
+            datetime(2026, 1, 1, 14, 0, tzinfo=timezone.utc),
+            datetime(2026, 7, 4, 14, 0, tzinfo=timezone.utc),
+            datetime(2026, 7, 11, 14, 0, tzinfo=timezone.utc),
+            datetime(2026, 12, 25, 14, 0, tzinfo=timezone.utc),
+        ],
+    )
+    def test_24_7_real_calendar_ignores_weekends_and_holidays(self, timestamp):
+        from lumibot.tools import get_trading_days
+
+        broker = _CalendarTestBroker.create()
+        broker.initialize_market_calendars(
+            get_trading_days(
+                market="24/7",
+                start_date=timestamp - timedelta(days=14),
+                end_date=timestamp + timedelta(days=15),
+            )
+        )
+
+        assert broker._is_market_open_from_initialized_calendar(timestamp) is True
+
     def test_utc_to_local_converts_aware_datetime_before_localizing(self):
         from dateutil import tz
         from lumibot.brokers.broker import Broker

--- a/tests/test_market_type_detection.py
+++ b/tests/test_market_type_detection.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -54,6 +54,35 @@ def test_us_futures_treated_as_non_continuous(strategy_executor):
 def test_true_continuous_markets_remain_continuous(strategy_executor):
     """24/7 markets should still be recognised as continuous."""
     assert strategy_executor._is_continuous_market("24/7") is True
+
+
+def test_24_5_market_is_not_treated_as_continuous(strategy_executor):
+    """24/5 has a weekend gap, so live startup still needs a current calendar."""
+    assert strategy_executor._is_continuous_market("24/5") is False
+
+
+def test_live_calendar_initialization_bounds_include_current_session(strategy_executor, mocker):
+    captured_kwargs = {}
+
+    def fake_get_trading_days(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return object()
+
+    initialize_spy = mocker.patch.object(strategy_executor.broker, "initialize_market_calendars")
+    mocker.patch(
+        "lumibot.strategies.strategy_executor.get_trading_days",
+        side_effect=fake_get_trading_days,
+    )
+
+    now = datetime(2026, 7, 8, 14, 7, 54, tzinfo=timezone.utc)
+    strategy_executor._initialize_live_market_calendars("NASDAQ", now_utc=now)
+
+    initialize_spy.assert_called_once()
+    assert captured_kwargs["market"] == "NASDAQ"
+    assert captured_kwargs["start_date"] <= now - timedelta(days=14)
+    # get_trading_days treats end_date as exclusive, so live startup must push beyond today.
+    assert captured_kwargs["end_date"] >= now + timedelta(days=15)
+    assert captured_kwargs["tzinfo"] is not None
 
 
 def test_ensure_progress_inside_open_session(strategy_executor, mocker):


### PR DESCRIPTION
## What
Fix live startup market-calendar handling so strategies do not sleep through an already-open market when the initialized calendar is stale. The release also hardens initialized-calendar semantics for weekends, holidays, overnight sessions, extended sessions, and continuous-market classification.

## Why
Live startup could initialize broker calendars with a default range that ended before the current trading day. The broker fast path then treated that stale calendar as authoritative `False`, causing live strategies to log `Sleeping until the market opens` during regular market hours.

## Risk
Market-open detection touches live startup behavior. The main risk is incorrectly treating a closed gap as open or a real open session as closed. The regression tests cover NASDAQ, NYSE, 24/5, 24/7, us_futures, equity holidays, futures weekend gaps, premarket/after-hours, overnight sessions, extended minutes, and an Alpaca-shaped broker path.

## Tests run
- `/Users/robertgrzesik/bin/safe-timeout 240s .venv/bin/python -m pytest <focused market-calendar/broker list> -q` -> `48 passed`
- `/Users/robertgrzesik/bin/safe-timeout 180s .venv/bin/python -m pytest tests/test_alpaca.py::TestAlpacaBroker::test_market_open_falls_back_when_initialized_calendar_is_stale tests/test_market_type_detection.py tests/test_scheduled_run_once.py -q` -> `25 passed`
- Read-only Alpaca paper broker smoke using local credentials: authenticated, read balances, read positions, read orders, verified fixed initialized-calendar path; no orders submitted.
- Full local `pytest -m "not apitest and not downloader" --tb=short -q --durations=30` was attempted under a 20-minute timeout and timed out without a failure trace. Per `docs/DEPLOYMENT.md`, release is gated on GitHub CI for the same marker expression.

## Docs
- `CHANGELOG.md`
- `docs/investigations/2026-07-08_LIVE_MARKET_CALENDAR_STARTUP.md`

## Prompts
No BotSpot Agent prompt change needed. This is LumiBot live-runtime calendar behavior, not strategy-generation guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live strategies now detect open markets more reliably at startup, even when a preloaded calendar is outdated.
  * Improved handling for markets with weekend gaps and overnight sessions, reducing false “market closed” results.
  * Added stronger fallback behavior so live market status can still be determined when calendar data is incomplete.

* **Documentation**
  * Added a release note and investigation summary for the market-calendar startup issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->