### PR TITLE
v4.5.87 - Schwab lifecycle reconciliation and runtime provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.5.87 - Unreleased
 
+### Documentation
+- **Fast order lifecycle guidance now separates strategy policy, broker constraints, and reusable state-machine invariants.** The new guide documents configurable monotonic deadlines, callback races, risk-scoped blocking, bounded reconciliation, Schwab request budgeting and measured cancel-response observations, plus a redacted telemetry contract for deadline and hedge diagnosis.
+
 ## 4.5.86 - Unreleased
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,21 @@
 
 ### Fixed
 
+- Schwab order lifecycle observations now converge through one serialized,
+  idempotent reducer shared by account-activity streaming and REST healing.
+  Cancel HTTP acceptance remains non-terminal, partial fills preserve delta
+  quantities, reconnects reconcile active orders, duplicate/out-of-order
+  observations do not repeat callbacks, and HTTP 429 responses honor bounded
+  endpoint-family backoff instead of inventing order state.
 - Define `Strategy.initial_budget` for live strategies as the first broker-verified
   portfolio equity snapshot, while preserving configured starting cash semantics in
   backtests.
 
 ### Documentation
+- **Lifecycle methods are documented as callbacks with precise live semantics.**
+  The Schwab and lifecycle references now define callback triggers, partial/full
+  fill quantity deltas, cancel acceptance versus terminal observation,
+  streaming-first reconciliation, reconnect behavior, and rate-limit handling.
 - **Fast order lifecycle guidance now separates strategy policy, broker constraints, and reusable state-machine invariants.** The new guide documents configurable monotonic deadlines, callback races, risk-scoped blocking, bounded reconciliation, Schwab request budgeting and measured cancel-response observations, plus a redacted telemetry contract for deadline and hedge diagnosis.
 
 ## 4.5.86 - Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 4.5.87 - Unreleased
+
 ## 4.5.86 - Unreleased
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.5.87 - Unreleased
+## 4.5.87 - 2026-08-30
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Fixed
 
+- Strategy parameter overrides now use the mode-neutral
+  `LUMIBOT_STRATEGY_PARAMETERS` contract in both backtests and live execution,
+  so a validated parameter set can be deployed unchanged. The former
+  `BACKTESTING_PARAMETERS` name remains a deprecated compatibility alias, and
+  logs expose parameter keys without values.
+- Backtests now record a safe `logs/data_provenance.json` artifact with the
+  versioned routing policy and data adapters actually observed, without
+  credentials or signed URLs.
+
 - Schwab order lifecycle observations now converge through one serialized,
   idempotent reducer shared by account-activity streaming and REST healing.
   Cancel HTTP acceptance remains non-terminal, partial fills preserve delta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 4.5.87 - Unreleased
 
+### Fixed
+
+- Define `Strategy.initial_budget` for live strategies as the first broker-verified
+  portfolio equity snapshot, while preserving configured starting cash semantics in
+  backtests.
+
 ### Documentation
 - **Fast order lifecycle guidance now separates strategy policy, broker constraints, and reusable state-machine invariants.** The new guide documents configurable monotonic deadlines, callback races, risk-scoped blocking, bounded reconciliation, Schwab request budgeting and measured cancel-response observations, plus a redacted telemetry contract for deadline and hedge diagnosis.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.5.87 - 2026-08-30
 
+Deploy marker: `79fdbd23938c`
+
 ### Fixed
 
 - Strategy parameter overrides now use the mode-neutral

--- a/docs/BACKTESTING_ARCHITECTURE.md
+++ b/docs/BACKTESTING_ARCHITECTURE.md
@@ -149,6 +149,20 @@ Where parallelism **does** fit today:
 - independent backtest runs (parameter sweeps, window sweeps, strategy comparisons),
 - and some bounded batching opportunities inside one run (for example grouped price lookups).
 
+Runtime strategy parameters are also mode-neutral. BotSpot and other runners
+pass one JSON object through ``LUMIBOT_STRATEGY_PARAMETERS``; LumiBot merges it
+over class and constructor defaults in both backtests and live execution. This
+keeps each run internally serial while allowing independent parameter sets to
+run in parallel at the process/container layer. ``BACKTESTING_PARAMETERS`` is
+only a deprecated compatibility alias for verified older runners and must not
+be used by new integrations.
+
+Completed runs also write ``logs/data_provenance.json``. The artifact records
+the versioned selection policy plus the adapter, vendor, exchange, symbol,
+feed, and resolution actually observed where the datasource can report those
+facts. Its schema is allowlisted so credentials, tokens, and signed URLs cannot
+enter the artifact.
+
 Practical guidance:
 
 - If you need “10 backtests at once,” prefer **process/container-level concurrency for independent runs**.

