### PR TITLE
Apply the canonical timestep aliases to BitunixData

### DIFF
--- a/lumibot/data_sources/bitunix_data.py
+++ b/lumibot/data_sources/bitunix_data.py
@@ -230,10 +230,44 @@ class BitunixData(DataSource):
     def get_timestep_from_string(self, timestep: str) -> str:
         """
         Maps a string representation of a timestep to the normalized timestep.
+
+        Matches the request and its canonical form against each row's
+        representations and their canonical forms. Both halves carry cases the
+        other does not: "15Min" and "240T" need the representations
+        canonicalized as well, since they only meet "15m" and "240m" there,
+        while "240" and "60" need the raw strings, because
+        ``canonicalize_timestep`` returns None for a bare number.
+        Matching the raw strings alone left six of the nine rows in
+        TIMESTEP_MAPPING unreachable by their own name -- "3 minutes",
+        "5 minutes", "15 minutes", "30 minutes", "2 hours" and "4 hours" each
+        fell through to the default below and were served as 1-minute candles.
         """
-        ts = timestep.lower().strip()
+        from lumibot.tools.helpers import canonicalize_timestep
+
+        # `.lower()` is the call this method already made; a non-string still
+        # fails on attribute access, as it did before. The isinstance test is
+        # load-bearing: canonicalize_timestep is lru_cached, and without it a
+        # bytearray raises TypeError from inside the cache instead of matching
+        # nothing, which is what it did on dev.
+        text = timestep.lower().strip()
+        canonical = canonicalize_timestep(text) if isinstance(text, str) else None
+        candidates = {str(text).lower()}
+        if canonical:
+            candidates.add(canonical)
+
         for mapping in self.TIMESTEP_MAPPING:
-            if ts in [r.lower() for r in mapping["representations"]]:
+            names = set()
+            for rep in mapping["representations"]:
+                names.add(str(rep).lower())
+                # Canonicalize the representations too, so an alias that
+                # normalizes to the same duration matches even when it is
+                # spelled differently: "240T" -> "240 minutes" reaches the
+                # "4 hours" row through its own "240m".
+                rep_canonical = canonicalize_timestep(rep)
+                if rep_canonical:
+                    names.add(rep_canonical)
+            if candidates & names:
                 return mapping["timestep"]
+
         # Default to "minute" if not found
         return "minute"

