### PR TITLE
Release LumiBot 4.5.85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 4.5.85 - Unreleased
 
+### Fixed
+- **Option orders now preserve open/close intent across brokers.** Generic
+  single-leg option buys and sells resolve centrally from signed positions and
+  active close quantities, high-level close helpers emit explicit close intent,
+  and ambiguous duplicate or zero-crossing closes fail before submission.
+  Alpaca now sends and restores `position_intent` for single-leg orders and
+  raises rejected submissions after marking the order errored.
+
 ## 4.5.84 - Unreleased
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.85 - Unreleased
+
 ## 4.5.84 - Unreleased
 
 ### Added

--- a/docs/evidence/2026-08-25-option-position-intent-red-baseline.md
+++ b/docs/evidence/2026-08-25-option-position-intent-red-baseline.md
@@ -1,0 +1,19 @@
+# Option position-intent red baseline
+
+Command:
+
+```text
+gtimeout 120s .venv/bin/python -m pytest tests/test_option_position_intent.py -q
+```
+
+Pre-fix result: **5 failed** on branch `version/4.5.85`.
+
+The failures reproduced the intended production paths:
+
+1. Alpaca's single-leg `OrderData` had no `position_intent` attribute after submitting an explicit `sell_to_close`.
+2. Alpaca parsing reconstructed broker-returned `sell_to_close` as generic `sell`.
+3. `Broker.close_position()` created a generic option `sell` rather than `sell_to_close`.
+4. A generic option sell was still submitted when an active `sell_to_close` already reserved the full long position.
+5. Alpaca submission rejection marked the order as errored but returned normally instead of raising the rejection.
+
+The complete pytest failure output was observed locally on 2026-08-25 before any product-code change. The preserved regression tests are `tests/test_option_position_intent.py`.

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -859,6 +859,12 @@ class Alpaca(Broker):
         # Quantity and side
         qty_value = getattr(response, 'qty', None) or resp_raw.get('qty')
         side_value = getattr(response, 'side', None) or resp_raw.get('side')
+        position_intent_value = (
+            getattr(response, 'position_intent', None)
+            or resp_raw.get('position_intent')
+        )
+        if mapped_asset_type == Asset.AssetType.OPTION and position_intent_value:
+            side_value = getattr(position_intent_value, "value", position_intent_value)
 
         # Determine order and class types
         order_type_value = getattr(response, 'order_type', None) or resp_raw.get('type')
@@ -1004,6 +1010,7 @@ class Alpaca(Broker):
         legs = []
         leg_quantities = []
         for order in orders:
+            self.resolve_option_order_intent(order)
             # Format option symbol
             if order.asset.asset_type == Asset.AssetType.OPTION:
                 strike_formatted = f"{order.asset.strike:08.3f}".replace('.', '').rjust(8, '0')
@@ -1014,23 +1021,13 @@ class Alpaca(Broker):
             # Determine leg side + position intent for Alpaca's mleg payload.
             # - leg.side must be "buy" or "sell"
             # - leg.position_intent must be one of: buy_to_open, buy_to_close, sell_to_open, sell_to_close
-            position_intent = getattr(order, "position_intent", None)
             raw_side = order.side
             if raw_side in ("buy_to_open", "buy_to_close"):
                 leg_side = "buy"
-                position_intent = position_intent or raw_side
             elif raw_side in ("sell_to_open", "sell_to_close"):
                 leg_side = "sell"
-                position_intent = position_intent or raw_side
             else:
-                leg_side = "buy" if order.is_buy_order() else "sell"
-                if not position_intent:
-                    # Fall back to position-based intent inference when the side doesn't encode open/close.
-                    pos = self.get_tracked_position(order.strategy, order.asset)
-                    if pos is not None and pos.quantity != 0:
-                        position_intent = "buy_to_close" if leg_side == "buy" else "sell_to_close"
-                    else:
-                        position_intent = "buy_to_open" if leg_side == "buy" else "sell_to_open"
+                raise ValueError(f"Alpaca option leg requires explicit position intent, got {raw_side}")
             # Collect leg quantities for GCD check
             leg_qty = int(abs(order.quantity))
             leg_quantities.append(leg_qty)
@@ -1038,7 +1035,7 @@ class Alpaca(Broker):
                 "symbol": option_symbol,
                 "ratio_qty": str(order.quantity),
                 "side": leg_side,
-                "position_intent": position_intent
+                "position_intent": str(raw_side)
             })
         # Ensure leg ratio quantities are relatively prime (GCD == 1)
         from functools import reduce
@@ -1194,6 +1191,8 @@ class Alpaca(Broker):
             "trail_price": str(trail_price) if trail_price is not None else None,
             "trail_percent": str(trail_percent) if trail_percent is not None else None,
         }
+        if order.asset.asset_type == Asset.AssetType.OPTION:
+            kwargs["position_intent"] = str(order.side)
         # Remove items with None values
         kwargs = {k: v for k, v in kwargs.items() if v}
 
@@ -1298,6 +1297,8 @@ class Alpaca(Broker):
                         color="red",
                     )
                 )
+
+            raise
 
         return order
 

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -2635,8 +2635,106 @@ class Broker(ABC):
 
     def submit_order(self, order) -> Order:
         """Conform an order for an asset to broker constraints and submit it."""
+        self.resolve_option_order_intent(order)
         self._conform_order(order)
         return self._submit_order(order)