--- a/docs/FAST_ORDER_LIFECYCLE_GUIDE.md
+++ b/docs/FAST_ORDER_LIFECYCLE_GUIDE.md
@@ -1,0 +1,267 @@
+# Fast Order Lifecycle Guide
+
+Broker-neutral guidance for deadline-driven cancellation, callback races, reconciliation, hedges, and request budgets.
+
+**Last Updated:** 2026-08-28  
+**Status:** Active design and strategy-authoring guide  
+**Audience:** LumiBot strategy authors, maintainers, broker-adapter engineers, and AI-agent prompt maintainers
+
+## Overview
+
+Fast order management is not one polling loop. It is a state machine with three
+different clocks and three different policy layers:
+
+1. **Local policy time:** when the strategy intends to dispatch a cancel.
+2. **Transport time:** how long the cancel API request takes to return.
+3. **Broker lifecycle time:** when the broker finally reports `FILLED`,
+   `CANCELED`, `EXPIRED`, or an error/rejection state.
+
+The reusable architecture is broker-neutral. Broker-specific behavior belongs
+in a broker profile, and the strategy still owns its deadline, replacement,
+hedge, and conflict policy. Do not turn one strategy's timeout or risk rule into
+a global LumiBot default.
+
+## The Core Model
+
+Track each order under a stable **causal group key**. Depending on the strategy,
+that key might identify one symbol, one entry-replacement chain, one spread, or
+one entry-plus-hedge relationship.
+
+Typical states are:
+
+```text
+IDLE
+ENTRY_ACTIVE
+CANCEL_PENDING
+RECONCILE_REQUIRED
+HEDGE_SUBMITTING
+HEDGE_ACTIVE
+HEDGE_FAILED
+TERMINAL
+```
+
+All event sources feed the same idempotent reducer:
+
+- the tracked local order object;
+- `on_partially_filled_order`;
+- `on_filled_order`;
+- `on_canceled_order`;
+- a cancel response or exception;
+- a bounded exact-order reconciliation read after a missed callback, restart,
+  reconnect, or ambiguous mutation result.
+
+Callbacks and reconciliation may repeat or arrive in a surprising order. Key
+side effects by the broker order identifier and causal group so a duplicate
+event cannot submit the same hedge or replacement twice.
+
+## Deadline Design
+
+The strategy or order policy supplies `cancel_after_seconds`. LumiBot should not
+invent a universal value. If the user defines a hard upper bound, derive a
+dispatch target from that bound and an explicit local safety margin:
+
+```python
+cancel_deadline = time.monotonic() + cancel_after_seconds
+dispatch_at = cancel_deadline - local_safety_margin_seconds
+```
+
+`time.monotonic()` is appropriate for elapsed-time deadlines because wall-clock
+adjustments cannot move it backward. The safety margin covers local scheduling
+overhead; it does not guarantee network latency or broker terminal time.
+
+`self.sleeptime = "1S"` means the next trading iteration begins after the
+current iteration finishes. It does not interrupt a slow scan. A deadline that
+is checked only in a later `on_trading_iteration` can therefore be late by the
+entire scan duration.
+
+For a deadline-critical order:
+
+1. Complete expensive universe, chain, quote, liquidity, and hedge-candidate
+   work before submission.
+2. Store the exact order returned by `submit_order` and arm the monotonic
+   deadline immediately.
+3. During the short deadline window, process local pending order events with
+   `self.sleep(..., process_pending_orders=True)` and inspect the tracked object.
+4. Dispatch `cancel_order` from the local clock. Do not place a broker-backed
+   read immediately in front of that dispatch.
+5. Yield to the event loop so queued callbacks can run.
+6. If terminal state remains unknown, schedule a bounded exact-order
+   reconciliation read with backoff.
+
+Checking local state every 50 or 100 milliseconds does not consume broker API
+quota. Calling `get_order` every 50, 250, or 500 milliseconds does.
+
+## What The Callbacks Mean
+
+### `on_filled_order`
+
+This is the fastest normal transition for a full fill. The callback already
+contains the filled order. If a hedge is required, pass that callback order
+directly to an idempotent hedge helper instead of making the hedge wait for
+another broker read.
+
+### `on_partially_filled_order`
+
+Use this when hedge or replacement quantity depends on partial fills. Track
+cumulative filled quantity and hedge only the unprocessed delta. A later full
+fill callback must reuse the same idempotency state.
+
+### `on_canceled_order`
+
+This reports a terminal cancellation transition. It does **not** schedule or
+initiate the cancel. `cancel_order()` can return before the strategy's queued
+`on_canceled_order` callback runs, so code must not assume the callback executed
+synchronously inside the cancel call.
+
+These callbacks are complementary, not competing timers. Fill and cancel are
+racing broker outcomes; both should enter one reducer. Whichever terminal fact
+is accepted first wins the transition, and duplicate or stale events become
+no-ops.
+
+## Scope Blocking To Actual Risk
+
+Unknown state is not terminal, but it also does not automatically justify a
+strategy-wide freeze.
+
+- A cancel-pending order must block a conflicting replacement or additional
+  exposure for the **same causal group**.
+- An entry-plus-required-hedge group remains unresolved until its hedge policy
+  is reconciled.
+- Independent symbols or groups may continue when the strategy's capital and
+  risk policy permits.
+- A strategy-wide blocker is correct only when the strategy truly has a global
+  invariant, such as one shared capital slot or one-at-a-time execution.
+- A missing read, rate limit, or cancel exception must not be treated as
+  terminal. Defer only decisions that depend on the missing state unless a
+  broader risk policy requires more.
+
+This distinction prevents two opposite bugs: duplicate/conflicting exposure on
+one side, and unnecessarily stopping unrelated trading on the other.
+
+## Broker Request Budgets
+
+Treat rate limits as a total request budget, not a `get_order` rule. Quotes,
+option chains, broad order lists, exact order reads, account refreshes, submits,
+cancels, and replaces may all contribute to broker throttling.
+
+Prefer, in order:
+
+1. local stream/callback state for the deadline hot path;
+2. bulk market-data calls and bounded caches for scans;
+3. one exact-order read for missed callbacks or ambiguous state;
+4. broad account order reads outside the deadline-critical path;
+5. bounded retry with exponential backoff and jitter after throttling.
+
+Record a broker call budget per iteration and per endpoint family. A retry loop
+without both per-call and per-iteration bounds is a production risk.
+
+## Schwab Profile
+
+Schwab developer applications expose an application-level order limit for
+order-related requests per minute. The `schwab-py` setup guide states that
+make, cancel, and replace requests beyond the configured limit are throttled
+and rejected. Do not infer a universal market-data limit or requests-per-second
+guarantee from that application setting.
+
+An authorized local sample across two test dates measured 16 unique successful
+Schwab cancel HTTP responses:
+
+| Statistic | Client-observed cancel response time |
+|---|---:|
+| Minimum | 228 ms |
+| Median | 302.5 ms |
+| Mean | 315.6 ms |
+| Population standard deviation | 69.9 ms |
+| 90th percentile | 440.5 ms |
+| 95th percentile | 444 ms |
+| Maximum | 444 ms |
+
+The individual values were `228, 236, 249, 261, 264, 272, 275, 295, 310,
+311, 324, 343, 356, 437, 444, 444` milliseconds.
+
+This small sample describes client-observed DELETE response latency for one
+account, network path, and library version. It is not a Schwab SLA, it does not
+measure every rate-limit condition, and it does not prove when the broker's
+terminal callback becomes visible. Strategy deadlines must come from user
+intent and risk policy, not by doubling this sample's maximum.
+
+References:
+
+- [schwab-py application order limit](https://schwab-py.readthedocs.io/en/latest/getting-started.html#order-limit)
+- [schwab-py client response and timeout behavior](https://schwab-py.readthedocs.io/en/stable/client.html)
+
+## Telemetry Contract
+
+Fast lifecycle telemetry should make the three clocks observable without
+logging credentials, account numbers, raw broker payloads, or full order data.
+
+Recommended structured events:
+
+```text
+order.submit.request
+order.submit.accepted
+order.deadline.armed
+order.deadline.reached
+order.cancel.request
+order.cancel.response
+order.lifecycle.callback
+order.reconcile.request
+order.reconcile.response
+order.hedge.request
+order.hedge.accepted
+order.hedge.terminal
+broker.rate_limited
+strategy.iteration.summary
+```
+
+Recommended safe fields:
+
+- schema version and UTC timestamp;
+- run, deployment, and revision identifiers;
+- broker name and endpoint family;
+- a per-run HMAC or opaque `order_ref` and `causal_group_ref`;
+- event name and local status before/after;
+- broker status when safely normalized;
+- `elapsed_ms`, `deadline_budget_ms`, `deadline_lateness_ms`, and
+  `callback_queue_delay_ms`;
+- HTTP status, normalized error class, retry-after duration, and bounded
+  request-count window;
+- result category such as accepted, terminal, ambiguous, throttled, or failed.
+
+Never log authorization headers, access or refresh tokens, account numbers,
+callback query strings, raw request/response bodies, or a complete order spec.
+Symbols, quantities, prices, and broker order identifiers should be omitted or
+pseudonymized in shared production logs unless a separately controlled support
+surface requires them.
+
+Useful histograms and counters include:
+
+- submit response latency;
+- submit-to-cancel-decision time;
+- cancel request latency;
+- cancel-response-to-terminal-callback time;
+- submit-to-terminal time;
+- fill-callback-to-hedge-submit time;
+- iteration duration and deadline lateness;
+- request and HTTP 429 counts by broker endpoint family.
+
+## Testing Matrix
+
+A reusable regression suite should cover:
+
+- fill before the deadline;
+- partial fill followed by cancel;
+- fill while cancel is in flight;
+- cancel response before queued callback;
+- duplicate and out-of-order callbacks;
+- slow or missing exact-order reads;
+- rate limits across market-data and order endpoints;
+- restart/reconnect with ambiguous state;
+- rejected hedge and bounded retry;
+- same-risk-group replacement blocked while unrelated groups continue;
+- genuine strategy-wide risk policy that intentionally blocks all groups;
+- broker profiles with different callback and polling capabilities.
+
+Live broker tests are valuable for transport behavior, but deterministic unit
+tests should own the full race matrix. Never require real-money mutations in a
+production Agent eval.

--- a/docs/FAST_ORDER_LIFECYCLE_GUIDE.md
+++ b/docs/FAST_ORDER_LIFECYCLE_GUIDE.md
@@ -91,19 +91,31 @@ For a deadline-critical order:
 Checking local state every 50 or 100 milliseconds does not consume broker API
 quota. Calling `get_order` every 50, 250, or 500 milliseconds does.
 
-## What The Callbacks Mean
+## What Lifecycle Callback Methods Mean
+
+LumiBot's `on_*` lifecycle methods are callbacks: the framework invokes them
+after it observes an event. They are still methods on the strategy class, but
+thinking of them as callbacks makes their ownership clear. A callback reports
+an observation; it does not cause the broker event named in the method. Live
+callbacks can be delayed, duplicated by reconnect/reconciliation paths, or
+arrive while strategy iteration code is running, so their side effects must be
+idempotent and should avoid long blocking broker reads.
 
 ### `on_filled_order`
 
 This is the fastest normal transition for a full fill. The callback already
 contains the filled order. If a hedge is required, pass that callback order
 directly to an idempotent hedge helper instead of making the hedge wait for
-another broker read.
+another broker read. `quantity` is the quantity applied by this callback. It is
+the whole fill when no partial callback preceded it, or the remaining delta
+after earlier partial-fill callbacks.
 
 ### `on_partially_filled_order`
 
 Use this when hedge or replacement quantity depends on partial fills. Track
-cumulative filled quantity and hedge only the unprocessed delta. A later full
+cumulative filled quantity and hedge only the unprocessed delta. LumiBot passes
+`(position, order, price, quantity, multiplier)` and `quantity` is the newly
+observed fill delta, not the broker's cumulative filled quantity. A later full
 fill callback must reuse the same idempotency state.
 
 ### `on_canceled_order`
@@ -184,6 +196,20 @@ account, network path, and library version. It is not a Schwab SLA, it does not
 measure every rate-limit condition, and it does not prove when the broker's
 terminal callback becomes visible. Strategy deadlines must come from user
 intent and risk policy, not by doubling this sample's maximum.
+
+The Schwab adapter uses account-activity WebSocket messages as a wake-up signal,
+then reconciles only the locally tracked active orders through exact-order REST
+reads. WebSocket and REST observations feed the same serialized, idempotent
+transition reducer. The adapter performs an active-order reconciliation after
+login or reconnect and retains a 30-second broad order-history poll only as a
+healing fallback. It does not increase broad polling to once per second.
+
+A successful Schwab cancel HTTP response means the request was accepted. The
+local order remains `CANCELLING`, which is active and non-terminal, until a
+later broker observation says `CANCELED`, `FILLED`, `EXPIRED`, or rejected/error.
+Schwab 429 responses suppress more reads in the same endpoint family for the
+server's `Retry-After` interval, or bounded exponential backoff with jitter when
+that header is absent. A throttled or missing read never invents terminal state.
 
 References:
 

--- a/docs/FAST_ORDER_LIFECYCLE_GUIDE.md
+++ b/docs/FAST_ORDER_LIFECYCLE_GUIDE.md
@@ -2,8 +2,8 @@
 
 Broker-neutral guidance for deadline-driven cancellation, callback races, reconciliation, hedges, and request budgets.
 
-**Last Updated:** 2026-08-28  
-**Status:** Active design and strategy-authoring guide  
+**Last Updated:** 2026-08-28
+**Status:** Active design and strategy-authoring guide
 **Audience:** LumiBot strategy authors, maintainers, broker-adapter engineers, and AI-agent prompt maintainers
 
 ## Overview

--- a/docs/STRATEGY_INITIAL_BUDGET_RUNTIME_PARITY.md
+++ b/docs/STRATEGY_INITIAL_BUDGET_RUNTIME_PARITY.md
@@ -1,0 +1,16 @@
+# Strategy `initial_budget` runtime parity
+
+`Strategy.initial_budget` is available in both execution modes:
+
+- Backtest: the configured starting cash after `BACKTESTING_BUDGET` resolution.
+- Live: the first broker-verified portfolio equity snapshot captured during strategy
+  initialization. This includes the marked value of existing positions and must not
+  be interpreted as cash alone.
+
+If a live broker cannot provide the initial balance snapshot, the value remains
+`None`; strategies that require a persistent risk baseline should validate the value
+before using it and save their accepted baseline in strategy state.
+
+The regression test in `tests/test_strategy_initial_budget.py` covers cash-only and
+existing-position accounts and protects the constructor path that previously raised
+`AttributeError` in live execution.

--- a/docs/investigations/2026-08-28_SCHWAB_ORDER_LIFECYCLE_CALLBACKS.md
+++ b/docs/investigations/2026-08-28_SCHWAB_ORDER_LIFECYCLE_CALLBACKS.md
@@ -2,8 +2,8 @@
 
 Broker-safe lifecycle reducer, streaming wake-ups, cancellation truth, rate limiting, and callback quantity semantics.
 
-**Last Updated:** 2026-08-28  
-**Status:** Implemented locally on the active version branch; deterministic qualification complete; live stream payload capture still pending  
+**Last Updated:** 2026-08-28
+**Status:** Implemented locally on the active version branch; deterministic qualification complete; live stream payload capture still pending
 **Audience:** LumiBot maintainers, broker-adapter engineers, BotSpot runtime engineers, and Agent prompt/eval maintainers
 
 ## Overview

--- a/docs/investigations/2026-08-28_SCHWAB_ORDER_LIFECYCLE_CALLBACKS.md
+++ b/docs/investigations/2026-08-28_SCHWAB_ORDER_LIFECYCLE_CALLBACKS.md
@@ -1,0 +1,163 @@
+# Schwab Order Lifecycle Callback Investigation
+
+Broker-safe lifecycle reducer, streaming wake-ups, cancellation truth, rate limiting, and callback quantity semantics.
+
+**Last Updated:** 2026-08-28  
+**Status:** Implemented locally on the active version branch; deterministic qualification complete; live stream payload capture still pending  
+**Audience:** LumiBot maintainers, broker-adapter engineers, BotSpot runtime engineers, and Agent prompt/eval maintainers
+
+## Overview
+
+The Schwab adapter had two competing sources of local truth. Its five-second
+REST poll treated every parsed order as new, while successful cancel HTTP
+responses immediately marked orders terminal and emitted cancellation
+callbacks. That combination could lose fill/partial/cancel/reject transitions,
+duplicate callbacks after reconciliation, and release local strategy state
+before Schwab had actually confirmed cancellation.
+
+This change replaces those behaviors with one serialized transition reducer.
+Account-activity WebSocket messages wake bounded exact-order reconciliation;
+REST snapshots and stream-triggered reads enter the same reducer. Broad order
+history remains a 30-second healing path. No strategy timeout, hedge rule,
+symbol rule, or customer-specific blocking policy is embedded in the adapter.
+
+## Preserved Red Baselines
+
+The first deterministic lifecycle suite ran before product changes and produced
+`9 failed, 45 passed`. The failures reproduced the shared contracts:
+
+- a successful cancel DELETE emitted a cancellation callback and terminal local
+  status before any terminal broker observation;
+- `PARTIALLY_FILLED` degraded instead of producing an incremental fill event;
+- polled status changes were sent through the new-order path rather than a
+  transition reducer;
+- duplicate, out-of-order, cancel/fill, reject, and expiration observations did
+  not converge through one exactly-once lifecycle path.
+
+Three streaming contract tests were then added before the stream integration.
+They failed because the healing poll was still five seconds, the account
+activity handler/subscription path did not exist, and stream activity could not
+wake bounded reconciliation. A reconnect snapshot test separately failed until
+successful login/subscription woke active-order reconciliation.
+
+A rate-limit test failed because two immediate exact-order reads both called the
+broker after the first response returned HTTP 429 with `Retry-After: 2`.
+
+A deterministic concurrent test forced the REST and stream paths to observe the
+same partial fill simultaneously. Before the reducer lock, both paths emitted
+the callback. This established that dictionaries alone were not an exactly-once
+contract.
+
+## Implemented Contract
+
+### Cancellation acceptance is non-terminal
+
+`cancel_order()` always sends the explicit Schwab request when the adapter is
+ready. A successful HTTP response changes a non-terminal order to
+`CANCELLING`; it does not mark the order or child orders canceled and does not
+emit `CANCELED_ORDER`. A later broker-observed `CANCELED`, `FILLED`, `EXPIRED`,
+or rejection/error state owns the terminal transition.
+
+`Order.is_canceled()` no longer treats `CANCELLING` as terminal. This is a
+broker-neutral semantic correction: cancellation in progress is still exposed
+to a possible fill/cancel race.
+
+### One serialized transition reducer
+
+Every observed Schwab snapshot is serialized through an `RLock` and keyed by
+broker order identifier. The reducer maintains:
+
+- a cumulative executed-quantity high-water mark;
+- terminal observation keys;
+- monotonic status handling so an old `NEW` snapshot cannot overwrite
+  `CANCELLING`;
+- delta-only partial/full fill callbacks;
+- fill precedence while local cancellation is still pending;
+- exactly-once cancel and error/expiration callbacks;
+- no replay of unrelated terminal rows from the seven-day history response.
+
+Schwab execution activities are reduced to cumulative quantity and a weighted
+average fill price. The reducer converts cumulative broker values into the
+newly observed delta required by LumiBot's callback contract.
+
+### Streaming-first observation with bounded REST healing
+
+The handler is registered before stream login and account-activity
+subscription. An account-activity message is treated as an opaque wake-up, not
+as trusted order data. The reconciler performs exact reads only for locally
+tracked active orders. Successful login/reconnect also wakes reconciliation so
+events missed while disconnected are repaired.
+
+The raw account-activity payload is intentionally not parsed into order state in
+this revision. That avoids inventing an unstable provider schema before a
+sanitized Dev/local capture exists. The provider-authoritative REST response is
+the observation fed to the reducer. The broad history poll remains at 30
+seconds solely as slow healing.
+
+### Rate-limit behavior
+
+HTTP 429 on exact-order or order-history reads records a deadline per endpoint
+family. `Retry-After` is honored when present; otherwise the adapter uses
+bounded exponential backoff plus jitter, capped at 60 seconds. Reads inside the
+backoff return no observation without calling Schwab. Missing or throttled reads
+do not synthesize terminal state.
+
+One-second broad polling was rejected. It would multiply seven-day order-history
+requests without eliminating races, and it conflicts with the already observed
+aggregate 429 pressure from scans, order reads, positions, submissions, cancels,
+and market-data requests.
+
+### Safe lifecycle telemetry
+
+The adapter emits structured log fragments for cancel request/response,
+lifecycle callback, stream health, and rate-limit events. Broker order ids are
+represented by a per-process salted SHA-256 prefix. Logs omit account numbers,
+symbols, quantities, prices, response bodies, tokens, and raw stream payloads.
+The telemetry can measure HTTP response time and callback transitions but does
+not claim to measure Schwab's internal terminal-commit time.
+
+## Quantity and Callback Semantics
+
+The public contract now calls `on_*` methods lifecycle callback methods:
+
+- `on_partially_filled_order(position, order, price, quantity, multiplier)` is
+  called with the newly observed fill delta;
+- `on_filled_order(...)` receives the full fill when there were no partial
+  callbacks, or the remaining delta after earlier partials;
+- `on_canceled_order(order)` is terminal observation, not a command or timer;
+- live callbacks may be delayed or reconstructed after reconciliation, so
+  side effects must be idempotent and callback bodies should not require a
+  redundant broker read before using the supplied event.
+
+## Qualification Results
+
+The targeted deterministic gate is green:
+
+```text
+pytest tests/test_schwab_positions_unit.py tests/test_order.py -q
+83 passed
+```
+
+The suite covers non-terminal cancel acceptance, partial/final fill deltas,
+duplicate and out-of-order observations, cancel/fill races, error/expiration,
+concurrent REST/stream duplicates, handler registration order, reconnect
+reconciliation, active-only exact reads, slow broad healing, opaque telemetry,
+and `Retry-After` suppression.
+
+## Remaining Live Qualification Boundary
+
+The deterministic product contract is implemented and tested, but a sanitized
+Dev/local capture of current Schwab account-activity message types and a forced
+socket reconnect have not yet been recorded against this revision. Until that
+evidence exists, the stream remains a wake-up channel and REST remains the
+authoritative parsed order snapshot. This limitation does not reintroduce
+premature terminal state or duplicate callbacks; it limits how much REST load
+the first streaming version can remove.
+
+A live account-activity API test was added and attempted after the deterministic
+gate. The saved access token had expired and Schwab rejected automatic refresh
+with `invalid_client` because the local run had no configured app secret. Broker
+initialization therefore stopped before stream login and before any order was
+submitted. This is preserved as an authentication-precondition failure, not
+reported as streaming evidence. Re-run the marked API test after a fresh local
+authorization to close this boundary.

--- a/docsrc/_extra/sitemap.xml
+++ b/docsrc/_extra/sitemap.xml
@@ -210,7 +210,7 @@
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.schwab.html</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-08-28</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/brokers.tradier.html</loc>
@@ -342,11 +342,11 @@
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.on_canceled_order.html</loc>
-    <lastmod>2024-08-23</lastmod>
+    <lastmod>2026-08-28</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.on_filled_order.html</loc>
-    <lastmod>2024-08-23</lastmod>
+    <lastmod>2026-08-28</lastmod>
   </url>
   <url>
     <loc>https://lumibot.lumiwealth.com/lifecycle_methods.on_new_order.html</loc>

--- a/docsrc/brokers.schwab.rst
+++ b/docsrc/brokers.schwab.rst
@@ -132,6 +132,64 @@ If Schwab cannot return fresh cash or portfolio value, ``self.get_cash()`` and
 ``self.get_portfolio_value()`` return ``None`` and leave cached values unchanged.
 Do not treat ``None`` as zero.
 
+Fast cancellation and request budgets
+-------------------------------------
+
+Separate three measurements when implementing a cancel-after deadline:
+
+* the local time at which the strategy dispatches ``cancel_order``;
+* the HTTP response time for the cancel request;
+* the later broker-terminal outcome such as ``CANCELED`` or ``FILLED``.
+
+The strategy controls the first measurement. It cannot guarantee the other two
+at an exact deadline.
+
+Use a configurable ``cancel_after_seconds`` policy and an absolute
+``time.monotonic()`` deadline. Do not use one fixed timeout for every strategy.
+Finish expensive chain, quote, and liquidity work before submission; then
+process local pending order events while waiting for the deadline:
+
+.. code-block:: python
+
+   deadline = time.monotonic() + cancel_after_seconds
+   while time.monotonic() < deadline and order.is_active():
+       remaining = deadline - time.monotonic()
+       self.sleep(min(0.05, remaining), process_pending_orders=True)
+
+   if order.is_active():
+       self.cancel_order(order)
+
+The short ``self.sleep`` calls above process local queued events. They are not
+broker polls. Avoid calling ``self.get_order`` every fraction of a second or
+placing a broker read immediately before the deadline. Use a bounded exact-order
+read later for a missed callback, restart/reconnect, or ambiguous cancel result.
+
+``on_filled_order`` is the fast path for a fill and already includes the filled
+order. ``on_canceled_order`` reports terminal cancellation; it does not initiate
+the cancel. ``cancel_order`` may return before the queued
+``on_canceled_order`` callback runs. Route callbacks and later reconciliation
+through one idempotent reducer keyed by the broker order identifier or a stable
+causal group.
+
+Scope blocking to the strategy's actual risk invariant. A cancel-pending order
+must block a conflicting replacement for the same exposure. Independent symbols
+may continue when capital and risk policy permit. Unknown broker state is not
+terminal, but it does not automatically require a strategy-wide freeze.
+
+Schwab developer applications have an application-level order limit for make,
+cancel, and replace requests per minute. Treat throttling as an aggregate
+broker-call budget across market data, order lists, exact reads, submits,
+cancels, and replaces. Do not infer a universal requests-per-second guarantee.
+See the `schwab-py order-limit documentation
+<https://schwab-py.readthedocs.io/en/latest/getting-started.html#order-limit>`_
+and :doc:`lifecycle_methods.on_canceled_order`.
+
+An authorized local sample of 16 successful cancel HTTP responses ranged from
+228 ms to 444 ms, with a 302.5 ms median and 444 ms 95th percentile. This small
+sample is not a Schwab service-level guarantee and does not measure terminal
+callback visibility. Do not choose a strategy deadline by multiplying these
+observations.
+
 Example ``.env``
 ----------------
 
@@ -334,9 +392,15 @@ Market Data
 Rate Limits & Token Expiry
 --------------------------
 
-- **~120 requests/minute** for data; **2–4 trade requests/sec**.
-- Exceeding limits returns HTTP 429 errors.
-- Error codes: `429-001` = rate, `429-005` = burst; back-off 60 seconds if hit.
+- Schwab developer applications expose a configurable **order limit**: the
+  number of make, cancel, and replace requests the app may place per minute.
+  The application's configured value is authoritative for that app.
+- Schwab may return HTTP 429 when a request budget or burst limit is exceeded.
+  Respect ``Retry-After`` when present; otherwise use bounded exponential
+  backoff with jitter.
+- Do not rely on a universal data-requests-per-minute or trade-requests-per-second
+  value. Budget all broker endpoint families and measure the target app's
+  actual behavior.
 - Access tokens expire after 30 minutes; refresh tokens after 7 days.
 
 Known Issues & Best Practices

--- a/docsrc/brokers.schwab.rst
+++ b/docsrc/brokers.schwab.rst
@@ -117,9 +117,12 @@ Simple stock and single-leg option ``self.modify_order(...)`` calls use Schwab's
 replace-order endpoint. Schwab returns a new broker order id for the replacement;
 LumiBot updates the order object's ``identifier`` and keeps the old id in
 ``previous_identifiers``. For timeout logic where the intended behavior is to
-remove the order, prefer ``self.cancel_order(order)`` plus a direct
-``self.get_order(order.identifier)`` confirmation instead of modifying the
-order into a different price.
+remove the order, prefer ``self.cancel_order(order)`` instead of modifying the
+order into a different price. A successful cancel response is acceptance, not
+terminal confirmation: the order remains active with ``CANCELLING`` status
+until Schwab later reports ``CANCELED``, ``FILLED``, ``EXPIRED``, or a
+rejection/error. Do not put an immediate direct order read in front of the
+cancellation deadline.
 
 Schwab account history can include rows that are not ordinary strategy orders,
 such as mutual funds, sweep/cash-equivalent records, bonds, option exercise
@@ -171,6 +174,19 @@ the cancel. ``cancel_order`` may return before the queued
 through one idempotent reducer keyed by the broker order identifier or a stable
 causal group.
 
+These ``on_*`` methods are lifecycle callback methods: LumiBot invokes them
+after broker observations. ``on_partially_filled_order(position, order, price,
+quantity, multiplier)`` receives the newly observed fill delta in ``quantity``;
+it is not cumulative across callbacks. A later ``on_filled_order`` receives the
+remaining fill delta and must share the same idempotency state.
+
+LumiBot uses Schwab account-activity WebSocket messages to wake exact reads of
+locally tracked active orders. REST snapshots and stream-triggered observations
+feed one serialized transition reducer, including after login or reconnect. A
+30-second broad history poll remains as a healing fallback. This is deliberately
+not one-second broad polling: one-second polling multiplies request pressure and
+does not remove fill/cancel races.
+
 Scope blocking to the strategy's actual risk invariant. A cancel-pending order
 must block a conflicting replacement for the same exposure. Independent symbols
 may continue when capital and risk policy permit. Unknown broker state is not
@@ -183,6 +199,11 @@ cancels, and replaces. Do not infer a universal requests-per-second guarantee.
 See the `schwab-py order-limit documentation
 <https://schwab-py.readthedocs.io/en/latest/getting-started.html#order-limit>`_
 and :doc:`lifecycle_methods.on_canceled_order`.
+
+When Schwab returns HTTP 429, LumiBot honors ``Retry-After`` when present and
+otherwise applies bounded exponential backoff with jitter for that endpoint
+family. A throttled read returns no new observation and never converts the
+tracked order to a terminal status.
 
 An authorized local sample of 16 successful cancel HTTP responses ranged from
 228 ms to 444 ms, with a 302.5 ms median and 444 ms 95th percentile. This small

--- a/docsrc/environment_variables.rst
+++ b/docsrc/environment_variables.rst
@@ -63,16 +63,24 @@ BACKTESTING_BUDGET
   - When set, this value is preferred over any ``budget=`` passed in strategy code, so it can be controlled per-run via injected environment variables.
   - Default (when unset and no code budget is provided): ``100000``.
 
-BACKTESTING_PARAMETERS
-^^^^^^^^^^^^^^^^^^^^^^
+LUMIBOT_STRATEGY_PARAMETERS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Purpose: Override or inject strategy parameters via environment variable, without modifying strategy code.
+- Purpose: Override or inject strategy parameters without modifying strategy code. The same parameter contract applies to backtests and live strategy execution.
 - Format: JSON string representing a dictionary. Example: ``{"symbol": "AAPL", "quantity": 10}``
 - Notes:
   - When set, the parsed dict is merged on top of the strategy's existing ``parameters`` dict with highest priority (wins over both class-level defaults and code-level overrides).
-  - Useful for parameter sweeps: run the same strategy code with different parameter sets per backtest.
+  - Useful for parameter sweeps and for deploying the exact parameter set validated by a backtest.
   - Nested dicts are supported (e.g. ``{"ALLOCATION": {"SPY": 0.50, "IWM": 0.50}}``).
   - Invalid JSON or non-dict values are ignored with a warning.
+  - ``BACKTESTING_PARAMETERS`` remains a deprecated compatibility alias for older external runners. If both are present, ``LUMIBOT_STRATEGY_PARAMETERS`` wins.
+
+BOTSPOT_DATA_ROUTING_POLICY
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Purpose: Attach the non-secret version of the routing policy that selected a backtest datasource.
+- Format: JSON object containing a ``version`` field.
+- Notes: LumiBot writes the policy version and the adapters actually observed during the run to ``logs/data_provenance.json``. Credentials, tokens, and signed URLs are never included.
 
 BACKTESTING_DATA_SOURCE
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docsrc/faq.rst
+++ b/docsrc/faq.rst
@@ -441,7 +441,7 @@ Yes. LumiBot supports several environment variables for backtest configuration:
 - ``BACKTESTING_START`` / ``BACKTESTING_END`` -- date range (``YYYY-MM-DD``)
 - ``BACKTESTING_BUDGET`` -- starting cash (e.g., ``100000``)
 - ``BACKTESTING_DATA_SOURCE`` -- data source (``yahoo``, ``polygon``, ``thetadata``, etc.)
-- ``BACKTESTING_PARAMETERS`` -- JSON string of strategy parameters
+- ``LUMIBOT_STRATEGY_PARAMETERS`` -- JSON string of reusable strategy parameters (backtest and live)
 
 See :doc:`environment_variables` for the full list.
 
@@ -566,7 +566,7 @@ Define a ``parameters`` dict on your class, then access them with ``self.paramet
             symbol = self.parameters["symbol"]
             period = self.parameters["sma_period"]
 
-Parameters can be overridden at runtime via ``BACKTESTING_PARAMETERS`` environment variable.
+Parameters can be overridden at runtime via ``LUMIBOT_STRATEGY_PARAMETERS``. The same JSON object works in a backtest and in live execution, which lets you deploy the exact parameter set you validated. ``BACKTESTING_PARAMETERS`` remains a deprecated compatibility alias.
 
 What order types does LumiBot support?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docsrc/lifecycle_methods.on_canceled_order.rst
+++ b/docsrc/lifecycle_methods.on_canceled_order.rst
@@ -1,7 +1,19 @@
 def on_canceled_order
 ===================================
 
-The lifecycle method called when an order has been successfully canceled by the broker. Use this lifecycle event to execute code when an order has been canceled by the broker
+The lifecycle method called when an order has been successfully canceled by the
+broker. Use this lifecycle event to reconcile terminal cancellation state.
+
+This callback does **not** initiate cancellation or act as a timer. Call
+``self.cancel_order(order)`` from the strategy's deadline logic. The broker call
+may return before this queued callback runs, so do not assume
+``on_canceled_order`` executed synchronously inside ``cancel_order``.
+
+If callbacks, cancel exceptions, and later exact-order reconciliation can all
+observe the same order, route them through one idempotent state transition keyed
+by ``order.identifier``. Clear only the conflicting order or causal exposure
+group. Independent symbols may continue when the strategy's capital and risk
+policy permits.
 
 Parameters:
 
@@ -11,7 +23,19 @@ order (Order): The corresponding order object that has been canceled
 
     class MyStrategy(Strategy):
         def on_canceled_order(self, order):
-            self.log_message(f"{order} has been canceled by the broker")
+            order_id = order.identifier
+            group = self.order_groups.get(order_id)
+            if group is None or group["state"] == "TERMINAL":
+                return
+
+            group["state"] = "TERMINAL"
+            group["terminal_status"] = "CANCELED"
+            self.log_message(f"Order {order_id} was canceled by the broker")
+
+For a deadline-driven pattern, process local pending events while waiting and
+use a bounded exact-order read only after a missed callback, restart/reconnect,
+or ambiguous cancel result. Repeated broker polling is not required for this
+callback to work.
 
 Reference
 ----------

--- a/docsrc/lifecycle_methods.on_canceled_order.rst
+++ b/docsrc/lifecycle_methods.on_canceled_order.rst
@@ -1,8 +1,9 @@
 def on_canceled_order
 ===================================
 
-The lifecycle method called when an order has been successfully canceled by the
-broker. Use this lifecycle event to reconcile terminal cancellation state.
+The lifecycle callback method called after LumiBot observes that an order has
+been terminally canceled by the broker. Use this callback to reconcile terminal
+cancellation state.
 
 This callback does **not** initiate cancellation or act as a timer. Call
 ``self.cancel_order(order)`` from the strategy's deadline logic. The broker call
@@ -36,6 +37,12 @@ For a deadline-driven pattern, process local pending events while waiting and
 use a bounded exact-order read only after a missed callback, restart/reconnect,
 or ambiguous cancel result. Repeated broker polling is not required for this
 callback to work.
+
+In live trading, callback delivery can occur after ``cancel_order`` returns or
+after reconnect reconciliation. Keep callback work idempotent and avoid long
+blocking broker reads. In backtests the broker simulator usually delivers the
+same callback deterministically, but strategies should use the live-safe
+idempotent pattern in both modes.
 
 Reference
 ----------

--- a/docsrc/lifecycle_methods.on_filled_order.rst
+++ b/docsrc/lifecycle_methods.on_filled_order.rst
@@ -1,8 +1,9 @@
 def on_filled_order
 ===================================
 
-The lifecycle method is called when an order has been successfully filled by
-the broker. Use this lifecycle event as the fast path for fill-dependent work.
+The lifecycle callback method is called after LumiBot observes that an order
+has been fully filled by the broker. Use it as the fast path for fill-dependent
+work.
 
 The callback already supplies the filled ``order``. A required hedge should not
 wait for another broker-backed ``self.get_order(order.identifier)`` call. Route
@@ -21,6 +22,12 @@ order (Order): The corresponding order object that has been filled
 price (float): The filled price
 quantity (int): The filled quantity
 multiplier (int): Options multiplier
+
+``quantity`` is the fill quantity applied by this callback. If no partial-fill
+callback preceded it, that is normally the full order quantity. If partial
+callbacks already applied quantity, this callback carries the remaining delta.
+It is not a new cumulative total. Live reconnect/reconciliation paths can repeat
+observations, so external side effects such as hedges must be idempotent.
 
 .. code-block:: python
 

--- a/docsrc/lifecycle_methods.on_filled_order.rst
+++ b/docsrc/lifecycle_methods.on_filled_order.rst
@@ -1,7 +1,18 @@
 def on_filled_order
 ===================================
 
-The lifecycle method is called when an order has been successfully filled by the broker. Use this lifecycle event to execute code when an order has been filled by the broker
+The lifecycle method is called when an order has been successfully filled by
+the broker. Use this lifecycle event as the fast path for fill-dependent work.
+
+The callback already supplies the filled ``order``. A required hedge should not
+wait for another broker-backed ``self.get_order(order.identifier)`` call. Route
+the callback order directly to an idempotent hedge helper keyed by the entry
+order identifier. The same helper may be called by cancel-exception or
+restart/reconciliation paths without submitting a duplicate hedge.
+
+If hedge sizing depends on partial fills, use
+``on_partially_filled_order`` to process only the newly filled quantity and
+share the same cumulative idempotency state with this full-fill callback.
 
 Parameters:
 
@@ -15,6 +26,10 @@ multiplier (int): Options multiplier
 
     class MyStrategy(Strategy):
         def on_filled_order(self, position, order, price, quantity, multiplier):
+            if order.identifier in self.processed_entry_order_ids:
+                return
+            self.processed_entry_order_ids.add(order.identifier)
+
             if order.side == "sell":
                 self.log_message(f"{quantity} shares of {order.symbol} has been sold at {price}$")
             elif order.side == "buy":

--- a/docsrc/lifecycle_methods.on_partially_filled_order.rst
+++ b/docsrc/lifecycle_methods.on_partially_filled_order.rst
@@ -1,22 +1,32 @@
 def on_partially_filled_order
 ===================================
 
-The lifecycle method called when an order has been partially filled by the broker. Use this lifecycle event to execute code when an order has been partially filled by the broker.
+The lifecycle callback method called after LumiBot observes a partial broker
+fill. Use it for quantity-sensitive work such as incremental hedging.
 
 Parameters:
 
+position (Position): The updated position after applying this fill
 order (Order): The order object that is being processed by the broker
 price (float): The filled price
-quantity (int): The filled quantity
+quantity (int): The newly observed fill quantity for this callback, not the cumulative filled quantity
 multiplier (int): Options multiplier
 
 .. code-block:: python
 
     class MyStrategy(Strategy):
-        def on_partially_filled_order(self, order, price, quantity, multiplier):
-            missing = order.quantity - quantity
+        def on_partially_filled_order(self, position, order, price, quantity, multiplier):
+            order_id = order.identifier
+            previously_processed = self.processed_fill_quantity.get(order_id, 0)
+            self.processed_fill_quantity[order_id] = previously_processed + quantity
+            missing = order.quantity - self.processed_fill_quantity[order_id]
             self.log_message(f"{quantity} has been filled")
             self.log_message(f"{quantity} waiting for the remaining {missing}")
+
+The later ``on_filled_order`` callback receives the remaining delta and should
+reuse the same idempotency state. Live callbacks may be delayed or reconstructed
+after reconciliation; keep the callback short and do not require a fresh broker
+read before acting on the supplied order and quantity.
 
 Reference
 ----------

--- a/docsrc/strategy_initial_budget_runtime_parity.md
+++ b/docsrc/strategy_initial_budget_runtime_parity.md
@@ -1,0 +1,10 @@
+# Strategy `initial_budget` across runtimes
+
+Use `self.initial_budget` for the strategy's starting value. Backtests expose the
+configured starting cash. Live strategies expose the first broker-verified portfolio
+equity snapshot, including existing positions. Therefore live `initial_budget` and
+live cash are not interchangeable.
+
+For long-running strategies, validate the value and persist an accepted baseline in
+strategy state when the business rule requires the baseline to survive a process
+restart.

--- a/lumibot/backtesting/data_provenance.py
+++ b/lumibot/backtesting/data_provenance.py
@@ -1,0 +1,101 @@
+"""Safe, portable provenance artifacts for completed backtests."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+
+_OBSERVED_ROUTE_KEYS = (
+    "assetClass",
+    "symbol",
+    "adapter",
+    "vendor",
+    "exchange",
+    "feedType",
+    "resolution",
+    "windowStart",
+    "windowEnd",
+    "fallbackDecision",
+)
+
+
+def _policy_version() -> str | None:
+    raw = os.environ.get("BOTSPOT_DATA_ROUTING_POLICY")
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    version = parsed.get("version") if isinstance(parsed, dict) else None
+    return str(version) if version else None
+
+
+def _safe_routes(routes: Iterable[Any]) -> List[Dict[str, Any]]:
+    safe: List[Dict[str, Any]] = []
+    for route in routes:
+        if not isinstance(route, dict):
+            continue
+        item = {
+            key: route[key]
+            for key in _OBSERVED_ROUTE_KEYS
+            if route.get(key) is not None and isinstance(route.get(key), (str, int, float, bool))
+        }
+        if item:
+            safe.append(item)
+    return safe
+
+
+def _infer_vendor(adapter_name: str) -> str:
+    normalized = adapter_name.lower()
+    for token, vendor in (
+        ("yahoo", "yahoo"),
+        ("theta", "thetadata"),
+        ("interactivebrokers", "interactive-brokers"),
+        ("ibkr", "interactive-brokers"),
+        ("ccxt", "ccxt"),
+        ("coinbase", "coinbase"),
+        ("polygon", "polygon"),
+        ("alpaca", "alpaca"),
+        ("databento", "databento"),
+    ):
+        if token in normalized:
+            return vendor
+    return normalized.removesuffix("databacktesting").removesuffix("backtesting")
+
+
+def build_backtest_data_provenance(data_source: Any) -> Dict[str, Any]:
+    observed = None
+    getter = getattr(data_source, "get_data_provenance", None)
+    if callable(getter):
+        try:
+            candidate = getter()
+            if isinstance(candidate, dict):
+                observed = candidate.get("observedRoutes")
+        except Exception:
+            observed = None
+
+    routes = _safe_routes(observed or [])
+    if not routes:
+        adapter = type(data_source).__name__
+        routes = [{"adapter": adapter, "vendor": _infer_vendor(adapter)}]
+
+    policy_version = _policy_version()
+    return {
+        "policyVersion": policy_version,
+        "selection": "BotSpot Auto" if policy_version else "Explicit data source",
+        "observedRoutes": routes,
+    }
+
+
+def write_backtest_data_provenance(data_source: Any, directory: str | Path = "logs") -> Path:
+    artifact = Path(directory) / "data_provenance.json"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text(
+        json.dumps(build_backtest_data_provenance(data_source), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return artifact

--- a/lumibot/backtesting/routed_backtesting.py
+++ b/lumibot/backtesting/routed_backtesting.py
@@ -1086,6 +1086,39 @@ class RoutedBacktestingPandas(ThetaDataBacktestingPandas):
         self._registry = _ProviderRegistry(self)
         self._routing = self._normalize_routing(self._extract_routing_config(getattr(self, "_config", None)))
         self._registry.validate_routing(self._routing)
+        self._observed_data_routes: Dict[tuple, Dict[str, str]] = {}
+
+    def _record_observed_route(
+        self,
+        asset: Asset,
+        provider_spec: ProviderSpec,
+        *,
+        timestep: Optional[str] = None,
+        feed_type: Optional[str] = None,
+    ) -> None:
+        asset_type = _normalize_asset_type(getattr(asset, "asset_type", "")) or "unknown"
+        symbol = str(getattr(asset, "symbol", "") or "").strip()
+        adapter = type(self._registry.adapter_for_spec(provider_spec)).__name__
+        route = {
+            "assetClass": asset_type,
+            "symbol": symbol,
+            "adapter": adapter,
+            "vendor": provider_spec.provider,
+        }
+        if provider_spec.ccxt_exchange_id:
+            route["exchange"] = provider_spec.ccxt_exchange_id
+        if feed_type:
+            route["feedType"] = feed_type
+        if timestep:
+            route["resolution"] = str(timestep)
+        key = (asset_type, symbol, provider_spec.provider, provider_spec.ccxt_exchange_id, feed_type, str(timestep or ""))
+        if not isinstance(getattr(self, "_observed_data_routes", None), dict):
+            self._observed_data_routes = {}
+        self._observed_data_routes[key] = route
+
+    def get_data_provenance(self) -> Dict[str, Any]:
+        observed = getattr(self, "_observed_data_routes", {})
+        return {"observedRoutes": list(observed.values()) if isinstance(observed, dict) else []}
 
     @staticmethod
     def _extract_routing_config(config: Any) -> Optional[Dict[str, str]]:
@@ -1164,6 +1197,12 @@ class RoutedBacktestingPandas(ThetaDataBacktestingPandas):
 
         provider_spec = self._provider_spec_for_asset(asset_separated)
         adapter = self._registry.adapter_for_spec(provider_spec)
+        self._record_observed_route(
+            asset_separated,
+            provider_spec,
+            timestep=timestep,
+            feed_type="quote" if require_quote_data and not require_ohlc_data else "ohlc",
+        )
         return adapter.update_pandas_data(
             asset=asset_separated,
             quote_asset=quote_asset,

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
+import asyncio
 import base64
+import hashlib
 import os
+import random
 import re
 import threading
+import time
+from pathlib import Path
 from threading import Thread
 
 from lumibot._lazy_imports import LazyLogger, lazy_class
+
 from .broker import Broker, LumibotBrokerAPIError
+from .oauth_refresh_mode import is_external_oauth_refresh_mode
 
 logger = LazyLogger(__name__)
 TYPE_CHECKING = False
@@ -15,11 +22,6 @@ datetime = lazy_class("datetime", "datetime")
 timedelta = lazy_class("datetime", "timedelta")
 Asset = lazy_class("lumibot.entities", "Asset")
 Order = lazy_class("lumibot.entities", "Order")
-
-import time
-from pathlib import Path
-
-from .oauth_refresh_mode import is_external_oauth_refresh_mode
 
 Client = None
 StreamClient = None
@@ -330,6 +332,59 @@ class Schwab(Broker):
             return "<set>"
         return f"{hash_value[:6]}...{hash_value[-4:]}"
 
+    def _schwab_order_ref(self, order_or_identifier) -> str:
+        """Return a per-broker-process opaque order reference for shared logs."""
+        identifier = getattr(order_or_identifier, "identifier", order_or_identifier)
+        if not hasattr(self, "_schwab_telemetry_salt"):
+            self._schwab_telemetry_salt = os.urandom(16)
+        return hashlib.sha256(self._schwab_telemetry_salt + str(identifier).encode("utf-8")).hexdigest()[:16]
+
+    def _log_schwab_lifecycle_event(self, event: str, order_or_identifier, **fields) -> None:
+        safe_fields = " ".join(
+            f"{key}={value}"
+            for key, value in fields.items()
+            if value is not None
+        )
+        logger.info(
+            f"[SchwabLifecycle] event={event} order_ref={self._schwab_order_ref(order_or_identifier)}"
+            + (f" {safe_fields}" if safe_fields else "")
+        )
+
+    def _schwab_now_value(self) -> float:
+        clock = getattr(self, "_schwab_now", None)
+        return float(clock()) if callable(clock) else time.monotonic()
+
+    def _schwab_request_allowed(self, endpoint_family: str) -> bool:
+        deadlines = getattr(self, "_schwab_rate_limit_deadlines", {})
+        return self._schwab_now_value() >= float(deadlines.get(endpoint_family, 0.0))
+
+    def _record_schwab_rate_limit(self, response, endpoint_family: str) -> None:
+        if not hasattr(self, "_schwab_rate_limit_deadlines"):
+            self._schwab_rate_limit_deadlines = {}
+        if not hasattr(self, "_schwab_rate_limit_attempts"):
+            self._schwab_rate_limit_attempts = {}
+
+        retry_after = None
+        headers = getattr(response, "headers", {}) or {}
+        try:
+            retry_after = float(headers.get("Retry-After"))
+        except (TypeError, ValueError):
+            retry_after = None
+        attempts = int(self._schwab_rate_limit_attempts.get(endpoint_family, 0)) + 1
+        self._schwab_rate_limit_attempts[endpoint_family] = attempts
+        if retry_after is None:
+            retry_after = min(2 ** min(attempts, 5), 30) + random.uniform(0, 1)
+        retry_after = max(0.25, min(float(retry_after), 60.0))
+        self._schwab_rate_limit_deadlines[endpoint_family] = self._schwab_now_value() + retry_after
+        logger.warning(
+            f"[SchwabLifecycle] event=broker.rate_limited endpoint_family={endpoint_family} "
+            f"retry_after_seconds={retry_after:.3f}"
+        )
+
+    def _clear_schwab_rate_limit(self, endpoint_family: str) -> None:
+        getattr(self, "_schwab_rate_limit_attempts", {}).pop(endpoint_family, None)
+        getattr(self, "_schwab_rate_limit_deadlines", {}).pop(endpoint_family, None)
+
     @classmethod
     def _redact_schwab_payload(cls, payload):
         if isinstance(payload, dict):
@@ -399,6 +454,15 @@ class Schwab(Broker):
         self.account_number = None
         self.stream_client = None
         self.stream = None
+        # Broker observations from REST snapshots and the Schwab account stream
+        # converge through one monotonic reducer.  These high-water marks keep
+        # duplicate/replayed snapshots from emitting duplicate strategy callbacks.
+        self._schwab_observed_fill_quantities = {}
+        self._schwab_terminal_observations = set()
+        self._schwab_order_transition_lock = threading.RLock()
+        self._schwab_telemetry_salt = os.urandom(16)
+        self._schwab_activity_wakeup = threading.Event()
+        self._schwab_activity_stop = threading.Event()
         # Store if SchwabData was the goal for later client assignment
         self._is_schwab_data_intended = is_schwab_data_intended
 
@@ -858,6 +922,12 @@ class Schwab(Broker):
             self.schwab_authorization_error = True
 
     def cleanup_streams(self):
+        activity_stop = getattr(self, "_schwab_activity_stop", None)
+        if activity_stop is not None:
+            activity_stop.set()
+        activity_wakeup = getattr(self, "_schwab_activity_wakeup", None)
+        if activity_wakeup is not None:
+            activity_wakeup.set()
         refresh_stop = getattr(self, "_schwab_token_refresh_stop", None)
         if refresh_stop is not None:
             refresh_stop.set()
@@ -1259,6 +1329,9 @@ class Schwab(Broker):
             logger.error(colored("Schwab client or account hash not initialized. Cannot pull all orders.", "red"))
             return [] # Return empty list
 
+        if not self._schwab_request_allowed("order_history"):
+            return []
+
         try:
             # Get orders from last 7 days
             from pytz import timezone
@@ -1270,10 +1343,14 @@ class Schwab(Broker):
                 from_entered_datetime=seek_start
             )
 
+            if response.status_code == 429:
+                self._record_schwab_rate_limit(response, "order_history")
+                return []
             if response.status_code != 200:
                 logger.error(colored(f"Error fetching orders from Schwab: {response.status_code}", "red"))
                 return []
 
+            self._clear_schwab_rate_limit("order_history")
             schwab_orders = response.json()
 
             return schwab_orders
@@ -1307,16 +1384,23 @@ class Schwab(Broker):
             logger.error(colored(f"Schwab client or account hash not initialized. Cannot pull order {identifier}.", "red"))
             return None # Return None
 
+        if not self._schwab_request_allowed("order_read"):
+            return None
+
         try:
             response = self.client.get_order(
                 identifier,
                 self.hash_value,
             )
 
+            if response.status_code == 429:
+                self._record_schwab_rate_limit(response, "order_read")
+                return None
             if response.status_code != 200:
                 logger.error(colored(f"Error fetching Schwab order {identifier}: {response.status_code}", "red"))
                 return None
 
+            self._clear_schwab_rate_limit("order_read")
             return response.json()
 
         except Exception as e:
@@ -1479,6 +1563,7 @@ class Schwab(Broker):
             "PENDING_REPLACE": Order.OrderStatus.CANCELLING,
             "REPLACED": Order.OrderStatus.CANCELED,
             "EXPIRED": Order.OrderStatus.EXPIRED,
+            "PARTIALLY_FILLED": Order.OrderStatus.PARTIALLY_FILLED,
             "FILLED": Order.OrderStatus.FILLED,
             "UNKNOWN": Order.OrderStatus.UNKNOWN,
         }
@@ -1490,6 +1575,47 @@ class Schwab(Broker):
             "yellow",
         ))
         return Order.OrderStatus.UNKNOWN
+
+    @staticmethod
+    def _schwab_execution_summary(schwab_order: dict, leg_id=None):
+        """Return cumulative executed quantity and VWAP from a Schwab snapshot.
+
+        Schwab order-history responses describe executions as cumulative activity.
+        LumiBot callbacks require the newly observed delta, so parsing keeps the
+        cumulative broker value on the observed Order and the reducer calculates
+        the delta against a per-order high-water mark.
+        """
+        execution_rows = []
+        for activity in schwab_order.get("orderActivityCollection") or schwab_order.get("activityCollection") or []:
+            if str(activity.get("activityType", "")).upper() not in {"EXECUTION", "ORDER_EXECUTION"}:
+                continue
+            for execution in activity.get("executionLegs") or []:
+                execution_leg_id = execution.get("legId")
+                if leg_id is not None and execution_leg_id is not None and str(execution_leg_id) != str(leg_id):
+                    continue
+                try:
+                    quantity = float(execution.get("quantity") or 0)
+                    price = float(execution.get("price"))
+                except (TypeError, ValueError):
+                    continue
+                if quantity > 0:
+                    execution_rows.append((quantity, price))
+
+        if execution_rows:
+            cumulative = sum(quantity for quantity, _ in execution_rows)
+            average_price = sum(quantity * price for quantity, price in execution_rows) / cumulative
+            return cumulative, average_price
+
+        try:
+            cumulative = float(schwab_order.get("filledQuantity") or 0)
+        except (TypeError, ValueError):
+            cumulative = 0.0
+        average_price = schwab_order.get("averagePrice") or schwab_order.get("price")
+        try:
+            average_price = float(average_price) if average_price is not None else None
+        except (TypeError, ValueError):
+            average_price = None
+        return cumulative, average_price
 
     def _schwab_instruction_to_side(self, instruction):
         side_mapping = {
@@ -1588,7 +1714,7 @@ class Schwab(Broker):
 
             # Process each leg as a separate order
             order_objects = []
-            for schwab_leg in schwab_legs:
+            for leg_index, schwab_leg in enumerate(schwab_legs):
                 # Get the asset information
                 instrument = schwab_leg.get("instrument", {})
 
@@ -1643,6 +1769,15 @@ class Schwab(Broker):
                     identifier=order_id,
                 )
 
+                cumulative_filled, average_fill_price = self._schwab_execution_summary(
+                    schwab_order,
+                    leg_id=schwab_leg.get("legId", leg_index + 1),
+                )
+                order._schwab_cumulative_filled_quantity = cumulative_filled
+                order._schwab_average_fill_price = average_fill_price
+                if average_fill_price is not None:
+                    order.avg_fill_price = average_fill_price
+
                 # Set the status and timestamps
                 order.status = status
                 order.broker_create_date = entered_time
@@ -1681,6 +1816,144 @@ class Schwab(Broker):
             logger.warning(colored(f"Skipping malformed Schwab simple order: {str(e)}", "yellow"))
             logger.debug(_format_exc())
             return []
+
+    def _process_schwab_order_snapshot(self, observed_order: Order) -> None:
+        """Serialize every REST/stream observation through one reducer."""
+        if not hasattr(self, "_schwab_order_transition_lock"):
+            self._schwab_order_transition_lock = threading.RLock()
+        with self._schwab_order_transition_lock:
+            self._reduce_schwab_order_snapshot(observed_order)
+
+    def _reduce_schwab_order_snapshot(self, observed_order: Order) -> None:
+        """Reduce one broker-observed Schwab order snapshot into lifecycle events.
+
+        HTTP submit/cancel acceptance is deliberately excluded: only a later
+        broker snapshot or stream observation may make an order terminal.
+        """
+        identifier = getattr(observed_order, "identifier", None)
+        if not identifier:
+            return
+
+        if not hasattr(self, "_schwab_observed_fill_quantities"):
+            self._schwab_observed_fill_quantities = {}
+        if not hasattr(self, "_schwab_terminal_observations"):
+            self._schwab_terminal_observations = set()
+
+        stored_order = self.get_tracked_order(identifier)
+        observed_status = getattr(observed_order, "status", Order.OrderStatus.UNKNOWN)
+
+        # A seven-day healing snapshot contains unrelated historical orders.
+        # Seed only active orders that are not already tracked; terminal history
+        # must not replay callbacks into the running strategy.
+        if stored_order is None:
+            if Order.is_equivalent_status(observed_status, self.NEW_ORDER) or Order.is_equivalent_status(
+                observed_status, Order.OrderStatus.CANCELLING
+            ):
+                self._process_new_order(observed_order)
+                if Order.is_equivalent_status(observed_status, Order.OrderStatus.CANCELLING):
+                    observed_order.status = Order.OrderStatus.CANCELLING
+            return
+
+        if (
+            stored_order.is_filled()
+            or stored_order.is_canceled()
+            or Order.is_equivalent_status(stored_order.status, self.ERROR_ORDER)
+            or Order.is_equivalent_status(stored_order.status, Order.OrderStatus.EXPIRED)
+        ):
+            return
+
+        if Order.is_equivalent_status(observed_status, self.NEW_ORDER):
+            # Never regress a local/broker cancel-pending order back to NEW when
+            # an older snapshot arrives out of order.
+            if not Order.is_equivalent_status(stored_order.status, Order.OrderStatus.CANCELLING):
+                stored_order.status = Order.OrderStatus.NEW
+            return
+
+        if Order.is_equivalent_status(observed_status, Order.OrderStatus.CANCELLING):
+            stored_order.status = Order.OrderStatus.CANCELLING
+            return
+
+        if Order.is_equivalent_status(observed_status, self.PARTIALLY_FILLED_ORDER) or Order.is_equivalent_status(
+            observed_status, self.FILLED_ORDER
+        ):
+            try:
+                cumulative_filled = float(getattr(observed_order, "_schwab_cumulative_filled_quantity", 0) or 0)
+            except (TypeError, ValueError):
+                cumulative_filled = 0.0
+            if Order.is_equivalent_status(observed_status, self.FILLED_ORDER) and cumulative_filled <= 0:
+                cumulative_filled = float(stored_order.quantity or observed_order.quantity or 0)
+
+            prior_filled = float(self._schwab_observed_fill_quantities.get(identifier, 0.0))
+            if cumulative_filled <= prior_filled:
+                return
+            fill_delta = cumulative_filled - prior_filled
+            price = (
+                getattr(observed_order, "_schwab_average_fill_price", None)
+                or getattr(observed_order, "avg_fill_price", None)
+                or getattr(observed_order, "limit_price", None)
+            )
+            if price is None:
+                logger.warning(
+                    "[SchwabLifecycle] event=order.lifecycle.deferred "
+                    f"order_ref={self._schwab_order_ref(identifier)} reason=missing_fill_price"
+                )
+                return
+
+            self._schwab_observed_fill_quantities[identifier] = cumulative_filled
+            event = (
+                self.FILLED_ORDER
+                if Order.is_equivalent_status(observed_status, self.FILLED_ORDER)
+                else self.PARTIALLY_FILLED_ORDER
+            )
+            self._process_trade_event(
+                stored_order,
+                event,
+                price=price,
+                filled_quantity=fill_delta,
+                multiplier=getattr(getattr(stored_order, "asset", None), "multiplier", 1) or 1,
+            )
+            self._log_schwab_lifecycle_event(
+                "order.lifecycle.callback",
+                stored_order,
+                callback=event,
+                broker_status=observed_status,
+                local_status=stored_order.status,
+            )
+            return
+
+        if Order.is_equivalent_status(observed_status, self.CANCELED_ORDER):
+            terminal_key = (identifier, self.CANCELED_ORDER)
+            if terminal_key not in self._schwab_terminal_observations:
+                self._schwab_terminal_observations.add(terminal_key)
+                self._process_trade_event(stored_order, self.CANCELED_ORDER)
+                self._log_schwab_lifecycle_event(
+                    "order.lifecycle.callback",
+                    stored_order,
+                    callback=self.CANCELED_ORDER,
+                    broker_status=observed_status,
+                    local_status=stored_order.status,
+                )
+            return
+
+        if Order.is_equivalent_status(observed_status, self.ERROR_ORDER) or Order.is_equivalent_status(
+            observed_status, Order.OrderStatus.EXPIRED
+        ):
+            terminal_key = (identifier, str(observed_status))
+            if terminal_key not in self._schwab_terminal_observations:
+                self._schwab_terminal_observations.add(terminal_key)
+                raw_status = getattr(observed_order, "_raw_order_status", None) or str(observed_status)
+                self._process_trade_event(
+                    stored_order,
+                    self.ERROR_ORDER,
+                    error=LumibotBrokerAPIError(f"Schwab order became terminal: {raw_status}"),
+                )
+                self._log_schwab_lifecycle_event(
+                    "order.lifecycle.callback",
+                    stored_order,
+                    callback=self.ERROR_ORDER,
+                    broker_status=observed_status,
+                    local_status=stored_order.status,
+                )
 
     def _finish_initialization(self, config, data_source, account_number, hash_value):
         """
@@ -1741,11 +2014,95 @@ class Schwab(Broker):
 
     # Unimplemented methods with stubs
     def _get_stream_object(self):
-        """Get the broker stream connection"""
+        """Return the slow REST healing stream used behind account activity."""
         from lumibot.trading_builtins import PollingStream
 
-        stream = PollingStream(5.0)  # 5 seconds polling interval
+        stream = PollingStream(30.0)
         return stream
+
+    def _handle_schwab_account_activity(self, message) -> None:
+        """Wake exact-order reconciliation without logging opaque account data."""
+        message_type = "unknown"
+        try:
+            content = message.get("content") or []
+            if content and isinstance(content[0], dict):
+                message_type = content[0].get("MESSAGE_TYPE") or content[0].get("message_type") or "unknown"
+        except Exception:
+            pass
+        message_type = re.sub(r"[^A-Za-z0-9_.:-]", "_", str(message_type))[:64] or "unknown"
+        logger.info(f"[SchwabLifecycle] account_activity_received type={message_type}")
+        wakeup = getattr(self, "_schwab_activity_wakeup", None)
+        if wakeup is not None:
+            wakeup.set()
+
+    async def _configure_schwab_account_activity_stream(self, stream_client) -> None:
+        """Register the handler before login/subscription so no event is dropped."""
+        stream_client.add_account_activity_handler(self._handle_schwab_account_activity)
+        await stream_client.login()
+        await stream_client.account_activity_sub()
+        # A reconnect may have missed events. Reconcile currently tracked active
+        # orders immediately instead of waiting for the next activity message or
+        # the slow broad-history healing poll.
+        self._schwab_activity_wakeup.set()
+
+    def _reconcile_active_schwab_orders(self) -> None:
+        """Re-read only locally active orders after an account-activity event."""
+        for stored_order in list(self.get_active_tracked_orders()):
+            identifier = getattr(stored_order, "identifier", None)
+            if not identifier:
+                continue
+            raw_order = self._pull_broker_order(identifier)
+            if not raw_order:
+                continue
+            observed_order = self._parse_broker_order(raw_order, stored_order.strategy)
+            if observed_order is not None:
+                self._process_schwab_order_snapshot(observed_order)
+
+    def _run_schwab_activity_reconciler(self) -> None:
+        stop_event = self._schwab_activity_stop
+        wakeup = self._schwab_activity_wakeup
+        while not stop_event.is_set():
+            wakeup.wait(1.0)
+            if stop_event.is_set():
+                return
+            if not wakeup.is_set():
+                continue
+            wakeup.clear()
+            try:
+                self._reconcile_active_schwab_orders()
+            except Exception:
+                logger.error(_format_exc())
+
+    async def _run_schwab_account_activity_async(self) -> None:
+        backoff_seconds = 1.0
+        while not self._schwab_activity_stop.is_set():
+            stream_client = self.stream_client
+            try:
+                await self._configure_schwab_account_activity_stream(stream_client)
+                logger.info("[SchwabLifecycle] account_activity_stream_connected")
+                backoff_seconds = 1.0
+                while not self._schwab_activity_stop.is_set():
+                    await stream_client.handle_message()
+            except Exception as exc:
+                if self._schwab_activity_stop.is_set():
+                    return
+                logger.warning(
+                    f"[SchwabLifecycle] account_activity_stream_disconnected retry_seconds={backoff_seconds:g} "
+                    f"error_type={type(exc).__name__}"
+                )
+                await asyncio.sleep(backoff_seconds)
+                backoff_seconds = min(backoff_seconds * 2, 30.0)
+                try:
+                    self.stream_client = _get_stream_client_class()(self.client, account_id=self.account_number)
+                except Exception:
+                    logger.error(_format_exc())
+
+    def _run_schwab_account_activity_stream(self) -> None:
+        try:
+            asyncio.run(self._run_schwab_account_activity_async())
+        except Exception:
+            if not self._schwab_activity_stop.is_set():
+                logger.error(_format_exc())
 
     def _register_stream_events(self):
         """Register callbacks for broker stream events"""
@@ -1767,8 +2124,7 @@ class Schwab(Broker):
                 for order_data in orders:
                     order = broker._parse_broker_order(order_data, broker._strategy_name)
                     if order:
-                        # Process each new order without checking against a nonexistent _orders attribute
-                        broker._process_new_order(order)
+                        broker._process_schwab_order_snapshot(order)
             except Exception:
                 logger.error(_format_exc())
 
@@ -1779,6 +2135,21 @@ class Schwab(Broker):
                 broker._process_trade_event(
                     order,
                     broker.FILLED_ORDER,
+                    price=price,
+                    filled_quantity=filled_quantity,
+                    multiplier=order.asset.multiplier,
+                )
+                return True
+            except Exception:
+                logger.error(_format_exc())
+
+        @broker.stream.add_action(broker.PARTIALLY_FILLED_ORDER)
+        def on_trade_event_partial_fill(order, price, filled_quantity):
+            logger.info(f"Processing action for partially filled order {order} | {price} | {filled_quantity}")
+            try:
+                broker._process_trade_event(
+                    order,
+                    broker.PARTIALLY_FILLED_ORDER,
                     price=price,
                     filled_quantity=filled_quantity,
                     multiplier=order.asset.multiplier,
@@ -1799,10 +2170,11 @@ class Schwab(Broker):
         def on_trade_event_error(order, error_msg):
             logger.error(f"Processing action for error order {order} | {error_msg}")
             try:
-                if order.is_active():
-                    broker._process_trade_event(order, broker.CANCELED_ORDER)
-                logger.error(error_msg)
-                order.set_error(error_msg)
+                broker._process_trade_event(
+                    order,
+                    broker.ERROR_ORDER,
+                    error=LumibotBrokerAPIError(str(error_msg)),
+                )
             except Exception:
                 logger.error(_format_exc())
 
@@ -2800,16 +3172,10 @@ class Schwab(Broker):
             logger.error(colored(error_msg, "red"))
             raise LumibotBrokerAPIError(error_msg)
 
-        logger.info(
-            "[SchwabCancelTelemetry] request "
-            f"order_id={order.identifier} "
-            f"symbol={getattr(getattr(order, 'asset', None), 'symbol', '<missing>')} "
-            f"asset_type={getattr(getattr(order, 'asset', None), 'asset_type', '<missing>')} "
-            f"side={getattr(order, 'side', '<missing>')} "
-            f"quantity={getattr(order, 'quantity', '<missing>')} "
-            f"order_type={getattr(order, 'order_type', '<missing>')} "
-            f"local_status={getattr(order, 'status', '<missing>')} "
-            f"account_hash={self._mask_hash_value(self.hash_value)}"
+        self._log_schwab_lifecycle_event(
+            "order.cancel.request",
+            order,
+            local_status=getattr(order, "status", "<missing>"),
         )
         cancel_started = time.perf_counter()
         try:
@@ -2835,12 +3201,12 @@ class Schwab(Broker):
             raise LumibotBrokerAPIError(error_msg)
 
         response_text = getattr(response, "text", "")
-        logger.info(
-            "[SchwabCancelTelemetry] response "
-            f"order_id={order.identifier} "
-            f"http_status={status_code} "
-            f"elapsed_ms={elapsed_ms} "
-            f"body={response_text[:500] if response_text else '<empty>'}"
+        self._log_schwab_lifecycle_event(
+            "order.cancel.response",
+            order,
+            http_status=status_code,
+            elapsed_ms=elapsed_ms,
+            result="accepted" if 200 <= int(status_code) < 300 else "rejected",
         )
 
         if not 200 <= int(status_code) < 300:
@@ -2856,12 +3222,16 @@ class Schwab(Broker):
             # cancel hot path. Enable SCHWAB_CANCEL_DIAGNOSTICS to restore it.
             self._log_cancel_direct_read(order.identifier, "after_cancel_accept")
 
-        self._mark_order_tree_canceled(order)
-
-        if getattr(self, "stream", None) and hasattr(self.stream, "dispatch"):
-            self.stream.dispatch(self.CANCELED_ORDER, wait_until_complete=True, order=order)
-        else:
-            order.set_canceled()
+        # A successful DELETE means Schwab accepted the request, not that the
+        # order is terminal.  Preserve cancel-pending state and let a later
+        # broker snapshot/stream observation emit CANCELED_ORDER or FILLED_ORDER.
+        if (
+            not order.is_filled()
+            and not order.is_canceled()
+            and not Order.is_equivalent_status(order.status, self.ERROR_ORDER)
+            and not Order.is_equivalent_status(order.status, Order.OrderStatus.EXPIRED)
+        ):
+            order.status = Order.OrderStatus.CANCELLING
         return None
 
     def _log_cancel_direct_read(self, order_id: str, context: str) -> None:
@@ -2925,6 +3295,18 @@ class Schwab(Broker):
         self._register_stream_events()
         t = Thread(target=self._run_stream, daemon=True, name=f"broker_{self.name}_thread")
         t.start()
+        activity_worker = Thread(
+            target=self._run_schwab_activity_reconciler,
+            daemon=True,
+            name=f"broker_{self.name}_activity_reconciler",
+        )
+        activity_worker.start()
+        activity_stream = Thread(
+            target=self._run_schwab_account_activity_stream,
+            daemon=True,
+            name=f"broker_{self.name}_account_activity",
+        )
+        activity_stream.start()
         # Removed blocking wait for stream connection establishment
         return
 

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import asyncio
 import base64
 import hashlib
 import os
-import random
 import re
 import threading
 import time
@@ -359,6 +357,8 @@ class Schwab(Broker):
         return self._schwab_now_value() >= float(deadlines.get(endpoint_family, 0.0))
 
     def _record_schwab_rate_limit(self, response, endpoint_family: str) -> None:
+        import random
+
         if not hasattr(self, "_schwab_rate_limit_deadlines"):
             self._schwab_rate_limit_deadlines = {}
         if not hasattr(self, "_schwab_rate_limit_attempts"):
@@ -2074,6 +2074,8 @@ class Schwab(Broker):
                 logger.error(_format_exc())
 
     async def _run_schwab_account_activity_async(self) -> None:
+        import asyncio
+
         backoff_seconds = 1.0
         while not self._schwab_activity_stop.is_set():
             stream_client = self.stream_client
@@ -2098,6 +2100,8 @@ class Schwab(Broker):
                     logger.error(_format_exc())
 
     def _run_schwab_account_activity_stream(self) -> None:
+        import asyncio
+
         try:
             asyncio.run(self._run_schwab_account_activity_async())
         except Exception:

--- a/lumibot/credentials.py
+++ b/lumibot/credentials.py
@@ -210,31 +210,36 @@ if backtesting_end:
 # Get the backtesting data source
 BACKTESTING_DATA_SOURCE = os.environ.get("BACKTESTING_DATA_SOURCE", "ThetaData")
 
-# Get backtesting parameters override (JSON string -> dict)
-# Allows injecting strategy parameters via environment variable without code changes.
-# Example: BACKTESTING_PARAMETERS='{"symbol": "AAPL", "quantity": 10}'
-BACKTESTING_PARAMETERS = None
-_bt_params_raw = os.environ.get("BACKTESTING_PARAMETERS")
-if _bt_params_raw is not None:
-    _bt_params_raw = _bt_params_raw.strip()
-    if _bt_params_raw and _bt_params_raw.lower() not in ("none", "null", "{}"):
+# Get mode-neutral strategy parameter overrides (JSON string -> dict). The
+# BACKTESTING_PARAMETERS alias is retained temporarily for verified external
+# strategy runners; new callers must use LUMIBOT_STRATEGY_PARAMETERS.
+STRATEGY_PARAMETERS = None
+_strategy_params_raw = os.environ.get("LUMIBOT_STRATEGY_PARAMETERS")
+if _strategy_params_raw is None:
+    _strategy_params_raw = os.environ.get("BACKTESTING_PARAMETERS")
+if _strategy_params_raw is not None:
+    _strategy_params_raw = _strategy_params_raw.strip()
+    if _strategy_params_raw and _strategy_params_raw.lower() not in ("none", "null", "{}"):
         try:
             import json as _json
-            _parsed_params = _json.loads(_bt_params_raw)
+            _parsed_params = _json.loads(_strategy_params_raw)
             if isinstance(_parsed_params, dict):
-                BACKTESTING_PARAMETERS = _parsed_params
+                STRATEGY_PARAMETERS = _parsed_params
             else:
                 colored_message = _colored(
-                    f"BACKTESTING_PARAMETERS must be a JSON object/dict, got {type(_parsed_params).__name__}. Ignoring.",
+                    f"LUMIBOT_STRATEGY_PARAMETERS must be a JSON object/dict, got {type(_parsed_params).__name__}. Ignoring.",
                     "yellow",
                 )
                 logger.warning(colored_message)
         except Exception as _e:
             colored_message = _colored(
-                f"Failed to parse BACKTESTING_PARAMETERS: {_e}. Expected valid JSON dict. Ignoring.",
+                f"Failed to parse LUMIBOT_STRATEGY_PARAMETERS: {_e}. Expected valid JSON dict. Ignoring.",
                 "yellow",
             )
             logger.warning(colored_message)
+
+# Compatibility readback for external code that imports the old constant.
+BACKTESTING_PARAMETERS = STRATEGY_PARAMETERS
 
 # Check if we should hide trades
 hide_trades = os.environ.get("HIDE_TRADES")

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -1268,7 +1268,10 @@ class Order:
         bool
             True if the order has been cancelled, False otherwise.
         """
-        return self.status.lower() in ["cancelled", "canceled", "cancel", "cancelling", "error", "expired"]
+        # ``cancelling`` means the broker has accepted or is processing a cancel
+        # request.  It is deliberately active/non-terminal because a fill can
+        # still win the race before the broker confirms cancellation.
+        return self.status.lower() in ["cancelled", "canceled", "cancel", "error", "expired"]
 
     def is_filled(self):
         """

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -215,6 +215,7 @@ class Order:
         OrderStatus.SUBMITTED,
         OrderStatus.OPEN,
         OrderStatus.NEW,
+        OrderStatus.CANCELLING,
         OrderStatus.PARTIALLY_FILLED,
     )
 

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -871,6 +871,11 @@ class _Strategy:
         # Set the the state of first iteration to True. This will later be updated to False by the strategy executor
         self._first_iteration = True
 
+        # Public Strategy.initial_budget is available in both runtimes. Backtests
+        # replace this with configured starting cash below; live strategies replace
+        # it with the first broker-verified account equity snapshot.
+        self._initial_budget = None
+
         # Setting execution parameters
         self._last_on_trading_iteration_datetime = None
         if not self.is_backtesting:
@@ -879,6 +884,7 @@ class _Strategy:
             if synchronize_broker_on_start:
                 self.update_broker_balances()
                 self.broker._set_initial_positions(self)
+                self._initial_budget = self._portfolio_value
         else:
             # Determine initial cash ("budget") for backtesting.
             # NOTE: In BotSpot/BotManager runs we often inject settings via environment variables.

--- a/lumibot/strategies/_strategy.py
+++ b/lumibot/strategies/_strategy.py
@@ -414,11 +414,13 @@ def _json_loads(*args, **kwargs):
     return _json_module().loads(*args, **kwargs)
 
 
-def _get_backtesting_parameters():
+def _get_strategy_parameters():
     if not _DEFER_CREDENTIALS_ON_IMPORT:
-        return getattr(_credentials(), "BACKTESTING_PARAMETERS", None)
+        return getattr(_credentials(), "STRATEGY_PARAMETERS", None)
 
-    raw = os.environ.get("BACKTESTING_PARAMETERS")
+    raw = os.environ.get("LUMIBOT_STRATEGY_PARAMETERS")
+    if raw is None:
+        raw = os.environ.get("BACKTESTING_PARAMETERS")
     if raw is None:
         return None
     raw = raw.strip()
@@ -1005,13 +1007,14 @@ class _Strategy:
         if parameters is not None and isinstance(self.parameters, dict):
             self.parameters = {**self.parameters, **parameters}
 
-        # Apply BACKTESTING_PARAMETERS env var override (highest priority, wins over code-level params)
-        BACKTESTING_PARAMETERS = _get_backtesting_parameters()
-        if BACKTESTING_PARAMETERS is not None and isinstance(BACKTESTING_PARAMETERS, dict):
-            self.parameters = {**self.parameters, **BACKTESTING_PARAMETERS}
+        # Apply one mode-neutral override with highest priority for both
+        # backtests and live execution.
+        strategy_parameter_overrides = _get_strategy_parameters()
+        if strategy_parameter_overrides is not None and isinstance(strategy_parameter_overrides, dict):
+            self.parameters = {**self.parameters, **strategy_parameter_overrides}
             self.logger.info(
                 colored(
-                    f"Applied BACKTESTING_PARAMETERS override: {list(BACKTESTING_PARAMETERS.keys())}",
+                    f"Applied strategy parameter override keys: {list(strategy_parameter_overrides.keys())}",
                     "green",
                 )
             )
@@ -3528,6 +3531,15 @@ class _Strategy:
                 tearsheet_metrics_file=tearsheet_metrics_file,
                 base_filename=base_filename,
             )
+
+            try:
+                from lumibot.backtesting.data_provenance import write_backtest_data_provenance
+
+                write_backtest_data_provenance(data_source, logdir)
+            except Exception as exc:
+                # Provenance is diagnostic metadata and must never make an otherwise valid
+                # trading simulation fail at the artifact-writing boundary.
+                self.logger.warning("Backtest data provenance artifact could not be written: %s", exc)
 
             end = datetime.datetime.now()
             backtesting_length = backtesting_end - backtesting_start

--- a/lumibot/strategies/strategy.py
+++ b/lumibot/strategies/strategy.py
@@ -186,10 +186,14 @@ class Strategy(_Strategy):
 
     @property
     def initial_budget(self):
-        """Returns the initial budget for the strategy.
+        """Returns the strategy's starting value.
+
+        In backtests this is the configured starting cash. In live trading it is
+        the first broker-verified portfolio equity snapshot, including existing
+        positions; it is not merely the account's cash balance.
 
         Returns:
-            float: The initial budget for the strategy.
+            float: Starting backtest cash or live account equity.
 
         Example
         -------

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.86",
+    version="4.5.87",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/tests/backtest/acceptance_strategies/AAPL Deep Dip Calls (Copy 4).py
+++ b/tests/backtest/acceptance_strategies/AAPL Deep Dip Calls (Copy 4).py
@@ -274,6 +274,15 @@ class AAPLDeepDipCalls(Strategy):
         if self.vars.option_asset is None:
             self.log_message("No option position to close.", color="yellow")
             return
+        active_closes = [
+            order
+            for order in self.get_orders(statuses=Order.ACTIVE_STATUSES, broker_refresh=False)
+            if order.asset == self.vars.option_asset
+            and order.side in {Order.OrderSide.SELL, Order.OrderSide.SELL_TO_CLOSE}
+        ]
+        if active_closes:
+            self.log_message("Option close is still active; waiting for its terminal callback.", color="yellow")
+            return
         pos = self.get_position(self.vars.option_asset)
         if pos is None or pos.quantity is None or pos.quantity == 0:
             self.log_message("Position already closed.", color="white")

--- a/tests/backtest/acceptance_strategies/manifest.json
+++ b/tests/backtest/acceptance_strategies/manifest.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "filename": "AAPL Deep Dip Calls (Copy 4).py",
-      "sha256": "40a78abb80eab44f19a0af8141c5980ec9603bf7bbd1af15d0990da125e9b75b"
+      "sha256": "37f72a2ed0639d120d92ceb3bc9eb37c34feb38ea9423fb17b65795af3b3d52a"
     },
     {
       "filename": "Backdoor Butterfly 0 DTE (Copy) - with SMART LIMITS.py",
@@ -32,4 +32,3 @@
     }
   ]
 }
