### PR TITLE
v4.5.77 - Preserve executable Alpaca option quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   Direct lookup normalizes numeric and string order IDs instead of treating
   response dictionaries like TWS objects or fabricating a placeholder order
   when no broker row exists.
+- **Alpaca live option chains preserve executable quote data.**
+  `get_chain_full_info()` now consumes Alpaca's native option snapshots so
+  strategies receive current bid, ask, quote size, latest trade, implied
+  volatility, and greeks instead of synthetic zero bid/ask fields. This keeps
+  option-credit guards and worked-order logic tied to broker-visible quotes.
 
 ## 4.5.76 - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.77 - Unreleased
+
 ## 4.5.76 - 2026-07-13
 
 Deploy marker: `deploy 4.5.76`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 4.5.77 - Unreleased
 
+### Fixed
+- **IBKR Client Portal order refresh now reads returned JSON order rows.**
+  Direct lookup normalizes numeric and string order IDs instead of treating
+  response dictionaries like TWS objects or fabricating a placeholder order
+  when no broker row exists.
+
 ## 4.5.76 - 2026-07-13
 
 Deploy marker: `deploy 4.5.76`

--- a/lumibot/brokers/interactive_brokers_rest.py
+++ b/lumibot/brokers/interactive_brokers_rest.py
@@ -363,18 +363,21 @@ class InteractiveBrokersREST(Broker):
 
     def _pull_broker_order(self, identifier: str) -> Order:
         """Get a broker order representation by its id"""
-        pull_order = [
-            order
-            for order in self.data_source.get_broker_all_orders()
-            if order.orderId == identifier
-        ]
-        response = pull_order[0] if len(pull_order) > 0 else None
-        if response is None:
-            logger.error(
-                colored(f"Order with identifier {identifier} not found.", "red")
+        for order in self.data_source.get_broker_all_orders():
+            # Client Portal returns JSON dictionaries and can change the order id
+            # between integer and string representations across endpoints.
+            order_id = (
+                order.get("orderId")
+                if isinstance(order, dict)
+                else getattr(order, "orderId", None)
             )
-            return Order(self._strategy_name)
-        return response
+            if order_id is not None and str(order_id) == str(identifier):
+                return order
+
+        logger.warning(
+            colored(f"Order with identifier {identifier} not found.", "yellow")
+        )
+        return None
 
     def _parse_broker_position(self, broker_position, strategy, orders=None):
         """Parse a broker position representation

--- a/lumibot/data_sources/alpaca_data.py
+++ b/lumibot/data_sources/alpaca_data.py
@@ -714,16 +714,6 @@ class AlpacaData(DataSource):
                     row[f"greeks.{greek}"] = float(value)
             rows.append(row)
 
-        if not rows:
-            return super().get_chain_full_info(
-                asset,
-                expiry_date,
-                chains=chains,
-                underlying_price=underlying_price,
-                risk_free_rate=risk_free_rate,
-                strike_min=strike_min,
-                strike_max=strike_max,
-            )
         return pd.DataFrame(rows)
 
     def get_last_price(self, asset, quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:

--- a/lumibot/data_sources/alpaca_data.py
+++ b/lumibot/data_sources/alpaca_data.py
@@ -419,6 +419,48 @@ class AlpacaData(DataSource):
         asset, quote = sanitize_base_and_quote_asset(base_asset, quote_asset)
         return asset, quote
 
+    @staticmethod
+    def _option_chain_snapshots(raw_chain_data) -> dict:
+        """Normalize Alpaca SDK and raw option-chain response shapes."""
+        if not isinstance(raw_chain_data, dict):
+            return {}
+        for key in ("option_chains", "snapshots"):
+            nested = raw_chain_data.get(key)
+            if isinstance(nested, dict):
+                return nested
+        return raw_chain_data
+
+    @staticmethod
+    def _parse_option_symbol(symbol: str, underlying_symbol: str):
+        """Return (expiration, right, strike) for an OCC-style Alpaca symbol."""
+        if not isinstance(symbol, str) or not symbol.startswith(underlying_symbol):
+            return None
+        contract = symbol[len(underlying_symbol):]
+        if len(contract) < 15:
+            return None
+        try:
+            expiration = dt.date(
+                int("20" + contract[:2]),
+                int(contract[2:4]),
+                int(contract[4:6]),
+            )
+            right_code = contract[6].upper()
+            right = "CALL" if right_code == "C" else "PUT" if right_code == "P" else None
+            if right is None:
+                return None
+            strike = float(contract[7:]) / 1000.0
+        except (TypeError, ValueError, IndexError):
+            return None
+        return expiration, right, strike
+
+    @staticmethod
+    def _snapshot_value(value, *names, default=0.0):
+        for name in names:
+            candidate = value.get(name) if isinstance(value, dict) else getattr(value, name, None)
+            if candidate is not None:
+                return candidate
+        return default
+
     def get_chains(self, asset: Asset) -> dict:
         """
         Get the options chain for the given asset.
@@ -477,22 +519,12 @@ class AlpacaData(DataSource):
                 }
             }
 
