### PR TITLE
fix: preserve legacy IB Gateway order duration

### DIFF
--- a/docs/LEGACY_IB_GATEWAY_ORDER_SEMANTICS.md
+++ b/docs/LEGACY_IB_GATEWAY_ORDER_SEMANTICS.md
@@ -1,0 +1,22 @@
+# Legacy IB Gateway Order Semantics
+
+Legacy Interactive Brokers Gateway order-duration behavior and backtesting parity.
+
+Last Updated: 2026-08-29
+
+Status: Active
+
+Audience: LumiBot contributors and maintainers
+
+## Overview
+
+The deprecated socket-based Interactive Brokers adapter must preserve an
+order's ``time_in_force`` and ``good_till_date`` on every native leg it creates
+for bracket, OTO, and OCO orders. Automatically generated advanced-order
+children inherit the same values so BacktestingBroker's existing DAY and GTD
+expiry rules model the same intent. This is intentionally centralized in the
+order entity and the legacy adapter; provider-generic strategy APIs remain
+unchanged.
+
+When a live last-price tick is unavailable, the legacy adapter may use the
+previous-close tick only when no last price has already been received.

--- a/docsrc/brokers.interactive_brokers_legacy.rst
+++ b/docsrc/brokers.interactive_brokers_legacy.rst
@@ -45,3 +45,13 @@ Set up your entry point file as above, except using Interactive Brokers. Here is
     trader.run_all()
 
 You can also see the file simple_start_ib.py for a working bot here: https://github.com/Lumiwealth/lumibot/blob/master/getting_started/simple_start_ib.py
+
+Order duration
+--------------
+
+The legacy Gateway adapter forwards ``time_in_force`` for simple and advanced
+orders. For ``time_in_force="gtd"``, also provide ``good_till_date`` as a
+``datetime``; LumiBot sends that date to every native order in a bracket, OTO,
+or OCO group. Backtesting preserves the same duration for automatically created
+advanced-order children, so ``day`` and ``gtd`` expiration behavior remains
+consistent with the legacy Gateway path.

--- a/lumibot/brokers/interactive_brokers.py
+++ b/lumibot/brokers/interactive_brokers.py
@@ -716,7 +716,7 @@ class IBWrapper(EWrapper):
 
         # If the last price is not available, then use yesterday's closing price
         # This can happen if the market is closed
-        if tickType == 9 and self.tick is None and self.should_use_last_close:
+        if tickType == 9 and self.price is None and self.should_use_last_close:
             self.price = price
             self.tick_type_used = tickType
 
@@ -1513,6 +1513,12 @@ class IBApp(IBWrapper, IBClient):
 
         return contract
 
+    @staticmethod
+    def _apply_time_in_force(ib_order, order):
+        """Copy LumiBot duration fields to every native order in an advanced order."""
+        ib_order.tif = order.time_in_force.upper()
+        ib_order.goodTillDate = order.good_till_date.strftime("%Y%m%d %H:%M:%S") if order.good_till_date else ""
+
     def create_order(self, order):
         ib_order = Order()
         if order.order_class == "bracket":
@@ -1529,6 +1535,7 @@ class IBApp(IBWrapper, IBClient):
             parent.totalQuantity = order.quantity
             parent.lmtPrice = order.limit_price
             parent.transmit = False
+            self._apply_time_in_force(parent, order)
 
             takeProfit = Order()
             takeProfit.orderId = self.nextOrderId()
@@ -1538,6 +1545,7 @@ class IBApp(IBWrapper, IBClient):
             takeProfit.lmtPrice = order.limit_price
             takeProfit.parentId = parent.orderId
             takeProfit.transmit = False
+            self._apply_time_in_force(takeProfit, order)
 
             stopLoss = Order()
             stopLoss.orderId = self.nextOrderId()
@@ -1547,6 +1555,7 @@ class IBApp(IBWrapper, IBClient):
             stopLoss.totalQuantity = order.quantity
             stopLoss.parentId = parent.orderId
             stopLoss.transmit = True
+            self._apply_time_in_force(stopLoss, order)
 
             bracketOrder = [parent, takeProfit, stopLoss]
 
@@ -1567,6 +1576,7 @@ class IBApp(IBWrapper, IBClient):
             parent.totalQuantity = order.quantity
             parent.lmtPrice = order.limit_price
             parent.transmit = False
+            self._apply_time_in_force(parent, order)
 
             if order.limit_price:
                 takeProfit = Order()