-

--- a/tests/test_backtest_data_provenance.py
+++ b/tests/test_backtest_data_provenance.py
@@ -1,0 +1,69 @@
+import json
+
+
+def test_build_backtest_data_provenance_prefers_observed_routes_and_redacts_secrets(monkeypatch):
+    from lumibot.backtesting.data_provenance import build_backtest_data_provenance
+
+    class RoutedSource:
+        def get_data_provenance(self):
+            return {
+                "observedRoutes": [
+                    {
+                        "assetClass": "crypto",
+                        "symbol": "BTC",
+                        "adapter": "CcxtRoutingAdapter",
+                        "vendor": "ccxt",
+                        "exchange": "coinbase",
+                        "feedType": "ohlc",
+                        "resolution": "minute",
+                        "apiKey": "must-not-leak",
+                        "signedUrl": "https://example.invalid/private",
+                    }
+                ]
+            }
+
+    monkeypatch.setenv(
+        "BOTSPOT_DATA_ROUTING_POLICY",
+        json.dumps({"version": "botspot-auto-2026-08-28", "routes": {"crypto": "coinbase"}}),
+    )
+
+    provenance = build_backtest_data_provenance(RoutedSource())
+
+    assert provenance == {
+        "policyVersion": "botspot-auto-2026-08-28",
+        "selection": "BotSpot Auto",
+        "observedRoutes": [
+            {
+                "assetClass": "crypto",
+                "symbol": "BTC",
+                "adapter": "CcxtRoutingAdapter",
+                "vendor": "ccxt",
+                "exchange": "coinbase",
+                "feedType": "ohlc",
+                "resolution": "minute",
+            }
+        ],
+    }
+    assert "must-not-leak" not in json.dumps(provenance)
+    assert "example.invalid" not in json.dumps(provenance)
+
+
+def test_write_backtest_data_provenance_creates_a_stable_artifact(tmp_path):
+    from lumibot.backtesting.data_provenance import write_backtest_data_provenance
+
+    class YahooDataBacktesting:
+        pass
+
+    artifact = write_backtest_data_provenance(YahooDataBacktesting(), tmp_path)
+
+    assert artifact == tmp_path / "data_provenance.json"
+    assert json.loads(artifact.read_text()) == {
+        "policyVersion": None,
+        "selection": "Explicit data source",
+        "observedRoutes": [
+            {
+                "adapter": "YahooDataBacktesting",
+                "vendor": "yahoo",
+            }
+        ],
+    }