+
+    def resolve_option_order_intent(
+        self,
+        order: Order,
+        additional_active_orders: list[Order] | None = None,
+    ) -> Order:
+        """Resolve a single-leg option order to an explicit open/close side.
+
+        Explicit ``*_to_open``/``*_to_close`` sides are preserved. Generic
+        ``buy``/``sell`` sides remain supported for backwards compatibility,
+        but are resolved here once using the tracked position and active orders.
+        An order that would over-close or duplicate a fully reserved close is
+        rejected instead of silently crossing through zero into a new position.
+        """
+        if getattr(getattr(order, "asset", None), "asset_type", None) != "option":
+            return order
+
+        side = Order.OrderSide(order.side)
+        explicit_sides = {
+            Order.OrderSide.BUY_TO_OPEN,
+            Order.OrderSide.BUY_TO_CLOSE,
+            Order.OrderSide.SELL_TO_OPEN,
+            Order.OrderSide.SELL_TO_CLOSE,
+        }
+        if side not in explicit_sides and side not in {
+            Order.OrderSide.BUY,
+            Order.OrderSide.SELL,
+        }:
+            raise ValueError(f"Unsupported option order side: {side}")
+
+        position = self.get_tracked_position(order.strategy, order.asset)
+        position_quantity = float(position.quantity) if position is not None else 0.0
+        close_side = None
+        open_side = None
+        if position_quantity > 0:
+            close_side = Order.OrderSide.SELL_TO_CLOSE
+            open_side = Order.OrderSide.BUY_TO_OPEN
+        elif position_quantity < 0:
+            close_side = Order.OrderSide.BUY_TO_CLOSE
+            open_side = Order.OrderSide.SELL_TO_OPEN
+
+        if side in {Order.OrderSide.BUY, Order.OrderSide.SELL}:
+            if position_quantity == 0:
+                order.side = (
+                    Order.OrderSide.BUY_TO_OPEN
+                    if side == Order.OrderSide.BUY
+                    else Order.OrderSide.SELL_TO_OPEN
+                )
+                return order
+
+            generic_closes_position = (
+                position_quantity > 0 and side == Order.OrderSide.SELL
+            ) or (
+                position_quantity < 0 and side == Order.OrderSide.BUY
+            )
+            order.side = close_side if generic_closes_position else open_side
+
+        if order.side != close_side:
+            return order
+
+        reserved_quantity = 0.0
+        active_orders = self.get_active_tracked_orders(order.strategy, order.asset)
+        if additional_active_orders:
+            active_orders.extend(
+                candidate
+                for candidate in additional_active_orders
+                if candidate.strategy == order.strategy and candidate.asset == order.asset
+            )
+        for active_order in active_orders:
+            try:
+                active_side = Order.OrderSide(active_order.side)
+            except (TypeError, ValueError):
+                continue
+            active_is_close = active_side == close_side
+            if not active_is_close:
+                active_is_close = (
+                    position_quantity > 0 and active_side == Order.OrderSide.SELL
+                ) or (
+                    position_quantity < 0 and active_side == Order.OrderSide.BUY
+                )
+            if not active_is_close:
+                continue
+
+            filled_quantity = sum(
+                float(transaction.quantity)
+                for transaction in getattr(active_order, "transactions", [])
+            )
+            reserved_quantity += max(0.0, float(active_order.quantity) - filled_quantity)
+
+        remaining_closable = max(0.0, abs(position_quantity) - reserved_quantity)
+        requested_quantity = float(order.quantity)
+        if requested_quantity > remaining_closable + 1e-9:
+            raise ValueError(
+                f"Option close quantity {requested_quantity:g} exceeds remaining closable quantity "
+                f"{remaining_closable:g} after active close orders"
+            )
+        return order
 
     def _conform_order(self, order):
         """Conform an order to broker constraints. Derived brokers should implement this method."""
@@ -2644,6 +2742,10 @@ class Broker(ABC):
 
     def submit_orders(self, orders, **kwargs) -> Union[Order, list[Order]]:
         """Submit orders"""
+        resolved_orders = []
+        for order in orders:
+            self.resolve_option_order_intent(order, additional_active_orders=resolved_orders)
+            resolved_orders.append(order)
         if hasattr(self, '_submit_orders'):
             return self._submit_orders(orders, **kwargs)
         else:

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -2218,6 +2218,8 @@ class Schwab(Broker):
         OrderBuilder
             The order builder object for Schwab API
         """
+        if order.side in (Order.OrderSide.BUY, Order.OrderSide.SELL):
+            self.resolve_option_order_intent(order)
         try:
             # Get order parameters
             quantity = int(order.quantity)

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -1972,9 +1972,6 @@ class Tradier(Broker):
         return cleaned
 
     def _lumi_side2tradier(self, order: Order) -> str:
-        # Make a copy of the side because we will modify it
-        original_side = order.side
-
         # Set the side that we will return
         side = order.side
 
@@ -1992,33 +1989,8 @@ class Tradier(Broker):
 
         # Convert the side to the Tradier side for options orders if necessary
         if side == Order.OrderSide.BUY or side == Order.OrderSide.SELL:
-            # Check if we currently own the option
-            position = self.get_tracked_position(order.strategy, order.asset)
-
-            # Check if we own the option then we need to sell to close or buy to close
-            if position is not None:
-                if position.quantity > 0 and side == Order.OrderSide.SELL:
-                    side = "sell_to_close"
-                elif position.quantity >= 0 and side == Order.OrderSide.BUY:
-                    side = "buy_to_open"
-                elif position.quantity < 0 and side == Order.OrderSide.BUY:
-                    side = "buy_to_close"
-                elif position.quantity <= 0 and side == Order.OrderSide.SELL:
-                    side = "sell_to_open"
-                else:
-                    logger.error(
-                        f"Unable to determine the correct side for the order. " f"Position: {position}, Order: {order}"
-                    )
-
-            # Otherwise, we don't own the option so we need to buy to open or sell to open
-            else:
-                side = "buy_to_open" if side == Order.OrderSide.BUY else "sell_to_open"
-
-        # Stoploss and limit orders are usually used to close positions, even if they are submitted "before" the
-        # position is technically open (i.e. buy and stoploss order are submitted simultaneously)
-        if (order.order_type in [Order.OrderType.STOP, Order.OrderType.TRAIL] and
-                (original_side == Order.OrderSide.BUY or original_side == Order.OrderSide.SELL)):
-            side = str(side).replace("to_open", "to_close")
+            self.resolve_option_order_intent(order)
+            side = order.side
 
         # Check if the side is a valid Tradier side
         if side not in ["buy_to_open", "buy_to_close", "sell_to_open", "sell_to_close"]:

--- a/lumibot/components/agents/builtins.py
+++ b/lumibot/components/agents/builtins.py
@@ -52,6 +52,18 @@ def _agent_memory_context_kwargs() -> dict[str, Any]:
     return kwargs
 
 
+def _broker_submission_outcome(*, certainty: str, retryable: bool = False) -> dict[str, Any]:
+    return {
+        "operation": "broker_order_submission",
+        "requiredness": "decision_critical",
+        "retryability": "retryable" if retryable else "not_applicable",
+        "fallback_used": False,
+        "decision_completed": True,
+        "broker_state_certainty": certainty,
+        "impact": "completed" if certainty == "confirmed_submitted" else "operator_attention_required",
+    }
+
+
 class _LazyModule:
     """Read-only proxy that imports the target module on first attribute access.
 
