### PR TITLE
v4.5.83 - AI-native options trading tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.83 - Unreleased
+
 ## 4.5.82 - 2026-08-03
 
 Deploy marker: `deploy 4.5.82`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 4.5.83 - Unreleased
 
+### Added
+- **AI agents can now operate generic option and multi-leg workflows through
+  built-in LumiBot tools.** Agents can retrieve chains and strikes, inspect
+  exact-contract Greeks and market quality, find listed strikes by delta,
+  calculate signed multi-leg prices, and submit atomic multi-leg orders. The
+  new ``ai_iron_condor.py`` example keeps all selection, sizing, construction,
+  execution, and management decisions inside one agent system prompt.
+
+### Changed
+- **Model requests no longer send a temperature parameter.** LumiBot now uses
+  each provider model's current default behavior instead of maintaining a
+  provider-specific temperature compatibility branch.
+
 ## 4.5.82 - 2026-08-03
 
 Deploy marker: `deploy 4.5.82`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 4.5.83 - Unreleased
+## 4.5.83 - 2026-08-05
+
+Deploy marker: `deploy 4.5.83`
 
 ### Added
 - **AI agents can now operate generic option and multi-leg workflows through

--- a/docs/AI_AGENT_BUILTIN_TOOLS.md
+++ b/docs/AI_AGENT_BUILTIN_TOOLS.md
@@ -4,6 +4,7 @@ Lumibot agents include built-ins for:
 
 - account and portfolio state
 - market prices and history tables
+- option chains, strikes, Greeks, and executable quote evaluation
 - DuckDB queries
 - Lumibot docs search
 - Alpaca news
@@ -13,6 +14,19 @@ Lumibot agents include built-ins for:
 - memory
 - notifications
 - orders
+
+Generic option tools:
+
+- `options_get_chain`
+- `options_get_strikes`
+- `options_get_greeks`
+- `options_find_strike_for_delta`
+- `options_evaluate_market`
+- `options_calculate_multileg_price`
+
+These tools expose LumiBot's configured broker or backtest data source. They do not choose an options strategy or its legs. The agent must retrieve a listed expiration and strikes, inspect exact contract data, and decide what to trade.
+
+`orders_submit_multileg` accepts exact option legs selected by the agent and submits them as one atomic multi-leg order. Each leg declares `symbol`, `expiration`, `strike`, `right`, `quantity`, and `side`. Opening actions are `buy_to_open` and `sell_to_open`; closing actions are `buy_to_close` and `sell_to_close`. Signed net prices are positive for debits and negative for credits.
 
 Alpaca news uses an active Alpaca broker when available. Outside Alpaca broker runs, it checks `ALPACA_NEWS_API_KEY` / `ALPACA_NEWS_API_SECRET`. If neither path is available, `alpaca_news` is not exposed to agents.
 
@@ -25,6 +39,7 @@ self.agents.create(name="researcher", allow_trading=False)
 `allow_trading=False` removes mutating order tools and actual-decision writes:
 
 - `orders_submit_order`
+- `orders_submit_multileg`
 - `orders_cancel_order`
 - `orders_modify_order`
 - `remember_decision`
@@ -33,13 +48,15 @@ It keeps read-only tools, including `orders_open_orders`, positions, portfolio, 
 
 Order readiness:
 
-Before an agent can submit an order with `orders_submit_order`, it must inspect account and price context in the same agent run:
+Before an agent can submit an order with `orders_submit_order` or `orders_submit_multileg`, it must inspect account and price context in the same agent run:
 
 - `account_portfolio` for cash and portfolio value
 - `account_positions` for current holdings
 - `market_last_price` for the ordered symbol
 
 If any of those checks are missing, the order tool returns a structured `ORDER_READINESS_REQUIRED` error instead of submitting the order. Lumibot does not silently resize orders and does not apply universal margin rules across asset classes; the agent must use the checked cash, portfolio value, positions, and price to size the explicit order it submits.
+
+For options, `account_positions` includes exact contract fields, signed quantity, average fill price, current price, market value, and P&L fields when available. This gives the agent the generic information needed to reconstruct and manage open multi-leg positions.
 
 Market-price tools accept one tradable symbol per call. Do not pass a comma-separated universe to `market_last_price` or `market_load_history_table`; call the tool once per symbol or load each symbol into DuckDB separately before querying.
 

--- a/docsrc/agents_builtin_tools.rst
+++ b/docsrc/agents_builtin_tools.rst
@@ -31,6 +31,7 @@ With ``allow_trading=False``, LumiBot removes tools that mutate orders and the
 actual-decision memory write:
 
 - submit order
+- submit multi-leg order
 - modify order
 - cancel order
 - remember decision
@@ -53,8 +54,9 @@ Agent order tools are intentionally broker-like: LumiBot either submits the
 exact order requested or rejects it. It does not silently resize, clip, or
 normalize a requested order into a different order.
 
-Before ``orders_submit_order`` can submit an order, the agent must inspect the
-required account and price context in the same agent run:
+Before ``orders_submit_order`` or ``orders_submit_multileg`` can submit an
+order, the agent must inspect the required account and price context in the
+same agent run:
 
 - ``account_portfolio`` for cash and portfolio value
 - ``account_positions`` for current holdings
@@ -86,6 +88,33 @@ These tools let agents understand what the strategy already knows:
 
 These tools are read-only. They remain available even when
 ``allow_trading=False``.
+
+Options And Multi-Leg Orders
+----------------------------
+
+LumiBot exposes generic options capabilities to every agent:
+
+- ``options_get_chain``
+- ``options_get_strikes``
+- ``options_get_greeks``
+- ``options_find_strike_for_delta``
+- ``options_evaluate_market``
+- ``options_calculate_multileg_price``
+
+The tools retrieve data through the configured LumiBot broker or backtest data
+source. They do not select a named options strategy or choose its legs. The
+agent must select an available expiration, exact listed strikes, quantities,
+and actions from the returned evidence.
+
+``orders_submit_multileg`` submits two or more exact option legs as one atomic
+multi-leg order. Opening actions are ``buy_to_open`` and ``sell_to_open``.
+Closing actions are ``buy_to_close`` and ``sell_to_close``. Signed net prices
+are positive for debits and negative for credits.
+
+``account_positions`` includes the exact contract, signed quantity, average
+fill, current value, and P&L fields when the active broker or backtest provides
+them. Agents can use those generic fields to reconstruct and manage existing
+option positions.
 
 Technical Indicators
 --------------------

--- a/docsrc/agents_example_ai_iron_condor.rst
+++ b/docsrc/agents_example_ai_iron_condor.rst
@@ -1,0 +1,29 @@
+AI-Only Iron Condor
+===================
+
+``ai_iron_condor.py`` is a minimal AI-only options strategy. Its Python class
+does two things: it creates one trading agent in ``initialize()`` and runs that
+agent in ``on_trading_iteration()``. All market retrieval, option selection,
+four-leg construction, sizing, execution, and position management belongs to
+the agent and its system prompt.
+
+The example uses ``gemini-3.5-flash-lite`` explicitly. Existing saved
+strategies keep the model identifier already stored in their code.
+
+Run a seven-day backtest ending today with an options-capable backtest data
+source:
+
+.. code-block:: bash
+
+   export GEMINI_API_KEY="your-key"
+   export BACKTESTING_DATA_SOURCE="ThetaData"
+   export DATADOWNLOADER_BASE_URL="https://<your-downloader-host>:8080"
+   export DATADOWNLOADER_API_KEY="your-downloader-key"
+   python -m lumibot.example_strategies.ai_iron_condor
+
+Set ``BACKTESTING_START`` and ``BACKTESTING_END`` in ``YYYY-MM-DD`` format to
+choose an exact historical window.
+
+.. literalinclude:: ../lumibot/example_strategies/ai_iron_condor.py
+   :language: python
+   :linenos:

--- a/docsrc/agents_examples.rst
+++ b/docsrc/agents_examples.rst
@@ -16,12 +16,19 @@ when you set ``IS_BACKTESTING = True`` in the flat runner.
    agents_example_warren_buffett_value
    agents_example_bill_ackman_concentrated
    agents_example_citadel_sector_pods