--- a/tests/test_lazy_exports.py
+++ b/tests/test_lazy_exports.py
@@ -81,6 +81,7 @@ def test_startup_class_exports_defer_heavy_dependencies():
     env = os.environ.copy()
     env["LUMIBOT_DISABLE_DOTENV"] = "1"
     env["LUMIBOT_DISABLE_DOTENV_LOCAL"] = "1"
+    env["LUMIBOT_LAZY_CREDENTIALS"] = "1"
     env["LUMIBOT_LOG_LEVEL"] = "ERROR"
 
     result = subprocess.run(

--- a/tests/test_schwab_live_refresh_apitest.py
+++ b/tests/test_schwab_live_refresh_apitest.py
@@ -1,14 +1,13 @@
+import asyncio
 import os
 import time
 from datetime import date
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
 from lumibot.brokers.schwab import Schwab
 from lumibot.entities import Asset, Order
-
 
 pytestmark = pytest.mark.apitest
 
@@ -49,6 +48,14 @@ def _poll_all_for_order(broker, order_id, strategy_name, *, timeout_seconds=4.0)
         if raw or time.perf_counter() >= deadline:
             return raw, parsed
         time.sleep(0.25)
+
+
+def _account_activity_message_type(message):
+    content = message.get("content") if isinstance(message, dict) else None
+    first = content[0] if isinstance(content, list) and content else {}
+    if not isinstance(first, dict):
+        return "unknown"
+    return str(first.get("MESSAGE_TYPE") or first.get("message_type") or "unknown")
 
 
 def _select_tsll_call_asset(broker):
@@ -143,6 +150,73 @@ def test_schwab_live_submit_read_cancel_refresh(monkeypatch):
         )
         assert post_cancel_all["status"] in {"CANCELED", "CANCELLED"}
         assert post_cancel_all_parsed.is_canceled()
