### PR TITLE
fix: isolate IBKR negative cache release fixtures

### DIFF
--- a/tests/backtest/test_ibkr_helper_stale_end_negative_cache.py
+++ b/tests/backtest/test_ibkr_helper_stale_end_negative_cache.py
@@ -23,6 +23,11 @@ def test_ibkr_stale_end_marks_missing_window_to_avoid_repeated_history_fetches(m
         # Disable remote cache; this is a unit test for local parquet behavior.
         monkeypatch.setenv("LUMIBOT_CACHE_BACKEND", "local")
         monkeypatch.setenv("LUMIBOT_CACHE_MODE", "disabled")
+        monkeypatch.setattr(
+            backtest_cache,
+            "CACHE_REMOTE_CONFIG",
+            {"backend": "local", "mode": "disabled"},
+        )
         backtest_cache.reset_backtest_cache_manager(for_testing=True)
 
         # Patch module-level cache root constants (ibkr_helper imports by value).
@@ -136,6 +141,11 @@ def test_ibkr_placeholder_window_suppresses_subwindow_refetch_after_restart(monk
     try:
         monkeypatch.setenv("LUMIBOT_CACHE_BACKEND", "local")
         monkeypatch.setenv("LUMIBOT_CACHE_MODE", "disabled")
+        monkeypatch.setattr(
+            backtest_cache,
+            "CACHE_REMOTE_CONFIG",
+            {"backend": "local", "mode": "disabled"},
+        )
         backtest_cache.reset_backtest_cache_manager(for_testing=True)
 
         monkeypatch.setattr(ibkr_helper, "LUMIBOT_CACHE_FOLDER", str(cache_root))


### PR DESCRIPTION
## Summary
- isolate the stale-end negative-cache tests from configured S3 cache state
- prevent shared cache secrets from changing deterministic release test behavior

## Verification
- python3 -m pytest tests/backtest/test_ibkr_helper_stale_end_negative_cache.py --tb=short -q (2 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test setup to explicitly disable caching during IBKR helper tests.
  * Improved test isolation and consistency across cache-related scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->