+   agents_example_ai_iron_condor
 
 These examples are inspired by public investing styles and firms. They are not
 affiliated with or endorsed by the investors, firms, or companies named.
 
 Examples
 --------
+
+``ai_iron_condor.py``
+   A single-agent, AI-only SPY options example. Python creates and runs the
+   agent. The system prompt makes the agent retrieve the chain, select and
+   evaluate four contracts, size and submit the atomic multi-leg order, and
+   manage the position on later iterations.
 
 ``ai_trading_team_citadel_sector_pods.py``
    Inspired by the pod-style structure associated with Ken Griffin's Citadel:

--- a/lumibot/components/agents/builtins.py
+++ b/lumibot/components/agents/builtins.py
@@ -12,9 +12,20 @@ from .tool_context import current_agent_tool_context
 
 
 AssetTypeArg = Literal["stock", "option", "future", "cont_future", "forex", "crypto", "index", "multileg", "us_equity"]
-OrderSideArg = Literal["buy", "sell", "buy_to_open", "sell_to_close", "sell_short", "buy_to_cover"]
+OrderSideArg = Literal[
+    "buy",
+    "sell",
+    "buy_to_open",
+    "buy_to_close",
+    "sell_to_open",
+    "sell_to_close",
+    "sell_short",
+    "buy_to_cover",
+]
 OrderTypeArg = Literal["market", "limit", "stop", "stop_limit", "trailing_stop", "smart_limit"]
 TimeInForceArg = Literal["day", "gtc", "gtd"]
+OptionRightArg = Literal["call", "put"]
+MultilegPriceStyleArg = Literal["market", "best", "mid", "fastest"]
 NewsSortArg = Literal["asc", "desc"]
 
 COMMON_INDICATORS = [
@@ -238,6 +249,15 @@ def _position_to_dict(position: Any) -> dict[str, Any]:
     return {
         "asset": asset_payload,
         "quantity": quantity,
+        "avg_fill_price": _jsonable(getattr(position, "avg_fill_price", None)),
+        "current_price": _jsonable(getattr(position, "current_price", None)),
+        "market_value": _jsonable(getattr(position, "market_value", None)),
+        "pnl": _jsonable(
+            getattr(position, "pnl", None)
+            if hasattr(position, "pnl")
+            else getattr(position, "unrealized_pnl", None)
+        ),
+        "pnl_percent": _jsonable(getattr(position, "pnl_percent", None)),
     }
 
 
@@ -262,6 +282,97 @@ def _order_to_dict(order: Any) -> dict[str, Any]:
     }
 
 
+def _options_helper_for_strategy(strategy: Any) -> Any:
+    helper = getattr(strategy, "_agent_options_helper", None)
+    if helper is None:
+        from lumibot.components.options_helper import OptionsHelper
+
+        helper = OptionsHelper(strategy)
+        setattr(strategy, "_agent_options_helper", helper)
+    return helper
+
+
+def _underlying_asset(
+    strategy: Any,
+    *,
+    symbol: str,
+    asset_type: Literal["stock", "index"] = "stock",
+) -> Any:
+    symbol = _require_single_symbol_text("symbol", symbol)
+    asset, _ = resolve_asset_and_quote(strategy, symbol=symbol, asset_type=asset_type)
+    return asset
+
+
+def _option_asset(
+    strategy: Any,
+    *,
+    symbol: str,
+    expiration: str,
+    strike: float,
+    right: OptionRightArg,
+) -> Any:
+    symbol = _require_single_symbol_text("symbol", symbol)
+    expiration_value = _coerce_expiration(_require_non_empty_text("expiration", expiration))
+    if not isinstance(expiration_value, date):
+        raise ValueError("expiration must use YYYY-MM-DD format.")
+    strike_value = _require_positive_number("strike", strike)
+    asset, _ = resolve_asset_and_quote(
+        strategy,
+        symbol=symbol,
+        asset_type="option",
+        expiration=expiration_value,
+        strike=strike_value,
+        right=right,
+    )
+    return asset
+
+
+def _parse_option_legs(strategy: Any, legs_json: str, *, time_in_force: TimeInForceArg = "day") -> list[Any]:
+    raw = _require_non_empty_text("legs_json", legs_json)
+    try:
+        legs = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"legs_json must be valid JSON: {exc}") from exc
+    if not isinstance(legs, list) or len(legs) < 2:
+        raise ValueError("legs_json must decode to a list containing at least two option legs.")
+
+    orders: list[Any] = []
+    for index, leg in enumerate(legs):
+        if not isinstance(leg, dict):
+            raise ValueError(f"legs_json item {index} must be a JSON object.")
+        try:
+            symbol = _require_single_symbol_text("symbol", leg.get("symbol"))
+            expiration = _require_non_empty_text("expiration", leg.get("expiration"))
+            strike = _require_positive_number("strike", leg.get("strike"))
+            right = str(leg.get("right") or "").strip().lower()
+            side = str(leg.get("side") or "").strip().lower()
+            quantity = _require_positive_number("quantity", leg.get("quantity"))
+        except ValueError as exc:
+            raise ValueError(f"Invalid option leg at index {index}: {exc}") from exc
+        if right not in {"call", "put"}:
+            raise ValueError(f"Invalid option leg at index {index}: right must be 'call' or 'put'.")
+        if side not in {
+            "buy",
+            "sell",
+            "buy_to_open",
+            "buy_to_close",
+            "sell_to_open",
+            "sell_to_close",
+        }:
+            raise ValueError(
+                f"Invalid option leg at index {index}: side must describe a buy or sell action for an option contract."
+            )
+        option = _option_asset(
+            strategy,
+            symbol=symbol,
+            expiration=expiration,
+            strike=strike,
+            right=right,
+        )
+        orders.append(strategy.create_order(option, quantity, side, time_in_force=time_in_force))
+    return orders
+
+
 def _bind_positions(strategy: Any, manager: Any) -> BoundTool:
     def positions() -> dict[str, Any]:
         return {
@@ -273,7 +384,9 @@ def _bind_positions(strategy: Any, manager: Any) -> BoundTool:
         name="account_positions",
         description=(
             "Return current positions as structured data. "
-            "Each entry includes asset fields and quantity. "
+            "Each entry includes exact asset fields, signed quantity, average fill price, current price, market value, and P&L fields when the broker or backtest provides them. "
+            "For options, signed quantity is authoritative: quantity > 0 is a long contract and must use sell_to_close to reduce it; quantity < 0 is a short contract and must use buy_to_close to reduce it. "
+            "Use expiration, strike, right, signed quantity, and average fill price to reconstruct and manage an existing multi-leg position. Never report the option portfolio as flat while any option entry has nonzero quantity. "
             "Use this before trading to understand current exposure, whether a symbol is already held, and whether the current portfolio is concentrated. "
             "Example: call this before rotating into a new symbol so you can compare it against what is already owned."
         ),
@@ -342,6 +455,304 @@ def _bind_last_price(strategy: Any, manager: Any) -> BoundTool:
             "Example: market_last_price(symbol='SPY', asset_type='stock')."
         ),
         function=last_price,