+    finally:
+        if submitted and submitted.identifier:
+            try:
+                raw = broker._pull_broker_order(submitted.identifier)
+                status = str(raw.get("status", "") if raw else "").upper()
+                if status not in {"CANCELED", "CANCELLED", "FILLED", "REJECTED", "EXPIRED"}:
+                    broker.cancel_order(submitted)
+            except Exception:
+                pass
+
+
+def test_schwab_live_account_activity_stream_observes_order_change(monkeypatch):
+    """Connects the real account stream and verifies an order change wakes it.
+
+    Raw provider messages are deliberately not written to test output or disk.
+    The product adapter treats them as opaque wake-ups and reconciles through an
+    exact REST order read.
+    """
+
+    broker = _schwab_broker(monkeypatch)
+    strategy_name = "schwab-live-account-activity-apitest"
+    submitted = None
+    observed_message_types = []
+
+    order = Order(
+        strategy=strategy_name,
+        asset=Asset("TSLL", asset_type=Asset.AssetType.STOCK),
+        quantity=1,
+        side=Order.OrderSide.BUY,
+        order_type=Order.OrderType.LIMIT,
+        limit_price=0.01,
+        time_in_force="day",
+        tag=strategy_name,
+    )
+
+    async def exercise_stream():
+        nonlocal submitted
+
+        def record_activity(message):
+            observed_message_types.append(_account_activity_message_type(message))
+
+        stream_client = broker.stream_client
+        stream_client.add_account_activity_handler(record_activity)
+        await broker._configure_schwab_account_activity_stream(stream_client)
+        try:
+            submitted = await asyncio.to_thread(broker._submit_order, order)
+            assert submitted is not None
+            assert submitted.identifier
+            try:
+                await asyncio.to_thread(broker.cancel_order, submitted)
+            except Exception:
+                # The order may transition to rejected before after-hours cancel;
+                # that broker transition should still produce account activity.
+                pass
+
+            deadline = time.monotonic() + 10
+            while not observed_message_types and time.monotonic() < deadline:
+                await asyncio.wait_for(stream_client.handle_message(), timeout=5)
+        finally:
+            try:
+                await stream_client.account_activity_unsubs()
+            finally:
+                await stream_client.logout()
+
+    try:
+        asyncio.run(exercise_stream())
+        assert observed_message_types
     finally:
         if submitted and submitted.identifier:
             try:

--- a/tests/test_schwab_positions_unit.py
+++ b/tests/test_schwab_positions_unit.py
@@ -1,7 +1,8 @@
+import asyncio
 import logging
 import time
 from datetime import date
-from threading import Event, RLock
+from threading import Barrier, BrokenBarrierError, Event, RLock, Thread
 from types import SimpleNamespace
 
 import pytest
@@ -64,6 +65,19 @@ class _OrderClient:
     def get_order(self, order_id, account_hash):
         self.get_order_calls.append((order_id, account_hash))
         return self.response
+
+
+class _RateLimitedOrderClient:
+    def __init__(self):
+        self.get_order_calls = []
+
+    def get_order(self, order_id, account_hash):
+        self.get_order_calls.append((order_id, account_hash))
+        return SimpleNamespace(
+            status_code=429,
+            headers={"Retry-After": "2"},
+            text="too many requests",
+        )
 
 
 class _OrderResponse:
@@ -133,6 +147,22 @@ class _Stream:
         self.dispatched.append((event, wait_until_complete, payload))
 
 
+class _AccountActivityStreamClient:
+    def __init__(self):
+        self.calls = []
+        self.handler = None
+
+    def add_account_activity_handler(self, handler):
+        self.calls.append("add_handler")
+        self.handler = handler
+
+    async def login(self):
+        self.calls.append("login")
+
+    async def account_activity_sub(self):
+        self.calls.append("subscribe")
+
+
 def _position(asset_type, symbol, quantity=1, **instrument):
     return {
         "instrument": {
@@ -183,6 +213,37 @@ def _order(status=Order.OrderStatus.SUBMITTED, identifier="order-123"):
         identifier=identifier,
         status=status,
     )
+
+
+def _observed_order(status, cumulative_filled=0, average_fill_price=None, identifier="order-123"):
+    order = _order(status=status, identifier=identifier)
+    order._schwab_cumulative_filled_quantity = float(cumulative_filled)
+    order._schwab_average_fill_price = average_fill_price
+    return order
+
+
+def _broker_for_lifecycle(stored_order):
+    broker = Schwab.__new__(Schwab)
+    broker._schwab_observed_fill_quantities = {}
+    broker._schwab_terminal_observations = set()
+    broker.get_tracked_order = lambda identifier: stored_order if identifier == stored_order.identifier else None
+    broker.get_all_orders = lambda: [stored_order]
+    broker._process_new_order = lambda order: order
+    broker._lifecycle_events = []
+
+    def process_trade_event(order, event, **payload):
+        broker._lifecycle_events.append((event, payload))
+        if event == broker.PARTIALLY_FILLED_ORDER:
+            order.status = Order.OrderStatus.PARTIALLY_FILLED
+        elif event == broker.FILLED_ORDER:
+            order.status = Order.OrderStatus.FILLED
+        elif event == broker.CANCELED_ORDER:
+            order.status = Order.OrderStatus.CANCELED
+        elif event == broker.ERROR_ORDER:
+            order.status = Order.OrderStatus.ERROR
+
+    broker._process_trade_event = process_trade_event
+    return broker
 
 
 def _option_asset():
@@ -1001,9 +1062,26 @@ def test_schwab_cancel_order_calls_client_with_order_id_then_account_hash():
     broker.cancel_order(order)
 
     assert client.cancel_calls == [("order-123", "account-hash")]
-    assert stream.dispatched == [
-        (broker.CANCELED_ORDER, True, {"order": order}),
-    ]
+    # A successful DELETE only accepts the request. Terminal cancellation must
+    # arrive later from a broker-observed order transition so a late fill cannot
+    # be hidden behind a premature on_canceled_order callback.
+    assert stream.dispatched == []
+    assert order.status == Order.OrderStatus.CANCELLING
+
+
+def test_schwab_cancel_lifecycle_telemetry_uses_opaque_order_reference(caplog):
+    caplog.set_level(logging.INFO, logger="lumibot.brokers.schwab")
+    client = _CancelClient()
+    broker = _broker_for_cancel(client=client, stream=None)
+    order = _order(identifier="sensitive-order-123")
+
+    broker.cancel_order(order)
+
+    lifecycle_rows = [record.message for record in caplog.records if "[SchwabLifecycle]" in record.message]
+    assert any("event=order.cancel.request" in row for row in lifecycle_rows)
+    assert any("event=order.cancel.response" in row and "elapsed_ms=" in row for row in lifecycle_rows)
+    assert all("sensitive-order-123" not in row for row in lifecycle_rows)
+    assert all("body=" not in row for row in lifecycle_rows)
 
 
 def test_schwab_cancel_order_calls_client_even_when_local_status_is_cancelling():
@@ -1029,7 +1107,25 @@ def test_schwab_pull_broker_order_calls_client_with_order_id_then_account_hash()
     assert raw["orderId"] == "order-123"
 
 
-def test_schwab_cancel_order_marks_canceled_without_stream_after_success():
+def test_schwab_exact_order_read_honors_retry_after_without_inventing_state():
+    client = _RateLimitedOrderClient()
+    broker = _broker_for_order_pull(client=client)
+    now = {"value": 100.0}
+    broker._schwab_now = lambda: now["value"]
+
+    assert broker._pull_broker_order("order-123") is None
+    assert broker._pull_broker_order("order-123") is None
+    assert client.get_order_calls == [("order-123", "account-hash")]
+
+    now["value"] = 103.0
+    assert broker._pull_broker_order("order-123") is None
+    assert client.get_order_calls == [
+        ("order-123", "account-hash"),
+        ("order-123", "account-hash"),
+    ]
+
+
+def test_schwab_cancel_order_acceptance_is_non_terminal_without_stream():
     client = _CancelClient()
     broker = _broker_for_cancel(client=client, stream=None)
     order = _order()
@@ -1037,11 +1133,11 @@ def test_schwab_cancel_order_marks_canceled_without_stream_after_success():
     broker.cancel_order(order)
 
     assert client.cancel_calls == [("order-123", "account-hash")]
-    assert order.status == broker.CANCELED_ORDER
-    assert order.is_canceled()
+    assert order.status == Order.OrderStatus.CANCELLING
+    assert not order.is_canceled()
 
 
-def test_schwab_cancel_order_marks_advanced_order_children_canceled():
+def test_schwab_cancel_order_does_not_mark_advanced_order_children_terminal_on_acceptance():
     client = _CancelClient()
     stream = _Stream()
     broker = _broker_for_cancel(client=client, stream=stream)
@@ -1062,9 +1158,197 @@ def test_schwab_cancel_order_marks_advanced_order_children_canceled():
     broker.cancel_order(order)
 
     assert client.cancel_calls == [("oco-parent", "account-hash")]
-    assert order.is_canceled()
-    assert all(child.is_canceled() for child in order.child_orders)
-    assert not order.is_active()
+    assert not order.is_canceled()
+    assert all(not child.is_canceled() for child in order.child_orders)
+    assert order.is_active()
+
+
+def test_schwab_status_maps_partial_fill_without_degrading_to_unknown():
+    broker = Schwab.__new__(Schwab)
+
+    assert broker._schwab_status_to_lumibot("PARTIALLY_FILLED") == Order.OrderStatus.PARTIALLY_FILLED
+
+
+def test_schwab_healing_poll_stays_slow_when_account_activity_stream_is_primary():
+    broker = Schwab.__new__(Schwab)
+
+    stream = broker._get_stream_object()
+
+    assert stream.polling_interval == 30.0
+
+
+def test_schwab_account_activity_handler_is_registered_before_login_and_subscription():
+    broker = Schwab.__new__(Schwab)
+    broker._schwab_activity_wakeup = Event()
+    client = _AccountActivityStreamClient()
+
+    asyncio.run(broker._configure_schwab_account_activity_stream(client))
+
+    assert client.calls == ["add_handler", "login", "subscribe"]
+    assert callable(client.handler)
+    assert broker._schwab_activity_wakeup.is_set()
+
+
+def test_schwab_account_activity_callback_only_wakes_bounded_reconciliation():
+    broker = Schwab.__new__(Schwab)
+    broker._schwab_activity_wakeup = Event()
+
+    broker._handle_schwab_account_activity(
+        {"service": "ACCT_ACTIVITY", "content": [{"MESSAGE_TYPE": "OrderFill"}]}
+    )
+
+    assert broker._schwab_activity_wakeup.is_set()
+
+
+def test_schwab_account_activity_log_sanitizes_provider_message_type(caplog):
+    broker = Schwab.__new__(Schwab)
+    broker._schwab_activity_wakeup = Event()
+    caplog.set_level(logging.INFO, logger="lumibot.brokers.schwab")
+
+    broker._handle_schwab_account_activity(
+        {"content": [{"MESSAGE_TYPE": "OrderFill\nraw-account-data"}]}
+    )
+
+    rows = [record.message for record in caplog.records if "account_activity_received" in record.message]
+    assert rows == ["[SchwabLifecycle] account_activity_received type=OrderFill_raw-account-data"]
+    assert all("\n" not in row for row in rows)
+
+
+def test_schwab_execution_activity_parses_cumulative_quantity_and_vwap():
+    broker = Schwab.__new__(Schwab)
+    payload = {
+        "orderId": "order-123",
+        "orderType": "LIMIT",
+        "status": "PARTIALLY_FILLED",
+        "price": 11,
+        "orderLegCollection": [
+            {
+                "legId": 1,
+                "instruction": "BUY",
+                "quantity": 3,
+                "orderLegType": "EQUITY",
+                "instrument": {"symbol": "SPY", "assetType": "EQUITY"},
+            }
+        ],
+        "orderActivityCollection": [
+            {
+                "activityType": "EXECUTION",
+                "executionLegs": [
+                    {"legId": 1, "quantity": 1, "price": 10},
+                    {"legId": 1, "quantity": 1, "price": 11},
+                ],
+            }
+        ],
+    }
+
+    observed = broker._parse_broker_order(payload, "unit-test")
+
+    assert observed.status == Order.OrderStatus.PARTIALLY_FILLED
+    assert observed._schwab_cumulative_filled_quantity == 2
+    assert observed._schwab_average_fill_price == 10.5
+
+
+def test_schwab_account_activity_reconciliation_reads_only_active_tracked_orders():
+    active = _order(status=Order.OrderStatus.CANCELLING, identifier="active-1")
+    broker = Schwab.__new__(Schwab)
+    broker.get_active_tracked_orders = lambda: [active]
+    broker._pull_broker_order_calls = []
+    broker._pull_broker_order = (
+        lambda identifier: broker._pull_broker_order_calls.append(identifier) or {"orderId": identifier}
+    )
+    observed = _observed_order(Order.OrderStatus.CANCELED, identifier="active-1")
+    broker._parse_broker_order = lambda raw, strategy: observed
+    broker._processed_snapshots = []
+    broker._process_schwab_order_snapshot = broker._processed_snapshots.append
+
+    broker._reconcile_active_schwab_orders()
+
+    assert broker._pull_broker_order_calls == ["active-1"]
+    assert broker._processed_snapshots == [observed]
+
+
+def test_schwab_snapshot_reducer_emits_incremental_partial_and_final_fill_once():
+    stored = _order(status=Order.OrderStatus.SUBMITTED)
+    broker = _broker_for_lifecycle(stored)
+
+    observations = [
+        _observed_order(Order.OrderStatus.PARTIALLY_FILLED, 1, 10.0),
+        _observed_order(Order.OrderStatus.PARTIALLY_FILLED, 1, 10.0),
+        _observed_order(Order.OrderStatus.PARTIALLY_FILLED, 2, 10.5),
+        _observed_order(Order.OrderStatus.PARTIALLY_FILLED, 1, 10.0),
+        _observed_order(Order.OrderStatus.FILLED, 3, 11.0),
+        _observed_order(Order.OrderStatus.FILLED, 3, 11.0),
+    ]
+    for observation in observations:
+        broker._process_schwab_order_snapshot(observation)
+
+    assert broker._lifecycle_events == [
+        (broker.PARTIALLY_FILLED_ORDER, {"price": 10.0, "filled_quantity": 1.0, "multiplier": 1}),
+        (broker.PARTIALLY_FILLED_ORDER, {"price": 10.5, "filled_quantity": 1.0, "multiplier": 1}),
+        (broker.FILLED_ORDER, {"price": 11.0, "filled_quantity": 1.0, "multiplier": 1}),
+    ]
+
+
+def test_schwab_snapshot_reducer_serializes_duplicate_stream_and_rest_observations():
+    stored = _order(status=Order.OrderStatus.SUBMITTED)
+    broker = _broker_for_lifecycle(stored)
+    simultaneous_gets = Barrier(2)
+
+    class _RacingHighWater(dict):
+        def get(self, key, default=None):
+            value = super().get(key, default)
+            try:
+                simultaneous_gets.wait(timeout=0.1)
+            except BrokenBarrierError:
+                pass
+            return value
+
+    broker._schwab_observed_fill_quantities = _RacingHighWater()
+    observation = _observed_order(Order.OrderStatus.PARTIALLY_FILLED, 1, 10.0)
+    workers = [Thread(target=broker._process_schwab_order_snapshot, args=(observation,)) for _ in range(2)]
+
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=2)
+
+    assert broker._lifecycle_events == [
+        (broker.PARTIALLY_FILLED_ORDER, {"price": 10.0, "filled_quantity": 1.0, "multiplier": 1}),
+    ]
+
+
+def test_schwab_snapshot_reducer_waits_for_terminal_cancel_and_dispatches_once():
+    stored = _order(status=Order.OrderStatus.CANCELLING)
+    broker = _broker_for_lifecycle(stored)
+
+    broker._process_schwab_order_snapshot(_observed_order(Order.OrderStatus.CANCELLING))
+    broker._process_schwab_order_snapshot(_observed_order(Order.OrderStatus.CANCELED))
+    broker._process_schwab_order_snapshot(_observed_order(Order.OrderStatus.CANCELED))
+
+    assert broker._lifecycle_events == [(broker.CANCELED_ORDER, {})]
+
+
+def test_schwab_snapshot_reducer_prefers_late_fill_over_local_cancel_pending():
+    stored = _order(status=Order.OrderStatus.CANCELLING)
+    broker = _broker_for_lifecycle(stored)
+
+    broker._process_schwab_order_snapshot(_observed_order(Order.OrderStatus.FILLED, 1, 25.0))
+
+    assert broker._lifecycle_events == [
+        (broker.FILLED_ORDER, {"price": 25.0, "filled_quantity": 1.0, "multiplier": 1}),
+    ]
+
+
+@pytest.mark.parametrize("terminal_status", [Order.OrderStatus.ERROR, Order.OrderStatus.EXPIRED])
+def test_schwab_snapshot_reducer_emits_terminal_error_once(terminal_status):
+    stored = _order(status=Order.OrderStatus.SUBMITTED)
+    broker = _broker_for_lifecycle(stored)
+
+    broker._process_schwab_order_snapshot(_observed_order(terminal_status))
+    broker._process_schwab_order_snapshot(_observed_order(terminal_status))
+
+    assert len(broker._lifecycle_events) == 1
+    assert broker._lifecycle_events[0][0] == broker.ERROR_ORDER
 
 
 @pytest.mark.parametrize(

--- a/tests/test_strategy_initial_budget.py
+++ b/tests/test_strategy_initial_budget.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lumibot.strategies import Strategy
+
+
+class _InitialBudgetStrategy(Strategy):
+    def on_trading_iteration(self):
+        pass
+
+
+@pytest.mark.parametrize(
+    ("cash", "positions_value", "expected_starting_equity"),
+    [
+        (10_000.0, 0.0, 10_000.0),
+        (4_000.0, 6_500.0, 10_500.0),
+    ],
+)
+def test_live_initial_budget_is_defined_as_verified_starting_account_equity(
+    cash,
+    positions_value,
+    expected_starting_equity,
+):
+    broker = MagicMock()
+    broker.name = "synthetic-live"
+    broker.quote_assets = set()
+    broker.IS_BACKTESTING_BROKER = False
+    broker._set_initial_positions = MagicMock()
+
+    def sync_balances(strategy, force_update=True):
+        strategy._cash = cash
+        strategy._portfolio_value = cash + positions_value
+        return True
+
+    with patch.object(Strategy, "update_broker_balances", autospec=True, side_effect=sync_balances):
+        strategy = _InitialBudgetStrategy(
+            broker=broker,
+            analyze_backtest=False,
+            parameters={},
+        )
+
+    assert strategy.initial_budget == pytest.approx(expected_starting_equity)
+    broker._set_initial_positions.assert_called_once_with(strategy)

--- a/tests/test_strategy_live_order_accessors.py
+++ b/tests/test_strategy_live_order_accessors.py
@@ -179,6 +179,17 @@ def test_get_orders_filters_by_order_status_enum_and_identifiers():
     assert [order.identifier for order in active_orders] == ["open-1"]
 
 
+def test_get_orders_active_statuses_include_cancel_pending_orders():
+    strategy, broker = _strategy()
+    cancel_pending = _order(strategy.name, "cancel-pending-1", Order.OrderStatus.CANCELLING)
+    broker._new_orders.append(cancel_pending)
+
+    active_orders = strategy.get_orders(statuses=Order.ACTIVE_STATUSES, broker_refresh=False)
+
+    assert [order.identifier for order in active_orders] == ["cancel-pending-1"]
+    assert cancel_pending.is_active() is True
+
+
 def test_get_orders_accepts_single_enum_status():
     strategy, broker = _strategy()
     broker._new_orders.append(_order(strategy.name, "open-1", Order.OrderStatus.OPEN))

--- a/tests/test_strategy_parameters.py
+++ b/tests/test_strategy_parameters.py
@@ -1,0 +1,45 @@
+"""Regression tests for mode-neutral strategy parameter overrides.
+
+These expectations intentionally supersede the backtest-only naming added in
+March 2026: one saved parameter set must resolve the same way in simulated and
+live execution.
+"""
+
+import importlib
+import json
+
+import pytest
+
+
+@pytest.mark.parametrize("is_backtesting", ["true", "false"])
+def test_generic_strategy_parameters_are_mode_neutral(monkeypatch, is_backtesting):
+    values = {"fast": 12, "slow": 26, "risk_fraction": 0.02}
+    monkeypatch.setenv("IS_BACKTESTING", is_backtesting)
+    monkeypatch.setenv("LUMIBOT_STRATEGY_PARAMETERS", json.dumps(values))
+    monkeypatch.delenv("BACKTESTING_PARAMETERS", raising=False)
+
+    import lumibot.credentials
+
+    credentials = importlib.reload(lumibot.credentials)
+    assert credentials.STRATEGY_PARAMETERS == values
+
+
+def test_generic_strategy_parameters_take_precedence_over_legacy_alias(monkeypatch):
+    monkeypatch.setenv("LUMIBOT_STRATEGY_PARAMETERS", '{"fast": 20}')
+    monkeypatch.setenv("BACKTESTING_PARAMETERS", '{"fast": 5}')
+
+    import lumibot.credentials
+
+    credentials = importlib.reload(lumibot.credentials)
+    assert credentials.STRATEGY_PARAMETERS == {"fast": 20}
+
+
+@pytest.mark.parametrize("payload", ["not-json", "[1, 2]", "null", "{}"])
+def test_invalid_or_empty_generic_strategy_parameters_are_ignored(monkeypatch, payload):
+    monkeypatch.setenv("LUMIBOT_STRATEGY_PARAMETERS", payload)
+    monkeypatch.delenv("BACKTESTING_PARAMETERS", raising=False)
+
+    import lumibot.credentials
+
+    credentials = importlib.reload(lumibot.credentials)
+    assert credentials.STRATEGY_PARAMETERS is None


### PR DESCRIPTION
## What

Releases LumiBot 4.5.87 with a serialized, idempotent Schwab order-transition reducer shared by streaming observations and REST healing; precise lifecycle callback semantics; bounded 429 recovery; strategy initial-budget parity; mode-neutral strategy parameters; and safe backtest data-provenance artifacts.

## Why

Fast live strategies need broker-terminal lifecycle truth without duplicate callbacks, false terminal cancellation, or excessive polling. The release also makes runtime parameters and data provenance inspectable across backtest and live execution.

## Risk

The highest-risk surface is live Schwab order reconciliation, including partial-fill deltas, cancel/fill races, reconnect snapshots, and duplicate/out-of-order observations. Regression tests cover these transitions. Bot Manager remains pinned to the prior release until the PyPI artifact is verified and its independent exact-candidate gate passes.

## Tests run

- `python3 -m pytest tests/test_schwab_positions_unit.py tests/test_schwab_live_refresh_apitest.py -m 'not apitest' -q` — 63 passed, 10 deselected
- `python3 -m pytest tests/test_strategy_initial_budget.py tests/test_strategy_parameters.py tests/test_backtest_data_provenance.py -q` — 11 passed
- `git diff --check v4.5.86..HEAD` — passed
- Formal sharded GitHub release CI is required before merge and tag.

## Docs

- `docs/FAST_ORDER_LIFECYCLE_GUIDE.md`
- `docs/investigations/2026-08-28_SCHWAB_ORDER_LIFECYCLE_CALLBACKS.md`
- Public Sphinx Schwab and lifecycle callback references
- `CHANGELOG.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Strategy parameters now apply consistently in backtests and live trading.
  - Completed backtests record safe data-source provenance.
  - Live strategies report verified initial portfolio equity, including existing positions.
  - Schwab order updates support partial fills, reconciliation, streaming observations, and rate-limit handling.

- **Bug Fixes**
  - Orders remain non-terminal until cancellation is confirmed.
  - Duplicate lifecycle events and fill notifications are prevented.
  - Duplicate close orders are avoided while cancellation is pending.

- **Documentation**
  - Added guidance for strategy parameters, initial budgets, lifecycle callbacks, and fast order management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->