@@ -463,7 +475,7 @@ def _order_to_dict(order: Any) -> dict[str, Any]:
         quantity = float(quantity)
     except Exception:
         quantity = quantity
-    return {
+    payload = {
         "identifier": _jsonable(getattr(order, "identifier", None)),
         "status": _jsonable(getattr(order, "status", None)),
         "side": _jsonable(getattr(order, "side", None)),
@@ -474,6 +486,10 @@ def _order_to_dict(order: Any) -> dict[str, Any]:
         "limit_price": _jsonable(getattr(order, "limit_price", None)),
         "stop_price": _jsonable(getattr(order, "stop_price", None)),
     }
+    decision_provenance = getattr(order, "decision_provenance", None)
+    if isinstance(decision_provenance, dict):
+        payload["decision_provenance"] = _jsonable(decision_provenance)
+    return payload
 
 
 def _options_helper_for_strategy(strategy: Any) -> Any:
@@ -2563,9 +2579,28 @@ def _bind_submit_order(strategy: Any, manager: Any) -> BoundTool:
             quote=quote,
             time_in_force=time_in_force,
         )
-        submitted = strategy.submit_order(created)
-        order_payload = _order_to_dict(submitted)
         memory = getattr(strategy, "memory", None)
+        memory_context = _agent_memory_context_kwargs()
+        decision_provenance = None
+        if memory is not None and hasattr(memory, "decision_provenance"):
+            decision_provenance = memory.decision_provenance(**memory_context)
+            setattr(created, "decision_provenance", decision_provenance)
+        try:
+            submitted = strategy.submit_order(created)
+        except Exception as exc:
+            return {
+                "ok": False,
+                "tool_error": True,
+                "tool_name": "orders_submit_order",
+                "error": {"type": exc.__class__.__name__, "message": str(exc)},
+                "execution_outcome": _broker_submission_outcome(
+                    certainty="unknown",
+                    retryable=isinstance(exc, (TimeoutError, ConnectionError)),
+                ),
+            }
+        if decision_provenance is not None and not hasattr(submitted, "decision_provenance"):
+            setattr(submitted, "decision_provenance", decision_provenance)
+        order_payload = _order_to_dict(submitted)
         if memory is not None and hasattr(memory, "record_order_submitted"):
             try:
                 memory.record_order_submitted(
@@ -2584,11 +2619,15 @@ def _bind_submit_order(strategy: Any, manager: Any) -> BoundTool:
                     exchange=exchange,
                     time_in_force=time_in_force,
                     order_payload=order_payload,
-                    **_agent_memory_context_kwargs(),
+                    metadata={"decision_provenance": decision_provenance or {}},
+                    **memory_context,
                 )
             except Exception:
                 pass
-        return {"order": order_payload}
+        return {
+            "order": order_payload,
+            "execution_outcome": _broker_submission_outcome(certainty="confirmed_submitted"),
+        }
 
     return BoundTool(
         name="orders_submit_order",

--- a/lumibot/components/agents/manager.py
+++ b/lumibot/components/agents/manager.py
@@ -576,6 +576,37 @@ def _runtime_timing_payload(result: AgentRunResult) -> dict[str, Any]:
     }
 
 
+def _managed_ai_execution_outcome(
+    *,
+    required_for_decision: bool,
+    decision_completed: bool,
+    error_category: str | None = None,
+    fallback_used: bool = False,
+) -> dict[str, Any]:
+    return {
+        "operation": "managed_ai_inference",
+        "requiredness": "decision_critical" if required_for_decision else "optional",
+        "retryability": (
+            "retryable"
+            if error_category in {"transient", "unknown"}
+            else "non_retryable"
+            if error_category
+            else "not_applicable"
+        ),
+        "fallback_used": bool(fallback_used),
+        "decision_completed": bool(decision_completed),
+        "broker_state_certainty": "not_observed",
+        "impact": (
+            "completed"
+            if decision_completed
+            else "decision_blocked"
+            if required_for_decision
+            else "optional_component_failed"
+        ),
+        "error_category": error_category,
+    }
+
+
 def _iter_timestamp_candidates(value: Any, *, path: str = "payload", hinted: bool = False):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -1599,6 +1630,12 @@ class AgentHandle:
                 "runtime_error": True,
                 "error_class": exc.__class__.__name__,
                 "error_message": str(exc)[:800],
+                "execution_outcome": _managed_ai_execution_outcome(
+                    required_for_decision=self.allow_trading,
+                    decision_completed=False,
+                    error_category=category,
+                    fallback_used=True,
+                ),
             }
             self._finalize_runtime_timing(
                 result,
@@ -1628,6 +1665,10 @@ class AgentHandle:
         )
         result.cache_key = cache_key
         result.warnings = self._derive_warnings(result, runtime_context)