-            # The Alpaca API may return option symbols in different structures
-            # Let's check what we actually got and parse accordingly
-            option_symbols = []
-
-            if isinstance(raw_chain_data, dict):
-                # Check for different possible structures
-                if "next_page_token" in raw_chain_data and "option_chains" in raw_chain_data:
-                    # New structure: {"option_chains": {"SPY250731C00501000": {...}, ...}, "next_page_token": ...}
-                    option_symbols = list(raw_chain_data["option_chains"].keys())
-                elif "snapshots" in raw_chain_data:
-                    # Old structure: {"snapshots": {"SPY250731C00501000": {...}, ...}}
-                    option_symbols = list(raw_chain_data["snapshots"].keys())
-                else:
-                    # Direct structure: {"SPY250731C00501000": {...}, ...}
-                    # Filter to only option symbols (they should start with the underlying symbol)
-                    option_symbols = [key for key in raw_chain_data.keys() if key.startswith(asset.symbol) and len(key) > len(asset.symbol)]
+            snapshots = self._option_chain_snapshots(raw_chain_data)
+            option_symbols = [
+                key
+                for key in snapshots
+                if isinstance(key, str) and key.startswith(asset.symbol) and len(key) > len(asset.symbol)
+            ]
 
             if not option_symbols:
                 logger.warning(f"No option symbols found for {asset.symbol}")
@@ -595,6 +627,104 @@ class AlpacaData(DataSource):
                 # This ensures the user sees the actual error, not a generic auth message
                 logger.error("This does not appear to be an authentication error - re-raising original error")
                 raise e
