### PR TITLE
v4.5.81 - Self-heal IBKR hourly cache gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.81 - Unreleased
+
 ## 4.5.80 - 2026-07-30
 
 Deploy marker: `deploy 4.5.80`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.81 - Unreleased
+## 4.5.81 - 2026-07-30
+
+Deploy marker: `deploy 4.5.81`
 
 ### Fixed
 - **IBKR stock and index hourly caches now repair large internal holes lazily.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 4.5.81 - Unreleased
 
+### Fixed
+- **IBKR stock and index hourly caches now repair large internal holes lazily.**
+  LumiBot detects gaps longer than a normal market closure, downloads the
+  missing hourly range in bounded pages, merges real bars without deleting the
+  shared cache, and preserves partial progress for a later run. Complete warm
+  caches make no repair requests.
+- **IBKR cache repair no longer lets one symbol starve later symbols.** Daily
+  repair uses a per-series deadline and one bounded range request. Hourly repair
+  has its own deadline, and partial hourly progress is not mislabeled as a
+  24-hour no-data window.
+- **Closed-market request boundaries no longer create false underfill
+  warnings.** Weekend and overnight stock/index boundaries are evaluated
+  against the first market open and last market close.
+
 ## 4.5.80 - 2026-07-30
 
 Deploy marker: `deploy 4.5.80`

--- a/docs/BACKTESTING_PERFORMANCE.md
+++ b/docs/BACKTESTING_PERFORMANCE.md
@@ -372,12 +372,19 @@ Production containers are ephemeral. Even if S3 is warm:
 - Incomplete cache coverage: you cached EOD but not quote snapshots, or vice versa.
 - Many small objects: even “warm” runs are slow because S3 has to read thousands of tiny files.
 
-IBKR US stock and index day caches are checked for missing completed NYSE sessions when the
-series is loaded. A complete cache stays on the normal warm path with no downloader call and no
-S3 write. If a gap is found, LumiBot requests only the affected month, up to 12 months for that
-series and within a shared 15-second process budget. A timeout leaves the available bars usable
-and does not fail the backtest. Unresolved sessions receive a 24-hour retry marker so repeated
-backtests do not create a downloader storm.
+IBKR US stock and index caches are checked lazily for missing history. Daily
+series compare real bars with completed NYSE sessions and repair the affected
+range with one request under a 45-second per-series deadline. Hourly series
+look only for internal holes longer than seven days, then fetch the missing
+range in 2000-hour pages under a five-minute per-series deadline. The longer
+hourly deadline applies only when a damaged cache is detected.
+
+A complete cache stays on the normal warm path with no downloader call and no
+S3 write. A timeout leaves available bars usable and does not fail the
+backtest. Partial hourly progress is saved without suppressing the next repair.
+Only a genuine empty response receives a 24-hour retry marker, which prevents a
+downloader storm without making a partial cache look complete. Older generic
+missing-window markers do not block the new hourly internal-gap repair.
 
 ### 5.4 Cache design principle: fewer, larger objects
 

--- a/docs/REMOTE_CACHE.md
+++ b/docs/REMOTE_CACHE.md
@@ -110,6 +110,11 @@ Operationally:
   same object first, LumiBot downloads that newer object, merges both versions,
   and retries. Real bars take precedence over no-data placeholders. This avoids
   last-writer-wins data loss without adding an S3 read to the normal warm path.
+* IBKR US stock and index series self-heal known cache gaps when loaded. Daily
+  gaps use one bounded range request per series. Hourly gaps longer than seven
+  days use bounded 2000-hour pages. Partial hourly progress remains retryable,
+  while a genuine empty response receives an expiring no-data marker. No cache
+  purge or namespace cutover is required.
 * Remote uploads run only in `s3_readwrite` mode. The read-only path returns
   early, leaving a TODO hook (`BacktestCacheManager.on_local_update`) for the
   Lambda-triggered workflow.

--- a/docsrc/backtesting.ibkr.rst
+++ b/docsrc/backtesting.ibkr.rst
@@ -83,15 +83,20 @@ IBKR backtests cache historical bars as Parquet:
 - Local: ``LUMIBOT_CACHE_FOLDER/ibkr/...``
 - Optional S3 mirroring: configured via the standard ``LUMIBOT_CACHE_*`` variables (see :ref:`environment_variables`).
 
-For US stock and index day bars, LumiBot checks the expected NYSE sessions after loading the
-series. If a completed session is absent, LumiBot makes a small, best-effort request for the
-affected month and merges any returned bars into the existing cache. The check runs once per
-requested series window, has a process-wide 15-second repair budget, and never turns a partial
-data condition into a backtest exception. Complete warm caches do not call the downloader.
+For US stock and index bars, LumiBot checks for cache gaps after loading the
+series. Daily bars are compared with completed NYSE sessions and the affected
+range is repaired under a 45-second per-series deadline. Hourly bars are
+checked for internal holes longer than seven days and repaired in bounded
+2000-hour pages under a five-minute per-series deadline. These checks never
+turn partial data into a backtest exception, and complete warm caches do not
+call the downloader.
 
 No-data markers include a retry timestamp. Until that timestamp expires, the marker prevents
 repeated downloads. Legacy markers without a retry timestamp are eligible for one lazy repair
-attempt. When a real bar and a no-data marker share a timestamp, the real bar always wins.
+attempt. Partial hourly progress remains immediately retryable and does not
+receive a no-data marker. Older generic missing-window markers do not block the
+hourly internal-gap repair. When a real bar and a no-data marker share a
+timestamp, the real bar always wins.
 
 Conid lookups also maintain cache files under ``LUMIBOT_CACHE_FOLDER/ibkr``:
 

--- a/lumibot/tools/ibkr_helper.py
+++ b/lumibot/tools/ibkr_helper.py
@@ -59,9 +59,12 @@ IBKR_DEFAULT_INDEX_HISTORY_SOURCE = "Midpoint"
 # windows, extend ``_history_period_for_request`` to pick a smaller period
 # tailored to the bar size rather than tightening this cap.
 IBKR_STOCK_INDEX_DAILY_MAX_PERIOD = "5y"
-IBKR_DAILY_GAP_RETRY_TTL_SECONDS = 24 * 60 * 60
-IBKR_DAILY_GAP_REPAIR_TOTAL_BUDGET_SECONDS = 15.0
-IBKR_DAILY_GAP_REPAIR_MAX_MONTHS_PER_SERIES = 12
+IBKR_GAP_RETRY_TTL_SECONDS = 24 * 60 * 60
+IBKR_DAILY_GAP_REPAIR_TIMEOUT_SECONDS = 45.0
+IBKR_HOURLY_GAP_REPAIR_TIMEOUT_SECONDS = 300.0
+IBKR_HOURLY_INTERNAL_GAP_THRESHOLD = timedelta(days=7)
+IBKR_HOURLY_GAP_REPAIR_MAX_SEGMENTS_PER_SERIES = 4
+IBKR_STOCK_INDEX_HOURLY_REPAIR_PERIOD = "2000h"
 
 IBKR_CONID_NEGATIVE_CACHE_TTL_SECONDS = 24 * 60 * 60  # 24h (persisted via BacktestCacheManager when enabled)
 
@@ -83,7 +86,7 @@ _IBKR_EQUITY_ACTIONS_CACHE: Dict[str, pd.DataFrame] = {}
 _RUNTIME_CONID_CACHE: Dict[str, int] = {}
 _RUNTIME_HISTORY_NO_DATA_WINDOWS: Dict[str, Tuple[datetime, datetime]] = {}
 _RUNTIME_DAILY_GAP_CHECKED_WINDOWS: set[tuple[str, str, str]] = set()