+        metadata={"kind": "builtin", "replay_on_cache": True},
+    )
+
+
+def _bind_options_get_chain(strategy: Any, manager: Any) -> BoundTool:
+    def get_chain(
+        *,
+        symbol: str,
+        underlying_asset_type: Literal["stock", "index"] = "stock",
+        include_strikes: bool = False,
+    ) -> dict[str, Any]:
+        underlying = _underlying_asset(strategy, symbol=symbol, asset_type=underlying_asset_type)
+        chains = strategy.get_chains(underlying)
+        if not chains:
+            return {
+                "symbol": symbol.upper(),
+                "underlying_asset_type": underlying_asset_type,
+                "available": False,
+                "call_expirations": [],
+                "put_expirations": [],
+            }
+
+        chain_root = chains.get("Chains", {}) if hasattr(chains, "get") else {}
+        call_map = chain_root.get("CALL", {}) if isinstance(chain_root, dict) else {}
+        put_map = chain_root.get("PUT", {}) if isinstance(chain_root, dict) else {}
+
+        def side_payload(side_map: Any) -> dict[str, Any]:
+            if not isinstance(side_map, dict):
+                return {}
+            result: dict[str, Any] = {}
+            for expiration in sorted(str(value) for value in side_map.keys()):
+                strikes = side_map.get(expiration) or []
+                normalized_strikes = sorted({float(value) for value in strikes})
+                entry: dict[str, Any] = {
+                    "strike_count": len(normalized_strikes),
+                    "min_strike": normalized_strikes[0] if normalized_strikes else None,
+                    "max_strike": normalized_strikes[-1] if normalized_strikes else None,
+                }
+                if include_strikes:
+                    entry["strikes"] = normalized_strikes
+                result[expiration] = entry
+            return result
+
+        calls = side_payload(call_map)
+        puts = side_payload(put_map)
+        return {
+            "symbol": symbol.upper(),
+            "underlying_asset_type": underlying_asset_type,
+            "available": True,
+            "multiplier": _jsonable(chains.get("Multiplier") if hasattr(chains, "get") else None),
+            "exchange": _jsonable(chains.get("Exchange") if hasattr(chains, "get") else None),
+            "call_expirations": list(calls.keys()),
+            "put_expirations": list(puts.keys()),
+            "calls": calls,
+            "puts": puts,
+            "strikes_included": include_strikes,
+            "datetime": strategy.get_datetime().isoformat(),
+        }
+
+    return BoundTool(
+        name="options_get_chain",
+        description=(
+            "Retrieve the option chain available for one underlying through LumiBot's configured broker or backtest data source. "
+            "Arguments: symbol, optional underlying_asset_type='stock' or 'index', optional include_strikes. "
+            "The default compact response lists call and put expirations plus strike counts and ranges. Set include_strikes=true only when you need every strike for every expiration. "
+            "Use this before choosing option contracts. Never invent an expiration or strike that is absent from this result. "
+            "Example: options_get_chain(symbol='SPY', include_strikes=false)."
+        ),
+        function=get_chain,
+        metadata={"kind": "builtin", "replay_on_cache": True},
+    )
+
+
+def _bind_options_get_strikes(strategy: Any, manager: Any) -> BoundTool:
+    def get_strikes(
+        *,
+        symbol: str,
+        expiration: str,
+        right: OptionRightArg,
+        underlying_asset_type: Literal["stock", "index"] = "stock",
+    ) -> dict[str, Any]:
+        underlying = _underlying_asset(strategy, symbol=symbol, asset_type=underlying_asset_type)
+        expiration_value = _coerce_expiration(_require_non_empty_text("expiration", expiration))
+        if not isinstance(expiration_value, date):
+            raise ValueError("expiration must use YYYY-MM-DD format.")
+        chains = strategy.get_chains(underlying)
+        if not chains:
+            strikes: list[float] = []
+        elif hasattr(chains, "strikes"):
+            strikes = chains.strikes(expiration_value, right.upper()) or []
+        else:
+            strikes = (
+                chains.get("Chains", {})
+                .get(right.upper(), {})
+                .get(expiration_value.isoformat(), [])
+            )
+        normalized = sorted({float(value) for value in strikes})
+        return {
+            "symbol": symbol.upper(),
+            "expiration": expiration_value.isoformat(),
+            "right": right,
+            "strikes": normalized,
+            "count": len(normalized),
+            "datetime": strategy.get_datetime().isoformat(),
+        }
+
+    return BoundTool(
+        name="options_get_strikes",
+        description=(
+            "Return every listed strike for one exact underlying, expiration, and option right. "
+            "Arguments: symbol, expiration in YYYY-MM-DD, right='call' or 'put', optional underlying_asset_type='stock' or 'index'. "
+            "First use options_get_chain to choose a listed expiration, then use this result when selecting exact contracts. "
+            "Example: options_get_strikes(symbol='SPY', expiration='2026-09-18', right='put')."
+        ),
+        function=get_strikes,
+        metadata={"kind": "builtin", "replay_on_cache": True},
+    )
+
+
+def _bind_options_get_greeks(strategy: Any, manager: Any) -> BoundTool:
+    def get_greeks(
+        *,
+        symbol: str,
+        expiration: str,
+        strike: float,
+        right: OptionRightArg,
+        underlying_price: float | None = None,
+        option_price: float | None = None,
+        risk_free_rate: float | None = None,
+        query_greeks: bool = False,
+    ) -> dict[str, Any]:
+        option = _option_asset(
+            strategy,
+            symbol=symbol,
+            expiration=expiration,
+            strike=strike,
+            right=right,
+        )
+        greeks = strategy.get_greeks(
+            option,
+            asset_price=option_price,
+            underlying_price=underlying_price,
+            risk_free_rate=risk_free_rate,
+            query_greeks=query_greeks,
+        )
+        return {
+            "asset": _asset_to_dict(option),
+            "greeks": _jsonable(greeks),
+            "available": greeks is not None,
+            "datetime": strategy.get_datetime().isoformat(),
+        }
+
+    return BoundTool(
+        name="options_get_greeks",
+        description=(
+            "Get Greeks for one exact listed option contract. "
+            "Arguments: symbol, expiration, strike, right, and optional underlying_price, option_price, risk_free_rate, query_greeks. "
+            "Use the exact expiration and strike returned by options_get_chain/options_get_strikes. The result proves Greeks only for the exact strike and right named in the result. Never transfer or reuse that delta for a neighboring strike. A null greeks result means the data source cannot value that contract at the current runtime datetime. "
+            "Example: options_get_greeks(symbol='SPY', expiration='2026-09-18', strike=650, right='call')."
+        ),
+        function=get_greeks,
+        metadata={"kind": "builtin", "replay_on_cache": True},
+    )
+
+
+def _bind_options_find_strike_for_delta(strategy: Any, manager: Any) -> BoundTool:
+    def find_strike_for_delta(
+        *,
+        symbol: str,
+        expiration: str,
+        right: OptionRightArg,
+        target_delta: float,
+        underlying_price: float | None = None,
+        underlying_asset_type: Literal["stock", "index"] = "stock",
+    ) -> dict[str, Any]:
+        target_delta_value = float(target_delta)
+        if not math.isfinite(target_delta_value) or abs(target_delta_value) > 1:
+            raise ValueError("target_delta must be a finite value from -1 through 1.")
+        expiration_value = _coerce_expiration(_require_non_empty_text("expiration", expiration))
+        if not isinstance(expiration_value, date):
+            raise ValueError("expiration must use YYYY-MM-DD format.")
+        underlying = _underlying_asset(strategy, symbol=symbol, asset_type=underlying_asset_type)
+        if underlying_price is None:
+            underlying_price = strategy.get_last_price(underlying)
+        if underlying_price is None:
+            raise ValueError(f"No underlying price is available for {symbol.upper()}.")
+        chains = strategy.get_chains(underlying)
+        strike = _options_helper_for_strategy(strategy).find_strike_for_delta(
+            underlying,
+            float(underlying_price),
+            target_delta_value,
+            expiration_value,
+            right,
+            chains=chains,
+        )
+        return {
+            "symbol": symbol.upper(),
+            "expiration": expiration_value.isoformat(),
+            "right": right,
+            "target_delta": target_delta_value,
+            "underlying_price": float(underlying_price),
+            "strike": float(strike) if strike is not None else None,
+            "available": strike is not None,
+            "datetime": strategy.get_datetime().isoformat(),
+        }
+
+    return BoundTool(
+        name="options_find_strike_for_delta",
+        description=(
+            "Find the listed strike whose calculated delta is closest to a target for one expiration and right. "
+            "Arguments: symbol, expiration, right, target_delta, optional underlying_price, optional underlying_asset_type. "
+            "Use positive target delta for calls and negative target delta for puts. First retrieve the chain and choose a listed expiration. "
+            "The returned strike is only a search candidate. It does not prove that the contract's current delta equals or is acceptably close to target_delta. Call options_get_greeks on that exact strike, use the exact returned delta, and reject the candidate when it is outside the strategy's permitted range. Never relabel, round, or describe a materially different verified delta as the target delta. "
+            "Example: options_find_strike_for_delta(symbol='SPY', expiration='2026-09-18', right='put', target_delta=-0.16)."
+        ),
+        function=find_strike_for_delta,
+        metadata={"kind": "builtin", "replay_on_cache": True},
+    )
+
+
+def _bind_options_evaluate_market(strategy: Any, manager: Any) -> BoundTool:
+    def evaluate_market(
+        *,
+        symbol: str,
+        expiration: str,
+        strike: float,
+        right: OptionRightArg,
+        max_spread_pct: float | None = None,
+    ) -> dict[str, Any]:
+        option = _option_asset(
+            strategy,
+            symbol=symbol,
+            expiration=expiration,
+            strike=strike,
+            right=right,
+        )
+        evaluation = _options_helper_for_strategy(strategy).evaluate_option_market(
+            option,
+            max_spread_pct=max_spread_pct,
+        )
+        return {
+            "asset": _asset_to_dict(option),
+            "market": _jsonable(vars(evaluation)),
+            "datetime": strategy.get_datetime().isoformat(),
+        }
+
+    return BoundTool(
+        name="options_evaluate_market",
+        description=(
+            "Inspect executable quote quality for one exact option contract and return bid, ask, last, spread percentage, suggested buy/sell prices, and data-quality flags. "
+            "Arguments: symbol, expiration, strike, right, optional max_spread_pct as a fraction such as 0.20 for 20 percent. "
+            "Call this for every proposed leg before submitting a multi-leg order. Do not trade a contract whose response says the market is unavailable or unacceptably wide under your policy. "
+            "Example: options_evaluate_market(symbol='SPY', expiration='2026-09-18', strike=650, right='call', max_spread_pct=0.20)."
+        ),
+        function=evaluate_market,
+        metadata={"kind": "builtin", "replay_on_cache": True},
+    )
+
+
+def _bind_options_calculate_multileg_price(strategy: Any, manager: Any) -> BoundTool:
+    def calculate_multileg_price(
+        *,
+        legs_json: str,
+        price_style: Literal["best", "mid", "fastest"] = "mid",
+    ) -> dict[str, Any]:
+        orders = _parse_option_legs(strategy, legs_json)
+        net_price = _options_helper_for_strategy(strategy).calculate_multileg_limit_price(orders, price_style)
+        if net_price is None:
+            return {
+                "available": False,
+                "price_style": price_style,
+                "net_limit_price": None,
+                "legs": [_order_to_dict(order) for order in orders],
+            }
+        net_price = float(net_price)
+        order_type = "debit" if net_price > 0 else "credit" if net_price < 0 else "even"
+        return {
+            "available": True,
+            "price_style": price_style,
+            "net_limit_price": net_price,
+            "order_type": order_type,
+            "broker_price": abs(net_price),
+            "legs": [_order_to_dict(order) for order in orders],
+            "datetime": strategy.get_datetime().isoformat(),
+        }
+
+    return BoundTool(
+        name="options_calculate_multileg_price",
+        description=(
+            "Calculate a provider-generic net limit price for two or more exact option legs without submitting them. "
+            "Arguments: legs_json and optional price_style='best', 'mid', or 'fastest'. legs_json must be a JSON array; every leg requires symbol, expiration, strike, right, quantity, and side. "
+            "Use buy_to_open/sell_to_open when opening and buy_to_close/sell_to_close when closing. A positive net_limit_price is a debit and a negative value is a credit. "
+            "For a closing order, a positive account_positions quantity is long and requires sell_to_close; a negative quantity is short and requires buy_to_close. Closing quantity is the absolute value of the position quantity. "
+            "When comparing a per-unit multi-leg opening credit with a per-unit closing debit, price one contract per leg here. Use the full absolute position quantities only in the later orders_submit_multileg call. "
+            "Independently reconcile the returned net price from the four option midpoint values you just observed. For a defined-risk structure, reject a result that conflicts materially with those leg mids or violates the structure's economic bounds. "
+            "Example legs_json: [{\"symbol\":\"SPY\",\"expiration\":\"2026-09-18\",\"strike\":620,\"right\":\"put\",\"quantity\":1,\"side\":\"buy_to_open\"},{\"symbol\":\"SPY\",\"expiration\":\"2026-09-18\",\"strike\":625,\"right\":\"put\",\"quantity\":1,\"side\":\"sell_to_open\"}]."
+        ),
+        function=calculate_multileg_price,
         metadata={"kind": "builtin", "replay_on_cache": True},
     )
 