+
+    def get_chain_full_info(
+        self,
+        asset: Asset,
+        expiry,
+        chains=None,
+        underlying_price=None,
+        risk_free_rate=None,
+        strike_min=None,
+        strike_max=None,
+    ):
+        """Return Alpaca option snapshots without discarding live bid/ask.
+
+        Alpaca's option-chain endpoint already returns latest quotes, trades,
+        implied volatility, and greeks. The base implementation reconstructs
+        the chain from last prices and fills bid/ask with zero, which prevents
+        live strategies from making executable-credit decisions.
+        """
+        if isinstance(expiry, dt.datetime):
+            expiry_date = expiry.date()
+        elif isinstance(expiry, dt.date):
+            expiry_date = expiry
+        elif isinstance(expiry, str):
+            expiry_date = dt.date.fromisoformat(expiry[:10])
+        else:
+            raise TypeError("expiry must be a string, datetime.date, or datetime.datetime")
+
+        from alpaca.data.requests import OptionChainRequest
+
+        request = OptionChainRequest(
+            underlying_symbol=asset.symbol,
+            expiration_date=expiry_date,
+            strike_price_gte=strike_min,
+            strike_price_lte=strike_max,
+        )
+        snapshots = self._option_chain_snapshots(self._get_option_client().get_option_chain(request))
+        rows = []
+        for symbol, snapshot in snapshots.items():
+            parsed = self._parse_option_symbol(symbol, asset.symbol)
+            if parsed is None:
+                continue
+            expiration, right, strike = parsed
+            if expiration != expiry_date:
+                continue
+            if strike_min is not None and strike < strike_min:
+                continue
+            if strike_max is not None and strike > strike_max:
+                continue
+
+            quote = self._snapshot_value(snapshot, "latest_quote", "latestQuote", default=None)
+            trade = self._snapshot_value(snapshot, "latest_trade", "latestTrade", default=None)
+            greeks = self._snapshot_value(snapshot, "greeks", default=None)
+            bid = float(self._snapshot_value(quote, "bid_price", "bp", default=0.0) or 0.0)
+            ask = float(self._snapshot_value(quote, "ask_price", "ap", default=0.0) or 0.0)
+            bid_size = float(self._snapshot_value(quote, "bid_size", "bs", default=0.0) or 0.0)
+            ask_size = float(self._snapshot_value(quote, "ask_size", "as", default=0.0) or 0.0)
+            last = float(self._snapshot_value(trade, "price", "p", default=0.0) or 0.0)
+            last_size = float(self._snapshot_value(trade, "size", "s", default=0.0) or 0.0)
+            if last <= 0:
+                last = (bid + ask) / 2.0 if bid > 0 and ask > 0 else bid or ask
+
+            row = {
+                "symbol": symbol,
+                "last": last,
+                "expiration_date": expiration,
+                "strike": strike,
+                "option_type": right,
+                "underlying": asset.symbol,
+                "open_interest": 0,
+                "bid": bid,
+                "ask": ask,
+                "bidsize": bid_size,
+                "asksize": ask_size,
+                "volume": 0,
+                "last_volume": last_size,
+                "average_volume": 0,
+                "implied_volatility": float(
+                    self._snapshot_value(snapshot, "implied_volatility", "impliedVolatility", default=0.0) or 0.0
+                ),
+                "type": "option",
+            }
+            for greek in ("delta", "gamma", "rho", "theta", "vega"):
+                value = self._snapshot_value(greeks, greek, default=None)
+                if value is not None:
+                    row[f"greeks.{greek}"] = float(value)
+            rows.append(row)
+
+        if not rows:
+            return super().get_chain_full_info(
+                asset,
+                expiry_date,
+                chains=chains,
+                underlying_price=underlying_price,
+                risk_free_rate=risk_free_rate,
+                strike_min=strike_min,
+                strike_max=strike_max,
+            )
+        return pd.DataFrame(rows)
 
     def get_last_price(self, asset, quote=None, exchange=None, **kwargs) -> Union[float, Decimal, None]:
         """

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.76",
+    version="4.5.77",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_alpaca_option_chain_quotes.py
+++ b/tests/test_alpaca_option_chain_quotes.py
@@ -69,6 +69,30 @@ def test_get_chain_full_info_accepts_raw_nested_snapshots_and_uses_quote_midpoin
     assert row["greeks.delta"] == -0.25
 
 
+def test_get_chain_full_info_returns_empty_when_alpaca_has_no_native_snapshots():
+    data_source = _data_source()
+    captured = {}
+
+    def get_option_chain(request):
+        captured["request"] = request
+        return {}
+
+    data_source._option_client = SimpleNamespace(get_option_chain=get_option_chain)
+
+    result = data_source.get_chain_full_info(
+        Asset("SPY", asset_type="stock"),
+        "2026-08-21",
+        strike_min=490,
+        strike_max=510,
+    )
+
+    assert result.empty
+    assert captured["request"].underlying_symbol == "SPY"
+    assert captured["request"].expiration_date.isoformat() == "2026-08-21"
+    assert captured["request"].strike_price_gte == 490
+    assert captured["request"].strike_price_lte == 510
+
+
 def test_get_chains_still_parses_nested_snapshot_symbols():
     data_source = _data_source()
     data_source._option_client = SimpleNamespace(

--- a/tests/test_alpaca_option_chain_quotes.py
+++ b/tests/test_alpaca_option_chain_quotes.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+
+from lumibot.data_sources.alpaca_data import AlpacaData
+from lumibot.entities import Asset
+
+
+def _data_source():
+    return AlpacaData({"API_KEY": "test", "API_SECRET": "test"})
+
+
+def test_get_chain_full_info_preserves_native_quote_trade_and_greeks():
+    data_source = _data_source()
+    data_source._option_client = SimpleNamespace(
+        get_option_chain=lambda request: {
+            "KVYO260821P00015000": SimpleNamespace(
+                latest_quote=SimpleNamespace(bid_price=0.77, ask_price=0.83, bid_size=12, ask_size=8),
+                latest_trade=SimpleNamespace(price=0.80, size=10),
+                implied_volatility=0.81,
+                greeks=SimpleNamespace(delta=-0.2439, gamma=0.0654, rho=-0.012, theta=-0.0193, vega=0.0176),
+            ),
+            "KVYO260821C00015000": SimpleNamespace(
+                latest_quote=SimpleNamespace(bid_price=5.1, ask_price=5.4, bid_size=2, ask_size=3),
+                latest_trade=SimpleNamespace(price=5.2, size=1),
+                implied_volatility=0.72,
+                greeks=SimpleNamespace(delta=0.76, gamma=0.06, rho=0.03, theta=-0.02, vega=0.02),
+            ),
+        }
+    )
+
+    result = data_source.get_chain_full_info(
+        Asset("KVYO", asset_type="stock"),
+        "2026-08-21",
+        strike_min=15,
+        strike_max=15,
+    )
+
+    put = result[result["option_type"] == "PUT"].iloc[0]
+    assert put["symbol"] == "KVYO260821P00015000"
+    assert put["bid"] == 0.77
+    assert put["ask"] == 0.83
+    assert put["last"] == 0.80
+    assert put["bidsize"] == 12
+    assert put["asksize"] == 8
+    assert put["greeks.delta"] == -0.2439
+    assert put["implied_volatility"] == 0.81
+
+
+def test_get_chain_full_info_accepts_raw_nested_snapshots_and_uses_quote_midpoint():
+    data_source = _data_source()
+    data_source._option_client = SimpleNamespace(
+        get_option_chain=lambda request: {
+            "snapshots": {
+                "SPY260821P00500000": {
+                    "latestQuote": {"bp": 4.0, "ap": 4.4, "bs": 5, "as": 7},
+                    "latestTrade": None,
+                    "impliedVolatility": 0.2,
+                    "greeks": {"delta": -0.25},
+                }
+            }
+        }
+    )
+
+    result = data_source.get_chain_full_info(Asset("SPY", asset_type="stock"), "2026-08-21")
+
+    row = result.iloc[0]
+    assert row["bid"] == 4.0
+    assert row["ask"] == 4.4
+    assert row["last"] == 4.2
+    assert row["greeks.delta"] == -0.25
+
+
+def test_get_chains_still_parses_nested_snapshot_symbols():
+    data_source = _data_source()
+    data_source._option_client = SimpleNamespace(
+        get_option_chain=lambda request: {
+            "option_chains": {
+                "SPY260821P00500000": {},
+                "SPY260821C00510000": {},
+                "not-an-option": {},
+            }
+        }
+    )
+
+    result = data_source.get_chains(Asset("SPY", asset_type="stock"))
+
+    assert result["Chains"]["PUT"]["2026-08-21"] == [500.0]
+    assert result["Chains"]["CALL"]["2026-08-21"] == [510.0]

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -485,6 +485,29 @@ def test_ibkr_rest_submit_order_without_stream_does_not_crash(monkeypatch):
     assert order.status == Order.OrderStatus.SUBMITTED
 
 
+def test_ibkr_rest_pull_broker_order_reads_client_portal_mapping():
+    from lumibot.brokers.interactive_brokers_rest import InteractiveBrokersREST
+
+    raw_order = {"orderId": 1234567890, "status": "Submitted"}
+    broker = InteractiveBrokersREST.__new__(InteractiveBrokersREST)
+    broker.data_source = SimpleNamespace(get_broker_all_orders=lambda: [raw_order])
+
+    # Client Portal JSON uses a numeric orderId while strategy state can hold a string.
+    assert broker._pull_broker_order("1234567890") is raw_order
+
+
+def test_ibkr_rest_pull_broker_order_returns_none_when_missing():
+    from lumibot.brokers.interactive_brokers_rest import InteractiveBrokersREST
+
+    broker = InteractiveBrokersREST.__new__(InteractiveBrokersREST)
+    broker.data_source = SimpleNamespace(
+        get_broker_all_orders=lambda: [{"orderId": 111, "status": "Submitted"}]
+    )
+
+    # Missing broker data must not fabricate a truthy placeholder order.
+    assert broker._pull_broker_order("222") is None
+
+
 def test_interactive_brokers_keeps_required_orders_thread_enabled(monkeypatch):
     from lumibot.brokers import broker as broker_module
     from lumibot.brokers.interactive_brokers import InteractiveBrokers


### PR DESCRIPTION
## What

LumiBot 4.5.77 reads Alpaca option-chain snapshots through Alpaca's native option endpoint and preserves bid, ask, quote size, last trade, implied volatility, and Greeks. Missing native snapshots now fail closed with an empty chain instead of silently recreating zero bid/ask rows. The release also fixes IBKR Client Portal order lookup for JSON order rows and carries current `dev` documentation forward.

## Why

Live option strategies need broker-visible executable quotes for delta selection, minimum-credit checks, and worked limit orders. Synthetic zero bid/ask values caused valid chains to be rejected and made fill behavior impossible to verify accurately. A missing broker snapshot must remain visible as missing data rather than becoming fabricated pricing.

## Risk

The Alpaca SDK can return option snapshots as SDK models or nested/raw dictionaries; normalization and OCC parsing cover both. If Alpaca returns no native rows, the chain is now empty by design. This is detectable through the existing missing-chain path and prevents orders based on fabricated prices. IBKR order lookup now returns `None` rather than a fabricated placeholder when the broker row is absent.

## Tests run

- `pytest -q tests/test_alpaca_option_chain_quotes.py tests/test_broker_initialization.py::test_ibkr_rest_pull_broker_order_reads_client_portal_mapping tests/test_broker_initialization.py::test_ibkr_rest_pull_broker_order_returns_none_when_missing` (6 passed)
- Focused Alpaca/data-source suite before merging current dev (12 passed)
- Local wheel build: `uv run --with build python -m build --wheel`
- Release PR CI is the clean-environment full gate.

## Performance evidence

A read-only Alpaca integration check returned 42 SPY option contracts for one expiration in 0.894 seconds; every returned row had nonzero bid/ask and delta, matching the independent broker chain response.

## Docs

- `CHANGELOG.md` documents both fixes.
- `docs/DEPLOYMENT.md` release procedure followed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Interactive Brokers order refreshing when order IDs use different numeric or string formats.
  - Prevented missing broker orders from appearing as fabricated placeholder orders.
  - Preserved live Alpaca option quotes, trade data, sizes, implied volatility, and greeks in option-chain results.
  - Improved handling of Alpaca option-chain response formats and filtering by expiration and strike range.

- **Release**
  - Updated the package version to 4.5.77 (Unreleased).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->