### PR TITLE
Release LumiBot 4.5.86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.5.86 - Unreleased
+
+### Fixed
+- **Documentation configuration tests no longer leak mocked broker packages.**
+  Loading the Sphinx configuration in-process now restores `sys.modules`, so
+  later broker tests and runtime imports see the installed Tradier package.
+
 ## 4.5.85 - Unreleased
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.85",
+    version="4.5.86",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/test_public_docs_discovery.py
+++ b/tests/test_public_docs_discovery.py
@@ -1,6 +1,7 @@
 import importlib.util
 import os
 import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -8,9 +9,18 @@ from types import SimpleNamespace
 
 def _load_docs_config():
     config_path = Path(__file__).resolve().parents[1] / "docsrc" / "conf.py"
+    sitemap_path = config_path.parent / "_extra" / "sitemap.xml"
+    original_sitemap = sitemap_path.read_bytes()
     spec = importlib.util.spec_from_file_location("lumibot_docs_conf", config_path)
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    original_modules = sys.modules.copy()
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for module_name in set(sys.modules) - set(original_modules):
+            sys.modules.pop(module_name, None)
+        sys.modules.update(original_modules)
+        sitemap_path.write_bytes(original_sitemap)
     return module
 
 


### PR DESCRIPTION
## What
- restore sys.modules after in-process Sphinx configuration tests
- restore the generated sitemap after those tests
- carry forward the 4.5.85 option-intent correction unchanged

## Why
The v4.5.85 release gate proved that the documentation test leaked a mocked lumiwealth_tradier package into later unit tests, causing the real Tradier orders module import to fail. The v4.5.85 package was not published.

## Red and green evidence
- red: release run 32926715981, unit shard 1, ModuleNotFoundError for lumiwealth_tradier.orders after test_public_docs_discovery
- green: clean Python 3.10 environment ran test_public_docs_discovery.py followed by test_tradier_stream_optional_unit.py: 4 passed
- option-intent broker matrix remains 96 passed, 1 skipped, 2 deselected

## Risk
Test-isolation-only forward release. No runtime broker behavior changed beyond the already-reviewed option-intent correction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test isolation to prevent temporary mocked packages from affecting subsequent tests or runtime imports.
  - Documentation configuration checks now reliably restore the environment after execution.

- **Documentation**
  - Added an unreleased changelog entry describing the test isolation improvement.

- **Release**
  - Updated the package version to **4.5.86**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->