### PR TITLE
Restore scheduled broker import compatibility

### DIFF
--- a/lumibot/credentials.py
+++ b/lumibot/credentials.py
@@ -63,11 +63,11 @@ _BROKER_CLASS_NAMES = {
 
 
 def __getattr__(name: str):
-    if name == "BROKER":
+    if name in {"BROKER", "broker"}:
         value = get_default_broker()
         globals()[name] = value
         return value
-    if name == "DATA_SOURCE":
+    if name in {"DATA_SOURCE", "data_source"}:
         value = get_default_data_source()
         globals()[name] = value
         return value
@@ -1180,6 +1180,11 @@ else:
 # lazily so importing strategy modules remains config-only until a live broker
 # is actually needed.
 if _defer_default_credentials() and not IS_BACKTESTING:
+    # PEP 562 only calls module __getattr__ for missing names. Remove both
+    # legacy lowercase exports and canonical uppercase exports so explicit
+    # imports resolve the lazy broker instead of capturing the None sentinel.
+    globals().pop("broker", None)
+    globals().pop("data_source", None)
     globals().pop("BROKER", None)
     globals().pop("DATA_SOURCE", None)
 else:

--- a/tests/test_lazy_exports.py
+++ b/tests/test_lazy_exports.py
@@ -163,6 +163,34 @@ def test_scheduled_alpaca_credentials_defer_stream_dependencies():
     assert "alpaca_orders_thread" not in result.stdout
 
 
+def test_scheduled_legacy_lowercase_broker_import_resolves_lazy_default():
+    """Legacy ``from lumibot.credentials import broker`` must stay usable."""
+    env = os.environ.copy()
+    env["LUMIBOT_DISABLE_DOTENV"] = "1"
+    env["LUMIBOT_DISABLE_DOTENV_LOCAL"] = "1"
+    env["LUMIBOT_LOG_LEVEL"] = "ERROR"
+    env["LUMIBOT_SCHEDULED_EXECUTION"] = "true"
+    env["IS_BACKTESTING"] = "false"
+    env["TRADING_BROKER"] = "alpaca"
+    env["ALPACA_API_KEY"] = "fake"
+    env["ALPACA_API_SECRET"] = "fake"
+    env["ALPACA_IS_PAPER"] = "true"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from lumibot.credentials import broker; print(broker.name)",
+        ],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "alpaca"
+
+
 def test_scheduled_strategy_import_defers_default_broker_resolution():
     env = os.environ.copy()
     env["LUMIBOT_DISABLE_DOTENV"] = "1"


### PR DESCRIPTION
## Summary
- preserve legacy lowercase broker/data-source imports during scheduled lazy loading
- resolve explicit imports through lazy credential getters
- keep broker initialization deferred until requested

## Tests
- `tests/test_lazy_exports.py`: 33 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed legacy lowercase broker imports so they correctly resolve to the configured default broker during scheduled live execution.
  * Prevented deferred credential placeholders from being exposed through explicit imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->