+        execution_outcome = _managed_ai_execution_outcome(
+            required_for_decision=self.allow_trading,
+            decision_completed=True,
+        )
         trace_payload = {
             "agent": self.name,
             "model": model_name,
@@ -1663,11 +1704,13 @@ class AgentHandle:
             "usage": result.usage,
             "timing": _runtime_timing_payload(result),
             "duckdb_metrics": self.manager.duckdb.get_metrics(),
+            "execution_outcome": execution_outcome,
         }
         trace_path = self._write_trace(result, trace_payload)
         result.payload = {
             "trace_path": trace_path.as_posix(),
             "warnings": result.warnings,
+            "execution_outcome": execution_outcome,
         }
         if should_replay:
             self.manager.replay_cache.save(

--- a/lumibot/components/agents/manager.py
+++ b/lumibot/components/agents/manager.py
@@ -478,6 +478,19 @@ def _structured_operation_outcomes(result: AgentRunResult) -> list[dict[str, Any
                     "error_category": error.get("type") or "ToolError",
                 }
             )
+        else:
+            outcomes.append(
+                {
+                    "operation": f"tool:{event.tool_name or 'unknown'}",
+                    "requiredness": "optional",
+                    "retryability": "not_applicable",
+                    "fallback_used": False,
+                    "decision_completed": primary.get("decision_completed") is True,
+                    "broker_state_certainty": "not_observed",
+                    "impact": "completed",
+                    "error_category": None,
+                }
+            )
     return outcomes
 
 

--- a/lumibot/components/agents/manager.py
+++ b/lumibot/components/agents/manager.py
@@ -360,6 +360,14 @@ _AGENT_DETAIL_COLUMNS = [
     "memory_state_text",
     "memory_retrieval_ids",
     "warning_messages",
+    "outcome_operation",
+    "outcome_requiredness",
+    "outcome_retryability",
+    "outcome_fallback_used",
+    "outcome_decision_completed",
+    "outcome_broker_state_certainty",
+    "outcome_impact",
+    "outcome_error_category",
     "event_input_tokens",
     "event_output_tokens",
     "event_total_tokens",
@@ -1141,6 +1149,12 @@ class AgentHandle:
         trace_path = ""
         if isinstance(result.payload, dict):
             trace_path = str(result.payload.get("trace_path") or "")
+        execution_outcome = (
+            result.payload.get("execution_outcome")
+            if isinstance(result.payload, dict)
+            and isinstance(result.payload.get("execution_outcome"), dict)
+            else {}
+        )
         cache_root = self._cache_root()
         trace_relative_path = trace_path
         if trace_path:
@@ -1160,6 +1174,7 @@ class AgentHandle:
             "timing": _runtime_timing_payload(result),
             "tool_calls": [event.tool_name for event in result.tool_calls if event.tool_name],
             "warning_messages": result.warning_messages,
+            "execution_outcome": execution_outcome,
             "trace_path": trace_path,
             "trace_relative_path": trace_relative_path,
         }
@@ -1473,6 +1488,13 @@ class AgentHandle:
             cached = self.manager.replay_cache.load(cache_key)
             if cached is not None:
                 result = self._result_from_cached(cached, cache_key)
+                result.payload = {
+                    **(result.payload or {}),
+                    "execution_outcome": _managed_ai_execution_outcome(
+                        required_for_decision=self.allow_trading,
+                        decision_completed=True,
+                    ),
+                }
                 self._replay_cached_side_effects(result)
                 self.manager._record_agent_observability(
                     handle=self,
@@ -1821,6 +1843,12 @@ class AgentManager:
         trace_path = ""
         if isinstance(result.payload, dict):
             trace_path = str(result.payload.get("trace_path") or "")
+        execution_outcome = (
+            result.payload.get("execution_outcome")
+            if isinstance(result.payload, dict)
+            and isinstance(result.payload.get("execution_outcome"), dict)
+            else {}
+        )
         warning_messages = " | ".join(_sanitize_csv_text(message) for message in result.warning_messages if message)
         normalized_events = result.events or [AgentTraceEvent(kind="text", text=result.summary or "")]
         thinking_texts = _thinking_texts(result)
@@ -1860,6 +1888,14 @@ class AgentManager:
             "memory_state_text": memory_state_text,
             "memory_retrieval_ids": memory_retrieval_ids,
             "warning_messages": warning_messages,
+            "outcome_operation": execution_outcome.get("operation"),
+            "outcome_requiredness": execution_outcome.get("requiredness"),
+            "outcome_retryability": execution_outcome.get("retryability"),
+            "outcome_fallback_used": execution_outcome.get("fallback_used"),
+            "outcome_decision_completed": execution_outcome.get("decision_completed"),
+            "outcome_broker_state_certainty": execution_outcome.get("broker_state_certainty"),
+            "outcome_impact": execution_outcome.get("impact"),
+            "outcome_error_category": execution_outcome.get("error_category"),
             **timing,
             "trace_path": trace_path,
         }

--- a/lumibot/components/agents/manager.py
+++ b/lumibot/components/agents/manager.py
@@ -447,6 +447,40 @@ def _unwrap_tool_payload(payload: Any) -> Any:
     return payload
 
 
+def _structured_operation_outcomes(result: AgentRunResult) -> list[dict[str, Any]]:
+    """Return runtime-authored operation outcomes without interpreting log text."""
+
+    outcomes: list[dict[str, Any]] = []
+    primary: dict[str, Any] = {}
+    if isinstance(result.payload, dict):
+        primary_candidate = result.payload.get("execution_outcome")
+        primary = primary_candidate if isinstance(primary_candidate, dict) else {}
+        if isinstance(primary, dict) and primary.get("operation"):
+            outcomes.append(primary)
+    for event in result.tool_results:
+        payload = _unwrap_tool_payload(event.payload)
+        if not isinstance(payload, dict):
+            continue
+        outcome = payload.get("execution_outcome")
+        if isinstance(outcome, dict) and outcome.get("operation"):
+            outcomes.append(outcome)
+        elif payload.get("tool_error") is True:
+            error = payload.get("error") if isinstance(payload.get("error"), dict) else {}
+            outcomes.append(
+                {
+                    "operation": f"tool:{event.tool_name or 'unknown'}",
+                    "requiredness": "optional",
+                    "retryability": "unknown",
+                    "fallback_used": True,
+                    "decision_completed": primary.get("decision_completed") is True,
+                    "broker_state_certainty": "not_observed",
+                    "impact": "optional_component_failed",
+                    "error_category": error.get("type") or "ToolError",
+                }
+            )
+    return outcomes
+
+
 def _sanitize_csv_text(value: Any) -> str:
     if value is None:
         return ""
@@ -1186,6 +1220,7 @@ class AgentHandle:
             and isinstance(result.payload.get("execution_outcome"), dict)
             else {}
         )
+        operation_outcomes = _structured_operation_outcomes(result)
         cache_root = self._cache_root()
         trace_relative_path = trace_path
         if trace_path:
@@ -1195,6 +1230,8 @@ class AgentHandle:
                 trace_relative_path = trace_path
         record = {
             "timestamp": self._event_timestamp(),
+            "deployment_id": os.environ.get("BOTSPOT_DEPLOYMENT_ID") or "",
+            "run_id": os.environ.get("BOTSPOT_RUN_ID") or "",
             "agent_name": self.name,
             "mode": runtime_context.get("mode"),
             "model": result.model,
@@ -1206,6 +1243,7 @@ class AgentHandle:
             "tool_calls": [event.tool_name for event in result.tool_calls if event.tool_name],
             "warning_messages": result.warning_messages,
             "execution_outcome": execution_outcome,
+            "operation_outcomes": operation_outcomes,
             "trace_path": trace_path,
             "trace_relative_path": trace_relative_path,
         }