-_RUNTIME_DAILY_GAP_REPAIR_SECONDS_USED = 0.0
+_RUNTIME_HOURLY_GAP_CHECKED_SERIES: set[str] = set()
 _DISABLE_CONIDS_REMOTE_UPLOAD = False
 _LOGGED_CONIDS_REMOTE_UPLOAD_DISABLE = False
 _LOGGED_HISTORY_ALIASES: set[str] = set()
@@ -967,6 +970,24 @@ def get_price_data(
             source=history_source,
             source_was_explicit=source_was_explicit,
         )
+    elif (
+        not df_cache.empty
+        and asset_type in {"stock", "index"}
+        and str(timestep_component).endswith("hour")
+    ):
+        df_cache = _repair_us_stock_index_hourly_gaps(
+            df_cache,
+            cache_file=cache_file,
+            asset=asset,
+            quote=quote,
+            timestep=timestep,
+            start_dt=start_utc,
+            end_dt=end_utc,
+            exchange=effective_exchange,
+            include_after_hours=include_after_hours,
+            source=history_source,
+            source_was_explicit=source_was_explicit,
+        )
 
     if df_cache.empty:
         return df_cache
@@ -1821,6 +1842,7 @@ def _fetch_history_between_dates(
     _record_missing_on_empty: bool = True,
     _queue_timeout: Optional[float] = None,
     _max_timeout_attempts: Optional[int] = None,
+    _deadline_monotonic: Optional[float] = None,
 ) -> pd.DataFrame:
     conid = _resolve_conid(asset=asset, quote=quote, exchange=exchange)
     bar, bar_seconds, _cache_timestep = _timestep_to_ibkr_bar(timestep)