--- a/tests/test_bitunix_data_timesteps.py
+++ b/tests/test_bitunix_data_timesteps.py
@@ -1,0 +1,110 @@
+"""Timestep resolution for the BitUnix data source.
+
+Regression tests for the case where a canonical Lumibot timestep resolved to a
+different interval than the one asked for. ``get_timestep_from_string`` matched
+only each row's ``representations`` and fell back to ``"minute"``, so six of the
+nine entries in ``TIMESTEP_MAPPING`` were unreachable by their own name and a
+request for ``"4 hours"`` returned 1-minute candles with no error raised.
+"""
+
+import unittest
+
+from lumibot.data_sources.bitunix_data import BitunixData
+
+
+class TestBitunixTimesteps(unittest.TestCase):
+    def setUp(self):
+        # The timestep parser touches no client and needs no credentials.
+        self.data = BitunixData.__new__(BitunixData)
+
+    def test_canonical_timestep_names_resolve_to_their_own_interval(self):
+        """Every ``timestep`` in TIMESTEP_MAPPING must reach its own row.
+
+        Before the fix, "3 minutes", "5 minutes", "15 minutes", "30 minutes",
+        "2 hours" and "4 hours" all resolved to "1m".
+        """
+        expected = {
+            "minute": "1m",
+            "3 minutes": "3m",
+            "5 minutes": "5m",
+            "15 minutes": "15m",
+            "30 minutes": "30m",
+            "hour": "1h",
+            "2 hours": "2h",
+            "4 hours": "4h",
+            "day": "1d",
+        }
+        for mapping in BitunixData.TIMESTEP_MAPPING:
+            with self.subTest(timestep=mapping["timestep"]):
+                interval = self.data._parse_source_timestep(mapping["timestep"])
+                self.assertEqual(interval, expected[mapping["timestep"]])
+
+    def test_declared_representations_still_resolve(self):
+        """The aliases that already worked must keep working."""
+        for mapping in BitunixData.TIMESTEP_MAPPING:
+            for representation in mapping["representations"]:
+                with self.subTest(representation=representation):
+                    interval = self.data._parse_source_timestep(representation)
+                    self.assertIn(interval, mapping["representations"])
+
+    def test_shared_broker_aliases_resolve(self):
+        """The aliases canonicalize_timestep accepts for every other source."""
+        for alias, expected in (
+            ("4H", "4h"),
+            ("240T", "4h"),
+            ("1 hour", "1h"),
+            ("60m", "1h"),
+            ("15Min", "15m"),
+            ("30T", "30m"),
+            ("1Day", "1d"),
+        ):
+            with self.subTest(alias=alias):
+                self.assertEqual(self.data._parse_source_timestep(alias), expected)
+
+    def test_unsupported_interval_falls_back_rather_than_snapping(self):
+        """An interval BitUnix does not offer must not become a nearby one.
+
+        Resolving "45m" to "30m" or "10 minutes" to "5m" would be the same
+        defect this change fixes, wearing a different number: a request served
+        at an interval nobody asked for, with no error.
+        """
+        for timestep in ("45m", "10 minutes", "90m", "2 days", "week", "unknown"):
+            with self.subTest(timestep=timestep):
+                self.assertEqual(self.data._parse_source_timestep(timestep), "1m")
+
+    def test_surrounding_whitespace_is_ignored(self):
+        """`" 240 "` is `"240"`.
+
+        The previous implementation stripped before comparing, so dropping the
+        strip here would quietly send a padded timestep to the default.
+        """
+        for padded, expected in ((" 240 ", "4h"), ("  30 ", "30m"), (" 4h ", "4h"),
+                                 ("\t1Day\n", "1d")):
+            with self.subTest(timestep=padded):
+                self.assertEqual(self.data._parse_source_timestep(padded), expected)
+
+    def test_unhashable_input_falls_back_instead_of_raising(self):
+        """`bytearray` must still fall through, not blow up.
+
+        ``canonicalize_timestep`` is ``lru_cache``d, so handing it an unhashable
+        value raises TypeError from inside the decorator. On dev a bytearray
+        simply matched nothing and returned "1m"; that is preserved.
+        """
+        self.assertEqual(self.data._parse_source_timestep(bytearray(b"4h")), "1m")
+        self.assertEqual(self.data._parse_source_timestep(b"4h"), "1m")
+
+    def test_non_string_timestep_still_raises(self):
+        """``None`` must not become a minute either.
+
+        The previous implementation called ``timestep.lower()`` and raised
+        AttributeError; turning that into a silent "1m" would be a regression
+        of exactly the kind being fixed.
+        """
+        for timestep in (None, True, 1.0, 5):
+            with self.subTest(timestep=timestep):
+                with self.assertRaises(AttributeError):
+                    self.data._parse_source_timestep(timestep)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`BitunixData` overrides `_parse_source_timestep`, so the aliases `canonicalize_timestep` defines
never reached it. On `dev`, `3Min`, `5Min`, `5T`, `15Min`, `30Min` and `1Day` all resolve to
`minute` there. By the same gap, six of the nine rows in `TIMESTEP_MAPPING` are not listed among
their own representations, so they cannot be matched by name either.

## On `dev` at `c99491d`

```python
d = BitunixData.__new__(BitunixData)          # the parser needs no credentials
```

| alias | `canonicalize_timestep` | `get_timestep_from_string` |
|---|---|---|
| `3Min` | `3 minutes` | `minute` |
| `5Min`, `5T` | `5 minutes` | `minute` |
| `15Min` | `15 minutes` | `minute` |
| `30Min` | `30 minutes` | `minute` |
| `1Day` | `day` | `minute` |

By name, seven of the nine rows come back as `1m`, six of them wrongly:

```
minute -> 1m   3 minutes -> 1m   5 minutes -> 1m   15 minutes -> 1m   30 minutes -> 1m
hour   -> 1h   2 hours   -> 1m   4 hours   -> 1m   day        -> 1d
```

`"4 hours"` names a row whose representations are `["240", "240m", "4h"]`, and the lookup compares
only against that list. The result is passed to `client.get_kline(interval=...)`
(`bitunix_data.py:159`), so the request succeeds and returns candles of an interval the caller did
not ask for, with no exception raised.

## Which callers reach it