--- a/lumibot/components/memory/store.py
+++ b/lumibot/components/memory/store.py
@@ -348,6 +348,9 @@ class MemoryStore:
             "arguments": {key: value for key, value in order_kwargs.items() if value is not None},
             "metadata": metadata or {},
         }
+        decision_provenance = (metadata or {}).get("decision_provenance")
+        if isinstance(decision_provenance, dict):
+            payload["decision_provenance"] = decision_provenance
         text_parts = ["Submitted order"]
         if side:
             text_parts.append(str(side))
@@ -371,6 +374,42 @@ class MemoryStore:
         )
         self._export_artifacts_best_effort()
         return event
+
+    def decision_provenance(
+        self,
+        *,
+        agent_name: str | None = None,
+        model_call_id: str | None = None,
+    ) -> dict[str, str | None]:
+        """Return stable runtime and decision references for an order submission."""
+        decision_id = None
+        if model_call_id:
+            with self._connect() as conn:
+                row = conn.execute(
+                    """
+                    SELECT subject_id
+                    FROM memory_events
+                    WHERE event_type = 'decision.recorded'
+                      AND model_call_id = ?
+                      AND (? IS NULL OR agent_name = ?)
+                    ORDER BY sequence DESC
+                    LIMIT 1
+                    """,
+                    (model_call_id, agent_name, agent_name),
+                ).fetchone()
+            if row:
+                decision_id = str(row["subject_id"])
+        return {
+            "deployment_id": str(os.environ.get("BOTSPOT_DEPLOYMENT_ID") or "").strip() or None,
+            "run_id": str(
+                os.environ.get("BOTSPOT_ARTIFACT_RUN_ID")
+                or os.environ.get("BOTSPOT_RUN_ID")
+                or ""
+            ).strip()
+            or None,
+            "decision_id": decision_id,
+            "model_call_id": str(model_call_id or "").strip() or None,
+        }
 
     def get(self, memory_id: str) -> dict[str, Any] | None:
         with self._connect() as conn:

--- a/lumibot/entities/position.py
+++ b/lumibot/entities/position.py
@@ -199,13 +199,22 @@ class Position:
             logger.warning("get_selling_order is not supported for crypto futures. Use the broker's close_position method instead.")
             return None
         order = None
+        is_option = getattr(self.asset, "asset_type", None) == "option"
         if self.quantity < 0:
             order = entities.Order(
-                self.strategy, self.asset, abs(self.quantity), "buy", quote=quote_asset
+                self.strategy,
+                self.asset,
+                abs(self.quantity),
+                "buy_to_close" if is_option else "buy",
+                quote=quote_asset,
             )
         else:
             order = entities.Order(
-                self.strategy, self.asset, self.quantity, "sell", quote=quote_asset
+                self.strategy,
+                self.asset,
+                self.quantity,
+                "sell_to_close" if is_option else "sell",
+                quote=quote_asset,
             )
         return order
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.84",
+    version="4.5.85",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/backtest/test_agent_runtime_backtest.py
+++ b/tests/backtest/test_agent_runtime_backtest.py
@@ -803,6 +803,12 @@ def test_agent_detail_parquet_has_single_token_summary_row_and_full_events(monke
 
     summaries = df[df["event_kind"] == "call_summary"]
     assert len(summaries) == UsageTelemetryRuntime.call_count
+    assert set(summaries["outcome_operation"]) == {"managed_ai_inference"}
+    assert set(summaries["outcome_requiredness"]) == {"decision_critical"}
+    assert set(summaries["outcome_decision_completed"]) == {True}
+    assert set(summaries["outcome_fallback_used"]) == {False}
+    assert set(summaries["outcome_broker_state_certainty"]) == {"not_observed"}
+    assert set(summaries["outcome_impact"]) == {"completed"}
     call_numbers = list(range(1, UsageTelemetryRuntime.call_count + 1))
     assert summaries["call_input_tokens"].sum() == sum(1000 + idx for idx in call_numbers)
     assert summaries["call_output_tokens"].sum() == sum(200 + idx for idx in call_numbers)

--- a/tests/test_agent_tool_permissions.py
+++ b/tests/test_agent_tool_permissions.py
@@ -127,6 +127,11 @@ class _CaptureRuntime:
         )
 
 
+class _MissingProviderCredentialRuntime:
+    def run(self, request):
+        raise ValueError("No API key was provided")
+
+
 def test_agent_allow_trading_false_removes_only_mutating_order_tools(monkeypatch):
     monkeypatch.delenv("FRED_API_KEY", raising=False)
     strategy = _Strategy()