@@ -1577,6 +1587,7 @@ class IBApp(IBWrapper, IBClient):
                 takeProfit.lmtPrice = order.limit_price
                 takeProfit.parentId = parent.orderId
                 takeProfit.transmit = True
+                self._apply_time_in_force(takeProfit, order)
                 return [parent, takeProfit]
 
             elif order.stop_price:
@@ -1588,6 +1599,7 @@ class IBApp(IBWrapper, IBClient):
                 stopLoss.totalQuantity = order.quantity
                 stopLoss.parentId = parent.orderId
                 stopLoss.transmit = True
+                self._apply_time_in_force(stopLoss, order)
                 return [parent, stopLoss]
 
         elif order.order_class == "oco":
@@ -1598,6 +1610,7 @@ class IBApp(IBWrapper, IBClient):
             takeProfit.totalQuantity = order.quantity
             takeProfit.lmtPrice = order.limit_price
             takeProfit.transmit = False
+            self._apply_time_in_force(takeProfit, order)
 
             oco_Group = f"oco_{takeProfit.orderId}"
             takeProfit.ocaGroup = oco_Group
@@ -1610,6 +1623,7 @@ class IBApp(IBWrapper, IBClient):
             stopLoss.totalQuantity = order.quantity
             stopLoss.auxPrice = order.stop_price
             stopLoss.transmit = True
+            self._apply_time_in_force(stopLoss, order)
 
             stopLoss.ocaGroup = oco_Group
             stopLoss.ocaType = 1
@@ -1625,8 +1639,7 @@ class IBApp(IBWrapper, IBClient):
             if order.trail_price:
                 ib_order.auxPrice = order.trail_price
             ib_order.orderId = order.identifier if order.identifier else self.nextOrderId()
-            ib_order.tif = order.time_in_force.upper()
-            ib_order.goodTillDate = order.good_till_date.strftime("%Y%m%d %H:%M:%S") if order.good_till_date else ""
+            self._apply_time_in_force(ib_order, order)
             return [ib_order]
 
     def _create_multileg_order(self, order, exchange=None, **kwargs):
@@ -1684,8 +1697,7 @@ class IBApp(IBWrapper, IBClient):
         combo_order.action = "BUY" # TODO: This is a placeholder. This should be set based on the order side
         combo_order.orderId = combo_order_id
         combo_order.orderType = ORDERTYPE_MAPPING[order.order_type]
-        combo_order.tif = order.time_in_force.upper()
-        combo_order.goodTillDate = order.good_till_date if order.good_till_date else ""
+        self._apply_time_in_force(combo_order, order)
         combo_order.totalQuantity = min([child_order.quantity for child_order in order.child_orders])
 
         # Set the limit price if this is a limit order and a price is provided

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -954,6 +954,8 @@ class Order:
                     limit_price=self.limit_price,
                     order_type=Order.OrderType.LIMIT,
                     quote=self.quote,
+                    time_in_force=self.time_in_force,
+                    good_till_date=self.good_till_date,
                 )
                 stop_order = Order(
                     # Stop Type will be filled in automatically for child based on the Stop Modifiers
@@ -966,6 +968,8 @@ class Order:
                     trail_price=self.trail_price,
                     trail_percent=self.trail_percent,
                     quote=self.quote,
+                    time_in_force=self.time_in_force,
+                    good_till_date=self.good_till_date,
                 )
                 # Set dependencies so that the two orders will cancel the other in BackTesting
                 limit_order.dependent_order = stop_order
@@ -1001,6 +1005,8 @@ class Order:
                             limit_price=secondary_limit_price,
                             order_type=Order.OrderType.LIMIT,
                             quote=self.quote,
+                            time_in_force=self.time_in_force,
+                            good_till_date=self.good_till_date,
                         )
                     )
                 if secondary_stop_price is not None:
@@ -1016,6 +1022,8 @@ class Order:
                             trail_price=secondary_trail_price,
                             trail_percent=secondary_trail_percent,
                             quote=self.quote,
+                            time_in_force=self.time_in_force,
+                            good_till_date=self.good_till_date,
                         )
                     )
 
@@ -1054,6 +1062,8 @@ class Order:
                             limit_price=secondary_limit_price,
                             order_type=Order.OrderType.LIMIT,
                             quote=self.quote,