`Strategy.get_historical_prices` is not affected: it decomposes a multi-unit timestep first
(`strategy.py:4661`), fetches base-unit bars and resamples, so `"4 hours"` never arrives at the data
source. The paths that pass a timestep straight through are
`Strategy.get_historical_prices_for_assets` (`strategy.py:4940`, calling `data_source.get_bars`), the
deprecated `get_bars`, and direct `BitunixData` use.

## The change

Canonicalize the request and each representation, then compare. Both halves carry cases the other
does not, and I checked by deleting each: without the representations canonicalized, `15Min` and
`240T` fall back to `1m`, because they only meet `15m` and `240m` in canonical form; without the raw
strings, `240` and `60` fall back, because `canonicalize_timestep` returns `None` for a bare number. `DataSource._parse_source_timestep` does it differently — it canonicalizes only the request
and additionally matches each row's own `timestep` name. Canonicalizing both sides is what lets `240T` reach the `4 hours` row
through its own `240m`; on this mapping it also happens to make each row's name reachable, though
that would not hold for a mapping whose representations do not canonicalize (`TradierData`'s
`daily`/`weekly`/`monthly` are the counter-example), so this is not a general substitute for the
base class's explicit rule.

`timestep.lower()` is still the first call — the one this method already made — so a non-string
still fails on attribute access as it did before, and `bytes` and `bytearray` still match nothing and
fall through to the default. The `isinstance` test is what preserves that last part: delete it and a
`bytearray` raises `TypeError` from inside `canonicalize_timestep`'s `lru_cache` instead.

One behaviour does change: a `str`-like wrapper such as `collections.UserString("4 hours")` now
resolves instead of falling through. It is the canonical form of the row's `4h` representation that
matches it — `UserString` hashes equal to its own data, so the coercion is not what does it.

I kept the override rather than delegating to `super()` because the two differ on the unknown case:
the base raises `UnavailabeTimestep`, while `tests/test_broker_bitunix.py:298` pins BitUnix's `"1m"`.
Reconciling those is your call, not a stranger's.

## What this leaves alone

`24h`, `1440m` and `24 hours` denote a day, which BitUnix does offer, and they still return `1m`,
because `canonicalize_timestep` keeps hours and days as separate units rather than converting
(`lumibot/tools/helpers.py:950`). Teaching the day row those aliases is one line and is safe —
`representations` is input vocabulary only here, since this class has no `reverse=True` path and the
outbound interval comes from the if-chain above. I left it out because it is your mapping and those
aliases would be mine. Say the word and it goes in.

## Prior art

None of the 18 open PRs touches `bitunix_data.py` — I read the changed-file list of each — and no
open issue mentions BitUnix.

## Verification

`tests/test_bitunix_data_timesteps.py`, 7 tests / 54 subtests: every row resolves to its own
interval; every declared representation still resolves; the shared aliases resolve; whitespace is
ignored; an unsupported interval falls back to `1m` rather than snapping to a neighbour; an
unhashable `bytearray` falls through instead of raising; a non-string still raises; `"unknown"`
still returns `"1m"`.

I mutated every line this diff adds, one at a time at the defect site. The original method fails
**12**; dropping the canonicalization of the representations fails 9; dropping the raw
representation match fails 9; dropping the canonicalization of the request fails 6; dropping
`.strip()` fails 2; dropping the `isinstance` guard fails 1; dropping the `str().lower()` on the
request fails 1.

Some added lines have no failing mutant — mostly `.lower()` calls that a later `.lower()` already
covers, and two `None` guards that only keep `None` out of a set of strings. I left them where
removing one would be a silent behaviour change rather than a simplification: dropping the `.lower()`
on a representation, for instance, flips `collections.UserString("D")` from `day` to `minute`, and no
test in this file notices.

`tests/test_broker_bitunix.py` and `tests/test_timestep_aliases.py` are unmodified and pass, 24 in
total, on both trees. On `pytest tests/ -k "bitunix or timestep or helper or data_source"` the run
goes from 476 passed / 40 skipped on `dev` to 483 passed / 40 skipped here; the seven added passes
are this file's own tests. `ruff check --select F,I`, the rule set your CI uses, reports the same
three pre-existing `F821`s on this file before and after, and none in the new test file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Bitunix candle interval parsing for multi-minute and multi-hour timeframes.
  * Added support for common aliases, including `240T` and `15Min`.
  * Preserved correct fallback behavior for unsupported intervals and improved handling of whitespace and invalid inputs.

* **Tests**
  * Added coverage for canonical intervals, aliases, whitespace, unsupported values, and invalid input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->