@@ -151,6 +156,56 @@ def test_agent_allow_trading_false_removes_only_mutating_order_tools(monkeypatch
     assert "get_fred_latest" not in tool_names
     assert "get_fred_snapshot" not in tool_names
     assert agent.default_model == "openai/gpt-5.4-mini"
+
+
+def test_live_agent_auth_failure_emits_structured_decision_outcome():
+    strategy = _Strategy()
+    strategy.is_backtesting = False
+    manager = AgentManager(strategy)
+    agent = manager.create(
+        name="portfolio_manager",
+        model="gemini/gemini-3.1-pro-preview",
+        allow_trading=True,
+        _runtime=_MissingProviderCredentialRuntime(),
+    )
+
+    result = agent.run(task_prompt="Make the scheduled investment decision.")
+
+    assert result.payload["execution_outcome"] == {
+        "operation": "managed_ai_inference",
+        "requiredness": "decision_critical",
+        "retryability": "non_retryable",
+        "fallback_used": True,
+        "decision_completed": False,
+        "broker_state_certainty": "not_observed",
+        "impact": "decision_blocked",
+        "error_category": "auth",
+    }
+
+
+def test_optional_agent_auth_failure_does_not_mark_decision_blocked():
+    strategy = _Strategy()
+    strategy.is_backtesting = False
+    manager = AgentManager(strategy)
+    agent = manager.create(
+        name="optional_researcher",
+        model="anthropic/claude-sonnet-4-6",
+        allow_trading=False,
+        _runtime=_MissingProviderCredentialRuntime(),
+    )
+
+    result = agent.run(task_prompt="Enrich the completed decision with optional research.")
+
+    assert result.payload["execution_outcome"] == {
+        "operation": "managed_ai_inference",
+        "requiredness": "optional",
+        "retryability": "non_retryable",
+        "fallback_used": True,
+        "decision_completed": False,
+        "broker_state_certainty": "not_observed",
+        "impact": "optional_component_failed",
+        "error_category": "auth",
+    }
 
 
 def test_agent_timeout_options_forward_to_runtime_request(monkeypatch):
@@ -370,6 +425,15 @@ def test_order_submit_tool_records_memory_event(monkeypatch, tmp_path):
 
     strategy = _OrderStrategy()
     strategy.memory = MemoryStore(strategy, root_dir=tmp_path)
+    decision = strategy.memory.remember_decision(
+        "Buy TQQQ after the committee approved the risk-adjusted entry.",
+        symbol="TQQQ",
+        action="buy",
+        agent_name="trader",
+        model_call_id="call-order-1",
+    )
+    monkeypatch.setenv("BOTSPOT_DEPLOYMENT_ID", "deployment-123")
+    monkeypatch.setenv("BOTSPOT_ARTIFACT_RUN_ID", "run-456")
     monkeypatch.setattr(
         "lumibot.components.agents.builtins.resolve_asset_and_quote",
         lambda *args, **kwargs: (_Asset(), None),
@@ -380,11 +444,66 @@ def test_order_submit_tool_records_memory_event(monkeypatch, tmp_path):
     result = wrapped(symbol="TQQQ", quantity=10, side="buy")
 
     assert result["order"]["identifier"] == "order-123"
+    assert result["order"]["decision_provenance"] == {
+        "deployment_id": "deployment-123",
+        "run_id": "run-456",
+        "decision_id": decision["memory_id"],
+        "model_call_id": "call-order-1",
+    }
     events = pd.read_parquet(strategy.memory.export_artifacts(tmp_path, prefix="order_memory")["memory_events"])
     order_events = events[events["event_type"] == "order.submitted"]
     assert len(order_events) == 1
     assert order_events.iloc[0]["agent_name"] == "trader"
     assert order_events.iloc[0]["model_call_id"] == "call-order-1"
+    event_metadata = json.loads(order_events.iloc[0]["metadata_json"])
+    assert event_metadata["decision_provenance"] == result["order"]["decision_provenance"]
+
+
+def test_order_submit_timeout_reports_unknown_broker_state(monkeypatch):
+    from lumibot.components.agents.builtins import _bind_submit_order
+    from lumibot.components.agents.runtime import _wrap_tool_callable
+
+    class _Asset:
+        symbol = "TQQQ"
+        asset_type = "stock"
+
+    class _Order:
+        identifier = "order-timeout"
+        asset = _Asset()
+        quantity = 10
+        side = "buy"
+        order_type = "market"
+        time_in_force = "day"
+        limit_price = None
+        stop_price = None
+
+    class _TimeoutStrategy(_Strategy):
+        def create_order(self, *args, **kwargs):
+            return _Order()
+
+        def submit_order(self, order):
+            raise TimeoutError("broker response timed out")
+
+    strategy = _TimeoutStrategy()
+    monkeypatch.setattr(
+        "lumibot.components.agents.builtins.resolve_asset_and_quote",
+        lambda *args, **kwargs: (_Asset(), None),
+    )
+
+    result = _wrap_tool_callable(_bind_submit_order(strategy, manager=None))(
+        symbol="TQQQ", quantity=10, side="buy"
+    )
+
+    assert result["tool_error"] is True
+    assert result["execution_outcome"] == {
+        "operation": "broker_order_submission",
+        "requiredness": "decision_critical",
+        "retryability": "retryable",
+        "fallback_used": False,
+        "decision_completed": True,
+        "broker_state_certainty": "unknown",
+        "impact": "operator_attention_required",
+    }
 
 
 def test_builtin_indicator_schema_is_gemini_function_declaration_compatible():

--- a/tests/test_agent_tool_permissions.py
+++ b/tests/test_agent_tool_permissions.py
@@ -569,19 +569,24 @@ def test_completed_agent_records_data_tool_error_as_optional_operation_failure()
         events=[
             AgentTraceEvent(
                 kind="tool_result",
-                tool_name="get_fred_series",
+                tool_name="account_positions",
                 payload={
                     "tool_error": True,
                     "error": {"type": "ConnectionError", "message": "temporary outage"},
                 },
-            )
+            ),
+            AgentTraceEvent(
+                kind="tool_result",
+                tool_name="account_positions",
+                payload={"positions": []},
+            ),
         ],
     )
 
     outcomes = _structured_operation_outcomes(result)
 
     assert outcomes[1] == {
-        "operation": "tool:get_fred_series",
+        "operation": "tool:account_positions",
         "requiredness": "optional",
         "retryability": "unknown",
         "fallback_used": True,
@@ -589,6 +594,16 @@ def test_completed_agent_records_data_tool_error_as_optional_operation_failure()
         "broker_state_certainty": "not_observed",
         "impact": "optional_component_failed",
         "error_category": "ConnectionError",
+    }
+    assert outcomes[2] == {
+        "operation": "tool:account_positions",
+        "requiredness": "optional",
+        "retryability": "not_applicable",
+        "fallback_used": False,
+        "decision_completed": True,
+        "broker_state_certainty": "not_observed",
+        "impact": "completed",
+        "error_category": None,
     }
 
 

--- a/tests/test_agent_tool_permissions.py
+++ b/tests/test_agent_tool_permissions.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from lumibot.components.agents import AgentManager, AgentRunResult, AgentTraceEvent, BuiltinTools
-from lumibot.components.agents.manager import AgentModelCallLimitExceeded
+from lumibot.components.agents.manager import AgentModelCallLimitExceeded, _structured_operation_outcomes
 from lumibot.components.agents.schemas import BoundTool, ToolDefinition
 
 
@@ -503,6 +503,92 @@ def test_order_submit_timeout_reports_unknown_broker_state(monkeypatch):
         "decision_completed": True,
         "broker_state_certainty": "unknown",
         "impact": "operator_attention_required",