@@ -1431,13 +1842,84 @@ def _bind_submit_order(strategy: Any, manager: Any) -> BoundTool:
             "Valid asset_type values: stock, option, future, cont_future, forex, crypto, index, multileg, us_equity. "
             "Use stock for normal equities. "
             "Before using this tool, call account_portfolio, account_positions, and market_last_price for the same symbol in the current agent run; otherwise the order is rejected with ORDER_READINESS_REQUIRED. "
-            "Valid side values: buy, sell, buy_to_open, sell_to_close, sell_short, buy_to_cover. "
+            "Valid side values: buy, sell, buy_to_open, buy_to_close, sell_to_open, sell_to_close, sell_short, buy_to_cover. "
             "Valid order_type values: market, limit, stop, stop_limit, trailing_stop, smart_limit. "
             "Valid time_in_force values: day, gtc, gtd. "
             "Caveats: limit orders require limit_price; stop and stop_limit orders require stop_price; trailing_stop requires trail_price or trail_percent; smart_limit uses LumiBot's built-in smart-limit behavior. "
             "Example: orders_submit_order(symbol='SPY', quantity=100, side='buy', asset_type='stock', order_type='market')."
         ),
         function=submit_order,
+        metadata={"kind": "builtin", "replay_on_cache": True},
+    )
+
+
+def _bind_submit_multileg_order(strategy: Any, manager: Any) -> BoundTool:
+    def submit_multileg(
+        *,
+        legs_json: str,
+        price_style: MultilegPriceStyleArg = "mid",
+        net_limit_price: float | None = None,
+        time_in_force: TimeInForceArg = "day",
+    ) -> dict[str, Any]:
+        orders = _parse_option_legs(strategy, legs_json, time_in_force=time_in_force)
+        symbols = sorted({str(getattr(order.asset, "symbol", "")).upper() for order in orders})
+        for symbol in symbols:
+            _require_agent_order_readiness(symbol)
+
+        submit_kwargs: dict[str, Any] = {
+            "is_multileg": True,
+            "duration": time_in_force,
+        }
+        resolved_net_price: float | None = None
+        if price_style == "market":
+            if net_limit_price is not None:
+                raise ValueError("net_limit_price cannot be used when price_style='market'.")
+            submit_kwargs["order_type"] = "market"
+        else:
+            if net_limit_price is None:
+                calculated = _options_helper_for_strategy(strategy).calculate_multileg_limit_price(orders, price_style)
+                if calculated is None:
+                    raise ValueError(
+                        "Unable to calculate a multi-leg limit price from the current quotes. Evaluate every leg or use price_style='market' only if your trading policy permits it."
+                    )
+                resolved_net_price = float(calculated)
+            else:
+                resolved_net_price = float(net_limit_price)
+                if not math.isfinite(resolved_net_price):
+                    raise ValueError("net_limit_price must be finite.")
+            submit_kwargs["order_type"] = (
+                "debit" if resolved_net_price > 0 else "credit" if resolved_net_price < 0 else "even"
+            )
+            submit_kwargs["price"] = abs(resolved_net_price)
+
+        submitted = strategy.submit_order(orders, **submit_kwargs)
+        submitted_orders = submitted if isinstance(submitted, list) else [submitted]
+        return {
+            "submitted": [_order_to_dict(order) for order in submitted_orders if order is not None],
+            "legs": [_order_to_dict(order) for order in orders],
+            "price_style": price_style,
+            "net_limit_price": resolved_net_price,
+            "order_type": submit_kwargs["order_type"],
+            "time_in_force": time_in_force,
+            "datetime": strategy.get_datetime().isoformat(),
+        }
+
+    return BoundTool(
+        name="orders_submit_multileg",
+        description=(
+            "Create and submit one atomic multi-leg option order from exact contracts selected by the agent. This is generic and does not choose a strategy or its legs. "
+            "Arguments: legs_json, optional price_style='market', 'best', 'mid', or 'fastest', optional signed net_limit_price, optional time_in_force. legs_json must be a JSON array with at least two legs; each leg requires symbol, expiration, strike, right, quantity, and side. "
+            "Before submitting, call account_portfolio, account_positions, market_last_price for each underlying symbol, retrieve the chain, and evaluate every exact leg. "
+            "Opening sides are buy_to_open and sell_to_open. Closing sides are buy_to_close and sell_to_close. Use matching quantities when the intended position requires matched contracts. "
+            "When closing existing positions, map signed account quantities exactly: positive long quantity -> sell_to_close; negative short quantity -> buy_to_close. Reversing that mapping increases exposure instead of closing it. "
+            "Every proposed closing leg must reduce the corresponding exact position quantity toward zero. Do not use the same closing side for positive and negative position quantities. "
+            "Current nonzero option positions remain open until a later account_positions result shows zero quantity. A submitted or filled order result is not itself proof that positions are flat, and a final response must not claim submission unless this tool returned submitted orders. "
+            "Before opening more option exposure, compare the proposed legs with all current option positions and pending orders. Do not add another structure when the strategy policy permits only one open structure. "
+            "For limit execution, a positive signed net_limit_price is a debit and a negative value is a credit. If omitted, LumiBot calculates the selected best/mid/fastest price. "
+            "The agent must validate that signed price against its exact leg quotes and strategy economics before submission. For equal-width credit spreads, credit must be positive and strictly less than the wing width. "
+            "Use price_style='market' only when the strategy policy explicitly accepts market execution. The tool returns the submitted child orders and pricing classification."
+        ),
+        function=submit_multileg,
         metadata={"kind": "builtin", "replay_on_cache": True},
     )
 
