### PR TITLE
v4.5.82 - Restore LumiBot star history

### DIFF
--- a/.github/workflows/star-history-health.yml
+++ b/.github/workflows/star-history-health.yml
@@ -1,0 +1,21 @@
+name: Star History chart health
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-chart:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Verify the rendered LumiBot star chart
+        run: |
+          curl --fail --silent --show-error \
+            "https://lumibot-star-history.lumiwealth.workers.dev/chart.svg?theme=light" \
+            --output chart.svg
+          grep -Fq '<title id="title">LumiBot live star history</title>' chart.svg

--- a/.github/workflows/star-history-health.yml
+++ b/.github/workflows/star-history-health.yml
@@ -5,8 +5,7 @@ on:
     - cron: "17 */6 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   verify-chart:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.82 - Unreleased
+
 ## 4.5.81 - 2026-07-30
 
 Deploy marker: `deploy 4.5.81`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 4.5.82 - Unreleased
 
+### Fixed
+- **The README star-history integration now has an end-to-end health check.**
+  A scheduled workflow verifies the real rendered chart instead of treating a
+  configured but unauthorized GitHub token as healthy. The rotation runbook now
+  records the required organization owner, repository scope, and permissions.
+
 ## 4.5.81 - 2026-07-30
 
 Deploy marker: `deploy 4.5.81`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   A scheduled workflow verifies the real rendered chart instead of treating a
   configured but unauthorized GitHub token as healthy. The rotation runbook now
   records the required organization owner, repository scope, and permissions.
+  Worker failures now remain valid SVG after long escaped error messages, and
+  the README chart URLs bypass GitHub's cached broken response after rotation.
 
 ## 4.5.81 - 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -520,9 +520,9 @@ Crypto futures/perpetual backtests can route `Asset.AssetType.CRYPTO_FUTURE` thr
 
 <a href="https://www.star-history.com/?repos=Lumiwealth%2Flumibot&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://lumibot-star-history.lumiwealth.workers.dev/chart.svg?theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://lumibot-star-history.lumiwealth.workers.dev/chart.svg?theme=light" />
-   <img alt="Live LumiBot Star History Chart" src="https://lumibot-star-history.lumiwealth.workers.dev/chart.svg?theme=light" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://lumibot-star-history.lumiwealth.workers.dev/chart.svg?theme=dark&amp;v=20260802" />
+   <source media="(prefers-color-scheme: light)" srcset="https://lumibot-star-history.lumiwealth.workers.dev/chart.svg?theme=light&amp;v=20260802" />
+   <img alt="Live LumiBot Star History Chart" src="https://lumibot-star-history.lumiwealth.workers.dev/chart.svg?theme=light&amp;v=20260802" />
  </picture>
 </a>
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.81",
+    version="4.5.82",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/workers/lumibot-star-history/README.md
+++ b/workers/lumibot-star-history/README.md
@@ -4,8 +4,18 @@ This Cloudflare Worker renders the live GitHub star history used by the main
 README. It keeps the GitHub token out of the public repository and refreshes the
 chart from GitHub's API every five minutes.
 
-The token must be configured as the `GITHUB_TOKEN` Worker secret. It only needs
-read access to repository metadata for `Lumiwealth/lumibot`.
+The token must be configured as the `GITHUB_TOKEN` Worker secret. Create a
+fine-grained GitHub personal access token with these settings:
+
+- Resource owner: `Lumiwealth`
+- Repository access: only `Lumiwealth/lumibot`
+- Metadata: read-only
+- Contents: read and write
+- Expiration: the longest period allowed by the organization
+
+The resource owner matters. A token owned by a personal account can read the
+public repository metadata but GitHub will reject the restricted stargazers
+endpoint with `403 Resource not accessible by personal access token`.
 
 ```bash
 npx wrangler secret put GITHUB_TOKEN
@@ -13,8 +23,19 @@ npx wrangler deploy
 node --test test/*.test.mjs
 ```
 
+After rotating the secret, verify the actual chart rather than relying only on
+the configuration-only health response:
+
+```bash
+curl --fail --silent --show-error \
+  "https://lumibot-star-history.lumiwealth.workers.dev/chart.svg?theme=light" \
+  | grep -F '<title id="title">LumiBot live star history</title>'
+```
+
 Endpoints:
 
 - `/chart.svg` renders the light chart.
 - `/chart.svg?theme=dark` renders the dark chart.
