### PR TITLE
Fix Yahoo auto-adjusted OHLC handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Yahoo backtests retain complete OHLC data when automatic adjustment is
+  enabled.** The adjustment mode now reaches yfinance directly, and adjusted
+  and unadjusted responses use separate cache entries.
+
 ## 4.5.83 - 2026-08-05
 
 Deploy marker: `deploy 4.5.83`

--- a/docs/BACKTESTING_ARCHITECTURE.md
+++ b/docs/BACKTESTING_ARCHITECTURE.md
@@ -211,8 +211,10 @@ DataSource (ABC)
 **Flow:**
 1. `YahooDataBacktesting` inherits from `YahooData`
 2. `YahooData` uses `YahooHelper` to fetch data via `yfinance` library
-3. Data is **already split-adjusted** by Yahoo
-4. No additional split processing needed
+3. `auto_adjust` is passed through to `yfinance`, so adjusted OHLC values come
+   directly from Yahoo rather than being reconstructed from `Adj Close`
+4. Adjusted and unadjusted responses use separate cache files
+5. No additional split processing is needed for adjusted data
 
 **Key Function:** `YahooHelper.get_historical_prices()`
 

--- a/docsrc/backtesting.yahoo.rst
+++ b/docsrc/backtesting.yahoo.rst
@@ -7,6 +7,10 @@ Yahoo
 
 Yahoo backtesting is so named because we get data for the backtesting from the Yahoo Finance website. The user is not required to supply data. Any stock information that is available in the Yahoo Finance API should be available for backtesting. The Yahoo backtester is only for stock data (including ETFs). Additionally, you cannot use the Yahoo backtester for intra-day trading, it is for daily trading only. For other securities, use the Polygon or Pandas backtesters.
 
+When ``auto_adjust`` is enabled, LumiBot asks Yahoo Finance for adjusted OHLC
+data directly. Adjusted and unadjusted responses are cached separately so that
+switching this option cannot reuse prices from the other mode.
+
 Using Yahoo backtester, you can also run backtests very easily on your strategies, you do not have to modify anything in your strategies.
 
 To use the Yahoo backtester, you must import the ``YahooDataBacktesting`` and ``BacktestingBroker`` objects.

--- a/lumibot/data_sources/yahoo_data.py
+++ b/lumibot/data_sources/yahoo_data.py
@@ -343,6 +343,8 @@ class YahooData(DataSourceBacktesting):
                 auto_adjust=self.auto_adjust
             )
             for symbol, df in dfs.items():
+                if df is None:
+                    continue
                 # Find the corresponding asset for this symbol
                 for asset in assets:
                     asset_symbol = asset.symbol

--- a/lumibot/tools/yahoo_helper.py
+++ b/lumibot/tools/yahoo_helper.py
@@ -349,20 +349,28 @@ class YahooHelper:
             item = YahooHelper.download_symbol_data(symbols[0], interval, auto_adjust=auto_adjust)
             return {symbols[0]: item}
 
-        result = {}
+        result = {symbol: None for symbol in symbols}
         proxy = YahooHelper.sleep_and_get_proxy()
         if proxy:
             yf.set_config(proxy=proxy)
         tickers = yf.Tickers(" ".join(symbols))
-        df_yf = tickers.history(
-            period="max",
-            group_by="ticker",
-            auto_adjust=auto_adjust,
-            progress=False
-        )
+        history_kwargs = {
+            "interval": interval,
+            "group_by": "ticker",
+            "auto_adjust": auto_adjust,
+            "progress": False,
+        }
+        if interval == "1m":
+            history_kwargs["start"] = get_lumibot_datetime() - timedelta(days=7)
+        elif interval == "15m":
+            history_kwargs["start"] = get_lumibot_datetime() - timedelta(days=60)
+        else:
+            history_kwargs["period"] = "max"
+
+        df_yf = tickers.history(**history_kwargs)
 
         if df_yf is None or df_yf.empty:
-            return {symbol: None for symbol in symbols}
+            return result
 
         if isinstance(df_yf.columns, pd.MultiIndex):
             # group_by="ticker" normally puts symbols on level 0.  Accept the

--- a/lumibot/tools/yahoo_helper.py
+++ b/lumibot/tools/yahoo_helper.py
@@ -19,12 +19,22 @@ INFO_DATA = "info"
 INVALID_SYMBOLS = set()
 
 
+def _cache_file_name(symbol, data_type, auto_adjust=False):
+    """Return a cache name that keeps adjusted and unadjusted bars separate."""
+    normalized_type = data_type.lower()
+    if normalized_type == INFO_DATA:
+        return f"{symbol}_{normalized_type}.pickle"
+
+    adjustment = "adjusted" if auto_adjust else "unadjusted"
+    return f"{symbol}_{normalized_type}_{adjustment}.pickle"
+
+
 class _YahooData:
-    def __init__(self, symbol, type, data):
+    def __init__(self, symbol, type, data, auto_adjust=False):
         self.symbol = symbol
         self.type = type.lower()
         self.data = data
-        self.file_name = f"{symbol}_{type.lower()}.pickle"
+        self.file_name = _cache_file_name(symbol, type, auto_adjust)
 
     def is_up_to_date(self, last_needed_datetime=None):
         if last_needed_datetime is None:
@@ -82,9 +92,9 @@ class YahooHelper:
     # ====================Caching methods=================================
 
     @staticmethod
-    def check_pickle_file(symbol, type):
+    def check_pickle_file(symbol, type, auto_adjust=False):
         if YahooHelper.CACHING_ENABLED:
-            file_name = f"{symbol}_{type.lower()}.pickle"
+            file_name = _cache_file_name(symbol, type, auto_adjust)
             pickle_file_path = os.path.join(YahooHelper.LUMIBOT_YAHOO_CACHE_FOLDER, file_name)
 
             # CI/prod-like backtests start with empty disks. If the remote S3 cache is enabled,
@@ -112,10 +122,10 @@ class YahooHelper:
         return None
 
     @staticmethod
-    def dump_pickle_file(symbol, type, data):
+    def dump_pickle_file(symbol, type, data, auto_adjust=False):
         if YahooHelper.CACHING_ENABLED:
-            yahoo_data = _YahooData(symbol, type, data)
-            file_name = "%s_%s.pickle" % (symbol, type.lower())
+            yahoo_data = _YahooData(symbol, type, data, auto_adjust=auto_adjust)
+            file_name = _cache_file_name(symbol, type, auto_adjust)
             pickle_file_path = os.path.join(YahooHelper.LUMIBOT_YAHOO_CACHE_FOLDER, file_name)
             with open(pickle_file_path, "wb") as f:
                 pickle.dump(yahoo_data, f)
@@ -136,24 +146,27 @@ class YahooHelper:
         if df is None or df.empty:
             return df
 
+        # Do not mutate a cached frame.  yfinance already returns adjusted OHLC
+        # columns when auto_adjust=True.  Older yfinance releases exposed
+        # Adj Open/High/Low instead; only translate that complete legacy set.
+        # In particular, an Adj Close-only frame must not be treated as a source
+        # for fabricated adjusted OHLC values.
+        df = df.copy()
+
         if auto_adjust:
-            del df["Close"]
-            del df["Open"]
-            del df["High"]
-            del df["Low"]
-            df.rename(
-                columns={
-                    "Adj Close": "Close",
-                    "Adj Open": "Open",
-                    "Adj High": "High",
-                    "Adj Low": "Low",
-                },
-                inplace=True,
-            )
+            adjusted_columns = {"Adj Open", "Adj High", "Adj Low", "Adj Close"}
+            if adjusted_columns.issubset(df.columns):
+                df = df.drop(columns=["Open", "High", "Low", "Close"], errors="ignore")
+                df = df.rename(
+                    columns={
+                        "Adj Close": "Close",
+                        "Adj Open": "Open",
+                        "Adj High": "High",
+                        "Adj Low": "Low",
+                    }
+                )
         else:
-            for col in ["Adj Open", "Adj High", "Adj Low"]:
-                if col in df.columns:
-                    del df[col]
+            df = df.drop(columns=["Adj Open", "Adj High", "Adj Low"], errors="ignore")
 
         return df
 
@@ -226,7 +239,7 @@ class YahooHelper:
         return df["Close"].iloc[-1]
 
     @staticmethod
-    def download_symbol_data(symbol, interval="1d"):
+    def download_symbol_data(symbol, interval="1d", auto_adjust=False):
         """
         Attempts to download historical data from yfinance for the specified symbol and interval.
         Retries on empty/None data in case of transient rate limits.
@@ -255,19 +268,19 @@ class YahooHelper:
                     df = ticker.history(
                         interval=interval,
                         start=get_lumibot_datetime() - timedelta(days=7),
-                        auto_adjust=False
+                        auto_adjust=auto_adjust,
                     )
                 elif interval == "15m":
                     df = ticker.history(
                         interval=interval,
                         start=get_lumibot_datetime() - timedelta(days=60),
-                        auto_adjust=False
+                        auto_adjust=auto_adjust,
                     )
                 else:
                     df = ticker.history(
                         interval=interval,
                         period="max",
-                        auto_adjust=False
+                        auto_adjust=auto_adjust,
                     )
             except Exception as e:
                 logger.debug(f"{symbol}: Exception from ticker.history(): {e}")
@@ -331,9 +344,9 @@ class YahooHelper:
         return df
 
     @staticmethod
-    def download_symbols_data(symbols, interval="1d"):
+    def download_symbols_data(symbols, interval="1d", auto_adjust=False):
         if len(symbols) == 1:
-            item = YahooHelper.download_symbol_data(symbols[0], interval)
+            item = YahooHelper.download_symbol_data(symbols[0], interval, auto_adjust=auto_adjust)
             return {symbols[0]: item}
 
         result = {}
@@ -344,12 +357,20 @@ class YahooHelper:
         df_yf = tickers.history(
             period="max",
             group_by="ticker",
-            auto_adjust=False,
+            auto_adjust=auto_adjust,
             progress=False
         )
 
-        for i in df_yf.columns.levels[0]:
-            result[i] = YahooHelper.process_df(df_yf[i])
+        if df_yf is None or df_yf.empty:
+            return {symbol: None for symbol in symbols}
+
+        if isinstance(df_yf.columns, pd.MultiIndex):
+            # group_by="ticker" normally puts symbols on level 0.  Accept the
+            # alternate level ordering emitted by some yfinance versions too.
+            symbol_level = 0 if set(symbols).intersection(df_yf.columns.get_level_values(0)) else 1
+            for symbol in symbols:
+                if symbol in df_yf.columns.get_level_values(symbol_level):
+                    result[symbol] = YahooHelper.process_df(df_yf.xs(symbol, level=symbol_level, axis=1))
 
         return result
 
@@ -370,42 +391,47 @@ class YahooHelper:
         return data
 
     @staticmethod
-    def fetch_symbol_data(symbol, caching=True, last_needed_datetime=None, interval="1d"):
+    def fetch_symbol_data(
+        symbol, caching=True, last_needed_datetime=None, interval="1d", auto_adjust=False
+    ):
         if caching:
-            cached_data = YahooHelper.check_pickle_file(symbol, interval)
+            cached_data = YahooHelper.check_pickle_file(symbol, interval, auto_adjust=auto_adjust)
             if cached_data:
                 if cached_data.is_up_to_date(last_needed_datetime=last_needed_datetime):
                     return cached_data.data
 
         # Caching is disabled or no previous data found
         # or data found not up to date
-        data = YahooHelper.download_symbol_data(symbol, interval)
+        data = YahooHelper.download_symbol_data(symbol, interval, auto_adjust=auto_adjust)
 
         # Check if the data is empty
         if data is None or data.empty:
             return data
 
-        YahooHelper.dump_pickle_file(symbol, interval, data)
+        YahooHelper.dump_pickle_file(symbol, interval, data, auto_adjust=auto_adjust)
         return data
 
     @staticmethod
-    def fetch_symbols_data(symbols, interval, caching=True):
+    def fetch_symbols_data(symbols, interval, caching=True, auto_adjust=False):
         result = {}
         missing_symbols = symbols.copy()
 
         if caching:
             for symbol in symbols:
-                cached_data = YahooHelper.check_pickle_file(symbol, interval)
+                cached_data = YahooHelper.check_pickle_file(symbol, interval, auto_adjust=auto_adjust)
                 if cached_data:
                     if cached_data.is_up_to_date():
                         result[symbol] = cached_data.data
                         missing_symbols.remove(symbol)
 
         if missing_symbols:
-            missing_data = YahooHelper.download_symbols_data(missing_symbols, interval)
+            missing_data = YahooHelper.download_symbols_data(
+                missing_symbols, interval, auto_adjust=auto_adjust
+            )
             for symbol, data in missing_data.items():
                 result[symbol] = data
-                YahooHelper.dump_pickle_file(symbol, interval, data)
+                if data is not None and not data.empty:
+                    YahooHelper.dump_pickle_file(symbol, interval, data, auto_adjust=auto_adjust)
 
         return result
 
@@ -429,25 +455,26 @@ class YahooHelper:
                 interval=interval,
                 caching=caching,
                 last_needed_datetime=last_needed_datetime,
+                auto_adjust=auto_adjust,
             )
-            # Pass the received auto_adjust value to format_df
             return YahooHelper.format_df(df, auto_adjust)
         else:
             raise ValueError("Unknown interval %s" % interval)
 
     @staticmethod
     def get_symbols_data(symbols, interval="1d", auto_adjust=True, caching=True):
-        result = YahooHelper.fetch_symbols_data(symbols, interval=interval, caching=caching)
+        if interval not in ["1m", "15m", "1d"]:
+            raise ValueError("Unknown interval %s" % interval)
+
+        result = YahooHelper.fetch_symbols_data(
+            symbols,
+            interval=interval,
+            auto_adjust=auto_adjust,
+            caching=caching,
+        )
         for key, df in result.items():
             result[key] = YahooHelper.format_df(df, auto_adjust)
         return result
-
-    @staticmethod
-    def get_symbols_data(symbols, interval="1d", auto_adjust=True, caching=True):
-        if interval in ["1m", "15m", "1d"]:
-            return YahooHelper.get_symbols_data(symbols, interval=interval, auto_adjust=auto_adjust, caching=caching)
-        else:
-            raise ValueError("Unknown interval %s" % interval)
 
     @staticmethod
     def get_symbol_dividends(symbol, caching=True):

--- a/lumibot/tools/yahoo_helper.py
+++ b/lumibot/tools/yahoo_helper.py
@@ -496,6 +496,9 @@ class YahooHelper:
         result = {}
         data = YahooHelper.get_symbols_data(symbols, caching=caching)
         for symbol, df in data.items():
+            if df is None:
+                result[symbol] = None
+                continue
             dividends = df["Dividends"]
             result[symbol] = dividends[dividends != 0].dropna()
 
@@ -513,6 +516,9 @@ class YahooHelper:
         result = {}
         data = YahooHelper.get_symbols_data(symbols, caching=caching)
         for symbol, df in data.items():
+            if df is None:
+                result[symbol] = None
+                continue
             splits = df["Stock Splits"]
             result[symbol] = splits[splits != 0].dropna()
 
@@ -530,6 +536,9 @@ class YahooHelper:
         result = {}
         data = YahooHelper.get_symbols_data(symbols, caching=caching)
         for symbol, df in data.items():
+            if df is None:
+                result[symbol] = None
+                continue
             actions = df[["Dividends", "Stock Splits"]]
             result[symbol] = actions[actions != 0].dropna(how="all").fillna(0)
 

--- a/lumibot/tools/yahoo_helper.py
+++ b/lumibot/tools/yahoo_helper.py
@@ -378,7 +378,11 @@ class YahooHelper:
             symbol_level = 0 if set(symbols).intersection(df_yf.columns.get_level_values(0)) else 1
             for symbol in symbols:
                 if symbol in df_yf.columns.get_level_values(symbol_level):
-                    result[symbol] = YahooHelper.process_df(df_yf.xs(symbol, level=symbol_level, axis=1))
+                    symbol_data = YahooHelper.process_df(
+                        df_yf.xs(symbol, level=symbol_level, axis=1)
+                    )
+                    if not symbol_data.empty:
+                        result[symbol] = symbol_data
 
         return result
 

--- a/tests/test_yahoo_helper_auto_adjust.py
+++ b/tests/test_yahoo_helper_auto_adjust.py
@@ -153,3 +153,33 @@ def test_yahoo_batch_download_preserves_interval_and_missing_symbols(monkeypatch
     ]
     assert list(result["SPY"].columns) == ["Open", "High", "Low", "Close", "Volume"]
     assert result["QQQ"] is None
+
+
+def test_yahoo_batch_actions_preserve_missing_symbols(monkeypatch):
+    """Public action helpers must propagate explicit absence from partial responses."""
+    frame = pd.DataFrame(
+        {
+            "Dividends": [0.0, 1.25],
+            "Stock Splits": [2.0, 0.0],
+        },
+        index=pd.DatetimeIndex(["2025-01-01", "2025-01-02"]),
+    )
+    monkeypatch.setattr(
+        YahooHelper,
+        "get_symbols_data",
+        staticmethod(lambda symbols, caching=True: {"SPY": frame, "QQQ": None}),
+    )
+
+    dividends = YahooHelper.get_symbols_dividends(["SPY", "QQQ"])
+    splits = YahooHelper.get_symbols_splits(["SPY", "QQQ"])
+    actions = YahooHelper.get_symbols_actions(["SPY", "QQQ"])
+
+    assert dividends["SPY"].to_list() == [1.25]
+    assert splits["SPY"].to_list() == [2.0]
+    assert actions["SPY"].to_dict("list") == {
+        "Dividends": [0.0, 1.25],
+        "Stock Splits": [2.0, 0.0],
+    }
+    assert dividends["QQQ"] is None
+    assert splits["QQQ"] is None
+    assert actions["QQQ"] is None

--- a/tests/test_yahoo_helper_auto_adjust.py
+++ b/tests/test_yahoo_helper_auto_adjust.py
@@ -5,6 +5,7 @@ import pytest
 import pytz
 
 from lumibot.backtesting import YahooDataBacktesting
+from lumibot.entities import Asset
 from lumibot.tools import yahoo_helper
 from lumibot.tools.yahoo_helper import YahooHelper
 
@@ -183,3 +184,37 @@ def test_yahoo_batch_actions_preserve_missing_symbols(monkeypatch):
     assert dividends["QQQ"] is None
     assert splits["QQQ"] is None
     assert actions["QQQ"] is None
+
+
+def test_yahoo_data_source_skips_missing_batch_frames(monkeypatch):
+    """A partial batch response must not pass missing data into the data store."""
+    eastern = pytz.timezone("America/New_York")
+    source = YahooDataBacktesting(
+        datetime_start=eastern.localize(datetime(2025, 1, 1)),
+        datetime_end=eastern.localize(datetime(2025, 1, 3)),
+        show_progress_bar=False,
+    )
+    spy = Asset("SPY")
+    qqq = Asset("QQQ")
+    frame = pd.DataFrame(
+        {"Open": [101.0], "High": [103.0], "Low": [99.0], "Close": [102.0], "Volume": [1000]},
+        index=pd.DatetimeIndex(["2025-01-02 16:00:00-05:00"]),
+    )
+    appended = []
+
+    monkeypatch.setattr(
+        YahooHelper,
+        "get_symbols_data",
+        staticmethod(lambda symbols, interval, auto_adjust: {"SPY": frame, "QQQ": None}),
+    )
+    monkeypatch.setattr(source, "_append_data", lambda asset, data: appended.append((asset, data)))
+    monkeypatch.setattr(
+        source,
+        "_pull_source_symbol_bars",
+        lambda asset, length, timestep, timeshift: asset.symbol,
+    )
+
+    result = source._pull_source_bars([spy, qqq], length=1, timestep="day")
+
+    assert appended == [(spy, frame)]
+    assert result == {spy: "SPY", qqq: "QQQ"}

--- a/tests/test_yahoo_helper_auto_adjust.py
+++ b/tests/test_yahoo_helper_auto_adjust.py
@@ -1,6 +1,7 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pandas as pd
+import pytest
 import pytz
 
 from lumibot.backtesting import YahooDataBacktesting
@@ -114,28 +115,41 @@ def test_yahoo_auto_adjust_keeps_ohlcv_and_separates_cache_modes(monkeypatch, tm
         assert data_source.get_last_price("SPY", timestep="day") == expected_open
 
 
-def test_yahoo_batch_fetch_passes_adjustment_mode_without_recursing(monkeypatch):
-    """The multi-asset data-source path must use the same adjustment mode."""
-    frame = pd.DataFrame(
+@pytest.mark.parametrize(("interval", "lookback_days"), [("1m", 7), ("15m", 60)])
+def test_yahoo_batch_download_preserves_interval_and_missing_symbols(monkeypatch, interval, lookback_days):
+    """Bulk requests must preserve intraday bounds and explicit per-symbol absence."""
+    now = pytz.UTC.localize(datetime(2025, 1, 8, 12))
+    index = pd.DatetimeIndex(["2025-01-08 11:00:00+00:00"])
+    # Exercise the alternate yfinance layout with fields on level 0 and symbols on level 1.
+    columns = pd.MultiIndex.from_tuples([(field, "SPY") for field in ("Open", "High", "Low", "Close", "Volume")])
+    response = pd.DataFrame([[101.0, 103.0, 99.0, 102.0, 1000]], index=index, columns=columns)
+    history_calls = []
+
+    class FakeTickers:
+        def history(self, **kwargs):
+            history_calls.append(kwargs)
+            return response.copy()
+
+    class FakeBatchYFinance:
+        @staticmethod
+        def Tickers(symbols):
+            assert symbols == "SPY QQQ"
+            return FakeTickers()
+
+    monkeypatch.setattr(yahoo_helper, "yf", FakeBatchYFinance())
+    monkeypatch.setattr(yahoo_helper, "get_lumibot_datetime", lambda: now)
+    monkeypatch.setattr(YahooHelper, "sleep_and_get_proxy", staticmethod(lambda: None))
+
+    result = YahooHelper.download_symbols_data(["SPY", "QQQ"], interval=interval, auto_adjust=True)
+
+    assert history_calls == [
         {
-            "Open": [101.0],
-            "High": [103.0],
-            "Low": [99.0],
-            "Close": [102.0],
-            "Volume": [1000],
-        },
-        index=pd.DatetimeIndex(["2025-01-01 16:00:00-05:00"]),
-    )
-    calls = []
-
-    def fetch_symbols_data(symbols, interval, caching=True, auto_adjust=False):
-        calls.append((symbols, interval, caching, auto_adjust))
-        return {symbol: frame.copy() for symbol in symbols}
-
-    monkeypatch.setattr(YahooHelper, "fetch_symbols_data", staticmethod(fetch_symbols_data))
-
-    result = YahooHelper.get_symbols_data(["SPY", "QQQ"], auto_adjust=True, caching=False)
-
-    assert calls == [(["SPY", "QQQ"], "1d", False, True)]
-    assert set(result) == {"SPY", "QQQ"}
+            "interval": interval,
+            "group_by": "ticker",
+            "auto_adjust": True,
+            "progress": False,
+            "start": now - timedelta(days=lookback_days),
+        }
+    ]
     assert list(result["SPY"].columns) == ["Open", "High", "Low", "Close", "Volume"]
+    assert result["QQQ"] is None

--- a/tests/test_yahoo_helper_auto_adjust.py
+++ b/tests/test_yahoo_helper_auto_adjust.py
@@ -1,0 +1,141 @@
+from datetime import datetime
+
+import pandas as pd
+import pytz
+
+from lumibot.backtesting import YahooDataBacktesting
+from lumibot.tools import yahoo_helper
+from lumibot.tools.yahoo_helper import YahooHelper
+
+
+class _FakeTicker:
+    def __init__(self, symbol, frames, history_calls):
+        self.symbol = symbol
+        self._frames = frames
+        self._history_calls = history_calls
+
+    @property
+    def info(self):
+        return {}
+
+    def history(self, **kwargs):
+        auto_adjust = kwargs["auto_adjust"]
+        self._history_calls.append(auto_adjust)
+        return self._frames[auto_adjust].copy()
+
+
+class _FakeYFinance:
+    def __init__(self, frames, history_calls):
+        self._frames = frames
+        self._history_calls = history_calls
+
+    def Ticker(self, symbol):
+        return _FakeTicker(symbol, self._frames, self._history_calls)
+
+
+def test_yahoo_auto_adjust_keeps_ohlcv_and_separates_cache_modes(monkeypatch, tmp_path):
+    """Modern yfinance frames must retain OHLCV for both adjustment modes."""
+    index = pd.DatetimeIndex(["2025-01-01 16:00:00-05:00", "2025-01-02 16:00:00-05:00"])
+    frames = {
+        # yfinance's adjusted response has no Adj Open/High/Low columns.
+        True: pd.DataFrame(
+            {
+                "Open": [101.0, 102.0],
+                "High": [103.0, 104.0],
+                "Low": [99.0, 100.0],
+                "Close": [102.0, 103.0],
+                "Volume": [1000, 1100],
+                "Dividends": [0.0, 0.0],
+                "Stock Splits": [0.0, 0.0],
+                "Capital Gains": [0.0, 0.0],
+            },
+            index=index,
+        ),
+        False: pd.DataFrame(
+            {
+                "Open": [100.0, 101.0],
+                "High": [102.0, 103.0],
+                "Low": [98.0, 99.0],
+                "Close": [101.0, 102.0],
+                "Adj Close": [99.0, 100.0],
+                "Volume": [1000, 1100],
+                "Dividends": [0.0, 0.0],
+                "Stock Splits": [0.0, 0.0],
+                "Capital Gains": [0.0, 0.0],
+            },
+            index=index,
+        ),
+    }
+    history_calls = []
+    monkeypatch.setattr(yahoo_helper, "yf", _FakeYFinance(frames, history_calls))
+    monkeypatch.setattr(YahooHelper, "sleep_and_get_proxy", staticmethod(lambda: None))
+    monkeypatch.setattr(YahooHelper, "get_symbol_info", staticmethod(lambda symbol: {}))
+    monkeypatch.setattr(YahooHelper, "LUMIBOT_YAHOO_CACHE_FOLDER", str(tmp_path))
+    monkeypatch.setattr(YahooHelper, "CACHING_ENABLED", True)
+
+    eastern = pytz.timezone("America/New_York")
+    last_needed = eastern.localize(datetime(2025, 1, 2))
+    adjusted = YahooHelper.get_symbol_data("SPY", auto_adjust=True, last_needed_datetime=last_needed)
+    unadjusted = YahooHelper.get_symbol_data("SPY", auto_adjust=False, last_needed_datetime=last_needed)
+
+    ohlcv = ["Open", "High", "Low", "Close", "Volume"]
+    assert adjusted[ohlcv].to_dict("list") == {
+        "Open": [101.0, 102.0],
+        "High": [103.0, 104.0],
+        "Low": [99.0, 100.0],
+        "Close": [102.0, 103.0],
+        "Volume": [1000, 1100],
+    }
+    assert unadjusted[ohlcv].to_dict("list") == {
+        "Open": [100.0, 101.0],
+        "High": [102.0, 103.0],
+        "Low": [98.0, 99.0],
+        "Close": [101.0, 102.0],
+        "Volume": [1000, 1100],
+    }
+
+    cache_files = {path.name for path in tmp_path.glob("*.pickle")}
+    assert cache_files == {"SPY_1d_adjusted.pickle", "SPY_1d_unadjusted.pickle"}
+
+    # Repeating either request must hit its own mode-specific cache.
+    YahooHelper.get_symbol_data("SPY", auto_adjust=True, last_needed_datetime=last_needed)
+    YahooHelper.get_symbol_data("SPY", auto_adjust=False, last_needed_datetime=last_needed)
+    assert history_calls == [True, False]
+
+    # The data-source path now has a real opening price instead of None.
+    for auto_adjust, expected_open in ((True, 102.0), (False, 101.0)):
+        data_source = YahooDataBacktesting(
+            datetime_start=eastern.localize(datetime(2025, 1, 1)),
+            datetime_end=eastern.localize(datetime(2025, 1, 3)),
+            auto_adjust=auto_adjust,
+            show_progress_bar=False,
+        )
+        data_source._datetime = eastern.localize(datetime(2025, 1, 3))
+        assert data_source.get_last_price("SPY", timestep="day") == expected_open
+
+
+def test_yahoo_batch_fetch_passes_adjustment_mode_without_recursing(monkeypatch):
+    """The multi-asset data-source path must use the same adjustment mode."""
+    frame = pd.DataFrame(
+        {
+            "Open": [101.0],
+            "High": [103.0],
+            "Low": [99.0],
+            "Close": [102.0],
+            "Volume": [1000],
+        },
+        index=pd.DatetimeIndex(["2025-01-01 16:00:00-05:00"]),
+    )
+    calls = []
+
+    def fetch_symbols_data(symbols, interval, caching=True, auto_adjust=False):
+        calls.append((symbols, interval, caching, auto_adjust))
+        return {symbol: frame.copy() for symbol in symbols}
+
+    monkeypatch.setattr(YahooHelper, "fetch_symbols_data", staticmethod(fetch_symbols_data))
+
+    result = YahooHelper.get_symbols_data(["SPY", "QQQ"], auto_adjust=True, caching=False)
+
+    assert calls == [(["SPY", "QQQ"], "1d", False, True)]
+    assert set(result) == {"SPY", "QQQ"}
+    assert list(result["SPY"].columns) == ["Open", "High", "Low", "Close", "Volume"]


### PR DESCRIPTION
## Summary

- pass `auto_adjust` through the Yahoo single- and multi-symbol download paths
- keep adjusted and unadjusted history in separate cache entries
- preserve modern yfinance OHLC and explicit per-symbol absence in partial batch responses
- forward intraday intervals with Yahoo's bounded lookback windows
- document the adjustment/cache behavior and add regression coverage

Fixes #992.

## Reproduction

Against `dev`, a mocked modern yfinance response records `auto_adjust=False` even when `YahooHelper.get_symbol_data(..., auto_adjust=True)` is requested; the returned frame contains only `Close`, `Volume`, `Dividends`, and `Stock Splits`. With this change the request records `auto_adjust=True` and returns complete OHLCV data.

## Validation

- `pytest -q tests/test_yahoo_helper_auto_adjust.py tests/backtest/test_yahoo_helper_actions.py tests/test_yahoo_daily_last_price_fastpath.py` (8 passed)
- `pytest -q tests/backtest/test_yahoo.py -k no_future_bars_before_open` (1 passed, 1 deselected)
- `ruff check tests/test_yahoo_helper_auto_adjust.py`
- `ruff format --check tests/test_yahoo_helper_auto_adjust.py`
- `git diff --check`