@@ -1856,18 +1878,32 @@ def _fetch_history_between_dates(
 
     # Fetch backwards (end -> start) to accommodate IBKR's 1000 datapoint cap.
     while cursor_end > start_dt:
-        payload = _ibkr_history_request(
-            conid=conid,
-            period=period,
-            bar=bar,
-            start_time=cursor_end,
-            exchange=exchange,
-            include_after_hours=include_after_hours,
-            continuous=continuous,
-            source=source,
-            queue_timeout=_queue_timeout,
-            max_timeout_attempts=_max_timeout_attempts,
-        )
+        queue_timeout = _queue_timeout
+        if _deadline_monotonic is not None:
+            remaining = _deadline_monotonic - time.perf_counter()
+            if remaining <= 0:
+                if chunks:
+                    break
+                raise TimeoutError("IBKR history repair budget expired before the first page")
+            queue_timeout = remaining if queue_timeout is None else min(queue_timeout, remaining)
+
+        try:
+            payload = _ibkr_history_request(
+                conid=conid,
+                period=period,
+                bar=bar,
+                start_time=cursor_end,
+                exchange=exchange,
+                include_after_hours=include_after_hours,
+                continuous=continuous,
+                source=source,
+                queue_timeout=max(0.1, queue_timeout) if queue_timeout is not None else None,
+                max_timeout_attempts=_max_timeout_attempts,
+            )
+        except Exception:
+            if chunks and _deadline_monotonic is not None and time.perf_counter() >= _deadline_monotonic:
+                break
+            raise
 
         # IBKR typically returns {"data":[...]} (empty list means no data).
         data = payload.get("data") if isinstance(payload, dict) else None
@@ -2019,10 +2055,41 @@ def frame_covers_requested_window(
     except Exception:
         pass
 
-    return bool(
-        coverage_start <= (start_local + tolerance)
-        and coverage_end >= (end_local - tolerance)
-    )
+    start_covered = coverage_start <= (start_local + tolerance)
+    end_covered = coverage_end >= (end_local - tolerance)
+
+    if asset_type in {"stock", "index"} and (not start_covered or not end_covered):
+        try:
+            from lumibot.tools.helpers import get_trading_days
+
+            schedule = get_trading_days(
+                market="NYSE",
+                start_date=start_local.date(),
+                end_date=end_local.date(),
+                tzinfo=LUMIBOT_DEFAULT_PYTZ,
+            )
+            if schedule is not None and not schedule.empty:
+                first_open = pd.Timestamp(schedule["market_open"].iloc[0])
+                last_close = pd.Timestamp(schedule["market_close"].iloc[-1])
+                if coverage_start.tzinfo is not None:
+                    first_open = first_open.tz_convert(coverage_start.tzinfo)
+                if coverage_end.tzinfo is not None:
+                    last_close = last_close.tz_convert(coverage_end.tzinfo)
+                # A weekend or overnight request boundary needs no synthetic
+                # bars. The first open and last close are the real coverage
+                # boundaries for US stocks and indexes.
+                start_covered = start_covered or (
+                    start_local < first_open
+                    and coverage_start <= (first_open + tolerance)
+                )
+                end_covered = end_covered or (
+                    end_local > last_close
+                    and coverage_end >= (last_close - tolerance)
+                )
+        except Exception:
+            pass
+
+    return bool(start_covered and end_covered)
 
 
 def _downloader_history_meta(payload: Any) -> Dict[str, Any]:
@@ -2378,9 +2445,11 @@ def _repair_us_stock_index_daily_gaps(
     source: str,
     source_was_explicit: bool,
 ) -> pd.DataFrame:
-    """Best-effort lazy repair for internal US stock/index daily cache gaps."""
-    global _RUNTIME_DAILY_GAP_REPAIR_SECONDS_USED
+    """Best-effort lazy repair for internal US stock/index daily cache gaps.
 
+    The repair budget is per cached series. A slow symbol must never consume the
+    repair opportunity for every later symbol in the same backtest process.
+    """
     quote_symbol = str(getattr(quote, "symbol", "USD") or "USD").strip().upper()
     normalized_exchange = str(exchange or "").strip().upper()
     if quote_symbol != "USD" or normalized_exchange not in {
@@ -2412,55 +2481,44 @@ def _repair_us_stock_index_daily_gaps(
     if not gaps:
         return aligned
 
-    months: Dict[tuple[int, int], list[pd.Timestamp]] = {}
-    for session in gaps:
-        months.setdefault((session.year, session.month), []).append(session)
-
-    attempted: list[pd.Timestamp] = []
     working = aligned
-    for (year, month), sessions in list(months.items())[
-        :IBKR_DAILY_GAP_REPAIR_MAX_MONTHS_PER_SERIES
-    ]:
-        remaining_budget = (
-            IBKR_DAILY_GAP_REPAIR_TOTAL_BUDGET_SECONDS
-            - _RUNTIME_DAILY_GAP_REPAIR_SECONDS_USED
+    attempted: list[pd.Timestamp] = []
+    first_gap = min(gaps)
+    last_gap = max(gaps)
+    repair_start = first_gap.normalize() - pd.Timedelta(days=1)
+    repair_end = last_gap.normalize() + pd.Timedelta(days=2)
+    deadline = time.perf_counter() + IBKR_DAILY_GAP_REPAIR_TIMEOUT_SECONDS
+    try:
+        fetched = _fetch_history_between_dates(
+            asset=asset,
+            quote=quote,
+            timestep=timestep,
+            start_dt=repair_start.to_pydatetime(),
+            end_dt=repair_end.to_pydatetime(),
+            exchange=exchange,
+            include_after_hours=include_after_hours,
+            source=source,
+            source_was_explicit=source_was_explicit,
+            # One capped request can repair years of daily history. Month-by-month
+            # requests were slower and left later symbols without a repair chance.
+            _period_override=IBKR_STOCK_INDEX_DAILY_MAX_PERIOD,
+            _record_missing_on_empty=False,
+            _queue_timeout=IBKR_DAILY_GAP_REPAIR_TIMEOUT_SECONDS,
+            _max_timeout_attempts=1,
+            _deadline_monotonic=deadline,
         )
-        if remaining_budget <= 0:
-            break
-
-        month_start = pd.Timestamp(year=year, month=month, day=1, tz=LUMIBOT_DEFAULT_PYTZ)
-        next_month = month_start + pd.offsets.MonthBegin(1)
-        started = time.perf_counter()
-        try:
-            fetched = _fetch_history_between_dates(
-                asset=asset,
-                quote=quote,
-                timestep=timestep,
-                start_dt=month_start.to_pydatetime(),
-                end_dt=next_month.to_pydatetime(),
-                exchange=exchange,
-                include_after_hours=include_after_hours,
-                source=source,
-                source_was_explicit=source_was_explicit,
-                _period_override="1m",
-                _record_missing_on_empty=False,
-                _queue_timeout=max(0.1, remaining_budget),
-                _max_timeout_attempts=1,
-            )
-            attempted.extend(sessions)
-            if fetched is not None and not fetched.empty:
-                fetched = _align_stock_index_daily_to_session_close(fetched)
-                working = _merge_frames(working, fetched)
-        except Exception as exc:
-            logger.warning(
-                "IBKR daily gap repair skipped for %s %04d-%02d: %s",
-                getattr(asset, "symbol", None),
-                year,
-                month,
-                exc,
-            )
-        finally:
-            _RUNTIME_DAILY_GAP_REPAIR_SECONDS_USED += time.perf_counter() - started
+        attempted.extend(gaps)
+        if fetched is not None and not fetched.empty:
+            fetched = _align_stock_index_daily_to_session_close(fetched)
+            working = _merge_frames(working, fetched)
+    except Exception as exc:
+        logger.warning(
+            "IBKR daily gap repair skipped for %s %s through %s: %s",
+            getattr(asset, "symbol", None),
+            first_gap.date(),
+            last_gap.date(),
+            exc,
+        )
 
     if attempted:
         missing_mask = working["missing"].fillna(False).astype(bool)
@@ -2472,7 +2530,7 @@ def _repair_us_stock_index_daily_gaps(
         }
         unresolved = [session for session in attempted if session.date() not in real_dates]
         retry_after = datetime.now(timezone.utc) + timedelta(
-            seconds=IBKR_DAILY_GAP_RETRY_TTL_SECONDS
+            seconds=IBKR_GAP_RETRY_TTL_SECONDS
         )
         working = _merge_frames(
             working,
@@ -2481,6 +2539,271 @@ def _repair_us_stock_index_daily_gaps(
 
     if not working.equals(df_cache):
         _write_cache_frame(cache_file, working)
+    return working
+
+
+def _hourly_internal_gaps(
+    df_cache: pd.DataFrame,
+    *,
+    start_dt: datetime,
+    end_dt: datetime,
+    now: Optional[datetime] = None,
+) -> list[tuple[pd.Timestamp, pd.Timestamp]]:
+    """Return large internal holes between real hourly bars.
+
+    Seven days is longer than any normal US equity weekend or exchange holiday.
+    It avoids trying to manufacture bars during expected closures while still
+    detecting the multi-month and multi-year cache holes that invalidate a
+    historical indicator series.
+    """
+    if df_cache is None or df_cache.empty:
+        return []
+
+    frame = df_cache.copy()
+    idx = pd.DatetimeIndex(frame.index)
+    if idx.tz is None:
+        idx = idx.tz_localize(LUMIBOT_DEFAULT_PYTZ)
+    else:
+        idx = idx.tz_convert(LUMIBOT_DEFAULT_PYTZ)
+    frame.index = idx
+
+    missing_mask = (
+        frame["missing"].fillna(False).astype(bool)
+        if "missing" in frame.columns
+        else pd.Series(False, index=frame.index)
+    )
+    real_index = pd.DatetimeIndex(frame.index[~missing_mask]).sort_values().unique()
+    if len(real_index) < 2:
+        return []
+
+    start_local = pd.Timestamp(_to_utc(start_dt)).tz_convert(LUMIBOT_DEFAULT_PYTZ)
+    now_utc = pd.Timestamp(now or datetime.now(timezone.utc))
+    if now_utc.tzinfo is None:
+        now_utc = now_utc.tz_localize(timezone.utc)
+    else:
+        now_utc = now_utc.tz_convert(timezone.utc)
+    end_local = min(
+        pd.Timestamp(_to_utc(end_dt)).tz_convert(LUMIBOT_DEFAULT_PYTZ),
+        now_utc.tz_convert(LUMIBOT_DEFAULT_PYTZ),
+    )
+    real_index = real_index[(real_index >= start_local) & (real_index <= end_local)]
+    if len(real_index) < 2:
+        return []
+
+    gaps: list[tuple[pd.Timestamp, pd.Timestamp]] = []
+    for left, right in zip(real_index[:-1], real_index[1:]):
+        if right - left > IBKR_HOURLY_INTERNAL_GAP_THRESHOLD:
+            gaps.append((left, right))
+    return gaps
+
+
+def _gap_has_fresh_retry_marker(
+    df_cache: pd.DataFrame,
+    *,
+    gap_start: pd.Timestamp,
+    gap_end: pd.Timestamp,
+    now: Optional[datetime] = None,
+) -> bool:
+    if (
+        df_cache is None
+        or df_cache.empty
+        or "missing" not in df_cache.columns
+        or "missing_retry_after" not in df_cache.columns
+        or "missing_reason" not in df_cache.columns
+    ):
+        return False
+
+    missing_mask = df_cache["missing"].fillna(False).astype(bool)
+    hourly_gap_mask = (
+        df_cache["missing_reason"].fillna("").astype(str)
+        == "hourly_internal_gap_empty"
+    )
+    marker_rows = df_cache.loc[
+        missing_mask
+        & hourly_gap_mask
+        & (df_cache.index > gap_start)
+        & (df_cache.index < gap_end),
+        ["missing_retry_after"],
+    ]
+    if len(marker_rows) < 2:
+        return False
+    retry_after = pd.to_datetime(
+        marker_rows["missing_retry_after"],
+        utc=True,
+        errors="coerce",
+    ).dropna()
+    if len(retry_after) < 2:
+        return False
+    now_utc = pd.Timestamp(now or datetime.now(timezone.utc))
+    if now_utc.tzinfo is None:
+        now_utc = now_utc.tz_localize(timezone.utc)
+    else:
+        now_utc = now_utc.tz_convert(timezone.utc)
+    return bool((retry_after > now_utc).all())
+
+
+def _missing_window_placeholders(
+    gap_start: pd.Timestamp,
+    gap_end: pd.Timestamp,
+    *,
+    retry_after: datetime,
+    bar_step: pd.Timedelta,
+) -> pd.DataFrame:
+    left = gap_start + bar_step
+    right = gap_end - bar_step
+    if left >= right:
+        return pd.DataFrame()
+    return pd.DataFrame(
+        {
+            "open": [pd.NA, pd.NA],
+            "high": [pd.NA, pd.NA],
+            "low": [pd.NA, pd.NA],
+            "close": [pd.NA, pd.NA],
+            "volume": [pd.NA, pd.NA],
+            "missing": [True, True],
+            "missing_retry_after": [retry_after.isoformat(), retry_after.isoformat()],
+            "missing_reason": [
+                "hourly_internal_gap_empty",
+                "hourly_internal_gap_empty",
+            ],
+        },
+        index=pd.DatetimeIndex([left, right]),
+    )
+
+
+def _repair_us_stock_index_hourly_gaps(
+    df_cache: pd.DataFrame,
+    *,
+    cache_file: Path,
+    asset: Asset,
+    quote: Optional[Asset],
+    timestep: str,
+    start_dt: datetime,
+    end_dt: datetime,
+    exchange: Optional[str],
+    include_after_hours: bool,
+    source: str,
+    source_was_explicit: bool,
+) -> pd.DataFrame:
+    """Lazily fill large internal stock/index hourly cache holes once per process."""
+    quote_symbol = str(getattr(quote, "symbol", "USD") or "USD").strip().upper()
+    normalized_exchange = str(exchange or "").strip().upper()
+    if quote_symbol != "USD" or normalized_exchange not in {
+        "",
+        "SMART",
+        "NYSE",
+        "NASDAQ",
+        "ARCA",
+        "AMEX",
+        "IEX",
+    }:
+        return df_cache
+
+    series_key = str(cache_file)
+    if series_key in _RUNTIME_HOURLY_GAP_CHECKED_SERIES:
+        return df_cache
+
+    gaps = _hourly_internal_gaps(
+        df_cache,
+        start_dt=start_dt,
+        end_dt=end_dt,
+    )
+    gaps = [
+        gap
+        for gap in gaps
+        if not _gap_has_fresh_retry_marker(
+            df_cache,
+            gap_start=gap[0],
+            gap_end=gap[1],
+        )
+    ]
+    if not gaps:
+        return df_cache
+    _RUNTIME_HOURLY_GAP_CHECKED_SERIES.add(series_key)
+
+    logger.info(
+        "IBKR hourly cache repair found %d large internal gap(s) for %s",
+        len(gaps),
+        getattr(asset, "symbol", None),
+    )
+    working = df_cache
+    changed = False
+    deadline = time.perf_counter() + IBKR_HOURLY_GAP_REPAIR_TIMEOUT_SECONDS
+    attempted: list[tuple[pd.Timestamp, pd.Timestamp]] = []
+    for gap_start, gap_end in gaps[:IBKR_HOURLY_GAP_REPAIR_MAX_SEGMENTS_PER_SERIES]:
+        remaining = deadline - time.perf_counter()
+        if remaining <= 0:
+            break
+        try:
+            fetched = _fetch_history_between_dates(
+                asset=asset,
+                quote=quote,
+                timestep=timestep,
+                start_dt=gap_start.to_pydatetime(),
+                end_dt=gap_end.to_pydatetime(),
+                exchange=exchange,
+                include_after_hours=include_after_hours,
+                source=source,
+                source_was_explicit=source_was_explicit,
+                # With outside-RTH equity data, 2000 calendar hours stays below
+                # IBKR's roughly 1000-bar response cap while halving page count.
+                _period_override=IBKR_STOCK_INDEX_HOURLY_REPAIR_PERIOD,
+                _record_missing_on_empty=False,
+                _queue_timeout=max(0.1, remaining),
+                _max_timeout_attempts=1,
+                _deadline_monotonic=deadline,
+            )
+            attempted.append((gap_start, gap_end))
+            if fetched is not None and not fetched.empty:
+                working = _merge_frames(working, fetched)
+                changed = True
+        except Exception as exc:
+            logger.warning(
+                "IBKR hourly gap repair skipped for %s %s through %s: %s",
+                getattr(asset, "symbol", None),
+                gap_start,
+                gap_end,
+                exc,
+            )
+
+    remaining_gaps = _hourly_internal_gaps(
+        working,
+        start_dt=start_dt,
+        end_dt=end_dt,
+    )
+    unresolved = [
+        gap
+        for gap in remaining_gaps
+        if any(
+            gap[0] < attempted_end and gap[1] > attempted_start
+            for attempted_start, attempted_end in attempted
+        )
+    ]
+    # A partial response is useful progress, but it must not create a 24-hour
+    # negative-cache marker for the unfilled remainder. The next backtest can
+    # continue repairing from the newly advanced cache edge.
+    if unresolved and not changed:
+        retry_after = datetime.now(timezone.utc) + timedelta(
+            seconds=IBKR_GAP_RETRY_TTL_SECONDS
+        )
+        for gap_start, gap_end in unresolved:
+            placeholders = _missing_window_placeholders(
+                gap_start,
+                gap_end,
+                retry_after=retry_after,
+                bar_step=pd.Timedelta(hours=1),
+            )
+            if not placeholders.empty:
+                working = _merge_frames(working, placeholders)
+                changed = True
+
+    if changed:
+        _write_cache_frame(cache_file, working)
+    logger.info(
+        "IBKR hourly cache repair completed for %s with %d unresolved large gap(s)",
+        getattr(asset, "symbol", None),
+        len(unresolved),
+    )
     return working
 
 
@@ -2569,7 +2892,7 @@ def _record_missing_window(
 
     df = _read_cache_frame(cache_file)
     retry_after = datetime.now(timezone.utc) + timedelta(
-        seconds=IBKR_DAILY_GAP_RETRY_TTL_SECONDS
+        seconds=IBKR_GAP_RETRY_TTL_SECONDS
     )
     placeholder = pd.DataFrame(
         {

--- a/lumibot/tools/ibkr_helper.py
+++ b/lumibot/tools/ibkr_helper.py
@@ -86,7 +86,10 @@ _IBKR_EQUITY_ACTIONS_CACHE: Dict[str, pd.DataFrame] = {}
 _RUNTIME_CONID_CACHE: Dict[str, int] = {}
 _RUNTIME_HISTORY_NO_DATA_WINDOWS: Dict[str, Tuple[datetime, datetime]] = {}
 _RUNTIME_DAILY_GAP_CHECKED_WINDOWS: set[tuple[str, str, str]] = set()
-_RUNTIME_HOURLY_GAP_CHECKED_SERIES: Dict[str, tuple[int, str, str, int]] = {}
+_RUNTIME_HOURLY_GAP_CHECKED_SERIES: Dict[
+    str,
+    tuple[tuple[int, str, str, int], datetime, datetime],
+] = {}
 _DISABLE_CONIDS_REMOTE_UPLOAD = False
 _LOGGED_CONIDS_REMOTE_UPLOAD_DISABLE = False
 _LOGGED_HISTORY_ALIASES: set[str] = set()
@@ -2734,8 +2737,17 @@ def _repair_us_stock_index_hourly_gaps(
 
     series_key = str(cache_file)
     cache_signature = _hourly_cache_signature(df_cache)
-    if _RUNTIME_HOURLY_GAP_CHECKED_SERIES.get(series_key) == cache_signature:
-        return df_cache
+    request_start = _to_utc(start_dt)
+    request_end = _to_utc(end_dt)
+    previous_check = _RUNTIME_HOURLY_GAP_CHECKED_SERIES.get(series_key)
+    if previous_check is not None:
+        checked_signature, checked_start, checked_end = previous_check
+        if (
+            checked_signature == cache_signature
+            and checked_start <= request_start
+            and checked_end >= request_end
+        ):
+            return df_cache
 
     gaps = _hourly_internal_gaps(
         df_cache,
@@ -2752,7 +2764,11 @@ def _repair_us_stock_index_hourly_gaps(
         )
     ]
     if not gaps:
-        _RUNTIME_HOURLY_GAP_CHECKED_SERIES[series_key] = cache_signature
+        _RUNTIME_HOURLY_GAP_CHECKED_SERIES[series_key] = (
+            cache_signature,
+            request_start,
+            request_end,
+        )
         return df_cache
 
     logger.info(
@@ -2833,8 +2849,10 @@ def _repair_us_stock_index_hourly_gaps(
 
     if changed:
         _write_cache_frame(cache_file, working)
-    _RUNTIME_HOURLY_GAP_CHECKED_SERIES[series_key] = _hourly_cache_signature(
-        working
+    _RUNTIME_HOURLY_GAP_CHECKED_SERIES[series_key] = (
+        _hourly_cache_signature(working),
+        request_start,
+        request_end,
     )
     logger.info(
         "IBKR hourly cache repair completed for %s with %d unresolved large gap(s)",

--- a/lumibot/tools/ibkr_helper.py
+++ b/lumibot/tools/ibkr_helper.py
@@ -1901,7 +1901,7 @@ def _fetch_history_between_dates(
                 max_timeout_attempts=_max_timeout_attempts,
             )
         except Exception:
-            if chunks and _deadline_monotonic is not None and time.perf_counter() >= _deadline_monotonic:
+            if chunks and _deadline_monotonic is not None:
                 break
             raise
 

--- a/lumibot/tools/ibkr_helper.py
+++ b/lumibot/tools/ibkr_helper.py
@@ -86,7 +86,7 @@ _IBKR_EQUITY_ACTIONS_CACHE: Dict[str, pd.DataFrame] = {}
 _RUNTIME_CONID_CACHE: Dict[str, int] = {}
 _RUNTIME_HISTORY_NO_DATA_WINDOWS: Dict[str, Tuple[datetime, datetime]] = {}
 _RUNTIME_DAILY_GAP_CHECKED_WINDOWS: set[tuple[str, str, str]] = set()
-_RUNTIME_HOURLY_GAP_CHECKED_SERIES: set[str] = set()
+_RUNTIME_HOURLY_GAP_CHECKED_SERIES: Dict[str, tuple[int, str, str, int]] = {}
 _DISABLE_CONIDS_REMOTE_UPLOAD = False
 _LOGGED_CONIDS_REMOTE_UPLOAD_DISABLE = False
 _LOGGED_HISTORY_ALIASES: set[str] = set()
@@ -2065,7 +2065,8 @@ def frame_covers_requested_window(
             schedule = get_trading_days(
                 market="NYSE",
                 start_date=start_local.date(),
-                end_date=end_local.date(),
+                # get_trading_days treats end_date as exclusive.
+                end_date=end_local.date() + timedelta(days=1),
                 tzinfo=LUMIBOT_DEFAULT_PYTZ,
             )
             if schedule is not None and not schedule.empty:
@@ -2613,16 +2614,28 @@ def _gap_has_fresh_retry_marker(
     ):
         return False
 
-    missing_mask = df_cache["missing"].fillna(False).astype(bool)
+    try:
+        normalized_index = pd.DatetimeIndex(df_cache.index)
+        if normalized_index.tz is None:
+            normalized_index = normalized_index.tz_localize(
+                LUMIBOT_DEFAULT_PYTZ
+            )
+        else:
+            normalized_index = normalized_index.tz_convert(
+                LUMIBOT_DEFAULT_PYTZ
+            )
+    except Exception:
+        return False
+    missing_mask = df_cache["missing"].fillna(False).astype(bool).to_numpy()
     hourly_gap_mask = (
-        df_cache["missing_reason"].fillna("").astype(str)
+        df_cache["missing_reason"].fillna("").astype(str).to_numpy()
         == "hourly_internal_gap_empty"
     )
     marker_rows = df_cache.loc[
         missing_mask
         & hourly_gap_mask
-        & (df_cache.index > gap_start)
-        & (df_cache.index < gap_end),
+        & (normalized_index > gap_start)
+        & (normalized_index < gap_end),
         ["missing_retry_after"],
     ]
     if len(marker_rows) < 2:
@@ -2671,6 +2684,26 @@ def _missing_window_placeholders(
     )
 
 
+def _hourly_cache_signature(
+    df_cache: pd.DataFrame,
+) -> tuple[int, str, str, int]:
+    if df_cache is None or df_cache.empty:
+        return (0, "", "", 0)
+    try:
+        index = pd.DatetimeIndex(pd.to_datetime(df_cache.index, utc=True))
+        first = index.min().isoformat()
+        last = index.max().isoformat()
+    except Exception:
+        first = str(df_cache.index.min())
+        last = str(df_cache.index.max())
+    missing_count = (
+        int(df_cache["missing"].fillna(False).astype(bool).sum())
+        if "missing" in df_cache.columns
+        else 0
+    )
+    return (len(df_cache), first, last, missing_count)
+
+
 def _repair_us_stock_index_hourly_gaps(
     df_cache: pd.DataFrame,
     *,
@@ -2700,7 +2733,8 @@ def _repair_us_stock_index_hourly_gaps(
         return df_cache
 
     series_key = str(cache_file)
-    if series_key in _RUNTIME_HOURLY_GAP_CHECKED_SERIES:
+    cache_signature = _hourly_cache_signature(df_cache)
+    if _RUNTIME_HOURLY_GAP_CHECKED_SERIES.get(series_key) == cache_signature:
         return df_cache
 
     gaps = _hourly_internal_gaps(
@@ -2718,8 +2752,8 @@ def _repair_us_stock_index_hourly_gaps(
         )
     ]
     if not gaps:
+        _RUNTIME_HOURLY_GAP_CHECKED_SERIES[series_key] = cache_signature
         return df_cache
-    _RUNTIME_HOURLY_GAP_CHECKED_SERIES.add(series_key)
 
     logger.info(
         "IBKR hourly cache repair found %d large internal gap(s) for %s",
@@ -2799,6 +2833,9 @@ def _repair_us_stock_index_hourly_gaps(
 
     if changed:
         _write_cache_frame(cache_file, working)
+    _RUNTIME_HOURLY_GAP_CHECKED_SERIES[series_key] = _hourly_cache_signature(
+        working
+    )
     logger.info(
         "IBKR hourly cache repair completed for %s with %d unresolved large gap(s)",
         getattr(asset, "symbol", None),

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.80",
+    version="4.5.81",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_ibkr_daily_gap_self_healing.py
+++ b/tests/test_ibkr_daily_gap_self_healing.py
@@ -355,6 +355,49 @@ def test_hourly_retry_marker_lookup_accepts_tz_naive_cache_index() -> None:
     )
 
 
+def test_hourly_clean_scan_is_repeated_when_request_window_widens(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    ibkr_helper._RUNTIME_HOURLY_GAP_CHECKED_SERIES.clear()
+    left = _hourly_frame("2023-07-31 09:00", "2023-08-01 16:00")
+    right = _hourly_frame("2026-07-29 09:00", "2026-07-30 16:00")
+    frame = pd.concat([left, right]).sort_index()
+    calls = []
+    monkeypatch.setattr(
+        ibkr_helper,
+        "_fetch_history_between_dates",
+        lambda **kwargs: calls.append(kwargs)
+        or _hourly_frame("2023-08-01 17:00", "2026-07-29 08:00"),
+    )
+    monkeypatch.setattr(ibkr_helper, "_write_cache_frame", lambda *_args: None)
+    common = {
+        "df_cache": frame,
+        "cache_file": tmp_path / "QQQ-hour.parquet",
+        "asset": Asset("QQQ", asset_type=Asset.AssetType.STOCK),
+        "quote": Asset("USD", asset_type=Asset.AssetType.FOREX),
+        "timestep": "hour",
+        "exchange": None,
+        "include_after_hours": True,
+        "source": "Trades",
+        "source_was_explicit": False,
+    }
+
+    ibkr_helper._repair_us_stock_index_hourly_gaps(
+        **common,
+        start_dt=datetime(2023, 7, 30, tzinfo=timezone.utc),
+        end_dt=datetime(2023, 8, 2, tzinfo=timezone.utc),
+    )
+    assert calls == []
+
+    ibkr_helper._repair_us_stock_index_hourly_gaps(
+        **common,
+        start_dt=datetime(2023, 7, 30, tzinfo=timezone.utc),
+        end_dt=datetime(2026, 7, 30, 23, tzinfo=timezone.utc),
+    )
+    assert len(calls) == 1
+
+
 def test_partial_hourly_repair_does_not_negative_cache_the_remaining_gap(
     monkeypatch,
     tmp_path,

--- a/tests/test_ibkr_daily_gap_self_healing.py
+++ b/tests/test_ibkr_daily_gap_self_healing.py
@@ -26,6 +26,22 @@ def _daily_frame(dates: list[str], *, missing: bool = False) -> pd.DataFrame:
     )
 
 
+def _hourly_frame(start: str, end: str, *, missing: bool = False) -> pd.DataFrame:
+    index = pd.date_range(start=start, end=end, freq="h", tz="America/New_York")
+    values = [pd.NA] * len(index) if missing else [100.0 + i for i in range(len(index))]
+    return pd.DataFrame(
+        {
+            "open": values,
+            "high": values,
+            "low": values,
+            "close": values,
+            "volume": values,
+            "missing": [missing] * len(index),
+        },
+        index=index,
+    )
+
+
 def test_merge_frames_never_allows_placeholder_to_replace_real_bar() -> None:
     real = _daily_frame(["2026-07-27"])
     placeholder = _daily_frame(["2026-07-27"], missing=True)
@@ -78,12 +94,11 @@ def test_retryable_daily_gap_scan_is_fast_for_three_year_warm_cache() -> None:
     assert elapsed < 1.0
 
 
-def test_daily_gap_repair_fetches_only_missing_month_with_bounded_wait(
+def test_daily_gap_repair_fetches_missing_range_with_bounded_wait(
     monkeypatch,
     tmp_path,
 ) -> None:
     ibkr_helper._RUNTIME_DAILY_GAP_CHECKED_WINDOWS.clear()
-    monkeypatch.setattr(ibkr_helper, "_RUNTIME_DAILY_GAP_REPAIR_SECONDS_USED", 0.0)
     frame = _daily_frame(["2026-07-27", "2026-07-29"])
     calls = []
 
@@ -116,10 +131,15 @@ def test_daily_gap_repair_fetches_only_missing_month_with_bounded_wait(
     )
 
     assert len(calls) == 1
-    assert calls[0]["_period_override"] == "1m"
+    assert calls[0]["_period_override"] == ibkr_helper.IBKR_STOCK_INDEX_DAILY_MAX_PERIOD
     assert calls[0]["_record_missing_on_empty"] is False
     assert calls[0]["_max_timeout_attempts"] == 1
-    assert 0 < calls[0]["_queue_timeout"] <= 15
+    assert calls[0]["_deadline_monotonic"] > 0
+    assert (
+        0
+        < calls[0]["_queue_timeout"]
+        <= ibkr_helper.IBKR_DAILY_GAP_REPAIR_TIMEOUT_SECONDS
+    )
     assert [ts.date().isoformat() for ts in result.index] == [
         "2026-07-27",
         "2026-07-28",
@@ -133,7 +153,6 @@ def test_daily_gap_repair_failure_returns_available_bars_without_failing(
     tmp_path,
 ) -> None:
     ibkr_helper._RUNTIME_DAILY_GAP_CHECKED_WINDOWS.clear()
-    monkeypatch.setattr(ibkr_helper, "_RUNTIME_DAILY_GAP_REPAIR_SECONDS_USED", 0.0)
     frame = _daily_frame(["2026-07-27", "2026-07-29"])
 
     def _timeout(**_kwargs):
@@ -170,7 +189,6 @@ def test_daily_gap_repair_records_expiring_marker_when_small_request_is_empty(
     tmp_path,
 ) -> None:
     ibkr_helper._RUNTIME_DAILY_GAP_CHECKED_WINDOWS.clear()
-    monkeypatch.setattr(ibkr_helper, "_RUNTIME_DAILY_GAP_REPAIR_SECONDS_USED", 0.0)
     frame = _daily_frame(["2026-07-27", "2026-07-29"])
     writes = []
     monkeypatch.setattr(
@@ -202,3 +220,217 @@ def test_daily_gap_repair_records_expiring_marker_when_small_request_is_empty(
     assert bool(marker["missing"]) is True
     assert pd.Timestamp(marker["missing_retry_after"]).tzinfo is not None
     assert len(writes) == 1
+
+
+def test_hourly_gap_repair_fetches_large_internal_gap_once_with_bounded_deadline(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Reproduce the production QQQ shape: real bars at both ends and a multi-year hole."""
+    ibkr_helper._RUNTIME_HOURLY_GAP_CHECKED_SERIES.clear()
+    left = _hourly_frame("2023-07-31 09:00", "2023-08-01 16:00")
+    right = _hourly_frame("2026-07-29 09:00", "2026-07-30 16:00")
+    frame = pd.concat([left, right]).sort_index()
+    calls = []
+
+    def _fake_fetch(**kwargs):
+        calls.append(kwargs)
+        return _hourly_frame("2023-08-01 17:00", "2026-07-29 08:00")
+
+    writes = []
+    monkeypatch.setattr(ibkr_helper, "_fetch_history_between_dates", _fake_fetch)
+    monkeypatch.setattr(
+        ibkr_helper,
+        "_write_cache_frame",
+        lambda path, updated: writes.append((path, updated.copy())),
+    )
+
+    result = ibkr_helper._repair_us_stock_index_hourly_gaps(
+        frame,
+        cache_file=tmp_path / "QQQ-hour.parquet",
+        asset=Asset("QQQ", asset_type=Asset.AssetType.STOCK),
+        quote=Asset("USD", asset_type=Asset.AssetType.FOREX),
+        timestep="hour",
+        start_dt=datetime(2023, 7, 30, tzinfo=timezone.utc),
+        end_dt=datetime(2026, 7, 30, 23, tzinfo=timezone.utc),
+        exchange=None,
+        include_after_hours=True,
+        source="Trades",
+        source_was_explicit=False,
+    )
+
+    assert len(calls) == 1
+    assert (
+        calls[0]["_period_override"]
+        == ibkr_helper.IBKR_STOCK_INDEX_HOURLY_REPAIR_PERIOD
+    )
+    assert calls[0]["_record_missing_on_empty"] is False
+    assert calls[0]["_max_timeout_attempts"] == 1
+    assert calls[0]["_deadline_monotonic"] > 0
+    real = result.loc[~result["missing"].fillna(False)]
+    assert real.index.to_series().diff().dropna().max() <= pd.Timedelta(days=7)
+    assert len(writes) == 1
+
+
+def test_hourly_gap_repair_warm_complete_cache_makes_zero_downloader_calls(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    ibkr_helper._RUNTIME_HOURLY_GAP_CHECKED_SERIES.clear()
+    frame = _hourly_frame("2026-07-20 09:00", "2026-07-30 16:00")
+
+    monkeypatch.setattr(
+        ibkr_helper,
+        "_fetch_history_between_dates",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("complete hourly cache must not hit the downloader")
+        ),
+    )
+
+    result = ibkr_helper._repair_us_stock_index_hourly_gaps(
+        frame,
+        cache_file=tmp_path / "QQQ-hour.parquet",
+        asset=Asset("QQQ", asset_type=Asset.AssetType.STOCK),
+        quote=Asset("USD", asset_type=Asset.AssetType.FOREX),
+        timestep="hour",
+        start_dt=datetime(2026, 7, 20, tzinfo=timezone.utc),
+        end_dt=datetime(2026, 7, 31, tzinfo=timezone.utc),
+        exchange=None,
+        include_after_hours=True,
+        source="Trades",
+        source_was_explicit=False,
+    )
+
+    assert result.equals(frame)
+
+
+def test_partial_hourly_repair_does_not_negative_cache_the_remaining_gap(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    ibkr_helper._RUNTIME_HOURLY_GAP_CHECKED_SERIES.clear()
+    left = _hourly_frame("2023-07-31 09:00", "2023-08-01 16:00")
+    right = _hourly_frame("2026-07-29 09:00", "2026-07-30 16:00")
+    frame = pd.concat([left, right]).sort_index()
+    monkeypatch.setattr(
+        ibkr_helper,
+        "_fetch_history_between_dates",
+        lambda **_kwargs: _hourly_frame(
+            "2025-07-29 09:00",
+            "2026-07-29 08:00",
+        ),
+    )
+    writes = []
+    monkeypatch.setattr(
+        ibkr_helper,
+        "_write_cache_frame",
+        lambda path, updated: writes.append((path, updated.copy())),
+    )
+
+    result = ibkr_helper._repair_us_stock_index_hourly_gaps(
+        frame,
+        cache_file=tmp_path / "QQQ-hour.parquet",
+        asset=Asset("QQQ", asset_type=Asset.AssetType.STOCK),
+        quote=Asset("USD", asset_type=Asset.AssetType.FOREX),
+        timestep="hour",
+        start_dt=datetime(2023, 7, 30, tzinfo=timezone.utc),
+        end_dt=datetime(2026, 7, 30, 23, tzinfo=timezone.utc),
+        exchange=None,
+        include_after_hours=True,
+        source="Trades",
+        source_was_explicit=False,
+    )
+
+    assert ibkr_helper._hourly_internal_gaps(
+        result,
+        start_dt=datetime(2023, 7, 30, tzinfo=timezone.utc),
+        end_dt=datetime(2026, 7, 30, 23, tzinfo=timezone.utc),
+    )
+    assert not result["missing"].fillna(False).any()
+    assert len(writes) == 1
+
+
+def test_generic_fresh_missing_markers_do_not_block_hourly_self_healing(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    ibkr_helper._RUNTIME_HOURLY_GAP_CHECKED_SERIES.clear()
+    left = _hourly_frame("2023-07-31 09:00", "2023-08-01 16:00")
+    right = _hourly_frame("2026-07-29 09:00", "2026-07-30 16:00")
+    retry_after = datetime(2026, 7, 31, tzinfo=timezone.utc).isoformat()
+    generic_markers = pd.DataFrame(
+        {
+            "open": [pd.NA, pd.NA],
+            "high": [pd.NA, pd.NA],
+            "low": [pd.NA, pd.NA],
+            "close": [pd.NA, pd.NA],
+            "volume": [pd.NA, pd.NA],
+            "missing": [True, True],
+            "missing_retry_after": [retry_after, retry_after],
+        },
+        index=pd.to_datetime(
+            [
+                "2023-08-01 17:00:00-04:00",
+                "2026-07-29 08:00:00-04:00",
+            ],
+            utc=True,
+        ).tz_convert("America/New_York"),
+    )
+    frame = pd.concat([left, generic_markers, right]).sort_index()
+    calls = []
+    monkeypatch.setattr(
+        ibkr_helper,
+        "_fetch_history_between_dates",
+        lambda **kwargs: calls.append(kwargs)
+        or _hourly_frame("2023-08-01 17:00", "2026-07-29 08:00"),
+    )
+    monkeypatch.setattr(ibkr_helper, "_write_cache_frame", lambda *_args: None)
+
+    ibkr_helper._repair_us_stock_index_hourly_gaps(
+        frame,
+        cache_file=tmp_path / "QQQ-hour.parquet",
+        asset=Asset("QQQ", asset_type=Asset.AssetType.STOCK),
+        quote=Asset("USD", asset_type=Asset.AssetType.FOREX),
+        timestep="hour",
+        start_dt=datetime(2023, 7, 30, tzinfo=timezone.utc),
+        end_dt=datetime(2026, 7, 30, 23, tzinfo=timezone.utc),
+        exchange=None,
+        include_after_hours=True,
+        source="Trades",
+        source_was_explicit=False,
+    )
+
+    assert len(calls) == 1
+
+
+def test_daily_gap_repair_budget_is_per_series_not_global(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    ibkr_helper._RUNTIME_DAILY_GAP_CHECKED_WINDOWS.clear()
+    calls = []
+
+    def _fake_fetch(**kwargs):
+        calls.append(kwargs)
+        return _daily_frame(["2026-07-28"])
+
+    monkeypatch.setattr(ibkr_helper, "_fetch_history_between_dates", _fake_fetch)
+    monkeypatch.setattr(ibkr_helper, "_write_cache_frame", lambda *_args: None)
+
+    for symbol in ("QQQ", "SQQQ"):
+        result = ibkr_helper._repair_us_stock_index_daily_gaps(
+            _daily_frame(["2026-07-27", "2026-07-29"]),
+            cache_file=tmp_path / f"{symbol}-day.parquet",
+            asset=Asset(symbol, asset_type=Asset.AssetType.STOCK),
+            quote=Asset("USD", asset_type=Asset.AssetType.FOREX),
+            timestep="day",
+            start_dt=datetime(2026, 7, 27, tzinfo=timezone.utc),
+            end_dt=datetime(2026, 7, 30, 23, tzinfo=timezone.utc),
+            exchange=None,
+            include_after_hours=True,
+            source="Trades",
+            source_was_explicit=False,
+        )
+        assert pd.Timestamp("2026-07-28 16:00", tz="America/New_York") in result.index
+
+    assert len(calls) == 2

--- a/tests/test_ibkr_daily_gap_self_healing.py
+++ b/tests/test_ibkr_daily_gap_self_healing.py
@@ -278,6 +278,14 @@ def test_hourly_gap_repair_warm_complete_cache_makes_zero_downloader_calls(
 ) -> None:
     ibkr_helper._RUNTIME_HOURLY_GAP_CHECKED_SERIES.clear()
     frame = _hourly_frame("2026-07-20 09:00", "2026-07-30 16:00")
+    gap_scan_calls = []
+    original_gap_scan = ibkr_helper._hourly_internal_gaps
+    monkeypatch.setattr(
+        ibkr_helper,
+        "_hourly_internal_gaps",
+        lambda *args, **kwargs: gap_scan_calls.append((args, kwargs))
+        or original_gap_scan(*args, **kwargs),
+    )
 
     monkeypatch.setattr(
         ibkr_helper,
@@ -302,6 +310,49 @@ def test_hourly_gap_repair_warm_complete_cache_makes_zero_downloader_calls(
     )
 
     assert result.equals(frame)
+    second = ibkr_helper._repair_us_stock_index_hourly_gaps(
+        frame,
+        cache_file=tmp_path / "QQQ-hour.parquet",
+        asset=Asset("QQQ", asset_type=Asset.AssetType.STOCK),
+        quote=Asset("USD", asset_type=Asset.AssetType.FOREX),
+        timestep="hour",
+        start_dt=datetime(2026, 7, 20, tzinfo=timezone.utc),
+        end_dt=datetime(2026, 7, 31, tzinfo=timezone.utc),
+        exchange=None,
+        include_after_hours=True,
+        source="Trades",
+        source_was_explicit=False,
+    )
+    assert second.equals(frame)
+    assert len(gap_scan_calls) == 1
+
+
+def test_hourly_retry_marker_lookup_accepts_tz_naive_cache_index() -> None:
+    now = datetime(2026, 7, 30, 12, tzinfo=timezone.utc)
+    retry_after = datetime(2026, 7, 31, 12, tzinfo=timezone.utc).isoformat()
+    frame = pd.DataFrame(
+        {
+            "missing": [True, True],
+            "missing_retry_after": [retry_after, retry_after],
+            "missing_reason": [
+                "hourly_internal_gap_empty",
+                "hourly_internal_gap_empty",
+            ],
+        },
+        index=pd.DatetimeIndex(
+            [
+                "2026-07-20 12:00:00",
+                "2026-07-25 12:00:00",
+            ]
+        ),
+    )
+
+    assert ibkr_helper._gap_has_fresh_retry_marker(
+        frame,
+        gap_start=pd.Timestamp("2026-07-19 12:00", tz="America/New_York"),
+        gap_end=pd.Timestamp("2026-07-26 12:00", tz="America/New_York"),
+        now=now,
+    )
 
 
 def test_partial_hourly_repair_does_not_negative_cache_the_remaining_gap(

--- a/tests/test_ibkr_helper_unit.py
+++ b/tests/test_ibkr_helper_unit.py
@@ -323,6 +323,29 @@ def test_ibkr_hourly_frame_treats_weekend_start_as_covered():
     )
 
 
+def test_ibkr_hourly_frame_does_not_hide_missing_final_trading_day():
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    asset = Asset(symbol="QQQ", asset_type=Asset.AssetType.STOCK)
+    frame = pd.DataFrame(
+        {"close": [100.0, 101.0]},
+        index=pd.DatetimeIndex(
+            [
+                "2026-07-28 09:30:00-04:00",
+                "2026-07-29 16:00:00-04:00",
+            ]
+        ),
+    )
+
+    assert not ibkr_helper.frame_covers_requested_window(
+        frame,
+        asset=asset,
+        timestep="hour",
+        start_dt=datetime(2026, 7, 28, 13, 30, tzinfo=timezone.utc),
+        end_dt=datetime(2026, 7, 30, 16, tzinfo=timezone.utc),
+    )
+
+
 def test_ibkr_downloader_payload_contract_accepts_complete_and_explicit_no_data():
     import lumibot.tools.ibkr_helper as ibkr_helper
 

--- a/tests/test_ibkr_helper_unit.py
+++ b/tests/test_ibkr_helper_unit.py
@@ -201,6 +201,50 @@ def test_ibkr_fetch_history_between_dates_keeps_chunks_on_later_empty_page(monke
     assert calls["count"] == 2
 
 
+def test_ibkr_bounded_repair_preserves_pages_before_a_later_error(monkeypatch):
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    asset = Asset(symbol="QQQ", asset_type=Asset.AssetType.STOCK)
+    quote = Asset(symbol="USD", asset_type=Asset.AssetType.FOREX)
+    monkeypatch.setattr(ibkr_helper, "_resolve_conid", lambda **_kwargs: 123)
+    calls = {"count": 0}
+
+    def _history_request(**_kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return {
+                "data": [
+                    {
+                        "t": 1760000000000 + offset * 3_600_000,
+                        "o": 100 + offset,
+                        "h": 101 + offset,
+                        "l": 99 + offset,
+                        "c": 100.5 + offset,
+                        "v": 1000,
+                    }
+                    for offset in range(7)
+                ]
+            }
+        raise RuntimeError("provider failed after the first repair page")
+
+    monkeypatch.setattr(ibkr_helper, "_ibkr_history_request", _history_request)
+    result = ibkr_helper._fetch_history_between_dates(
+        asset=asset,
+        quote=quote,
+        timestep="hour",
+        start_dt=datetime(2025, 9, 1, tzinfo=timezone.utc),
+        end_dt=datetime(2025, 10, 31, tzinfo=timezone.utc),
+        exchange=None,
+        include_after_hours=True,
+        source="Trades",
+        source_was_explicit=False,
+        _deadline_monotonic=ibkr_helper.time.perf_counter() + 60,
+    )
+
+    assert len(result) == 7
+    assert calls["count"] == 2
+
+
 def test_ibkr_frame_covers_requested_window_rejects_underfilled_daily_series_and_allows_flat_series():
     import lumibot.tools.ibkr_helper as ibkr_helper
 

--- a/tests/test_ibkr_helper_unit.py
+++ b/tests/test_ibkr_helper_unit.py
@@ -256,6 +256,29 @@ def test_ibkr_frame_covers_requested_window_rejects_underfilled_daily_series_and
     )
 
 
+def test_ibkr_hourly_frame_treats_weekend_start_as_covered():
+    import lumibot.tools.ibkr_helper as ibkr_helper
+
+    asset = Asset(symbol="QQQ", asset_type=Asset.AssetType.STOCK)
+    frame = pd.DataFrame(
+        {"close": [100.0, 101.0]},
+        index=pd.DatetimeIndex(
+            [
+                "2023-07-31 04:00:00-04:00",
+                "2023-08-01 16:00:00-04:00",
+            ]
+        ),
+    )
+
+    assert ibkr_helper.frame_covers_requested_window(
+        frame,
+        asset=asset,
+        timestep="hour",
+        start_dt=datetime(2023, 7, 30, tzinfo=timezone.utc),
+        end_dt=datetime(2023, 8, 1, 20, tzinfo=timezone.utc),
+    )
+
+
 def test_ibkr_downloader_payload_contract_accepts_complete_and_explicit_no_data():
     import lumibot.tools.ibkr_helper as ibkr_helper
 


### PR DESCRIPTION
## What\nLumiBot now detects and lazily repairs large internal US stock/index hourly cache holes. It uses 2000-hour IBKR pages under a damaged-series-only five-minute ceiling, saves partial progress without suppressing the next repair, and ignores older generic missing markers for this new repair. Daily repair now has a per-series deadline. Closed-market request boundaries no longer produce false underfill warnings.\n\n## Why\nProduction evidence showed a three-year QQQ hourly cache with real bars at both ends and a multi-year internal hole. v4.5.80 repaired daily sessions only and used a shared process budget, so it could not repair the hourly stochastic data path.\n\n## Risk\nOnly US stock/index series with an internal hourly hole longer than seven days enter the new downloader path. Complete warm caches make zero extra requests. Repair remains best-effort and returns available bars on provider failure.\n\n## Tests run\n- 82 focused IBKR/cache/backtesting tests passed\n- 132 separate Bot Manager broker boundary and Schwab contract tests passed\n- Live isolated QQQ three-year damaged-cache proof: 12,015 real rows, zero large internal gaps\n- Live page measurement: 2000h returned 899 rows versus 439 rows for 1000h\n- Warm complete hourly cache test asserts zero downloader calls\n- Broad local suite passed 3 acceptance backtests, then was stopped after 14 minutes while a later acceptance subprocess remained active; the sharded GitHub release workflow is the final gate
- Bounded repair preserves completed pages if a later provider page fails\n\n## Performance evidence\nThe repair applies only to a detected damaged hourly series and completed the isolated three-year QQQ repair inside the five-minute cap. Warm cache behavior remains queue-free.\n\n## Docs\nUpdated CHANGELOG.md, docs/BACKTESTING_PERFORMANCE.md, docs/REMOTE_CACHE.md, and docsrc/backtesting.ibkr.rst. No visual is needed because this is a transparent cache correctness change with no UI or workflow layout. No Agent prompt change is needed because the normal broker-data contract is unchanged; the engine now returns complete cached history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lazy self-healing for IBKR stock/index history cache gaps across daily and hourly data.
  * Hourly repairs now focus on large internal gaps using bounded paging, with partial progress remaining retryable.
* **Bug Fixes**
  * Improved cache-gap detection across market session boundaries and final trading days to avoid incorrect underfill/no-data behavior.
  * Tightened retry/no-data marker semantics to prevent downloader/retry storms and avoid stale “missing” markers blocking repairs.
* **Documentation**
  * Updated caching/backtesting docs to reflect the new lazy repair flow and marker/retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