@@ -1472,6 +1954,26 @@ class _MarketTools:
             description="Load visible historical bars into DuckDB.",
             binder=_bind_load_history,
         )
+
+
+class _OptionsTools:
+    def get_chain(self) -> ToolDefinition:
+        return ToolDefinition(name="options_get_chain", description="Retrieve an underlying's available option chain.", binder=_bind_options_get_chain)
+
+    def get_strikes(self) -> ToolDefinition:
+        return ToolDefinition(name="options_get_strikes", description="List strikes for one expiration and option right.", binder=_bind_options_get_strikes)
+
+    def get_greeks(self) -> ToolDefinition:
+        return ToolDefinition(name="options_get_greeks", description="Get Greeks for one exact option contract.", binder=_bind_options_get_greeks)
+
+    def find_strike_for_delta(self) -> ToolDefinition:
+        return ToolDefinition(name="options_find_strike_for_delta", description="Find a listed option strike closest to a target delta.", binder=_bind_options_find_strike_for_delta)
+
+    def evaluate_market(self) -> ToolDefinition:
+        return ToolDefinition(name="options_evaluate_market", description="Evaluate quote quality for one exact option contract.", binder=_bind_options_evaluate_market)
+
+    def calculate_multileg_price(self) -> ToolDefinition:
+        return ToolDefinition(name="options_calculate_multileg_price", description="Calculate a signed net price for exact option legs.", binder=_bind_options_calculate_multileg_price)
 
 
 class _DuckDBTools:
@@ -1611,6 +2113,14 @@ class _OrderTools:
             metadata={"mutates_trading": True},
         )
 
+    def submit_multileg(self) -> ToolDefinition:
+        return ToolDefinition(
+            name="orders_submit_multileg",
+            description="Submit one atomic multi-leg option order from exact agent-selected contracts.",
+            binder=_bind_submit_multileg_order,
+            metadata={"mutates_trading": True},
+        )
+
     def open_orders(self) -> ToolDefinition:
         return ToolDefinition(name="orders_open_orders", description="List tracked orders and their identifiers.", binder=_bind_open_orders)
 
@@ -1626,6 +2136,7 @@ class _OrderTools:
 class _BuiltinTools:
     account = _AccountTools()
     market = _MarketTools()
+    options = _OptionsTools()
     duckdb = _DuckDBTools()
     docs = _DocsTools()
     news = _NewsTools()
@@ -1643,6 +2154,12 @@ class _BuiltinTools:
             self.account.portfolio(),
             self.market.last_price(),
             self.market.load_history_table(),
+            self.options.get_chain(),
+            self.options.get_strikes(),
+            self.options.get_greeks(),
+            self.options.find_strike_for_delta(),
+            self.options.evaluate_market(),
+            self.options.calculate_multileg_price(),
             self.duckdb.query(),
             self.docs.search(),
             self.news.alpaca_news(),
@@ -1673,6 +2190,7 @@ class _BuiltinTools:
             self.memory.update_thesis(),
             self.memory.close_thesis(),
             self.orders.submit(),
+            self.orders.submit_multileg(),
             self.orders.cancel(),
             self.orders.open_orders(),
             self.orders.modify(),

--- a/lumibot/components/agents/runtime.py
+++ b/lumibot/components/agents/runtime.py
@@ -984,19 +984,6 @@ def _resolve_model_for_adk(
     return model_type(model=model, **kwargs)
 
 
-def _supports_explicit_temperature_for_adk_model(model: Any) -> bool:
-    """Return True only for ADK-native models known to accept temperature.
-
-    ADK's LiteLlm bridge forwards GenerateContentConfig fields to provider APIs.
-    OpenAI GPT-5/reasoning-class models reject custom temperature values and only
-    allow the provider default. Passing temperature=0.0 therefore breaks those
-    models before the agent can run. Keep deterministic temperature only on the
-    Gemini-native path; let LiteLLM providers use their provider defaults unless
-    a future explicit per-provider compatibility layer is added.
-    """
-    return _is_native_gemini_model(model)
-
-
 class GoogleADKRuntime:
     def __init__(self, mcp_servers: list[MCPServer] | None = None) -> None:
         self.mcp_servers = mcp_servers or []
@@ -1357,8 +1344,6 @@ class GoogleADKRuntime:
         config_kwargs: dict[str, Any] = {
             "max_output_tokens": 65535,
         }
-        if _supports_explicit_temperature_for_adk_model(request.model):
-            config_kwargs["temperature"] = 0.0
         request_timeout_seconds = GoogleADKRuntime._model_request_timeout_seconds_for_request(request)
         if _is_native_gemini_model(request.model) and request_timeout_seconds is not None:
             timeout_millis = max(int(request_timeout_seconds * 1000), 1)

--- a/lumibot/components/grok_helper.py
+++ b/lumibot/components/grok_helper.py
@@ -159,7 +159,7 @@ Return only valid JSON following the schema.
 """
         return system_prompt
 
-    def _send_request(self, system_msg: str, user_query: str, model: str = "grok-2-latest", temperature: int = 0, retries: int = 3) -> str:
+    def _send_request(self, system_msg: str, user_query: str, model: str = "grok-2-latest", retries: int = 3) -> str:
         """
         Sends a request to the Grok/xAI API using the provided system message and user query.
         Implements a retry loop to mitigate transient failures.
@@ -173,8 +173,6 @@ Return only valid JSON following the schema.
             The user's query.
         model : str, optional
             The model to use (default is "grok-2-latest").
-        temperature : int, optional
-            The temperature setting (default is 0).
         retries : int, optional
             Number of retry attempts (default is 3).
         
@@ -196,7 +194,6 @@ Return only valid JSON following the schema.
                         {"role": "system", "content": system_msg},
                         {"role": "user", "content": user_query}
                     ],
-                    temperature=temperature,
                     max_tokens=500,
                     top_p=0.9,
                     stream=False

--- a/lumibot/components/options_helper.py
+++ b/lumibot/components/options_helper.py
@@ -1640,11 +1640,11 @@ class OptionsHelper:
                 continue
             if limit_type == "mid":
                 mid = (quote.ask + quote.bid) / 2
-                quotes.append(mid if order.side.lower() == "buy" else -mid)
+                quotes.append(mid if order.is_buy_order() else -mid)
             elif limit_type == "best":
-                quotes.append(quote.bid if order.side.lower() == "buy" else -quote.ask)
+                quotes.append(quote.bid if order.is_buy_order() else -quote.ask)
             elif limit_type == "fastest":