-- `/healthz` reports service readiness without revealing the secret.
+- `/healthz` reports that the Worker and secret binding are configured. The
+  scheduled `Star History chart health` workflow checks the rendered chart and
+  catches invalid, expired, or unauthorized tokens.

--- a/workers/lumibot-star-history/src/index.mjs
+++ b/workers/lumibot-star-history/src/index.mjs
@@ -209,14 +209,15 @@ export function buildChart(history, requestedTheme = "light") {
 </svg>`;
 }
 
-function errorChart(message, requestedTheme) {
+export function errorChart(message, requestedTheme) {
   const colors = THEMES[requestedTheme === "dark" ? "dark" : "light"];
+  const safeMessage = escapeXml(String(message).slice(0, 120));
   return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 180" role="img" aria-label="Live star history temporarily unavailable">
   <rect x="1" y="1" width="898" height="178" rx="16" fill="${colors.background}" stroke="${colors.border}" stroke-width="2" />
   <g font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
     <text x="40" y="70" fill="${colors.text}" font-size="24" font-weight="700">LumiBot Project Growth</text>
     <text x="40" y="108" fill="${colors.muted}" font-size="16">Live GitHub data is temporarily unavailable. Refresh shortly.</text>
-    <text x="40" y="140" fill="${colors.muted}" font-size="12">${escapeXml(message).slice(0, 120)}</text>
+    <text x="40" y="140" fill="${colors.muted}" font-size="12">${safeMessage}</text>
   </g>
 </svg>`;
 }

--- a/workers/lumibot-star-history/test/index.test.mjs
+++ b/workers/lumibot-star-history/test/index.test.mjs
@@ -30,6 +30,7 @@ test("buildChart renders current live data in both themes", () => {
   for (const theme of ["light", "dark"]) {
     const svg = buildChart(history, theme);
     assert.match(svg, /^<svg /);
+    assert.match(svg, /<title id="title">LumiBot live star history<\/title>/);
     assert.match(svg, /LumiBot Project Growth/);
     assert.match(svg, /Live GitHub star history/);
     assert.match(svg, /1\.8k/);

--- a/workers/lumibot-star-history/test/index.test.mjs
+++ b/workers/lumibot-star-history/test/index.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildChart, parseLastPage } from "../src/index.mjs";
+import { buildChart, errorChart, parseLastPage } from "../src/index.mjs";
 
 test("parseLastPage reads the final GitHub pagination link", () => {
   const header = [
@@ -36,4 +36,12 @@ test("buildChart renders current live data in both themes", () => {
     assert.match(svg, /Lumiwealth\/lumibot/);
     assert.doesNotMatch(svg, /undefined|NaN/);
   }
+});
+
+test("errorChart truncates before XML escaping", () => {
+  const message = `${"x".repeat(119)}"more text`;
+  const svg = errorChart(message, "light");
+
+  assert.match(svg, new RegExp(`${"x".repeat(119)}&quot;</text>`));
+  assert.doesNotMatch(svg, /&q<\/text>/);
 });


### PR DESCRIPTION
## What and why

Restores the live LumiBot star-history chart after GitHub rejected the previous fine-grained token. The chart worker now emits valid fallback SVGs, the README uses a cache-busted chart URL so GitHub Camo cannot retain the broken response, and a scheduled health check verifies the actual rendered chart.

## Risk

Low. Documentation, the isolated chart worker, and its monitoring workflow are the only affected surfaces. No LumiBot runtime or trading behavior changes.

## Tests

- `node --test workers/lumibot-star-history/test/*.test.mjs`
- Parsed `.github/workflows/star-history-health.yml` with PyYAML
- `git diff --check`
- Live Worker response: HTTP 200, valid SVG/XML, 1,873 stars
- Star History UI: graph rendered with no invalid-token warning

## Docs

Updated the worker rotation runbook with the required organization owner, repository scope, and GitHub permissions.

## Docs/Prompts

No prompt changes are needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated health monitoring for the README star-history chart, including rendered-content and authorization checks.
  - Added clearer guidance for configuring chart-service access and verifying token setup.

- **Bug Fixes**
  - Improved chart error handling to prevent malformed SVG output from special characters or long messages.
  - Updated chart links to ensure refreshed dark, light, and image versions are displayed.

- **Chores**
  - Updated the package version to 4.5.82.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->