+                            time_in_force=self.time_in_force,
+                            good_till_date=self.good_till_date,
                         )
                     )
                 elif secondary_stop_price is not None:
@@ -1069,6 +1079,8 @@ class Order:
                             trail_price=secondary_trail_price,
                             trail_percent=secondary_trail_percent,
                             quote=self.quote,
+                            time_in_force=self.time_in_force,
+                            good_till_date=self.good_till_date,
                         )
                     )
             elif len(self.child_orders) == 1:

--- a/tests/test_legacy_ib_gateway_order_semantics.py
+++ b/tests/test_legacy_ib_gateway_order_semantics.py
@@ -1,0 +1,88 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from lumibot.brokers.interactive_brokers import IBApp, IBWrapper
+from lumibot.entities import Asset, Order
+
+
+def _legacy_ib_app():
+    app = IBApp.__new__(IBApp)
+    identifiers = iter(range(1000, 1100))
+    app.nextOrderId = lambda: next(identifiers)
+    return app
+
+
+def _legacy_order(order_class):
+    return SimpleNamespace(
+        order_class=order_class,
+        identifier=999,
+        side="buy",
+        quantity=1,
+        order_type="limit",
+        limit_price=100.0,
+        stop_price=95.0,
+        trail_price=None,
+        trail_percent=None,
+        time_in_force="gtd",
+        good_till_date=datetime(2026, 9, 1, 15, 30),
+    )
+
+
+@pytest.mark.parametrize(
+    ("order_class", "expected_order_count"),
+    [("", 1), ("bracket", 3), ("oto", 2), ("oco", 2)],
+)
+def test_legacy_ib_orders_apply_gtd_to_every_native_leg(order_class, expected_order_count):
+    native_orders = _legacy_ib_app().create_order(_legacy_order(order_class))
+
+    assert len(native_orders) == expected_order_count
+    assert [native_order.tif for native_order in native_orders] == ["GTD"] * expected_order_count
+    assert [native_order.goodTillDate for native_order in native_orders] == ["20260901 15:30:00"] * expected_order_count
+
+
+def test_legacy_ib_last_close_populates_price_only_without_last_trade():
+    wrapper = IBWrapper.__new__(IBWrapper)
+    wrapper.should_use_last_close = True
+
+    wrapper.tickPrice(reqId=1, tickType=9, price=123.45, attrib=None)
+
+    assert wrapper.price == 123.45
+    assert wrapper.tick_type_used == 9
+
+    wrapper.tickPrice(reqId=1, tickType=4, price=125.00, attrib=None)
+    wrapper.tickPrice(reqId=1, tickType=9, price=123.45, attrib=None)
+
+    assert wrapper.price == 125.00
+    assert wrapper.tick_type_used == 4
+
+
+@pytest.mark.parametrize(
+    "order_class, prices",
+    [
+        (Order.OrderClass.OCO, {"limit_price": 110.0, "stop_price": 95.0}),
+        (Order.OrderClass.BRACKET, {"secondary_limit_price": 110.0, "secondary_stop_price": 95.0}),
+        (Order.OrderClass.OTO, {"secondary_limit_price": 110.0}),
+    ],
+)
+def test_automatic_advanced_children_inherit_parent_gtd(order_class, prices):
+    good_till_date = datetime(2026, 9, 1, 15, 30, tzinfo=timezone.utc)
+    order_kwargs = {
+        "strategy": "legacy_gateway_test",
+        "asset": Asset("SPY"),
+        "quantity": 1,
+        "side": Order.OrderSide.BUY,
+        "order_type": Order.OrderType.LIMIT,
+        "order_class": order_class,
+        "time_in_force": "gtd",
+        "good_till_date": good_till_date,
+    }
+    if order_class is not Order.OrderClass.OCO:
+        order_kwargs["limit_price"] = 100.0
+    order_kwargs.update(prices)
+    parent = Order(**order_kwargs)
+
+    assert parent.child_orders
+    assert all(child.time_in_force == "gtd" for child in parent.child_orders)
+    assert all(child.good_till_date == good_till_date for child in parent.child_orders)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Order duration settings now apply consistently across standard, bracket, OTO, OCO, and multileg orders.
  * Automatically generated child orders now inherit the parent order’s duration and good-till date.
  * Price fallback behavior now uses the previous close only when no current trading price is available.

* **Documentation**
  * Added guidance on legacy Interactive Brokers order-duration behavior, including GTD requirements and advanced-order handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->