-                quotes.append(quote.ask if order.side.lower() == "buy" else -quote.bid)
+                quotes.append(quote.ask if order.is_buy_order() else -quote.bid)
         if not quotes:
             self.strategy.log_message("No valid quotes for calculating limit price.", color="red")
             return None

--- a/lumibot/components/perplexity_helper.py
+++ b/lumibot/components/perplexity_helper.py
@@ -353,7 +353,6 @@ Return only valid JSON following the schema.
         system_msg: str,
         user_query: str,
         model: str = "sonar",
-        temperature: int = 0,
         retries: int = 3,
         max_tokens: int = 35000,
         stream: bool = None,
@@ -381,7 +380,6 @@ Return only valid JSON following the schema.
                         {"role": "system", "content": system_msg},
                         {"role": "user", "content": user_query}
                     ],
-                    "temperature": temperature,
                     "max_tokens": safe_max_tokens,
                     "top_p": 0.9,
                     "stream": stream,

--- a/lumibot/example_strategies/ai_iron_condor.py
+++ b/lumibot/example_strategies/ai_iron_condor.py
@@ -1,0 +1,224 @@
+"""AI-only SPY iron-condor strategy.
+
+The Python strategy only creates and runs a LumiBot agent. The agent retrieves
+option data, chooses contracts, constructs multi-leg orders, trades, and manages
+positions by following the system prompt.
+
+Local seven-day backtest:
+    GEMINI_API_KEY=... BACKTESTING_DATA_SOURCE=ThetaData \
+        python -m lumibot.example_strategies.ai_iron_condor
+"""
+
+import os
+from datetime import datetime, timedelta
+
+from lumibot.strategies.strategy import Strategy
+
+
+IRON_CONDOR_SYSTEM_PROMPT = """
+You are the complete decision-maker and operator for an AI-only SPY iron-condor
+strategy running inside LumiBot. You own the entire trading workflow. Retrieve
+all market and account data with tools, choose the expiration and all four exact
+contracts, size the position, construct and submit the atomic multi-leg order,
+and manage or close it on later iterations. There is no Python trading logic
+outside you. Never ask Python code or the user to make a trading decision.
+
+Operate only on SPY options. Use only information available at the current
+runtime datetime. Never assume or invent a price, expiration, strike, Greek,
+position, fill, or order status. A valid no-trade decision is required whenever
+the available data cannot support every rule below.
+
+At the beginning of every iteration:
+
+1. Call account_portfolio, account_positions, and orders_open_orders.
+2. Call market_last_price for SPY as a stock.
+3. Treat every nonzero SPY option position as part of the position you must
+   manage. Group the legs by expiration, strike, right, and signed quantity.
+   Ignore the USD forex cash entry, but never ignore a nonzero option entry.
+   Current account_positions tool evidence overrides your prior summary and
+   memory. You are not flat until account_positions contains zero SPY options.
+4. Never open a second iron condor while any SPY option position or pending SPY
+   option order exists. A filled closing-order status does not prove the
+   position is flat. Only current signed option quantities prove that. Manage or
+   close the existing exposure first.
+
+When an existing four-leg iron condor is open:
+
+1. Confirm it has one expiration, equal absolute contract quantities, one long
+   put below one short put, one short call below one long call, and no extra SPY
+   option exposure. If the exposure is incomplete or mismatched, do not add a
+   new position. Use the available tools and exact positions to reduce risk with
+   an atomic closing order when possible.
+2. Retrieve the current option chain and evaluate the exact market for every
+   open leg. Construct closing legs from this mandatory signed-quantity table:
+   - quantity > 0 means LONG: use sell_to_close for abs(quantity)
+   - quantity < 0 means SHORT: use buy_to_close for abs(quantity)
+   Never use buy_to_close on a positive quantity. Never use sell_to_close on a
+   negative quantity. Those incorrect actions add exposure instead of removing
+   it. For a normal iron condor the only valid closing pattern is:
+   - lower long put: sell_to_close
+   - higher short put: buy_to_close
+   - lower short call: buy_to_close
+   - higher long call: sell_to_close
+   Never use the same closing side for all four legs.
+3. Use options_calculate_multileg_price on all four closing legs with quantity=1
+   for every leg so the result is a per-condor closing debit. Use the full
+   absolute position quantities only when submitting the actual close.
+   Reconstruct the per-condor opening net credit from the signed positions and
+   their average fill prices when those fills are available. Calculate results
+   only with these equations:
+   - captured_profit = opening_credit - closing_debit
+   - captured_fraction = captured_profit / opening_credit
+   - 50 percent profit trigger is true only when closing_debit <=
+     0.50 * opening_credit
+   - 2x loss trigger is true only when closing_debit >=
+     2.00 * opening_credit
+   Example: opening credit 1.96 and closing debit 1.88 captures only 0.08, about
+   4 percent, so the 50 percent profit trigger is false. Do not claim a profit
+   target is met when required fill or quote data is missing.
+4. Submit one atomic four-leg closing order when any of these is true:
+   a. at least 50 percent of the opening credit has been captured;
+   b. 21 or fewer calendar days remain to expiration;
+   c. SPY is at or beyond either short strike;
+   d. either short option has absolute delta of at least 0.30;
+   e. the current closing debit is at least twice the opening credit.
+5. Before any closing submission, write a five-row internal truth table for
+   triggers a through e using exact numbers from tool results. The delta row is
+   false unless you called options_get_greeks for both current short contracts
+   on this iteration. Submit a close only when at least one row is demonstrably
+   true. Closing debit merely being above opening credit is not a trigger.
+   Example: opening credit 2.15 and closing debit 2.43 does not meet either the
+   50 percent profit trigger or the 2x loss trigger. The mandatory sequence is:
+   calculate closing debit, write the completed truth table, stop when all five
+   rows are false, and call orders_submit_multileg only when a row is true.
+   Never submit first and evaluate or cancel afterward. There is no cancellation
+   tool available, so never claim an order was canceled.
+6. Use a signed limit price supported by the current quotes. Do not leg out one
+   contract at a time. Immediately before calling orders_submit_multileg,
+   compare every proposed closing side with the signed quantity table above and
+   confirm in your reasoning that a fill would make each exact position quantity
+   zero. Reject your own proposed JSON and rebuild it if both long wings are not
+   sell_to_close or both short inner legs are not buy_to_close. If a safe atomic
+   close cannot be priced or submitted, place no new trade and clearly report
+   the unresolved exposure.
+
+When no SPY option position or pending SPY option order exists:
+
+1. Call options_get_chain for SPY. Choose a listed expiration from 30 through
+   45 calendar days away, preferring the date closest to 35 days. If no listed
+   expiration qualifies, do not trade. SPY is a stock underlying. Do not retry
+   it as an index, substitute market-history analysis, or search documentation
+   for a way around an unavailable chain.
+2. For that expiration, call options_get_strikes for puts and calls. Use
+   options_find_strike_for_delta to choose a short put near -0.16 delta and a
+   short call near +0.16 delta. Verify both exact contracts with
+   options_get_greeks. The verified absolute delta for each short must be from
+   0.12 through 0.20. If either verified delta falls outside that range, search
+   listed strikes again or do not trade. Never describe a verified -0.28 delta
+   as approximately -0.16. The strike-search result is only a candidate and its
+   target_delta input is not evidence of the candidate's actual delta. Do not
+   reuse a Greek from a neighboring strike as proof for the chosen short. A
+   contract verified inside the range may itself become the short. First lock
+   the two verified short strikes, then derive the long wings from them. For
+   example, if strike 690 is verified at -0.15, use 690 as the short put and
+   look for 685 as its long wing. Do not use 695 as the short put based on the
+   Greek you retrieved for 690. Search intelligently across listed strikes and
+   make at most 12 exact Greek calls per option right for candidate selection.
+   If no verified candidate qualifies within that bound, do not trade.
+3. Choose listed long-wing strikes exactly 5 points farther out of the money
+   when those strikes exist: long put strike equals short put strike minus 5,
+   and long call strike equals short call strike plus 5. If either exact wing is
+   not listed, do not trade. Do not silently change the wing width.
+4. Confirm this strict order before trading:
+   long put strike < short put strike < current SPY price < short call strike <
+   long call strike. All four legs must share the same expiration and quantity.
+5. Call options_evaluate_market for every exact leg with max_spread_pct=0.25.
+   Require an actionable market for every leg and reject any leg whose response
+   marks the spread too wide or required prices unavailable.
+6. Build opening legs in this exact economic structure:
+   buy_to_open the lower-strike put, sell_to_open the higher-strike put,
+   sell_to_open the lower-strike call, and buy_to_open the higher-strike call.
+7. Call options_calculate_multileg_price with price_style='mid'. Require a net
+   credit. The signed net limit price must therefore be negative. Do not submit
+   a debit iron condor and do not use a market order. Independently calculate
+   each leg midpoint as (bid + ask) / 2 from options_evaluate_market, then
+   calculate expected_credit = short_put_mid - long_put_mid + short_call_mid -
+   long_call_mid. The absolute tool credit and expected_credit must agree within
+   $0.05. Also require 0 < credit < 5.00 because each wing is exactly $5 wide.
+   If either check fails, do not submit the order.
+8. Size from current portfolio value and actual quoted credit. Maximum loss per
+   one-lot condor is (5.00 minus credit received) times 100. Choose the largest
+   whole number of contracts whose maximum loss is no more than 2 percent of
+   portfolio value, with an absolute cap of 10 contracts. If the result is less
+   than one contract, or maximum loss is not a positive number, do not trade.
+9. Submit all four opening legs together with orders_submit_multileg using the
+   exact net_limit_price returned by the immediately preceding
+   options_calculate_multileg_price call. Never substitute a different price
+   from your own arithmetic. If your independent midpoint arithmetic differs
+   by more than $0.05, do not submit. Never submit separate leg orders.
+   Immediately before submission, write an internal entry checklist containing
+   the exact chosen short-put strike and its most recent options_get_greeks
+   delta, the exact chosen short-call strike and its most recent
+   options_get_greeks delta, all four midpoint values, expected_credit, tool
+   credit, wing width, quantity, and maximum loss. If either exact short delta
+   is not from 0.12 through 0.20 in absolute value, do not submit. A candidate
+   search near 0.16 cannot override a verified delta outside that range.
+
+NON-NEGOTIABLE FINAL ENTRY SEQUENCE: after choosing the proposed four legs,
+call options_get_greeks again for the exact proposed short put and exact proposed
+short call. The strike and right in those two tool results must exactly equal
+the two sell_to_open legs. Then evaluate all four exact markets, calculate the
+multi-leg price, compare the two credit calculations, and submit the exact tool
+net_limit_price. If you did not perform this exact sequence, or any value fails
+its range, stop with no trade. Never claim that an uncalled strike was verified.
+
+NON-NEGOTIABLE POSITION STATE LOCK: the account_positions result at the start of
+this iteration fixes the mode for the entire iteration. If it contains even one
+nonzero SPY option quantity, this is a MANAGE-ONLY iteration. You may not submit
+any buy_to_open or sell_to_open leg later in that iteration, even if a closing
+order was submitted or reported filled. You may call opening tools only on a
+future iteration whose new account_positions result contains zero SPY options.
+Do not say that you submitted or closed anything unless orders_submit_multileg
+was actually called with the correct four closing sides and returned submitted
+orders. If a proposed close price conflicts with the four observed leg quotes,
+do not submit it and report that the position remains open.
+
+NON-NEGOTIABLE CLOSE GATE: pricing a possible close does not authorize it. After
+options_calculate_multileg_price returns, write all five trigger rows. When all
+five are false, the next action is the final hold summary, never
+orders_submit_multileg. Do not invent cancellation or reversal of an order.
+
+After every iteration, provide a short factual summary of the tool evidence,
+the decision, and any submitted order identifiers. Do not imply that an order
+filled unless the returned status proves it. Do not substitute stock, a
+single-leg option, a vertical spread, or any other structure for the required
+four-leg iron condor.
+""".strip()
+
+
+class AIIronCondorStrategy(Strategy):
+    def initialize(self):
+        self.sleeptime = "1D"
+        self.agents.create(name="iron_condor", model="gemini-3.5-flash-lite", allow_trading=True, system_prompt=IRON_CONDOR_SYSTEM_PROMPT)
+
+    def on_trading_iteration(self):
+        self.agents["iron_condor"].run(
+            task_prompt=(
+                "Run the complete SPY iron-condor workflow for this iteration. "
+                "Before any opening submission, repeat options_get_greeks for the exact two proposed sell_to_open strikes, then use the exact net_limit_price returned by options_calculate_multileg_price. No exact verification or any mismatch means no trade."
+                " For an existing position, calculate the close, complete all five trigger rows, and never submit or claim cancellation when every row is false."
+            ),
+            context={"current_datetime": self.get_datetime().isoformat()},
+        )
+
+
+if __name__ == "__main__":
+    backtesting_end = datetime.fromisoformat(os.environ.get("BACKTESTING_END", datetime.now().date().isoformat()))
+    backtesting_start = datetime.fromisoformat(os.environ.get("BACKTESTING_START", (backtesting_end - timedelta(days=7)).date().isoformat()))
+    AIIronCondorStrategy.backtest(
+        None,
+        backtesting_start=backtesting_start,
+        backtesting_end=backtesting_end,
+        benchmark_asset="SPY",
+        budget=100_000,
+    )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.82",
+    version="4.5.83",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_agent_options_builtins.py
+++ b/tests/test_agent_options_builtins.py
@@ -1,0 +1,200 @@
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from lumibot.components.agents import AgentManager, BuiltinTools
+from lumibot.components.agents.runtime import _wrap_tool_callable
+from lumibot.entities import Order
+from lumibot.entities.chains import Chains
+
+
+class _OptionsStrategy:
+    is_backtesting = True
+    parameters = {}
+
+    def __init__(self):
+        self.submissions = []
+
+    def get_datetime(self):
+        return datetime(2026, 8, 3, tzinfo=timezone.utc)
+
+    def log_message(self, *args, **kwargs):
+        return None
+
+    def get_positions(self, include_cash_positions=True):
+        return []
+
+    def get_cash(self):
+        return 100_000.0
+
+    def get_portfolio_value(self):
+        return 100_000.0
+
+    def get_last_price(self, asset, quote=None, exchange=None):
+        return 630.0
+
+    def get_chains(self, asset):
+        return Chains(
+            {
+                "Multiplier": 100,
+                "Exchange": "SMART",
+                "Chains": {
+                    "CALL": {"2026-09-18": [640.0, 645.0, 650.0]},
+                    "PUT": {"2026-09-18": [610.0, 615.0, 620.0]},
+                },
+            }
+        )
+
+    def get_greeks(self, asset, **kwargs):
+        return {"delta": 0.16 if str(asset.right).upper() == "CALL" else -0.16, "theta": -0.04}
+
+    def get_quote(self, asset, quote=None, exchange=None):
+        if float(asset.strike) in {610.0, 650.0}:
+            return SimpleNamespace(bid=0.45, ask=0.55)
+        return SimpleNamespace(bid=1.45, ask=1.55)
+
+    def create_order(self, asset, quantity, side, **kwargs):
+        return Order(
+            strategy="agent-options-test",
+            asset=asset,
+            quantity=quantity,
+            side=side,
+            time_in_force=kwargs.get("time_in_force", "day"),
+        )
+
+    def submit_order(self, orders, **kwargs):
+        self.submissions.append((orders, kwargs))
+        return orders
+
+
+def _wrapped_tools(strategy, definitions):
+    manager = AgentManager(strategy)
+    context = {
+        "agent_name": "options-agent",
+        "model_call_id": "options-test-call",
+        "enforce_order_readiness": True,
+        "tool_calls": [],
+    }
+    return {
+        definition.name: _wrap_tool_callable(definition.binder(strategy, manager), context)
+        for definition in definitions
+    }
+
+
+def _iron_condor_legs():
+    return [
+        {"symbol": "SPY", "expiration": "2026-09-18", "strike": 610, "right": "put", "quantity": 1, "side": "buy_to_open"},
+        {"symbol": "SPY", "expiration": "2026-09-18", "strike": 615, "right": "put", "quantity": 1, "side": "sell_to_open"},
+        {"symbol": "SPY", "expiration": "2026-09-18", "strike": 645, "right": "call", "quantity": 1, "side": "sell_to_open"},
+        {"symbol": "SPY", "expiration": "2026-09-18", "strike": 650, "right": "call", "quantity": 1, "side": "buy_to_open"},
+    ]
+
+
+def test_default_agent_tools_expose_generic_option_discovery_and_multileg_execution():
+    names = {definition.name for definition in BuiltinTools.all()}
+
+    assert {
+        "options_get_chain",
+        "options_get_strikes",
+        "options_get_greeks",
+        "options_find_strike_for_delta",
+        "options_evaluate_market",
+        "options_calculate_multileg_price",
+        "orders_submit_multileg",
+    }.issubset(names)
+    assert not any("condor" in name for name in names)
+
+
+def test_option_chain_and_contract_tools_return_exact_listed_contract_data():
+    strategy = _OptionsStrategy()
+    tools = _wrapped_tools(
+        strategy,
+        [
+            BuiltinTools.options.get_chain(),
+            BuiltinTools.options.get_strikes(),
+            BuiltinTools.options.get_greeks(),
+        ],
+    )
+
+    chain = tools["options_get_chain"](symbol="SPY")
+    strikes = tools["options_get_strikes"](
+        symbol="SPY",
+        expiration="2026-09-18",
+        right="put",
+    )
+    greeks = tools["options_get_greeks"](
+        symbol="SPY",
+        expiration="2026-09-18",
+        strike=615,
+        right="put",
+    )
+
+    assert chain["call_expirations"] == ["2026-09-18"]
+    assert chain["calls"]["2026-09-18"]["strike_count"] == 3
+    assert strikes["strikes"] == [610.0, 615.0, 620.0]
+    assert greeks["greeks"]["delta"] == -0.16
+
+
+def test_multileg_price_preserves_opening_side_direction():
+    strategy = _OptionsStrategy()
+    tool = BuiltinTools.options.calculate_multileg_price().binder(strategy, AgentManager(strategy))
+
+    result = tool.function(legs_json=json.dumps(_iron_condor_legs()), price_style="mid")
+
+    assert result["available"] is True
+    assert result["net_limit_price"] == -2.0
+    assert result["order_type"] == "credit"
+
+
+def test_multileg_submit_creates_one_atomic_four_leg_order_after_normal_readiness_checks():
+    strategy = _OptionsStrategy()
+    tools = _wrapped_tools(
+        strategy,
+        [
+            BuiltinTools.account.positions(),
+            BuiltinTools.account.portfolio(),
+            BuiltinTools.market.last_price(),
+            BuiltinTools.orders.submit_multileg(),
+        ],
+    )
+    tools["account_portfolio"]()
+    tools["account_positions"]()
+    tools["market_last_price"](symbol="SPY")
+
+    result = tools["orders_submit_multileg"](
+        legs_json=json.dumps(_iron_condor_legs()),
+        price_style="mid",
+    )
+
+    assert result["order_type"] == "credit"
+    assert len(result["submitted"]) == 4
+    assert len(strategy.submissions) == 1
+    orders, kwargs = strategy.submissions[0]
+    assert [str(order.side) for order in orders] == [
+        "buy_to_open",
+        "sell_to_open",
+        "sell_to_open",
+        "buy_to_open",
+    ]
+    assert kwargs["is_multileg"] is True
+    assert kwargs["order_type"] == "credit"
+    assert kwargs["price"] == 2.0
+
+
+def test_generic_option_tool_schemas_are_gemini_function_declaration_compatible():
+    from google.adk.tools.function_tool import FunctionTool
+
+    strategy = _OptionsStrategy()
+    manager = AgentManager(strategy)
+    for definition in [
+        BuiltinTools.options.get_chain(),
+        BuiltinTools.options.get_strikes(),
+        BuiltinTools.options.get_greeks(),
+        BuiltinTools.options.find_strike_for_delta(),
+        BuiltinTools.options.evaluate_market(),
+        BuiltinTools.options.calculate_multileg_price(),
+        BuiltinTools.orders.submit_multileg(),
+    ]:
+        bound = definition.binder(strategy, manager)
+        declaration = FunctionTool(_wrap_tool_callable(bound))._get_declaration().model_dump(exclude_none=True)
+        assert "additional_properties" not in str(declaration)

