### PR TITLE
Fix Alpaca end-of-day session wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 4.5.86 - Unreleased
 
 ### Fixed
+- **Alpaca live strategies no longer crash during the end-of-day market-close wait.** Alpaca now
+  inherits the generic live broker wait instead of calling the backtesting-only
+  ``process_pending_orders()`` method, and an already-closed session no longer waits for a future
+  session's close.
 - **Documentation configuration tests no longer leak mocked broker packages.**
   Loading the Sphinx configuration in-process now restores `sys.modules`, so
   later broker tests and runtime imports see the installed Tradier package.

--- a/docs/investigations/2026-08-27_ALPACA_AWAIT_CLOSE.md
+++ b/docs/investigations/2026-08-27_ALPACA_AWAIT_CLOSE.md
@@ -1,0 +1,80 @@
+# Alpaca Await-Market-Close Crash Investigation
+
+One-line description: Documents the live Alpaca end-of-day crash caused by calling a backtesting-only pending-order method.
+
+Last Updated: 2026-08-27
+
+Status: Fixed locally with credential-free regression coverage; Alpaca paper validation not run.
+
+Audience: LumiBot contributors and operators diagnosing Alpaca live-strategy lifecycle failures.
+
+## Overview
+
+LumiBot issue [#1113](https://github.com/Lumiwealth/lumibot/issues/1113) reports that an Alpaca
+paper strategy crashes after the market closes. The strategy reaches
+`Strategy.await_market_to_close()`, which delegates to the broker and raises:
+
+```text
+AttributeError: 'Alpaca' object has no attribute 'process_pending_orders'
+```
+
+The failure is in LumiBot's live broker path, not in strategy code or Alpaca's order API. No broker
+request is required to reproduce it.
+
+## Root Cause
+
+`Alpaca` had its own `_await_market_to_close()` override. The override was introduced in a May 2025
+commit aimed at stuck backtests and copied this call from `BacktestingBroker`:
+
+```python
+self.process_pending_orders(strategy=strategy)
+```
+
+`process_pending_orders()` simulates fills and exists only on `BacktestingBroker`. Live Alpaca
+orders are updated by the broker's WebSocket trade-event stream or OAuth polling stream, so an
+Alpaca broker neither defines nor needs that method.
+
+The override also bypassed the generic live broker's `is_market_open()` guard. After a session had
+already closed, Alpaca's next-close timestamp could refer to a future session rather than a wait
+that should be skipped.
+
+## Fix and Invariants
+
+The Alpaca override is removed so `Alpaca` inherits `Broker._await_market_to_close()`. The generic
+implementation:
+
+- waits only while the configured market is open;
+- preserves the strategy's minutes-before-closing buffer;
+- uses the broker sleep abstraction; and
+- does not simulate pending-order fills in a live broker.
+
+The change does not alter the public `Strategy.await_market_to_close()` contract, order submission,
+fill processing, positions, cash accounting, or backtesting. `BacktestingBroker` retains its own
+override and continues to process simulated pending orders before advancing simulated time.
+
+## Regression Evidence
+
+The credential-free regression test constructs an Alpaca instance without running its initializer,
+replaces the market clock and sleep boundary with mocks, and calls the public strategy method.
+
+Before the fix:
+
+```text
+2 failed
+AttributeError: 'Alpaca' object has no attribute 'process_pending_orders'
+```
+
+After the fix, the test verifies both relevant live states:
+
+1. An open session sleeps for `time_to_close - minutes_before_closing`.
+2. A closed session does not request the next close and does not sleep.
+
+The existing legacy backtesting await-close tests remain unchanged and continue to protect
+backtesting pending-order processing.
+
+## Live Validation Boundary
+
+No Alpaca credentials, account, or live/paper broker connection were used for this fix. The issue
+does not provide the reporter's saved strategy artifact, so the exact customer deployment cannot be
+run locally. A maintainer or reporter with an isolated Alpaca paper account should confirm the full
+strategy lifecycle through market close before describing the customer path as end-to-end proven.

--- a/docsrc/brokers.alpaca.rst
+++ b/docsrc/brokers.alpaca.rst
@@ -15,6 +15,18 @@ Features
 * **Live Streaming**: Real-time trade updates and market data
 * **Cash Events**: Live cloud payloads can include normalized broker cash events such as deposits, withdrawals, interest, dividends, fees, journals, and adjustments
 
+End-of-Day Lifecycle
+--------------------
+
+Live and paper Alpaca strategies use LumiBot's standard live-broker market-close wait. Order fills
+continue to arrive through Alpaca's WebSocket stream or OAuth polling stream; the simulated
+``process_pending_orders()`` step is used only by backtesting brokers.
+
+Older LumiBot releases affected by `issue #1113 <https://github.com/Lumiwealth/lumibot/issues/1113>`__
+could raise ``AttributeError: 'Alpaca' object has no attribute 'process_pending_orders'`` while
+entering the end-of-day lifecycle. Upgrade to a release containing the fix rather than adding a
+``process_pending_orders`` method to a strategy or live broker.
+
 Getting Started
 ---------------
 

--- a/lumibot/brokers/alpaca.py
+++ b/lumibot/brokers/alpaca.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import time
 from collections import Counter
 
 from lumibot._lazy_imports import LazyLogger, LazyModule, lazy_class
@@ -643,34 +642,9 @@ class Alpaca(Broker):
         time_to_close = closing_time - curr_time
         return time_to_close
 
-    def _await_market_to_close(self, timedelta=None, strategy=None):
-        """
-        Block execution until the regular-market close (live‑trading version).
-
-        Parameters
-        ----------
-        timedelta : int | None
-            Optional buffer in minutes before the official close to wake up.
-        strategy : Strategy | None
-            The calling strategy; forwarded so pending orders can be processed
-            the same way BacktestingBroker does.
-        """
-        # First, handle any orders waiting to be processed.
-        self.process_pending_orders(strategy=strategy)
-
-        # Seconds until the bell rings
-        time_to_close = self.get_time_to_close()
-
-        # Apply an optional buffer (minutes before close)
-        if timedelta is not None:
-            time_to_close -= 60 * timedelta
-
-        # Nothing to wait for?  Bail out early.
-        if time_to_close <= 0:
-            return
-
-        logger.info(f"Sleeping {time_to_close:.0f} seconds until market close")
-        time.sleep(time_to_close)
+    # Alpaca intentionally inherits Broker._await_market_to_close(). The former
+    # override was removed because it called the backtesting-only
+    # process_pending_orders(); live Alpaca fills arrive through broker events.
 
     # =========Positions functions==================
 

--- a/tests/test_alpaca_await_market_close.py
+++ b/tests/test_alpaca_await_market_close.py
@@ -1,0 +1,56 @@
+"""Regression tests for Alpaca's inherited live market-close wait."""
+
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+
+from lumibot.brokers.alpaca import Alpaca
+from lumibot.strategies.strategy import Strategy
+
+
+def _alpaca_wait_stub(
+    *, market_open: bool, seconds_to_close: int = 900
+) -> tuple[Alpaca, MagicMock, MagicMock, MagicMock]:
+    """Build a credential-free Alpaca broker with a deterministic market clock.
+
+    Args:
+        market_open: Whether the simulated live market is open.
+        seconds_to_close: Seconds remaining in the simulated market session.
+
+    Returns:
+        The broker and its market-open, time-to-close, and sleep mocks.
+    """
+    broker = Alpaca.__new__(Alpaca)
+    broker.market = "NYSE"
+    broker.logger = MagicMock()
+    is_market_open = MagicMock(return_value=market_open)
+    get_time_to_close = MagicMock(return_value=seconds_to_close)
+    sleep = MagicMock()
+    broker.is_market_open = is_market_open
+    broker.get_time_to_close = get_time_to_close
+    broker.sleep = sleep
+    return broker, is_market_open, get_time_to_close, sleep
+
+
+def test_strategy_await_market_close_uses_live_broker_wait() -> None:
+    """Alpaca must not call the backtesting-only pending-order processor."""
+    broker, is_market_open, get_time_to_close, sleep = _alpaca_wait_stub(market_open=True)
+    strategy = cast(Strategy, SimpleNamespace(broker=broker, minutes_before_closing=5))
+
+    Strategy.await_market_to_close(strategy)
+
+    is_market_open.assert_called_once_with()
+    get_time_to_close.assert_called_once_with()
+    sleep.assert_called_once_with(600)
+
+
+def test_strategy_await_market_close_returns_when_market_is_closed() -> None:
+    """A closed Alpaca session must not wait for the next session's close."""
+    broker, is_market_open, get_time_to_close, sleep = _alpaca_wait_stub(market_open=False)
+    strategy = cast(Strategy, SimpleNamespace(broker=broker, minutes_before_closing=5))
+
+    Strategy.await_market_to_close(strategy)
+
+    is_market_open.assert_called_once_with()
+    get_time_to_close.assert_not_called()
+    sleep.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #1113 by removing Alpaca's invalid live `_await_market_to_close()` override and inheriting LumiBot's standard live-broker implementation.

## Problem

When an Alpaca strategy entered its end-of-day wait, the broker-specific override called `process_pending_orders()`. That method exists only on `BacktestingBroker`, causing live or paper Alpaca strategies to raise:

`AttributeError: 'Alpaca' object has no attribute 'process_pending_orders'`

The override also bypassed the base broker's market-open guard, so a closed session could incorrectly consider a future session's close.

## Change

- Remove Alpaca's `_await_market_to_close()` override and unused `time` import.
- Inherit `Broker._await_market_to_close()`.
- Preserve simulated pending-order processing exclusively in `BacktestingBroker`.
- Add deterministic coverage through the public `Strategy.await_market_to_close()` path.
- Document the live/backtesting invariant in engineering and public documentation.
- Add the fix to the unreleased changelog.

## Verification

Credential-free checks:

- Alpaca unit surface: 25 passed, 5 deselected
- Live/backtest wait boundary: 14 passed
- Frozen legacy backtesting selection: 4 passed, 31 deselected
- New-test Ruff F/I: passed
- New-test Pyright: 0 errors and 0 warnings
- Diff-range public-hygiene scan: passed
- Diff whitespace check: passed
- Sphinx HTML build: succeeded across 195 sources

The full Alpaca module retains the same five pre-existing Ruff findings as `upstream/dev`; this change introduces no finding on an added line.

## Trading behavior

The public strategy API is unchanged. Live Alpaca fills continue to arrive through WebSocket trade updates or the OAuth polling stream. Backtesting continues to process simulated pending orders before advancing simulated time.

No order submission, position, cash-accounting, or fill-processing behavior was changed.

## Documentation

- Added an engineering investigation describing the root cause and lifecycle invariants.
- Updated the public Alpaca broker documentation.
- Updated the unreleased changelog.

## Validation boundary

No Alpaca credentials or live/paper broker connection were used. The reported failure is covered with deterministic credential-free tests, but the reporter's exact deployed strategy lifecycle has not been reproduced against an isolated paper account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Alpaca live and paper strategies crashing during the end-of-day market-close wait.
  - Strategies now return immediately when the market session is already closed.
  - Prevented backtesting-only order processing from being invoked during live trading.

- **Documentation**
  - Added guidance on Alpaca’s end-of-day lifecycle and the recommended upgrade path.

- **Tests**
  - Added regression coverage for open and already-closed market scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->