+    }
+
+
+def test_agent_summary_preserves_structured_tool_operation_outcomes(monkeypatch, tmp_path):
+    ai_outcome = {
+        "operation": "managed_ai_inference",
+        "requiredness": "decision_critical",
+        "decision_completed": True,
+        "broker_state_certainty": "not_observed",
+        "impact": "completed",
+    }
+    broker_outcome = {
+        "operation": "broker_order_submission",
+        "requiredness": "decision_critical",
+        "retryability": "retryable",
+        "fallback_used": False,
+        "decision_completed": True,
+        "broker_state_certainty": "unknown",
+        "impact": "operator_attention_required",
+    }
+    result = AgentRunResult(
+        summary="Submitted the rebalance.",
+        model="openai/gpt-5.4-mini",
+        payload={"execution_outcome": ai_outcome},
+        events=[
+            AgentTraceEvent(
+                kind="tool_result",
+                tool_name="orders_submit_order",
+                payload={"payload": {"execution_outcome": broker_outcome}},
+            )
+        ],
+    )
+
+    assert _structured_operation_outcomes(result) == [ai_outcome, broker_outcome]
+
+    monkeypatch.setenv("LUMIBOT_CACHE_FOLDER", str(tmp_path))
+    monkeypatch.setenv("BOTSPOT_DEPLOYMENT_ID", "deployment-current")
+    monkeypatch.setenv("BOTSPOT_RUN_ID", "run-current")
+    handle = AgentManager(_Strategy()).create(
+        name="trader",
+        model="openai/gpt-5.4-mini",
+        allow_trading=True,
+    )
+    handle._append_run_artifact_summary(result, {"mode": "live"})
+    summary = json.loads((tmp_path / "agent_runtime" / "agent_run_summaries.jsonl").read_text())
+    assert summary["deployment_id"] == "deployment-current"
+    assert summary["run_id"] == "run-current"
+    assert summary["operation_outcomes"] == [ai_outcome, broker_outcome]
+
+
+def test_completed_agent_records_data_tool_error_as_optional_operation_failure():
+    result = AgentRunResult(
+        summary="Used the remaining data to complete the decision.",
+        model="anthropic/claude-sonnet-4-6",
+        payload={
+            "execution_outcome": {
+                "operation": "managed_ai_inference",
+                "requiredness": "decision_critical",
+                "decision_completed": True,
+                "broker_state_certainty": "not_observed",
+                "impact": "completed",
+            }
+        },
+        events=[
+            AgentTraceEvent(
+                kind="tool_result",
+                tool_name="get_fred_series",
+                payload={
+                    "tool_error": True,
+                    "error": {"type": "ConnectionError", "message": "temporary outage"},
+                },
+            )
+        ],
+    )
+
+    outcomes = _structured_operation_outcomes(result)
+
+    assert outcomes[1] == {
+        "operation": "tool:get_fred_series",
+        "requiredness": "optional",
+        "retryability": "unknown",
+        "fallback_used": True,
+        "decision_completed": True,
+        "broker_state_certainty": "not_observed",
+        "impact": "optional_component_failed",
+        "error_category": "ConnectionError",
     }
 
 

--- a/tests/test_alpaca.py
+++ b/tests/test_alpaca.py
@@ -85,6 +85,7 @@ class TestAlpacaBroker:
     def test_submit_order_calls_conform_order(self):
         broker = Alpaca(ALPACA_UNIT_CONFIG, connect_stream=False)
         broker._conform_order = MagicMock()
+        broker._submit_order = MagicMock(side_effect=lambda submitted: submitted)
         order = Order(asset=Asset("SPY"), quantity=10, side=Order.OrderSide.BUY, strategy='abc')
         broker.submit_order(order=order)
         broker._conform_order.assert_called_once()