--- a/tests/test_agent_runtime_provider_keys.py
+++ b/tests/test_agent_runtime_provider_keys.py
@@ -12,7 +12,6 @@ from lumibot.components.agents.runtime import (
     _aggregate_usage_metadata,
     _resolve_model_for_adk,
     _strip_thought_parts_from_litellm_request,
-    _supports_explicit_temperature_for_adk_model,
     _sync_together_api_key_alias,
     _sync_xai_api_key_alias,
     _classify_agent_error,
@@ -463,18 +462,3 @@ def test_gemini_native_path_uses_plain_model_id_for_implicit_or_adk_context_cach
     # only for LiteLLM providers; Gemini implicit caching and ADK explicit
     # ContextCacheConfig are configured outside the LiteLLM wrapper.
     assert _resolve_model_for_adk("gemini-3.1-pro-preview", prompt_cache_key="stable-prefix-key") == "gemini-3.1-pro-preview"
-
-
-def test_explicit_temperature_only_sent_to_gemini_native_models():
-    assert _supports_explicit_temperature_for_adk_model("gemini-3.1-pro-preview") is True
-    assert _supports_explicit_temperature_for_adk_model("models/gemini-3.1-pro-preview") is True
-
-    # GPT-5/reasoning-class OpenAI models reject custom temperature values; the
-    # provider default is the only accepted value.
-    assert _supports_explicit_temperature_for_adk_model("openai/gpt-5.4") is False
-    assert _supports_explicit_temperature_for_adk_model("openai/gpt-5.4-mini") is False
-    assert _supports_explicit_temperature_for_adk_model("xai/grok-4.20-0309-reasoning") is False
-    assert _supports_explicit_temperature_for_adk_model("anthropic/claude-opus-4-7") is False
-    assert _supports_explicit_temperature_for_adk_model("deepseek/deepseek-v4-flash") is False
-    assert _supports_explicit_temperature_for_adk_model("together_ai/moonshotai/Kimi-K2.6") is False
-    assert _supports_explicit_temperature_for_adk_model("cerebras/gpt-oss-120b") is False


### PR DESCRIPTION
## What
- Add generic option-chain, contract inspection, delta strike, signed multi-leg pricing, and atomic multi-leg order tools for LumiBot AI agents.
- Add the minimal AI-only iron condor example with all trading decisions owned by the agent prompt.
- Remove temperature from active model requests.

## Why
Enable AI-only options strategies without deterministic Python trade construction while keeping the agent tools reusable across option structures.

## Risk
Medium. This expands agent tool access to existing broker and order paths. Existing strategy revisions remain pinned to their selected models.

## Tests
- Targeted AI/options tests: 76 passed, 2 skipped.
- Full local non-API/non-downloader suite was attempted with the documented 15-minute guard and timed out during a slow test without emitting a failure. Required PR CI remains the merge gate.

## Docs
- Updated agent tool documentation, example catalog, and CHANGELOG.
- No architecture diagram is needed for this tool/reference and example change.

## Prompts
- Added the complete AI-only iron condor system prompt in the new example.
- BotSpot Agent skill and routing updates are maintained in the BotSpot Agent repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in AI tools for option-chain discovery, strike selection, Greeks, market-quality checks, delta-based searches, and multi-leg pricing.
  * Added atomic multi-leg order submission with market or calculated limit pricing.
  * Added an AI-driven SPY Iron Condor example with backtesting support.
  * Option positions now include detailed pricing, market value, and profit/loss information.

* **Documentation**
  * Expanded AI agent tool guidance, trading-readiness requirements, multi-leg workflows, and option position details.
  * Added the Iron Condor example to the documentation index.

* **Improvements**
  * Model requests now use provider default settings for temperature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->