--- a/tests/test_option_position_intent.py
+++ b/tests/test_option_position_intent.py
@@ -1,0 +1,205 @@
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from lumibot.brokers.alpaca import Alpaca
+from lumibot.brokers.interactive_brokers import IBApp
+from lumibot.entities import Asset, Order, Position
+
+
+ALPACA_UNIT_CONFIG = {
+    "API_KEY": "test_api_key",
+    "API_SECRET": "test_api_secret",
+    "PAPER": True,
+}
+
+
+def _option() -> Asset:
+    return Asset(
+        "SPY",
+        asset_type=Asset.AssetType.OPTION,
+        expiration=date(2026, 9, 18),
+        strike=500,
+        right="CALL",
+    )
+
+
+def _broker() -> Alpaca:
+    return Alpaca(ALPACA_UNIT_CONFIG, connect_stream=False)
+
+
+def test_alpaca_single_leg_submission_preserves_explicit_position_intent():
+    broker = _broker()
+    broker.api.submit_order = MagicMock(
+        return_value=SimpleNamespace(id="alpaca-order-1", status="accepted")
+    )
+    order = Order(
+        strategy="intent-test",
+        asset=_option(),
+        quantity=1,
+        side=Order.OrderSide.SELL_TO_CLOSE,
+    )
+
+    broker.submit_order(order)
+
+    request = broker.api.submit_order.call_args.kwargs["order_data"]
+    assert str(request.side) == "sell"
+    assert str(request.position_intent) == "sell_to_close"
+
+
+def test_alpaca_parser_restores_broker_returned_position_intent():
+    broker = _broker()
+    response = {
+        "id": "alpaca-order-2",
+        "symbol": "SPY260918C00500000",
+        "qty": "1",
+        "side": "sell",
+        "position_intent": "sell_to_close",
+        "asset_class": "us_option",
+        "type": "market",
+        "time_in_force": "day",
+        "status": "accepted",
+        "order_class": "simple",
+    }
+
+    parsed = broker._parse_broker_order(response, "intent-test")
+
+    assert parsed.side == Order.OrderSide.SELL_TO_CLOSE
+
+
+def test_close_position_emits_explicit_option_close():
+    broker = _broker()
+    option = _option()
+    broker._filled_positions.append(Position("intent-test", option, 2))
+    broker._submit_order = MagicMock(side_effect=lambda order: order)
+
+    result = broker.close_position("intent-test", option)
+
+    assert result.side == Order.OrderSide.SELL_TO_CLOSE
+
+
+def test_generic_option_sell_fails_when_pending_close_exhausts_position():
+    broker = _broker()
+    option = _option()
+    broker._filled_positions.append(Position("intent-test", option, 1))
+    pending_close = Order(
+        strategy="intent-test",
+        asset=option,
+        quantity=1,
+        side=Order.OrderSide.SELL_TO_CLOSE,
+        status=Order.OrderStatus.NEW,
+    )
+    broker._new_orders.append(pending_close)
+    broker.api.submit_order = MagicMock()
+    duplicate = Order(
+        strategy="intent-test",
+        asset=option,
+        quantity=1,
+        side=Order.OrderSide.SELL,
+    )
+
+    with pytest.raises(ValueError, match="remaining closable quantity"):
+        broker.submit_order(duplicate)
+
+    broker.api.submit_order.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("position_quantity", "generic_side", "expected_side"),
+    [
+        (2, Order.OrderSide.SELL, Order.OrderSide.SELL_TO_CLOSE),
+        (2, Order.OrderSide.BUY, Order.OrderSide.BUY_TO_OPEN),
+        (-2, Order.OrderSide.BUY, Order.OrderSide.BUY_TO_CLOSE),
+        (-2, Order.OrderSide.SELL, Order.OrderSide.SELL_TO_OPEN),
+        (0, Order.OrderSide.BUY, Order.OrderSide.BUY_TO_OPEN),
+        (0, Order.OrderSide.SELL, Order.OrderSide.SELL_TO_OPEN),
+    ],
+)
+def test_generic_option_sides_resolve_centrally(
+    position_quantity, generic_side, expected_side
+):
+    broker = _broker()
+    option = _option()
+    if position_quantity:
+        broker._filled_positions.append(
+            Position("intent-test", option, position_quantity)
+        )
+    order = Order(
+        strategy="intent-test",
+        asset=option,
+        quantity=1,
+        side=generic_side,
+    )
+
+    resolved = broker.resolve_option_order_intent(order)
+
+    assert resolved.side == expected_side
+
+
+def test_explicit_option_open_intent_wins_even_with_opposite_position():
+    broker = _broker()
+    option = _option()
+    broker._filled_positions.append(Position("intent-test", option, 2))
+    order = Order(
+        strategy="intent-test",
+        asset=option,
+        quantity=1,
+        side=Order.OrderSide.SELL_TO_OPEN,
+    )
+
+    resolved = broker.resolve_option_order_intent(order)
+
+    assert resolved.side == Order.OrderSide.SELL_TO_OPEN
+
+
+def test_batch_of_generic_option_closes_cannot_cross_zero():
+    broker = _broker()
+    option = _option()
+    broker._filled_positions.append(Position("intent-test", option, 1))
+    broker._submit_orders = MagicMock()
+    closes = [
+        Order(
+            strategy="intent-test",
+            asset=option,
+            quantity=1,
+            side=Order.OrderSide.SELL,
+        )
+        for _ in range(2)
+    ]
+
+    with pytest.raises(ValueError, match="remaining closable quantity"):
+        broker.submit_orders(closes)
+
+    broker._submit_orders.assert_not_called()
+
+
+def test_alpaca_rejection_is_raised_after_order_is_marked_error():
+    broker = _broker()
+    rejection = RuntimeError("account not eligible to trade uncovered option contracts")
+    broker.api.submit_order = MagicMock(side_effect=rejection)
+    order = Order(
+        strategy="intent-test",
+        asset=_option(),
+        quantity=1,
+        side=Order.OrderSide.SELL_TO_CLOSE,
+    )
+
+    with pytest.raises(RuntimeError, match="uncovered option contracts"):
+        broker.submit_order(order)
+
+    assert order.status == Order.OrderStatus.ERROR
+
+
+@pytest.mark.parametrize(
+    ("intent", "ibkr_action"),
+    [
+        (Order.OrderSide.BUY_TO_OPEN, "BUY"),
+        (Order.OrderSide.BUY_TO_CLOSE, "BUY"),
+        (Order.OrderSide.SELL_TO_OPEN, "SELL"),
+        (Order.OrderSide.SELL_TO_CLOSE, "SELL"),
+    ],
+)
+def test_ibkr_translation_accepts_all_explicit_option_intents(intent, ibkr_action):
+    assert IBApp.get_safe_action(None, intent) == ibkr_action

--- a/tests/test_tradier.py
+++ b/tests/test_tradier.py
@@ -337,11 +337,11 @@ class TestTradierBroker:
         option_order.side = "blah"
         assert not broker._lumi_side2tradier(option_order)
 
-        # Stoploss always submits as a "to_close" order
+        # Generic stop sides use the same position-aware resolver as other option orders.
         stop_stock_order = Order(strategy, stock_asset, 1, 'sell', order_type='stop', stop_price=100.0)
         assert broker._lumi_side2tradier(stop_stock_order) == "sell"
         stop_option_order = Order(strategy, option_asset, 1, 'sell', order_type='stop', stop_price=100.0)
-        assert broker._lumi_side2tradier(stop_option_order) == "sell_to_close"
+        assert broker._lumi_side2tradier(stop_option_order) == "sell_to_open"
 
         # TODO: Fix this test, it's commented out temporarily until we can figure out how to handle this case.
         # limit_option_order = Order(strategy, option_asset, 1, 'sell', order_type='limit', limit_price=100.0)


### PR DESCRIPTION
## Summary
- centralize single-leg option open/close intent resolution
- preserve Alpaca position_intent on submission and parsing
- fail duplicate/zero-crossing closes and surface broker rejections
- preserve explicit intent across Alpaca, Tradier, Schwab, and IBKR paths

## Red baseline
- tests/test_option_position_intent.py failed 5/5 before the fix for the production failure modes
- evidence: docs/evidence/2026-08-25-option-position-intent-red-baseline.md

## Verification
- tests/test_option_position_intent.py: 17 passed
- focused Alpaca/Tradier/Schwab/close-position matrix: 96 passed, 1 skipped, 2 deselected

No Bot Manager or BotSpot environment deployment is included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved options trading intent handling across supported brokers.
  * Automatically distinguishes opening and closing option orders where appropriate.
  * Added clearer protection against duplicate, ambiguous, or oversized position-closing orders.
  * Option positions now generate explicit close orders when being sold.
  * Added structured order outcomes and decision provenance to agent execution records.
* **Bug Fixes**
  * Improved Alpaca option order submission, parsing, and rejected-order error reporting.
* **Documentation**
  * Added release notes and evidence documenting option-intent behavior and regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->