### PR TITLE
Implement IBKR REST advanced-order handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,11 +220,14 @@ Deploy marker: `79fdbd23938c`
 ## 4.5.86 - Unreleased
 
 ### Changed
-- **Documented IBKR Client Portal REST advanced-order semantics.** The
-  contributor and broker guides now describe atomic BRACKET/OTO packages,
-  executable-child-only OCO packages, native-leg tracking and cancellation,
-  polling relationships, and the explicit REST GTD limitation. Legacy socket
-  GTD behavior remains separate.
+- **IBKR Client Portal REST now supports provider-specific advanced-order
+  packages.** BRACKET and OTO submit their executable parent and children in
+  one request; OCO submits only its two broker-backed children as an OCA group.
+  Native legs receive separate normalized IDs, polling preserves local order
+  trees, advanced cancellation attempts every known broker-backed member, and
+  partial acknowledgements trigger compensating cancellation. Unverified REST
+  GTD submission now fails explicitly while Legacy socket GTD remains supported.
+  Contributor and broker documentation describe these semantics and limits.
 
 ### Fixed
 - **Documentation configuration tests no longer leak mocked broker packages.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,13 @@ Deploy marker: `79fdbd23938c`
 
 ## 4.5.86 - Unreleased
 
+### Changed
+- **Documented IBKR Client Portal REST advanced-order semantics.** The
+  contributor and broker guides now describe atomic BRACKET/OTO packages,
+  executable-child-only OCO packages, native-leg tracking and cancellation,
+  polling relationships, and the explicit REST GTD limitation. Legacy socket
+  GTD behavior remains separate.
+
 ### Fixed
 - **Documentation configuration tests no longer leak mocked broker packages.**
   Loading the Sphinx configuration in-process now restores `sys.modules`, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,9 +225,15 @@ Deploy marker: `79fdbd23938c`
   one request; OCO submits only its two broker-backed children as an OCA group.
   Native legs receive separate normalized IDs, polling preserves local order
   trees, advanced cancellation attempts every known broker-backed member, and
-  partial acknowledgements trigger compensating cancellation. Unverified REST
-  GTD submission now fails explicitly while Legacy socket GTD remains supported.
-  Contributor and broker documentation describe these semantics and limits.
+  partial acknowledgements trigger bounded client-ID reconciliation followed by
+  compensating cancellation if any native ticket remains unresolved. BRACKET
+  and OTO children now receive distinct correlation IDs because Client Portal
+  can return fewer immediate acknowledgement rows than submitted tickets. REST
+  stop tickets now use Client Portal's required ``price`` trigger field, while
+  stop-limit tickets keep their trigger in ``auxPrice``.
+  Unverified REST GTD submission now fails explicitly while Legacy socket GTD
+  remains supported. Contributor and broker documentation describe these
+  semantics and limits.
 
 ### Fixed
 - **Documentation configuration tests no longer leak mocked broker packages.**

--- a/docs/IBKR_REST_GATEWAY.md
+++ b/docs/IBKR_REST_GATEWAY.md
@@ -2,7 +2,7 @@
 
 Architecture and safety notes for LumiBot's Interactive Brokers Client Portal REST transport.
 
-Last Updated: 2026-07-13
+Last Updated: 2026-08-29
 
 Status: Paper proof of concept
 
@@ -16,6 +16,16 @@ Audience: LumiBot contributors and downstream runtime integrators
 - an HTTP client that sends REST requests and can later carry OAuth request signing.
 
 This keeps broker, order, position, contract, and market-data behavior independent from authentication. Local individual-account testing can use IBeam temporarily. Approved third-party integrations can later inject an OAuth-capable HTTP session without rewriting broker methods.
+
+## Order Time-In-Force Limitation
+
+The Client Portal REST adapter rejects `time_in_force="gtd"` and a supplied
+`good_till_date` before contract lookup or order execution. IBKR documents an
+exact-date `goodTillDate` field for the Legacy socket API, but the Client Portal
+order schema does not document a verified REST equivalent. The adapter must not
+silently omit the requested expiration or pass an undocumented field. Existing
+broker responses containing `goodTillDate` continue to be parsed; this is a
+submission limitation only.
 
 ## Supported Transport Shapes
 

--- a/docs/IBKR_REST_GATEWAY.md
+++ b/docs/IBKR_REST_GATEWAY.md
@@ -83,3 +83,22 @@ python -m pytest \
 ```
 
 Real broker smoke testing must use a dedicated paper username, verify the paper account before any order action, and record account identifiers only in masked form. A passing paper smoke does not prove production or OAuth readiness.
+
+## Paper Order API-Test Safety Gate
+
+Any future REST test that constructs, submits, changes, or cancels an order must
+be marked with both `pytest.mark.apitest` and `pytest.mark.ibkr`, and must use
+the `ibkr_rest_paper_order_data_source` fixture from
+`tests/ibkr_rest_paper_order_safety.py`. The fixture:
+
+- skips when required local credentials are absent or the gateway cannot be reached;
+- requires the raw `IB_USE_PAPER_ACCOUNT` environment variable to be explicitly
+  set to `true`, rather than accepting the LumiBot configuration default;
+- reads the authenticated account selection before an order object is constructed;
+- requires the paper-account `DU` prefix and an exact match with an explicitly
+  configured `IB_ACCOUNT_ID`;
+- emits account identifiers only as masked suffixes and never logs gateway
+  response payloads.
+
+The gate is intentionally test-scoped. It does not change production account
+selection or broker behavior.

--- a/docs/IBKR_REST_ORDER_SEMANTICS.md
+++ b/docs/IBKR_REST_ORDER_SEMANTICS.md
@@ -114,6 +114,8 @@ paper ``DU`` identity convention and, when supplied, matches
 authenticated to the paper account: the local paper flag does not convert an
 external live session. Missing configuration or an unavailable gateway skips
 the suite; a configured live-style account fails before an order request.
+Within one pytest invocation, the paper fixture reuses a single authenticated
+data source so its tests do not start competing local IBeam containers.
 
 Run only the focused modules, from the `lumibot-dev` environment, after
 confirming that the gateway is the intended paper session:

--- a/docs/IBKR_REST_ORDER_SEMANTICS.md
+++ b/docs/IBKR_REST_ORDER_SEMANTICS.md
@@ -97,6 +97,9 @@ for the separate provider contracts.
 
 ## Authorized paper-validation runbook
 
+For the complete credential-free operator procedure, see
+[IBKR REST Paper-Test Runbook](IBKR_REST_PAPER_TEST_RUNBOOK.md).
+
 The repository's IBKR REST paper suites are real broker API tests. A paper
 account limits the financial impact; it does not make the tests unit tests or
 safe for an unattended production session. They are marked ``apitest`` and
@@ -117,12 +120,13 @@ the suite; a configured live-style account fails before an order request.
 Within one pytest invocation, the paper fixture reuses a single authenticated
 data source so its tests do not start competing local IBeam containers.
 
-Run only the focused modules, from the `lumibot-dev` environment, after
-confirming that the gateway is the intended paper session:
+Run only the focused modules from an environment with LumiBot and its test
+dependencies installed, after confirming that the gateway is the intended
+paper session:
 
 ```bash
-conda run -n lumibot-dev python -m pytest -q -m "apitest and ibkr" tests/test_ibkr_rest_advanced_orders_paper_apitest.py
-conda run -n lumibot-dev python -m pytest -q -m "apitest and ibkr" tests/test_ibkr_rest_gtd_paper_apitest.py
+python -m pytest -q -m "apitest and ibkr" tests/test_ibkr_rest_advanced_orders_paper_apitest.py
+python -m pytest -q -m "apitest and ibkr" tests/test_ibkr_rest_gtd_paper_apitest.py
 ```
 
 The advanced-order suite obtains a current reference price, submits deliberately

--- a/docs/IBKR_REST_ORDER_SEMANTICS.md
+++ b/docs/IBKR_REST_ORDER_SEMANTICS.md
@@ -27,12 +27,19 @@ The adapter sends each advanced package in one `execute_order()` request:
   the same cOID/`parentId` relationship.
 - **OCO** does not send the conceptual LumiBot parent. It sends exactly the two
   executable children as an IBKR single-group/OCA package (`isSingleGroup`).
-  The conceptual parent remains a local container.
+  Each child receives a unique `cOID` so acknowledgements can be correlated if
+  IBKR returns them out of request order. The conceptual parent remains a local
+  container.
 
 Each executable native leg receives and tracks its own broker order ID. For
 BRACKET and OTO, the tracked parent uses the broker ID as the children's
 `parent_identifier`. For OCO, children retain the local container's identifier;
 the local parent has no broker order ID.
+
+IBKR's documented OCA example returns tickets in a different order from the
+request. LumiBot therefore uses response `local_order_id` values to correlate
+OCO acknowledgements. If the complete mapping remains ambiguous, submission
+fails closed and every acknowledged broker ID receives a cancellation attempt.
 
 Strategies should use the current generic parameter names when constructing
 packages, for example:
@@ -43,6 +50,7 @@ entry = strategy.create_order(
     quantity=10,
     side="buy",
     order_type="limit",
+    order_class="bracket",
     limit_price=100,
     secondary_limit_price=110,
     secondary_stop_price=95,
@@ -82,6 +90,7 @@ contain and be parsed from `goodTillDate`.
 
 Exact-date GTD remains separately supported by the Legacy IBKR socket adapter;
 this REST limitation does not change generic `Order`, backtesting, Polymarket,
-or other broker behavior. See the [IBKR Client Portal API documentation](https://ibkrcampus.com/campus/ibkr-api-page/cpapi-v1/)
-and [IBKR TWS API order documentation](https://ibkrcampus.com/campus/ibkr-api-page/twsapi-doc/)
-for provider documentation.
+or other broker behavior. See IBKR's [Web API order documentation](https://ibkrcampus.com/campus/ibkr-api-page/webapi-doc/#orders),
+[new-order endpoint reference](https://ibkrcampus.com/docs/web-api/api-reference/trading/trading-orders/submit-new-order),
+and [TWS API documentation](https://www.interactivebrokers.com/docs/tws-api/doc/introduction)
+for the separate provider contracts.

--- a/docs/IBKR_REST_ORDER_SEMANTICS.md
+++ b/docs/IBKR_REST_ORDER_SEMANTICS.md
@@ -2,7 +2,7 @@
 
 Contributor and user reference for advanced orders submitted through the IBKR Client Portal REST adapter.
 
-Last Updated: 2026-08-29
+Last Updated: 2026-08-31
 
 Status: Current behavior
 
@@ -21,10 +21,10 @@ boundaries.
 The adapter sends each advanced package in one `execute_order()` request:
 
 - **BRACKET** sends the executable parent followed by one or two attached
-  children. The parent receives a Client Portal `cOID`; each child receives
-  `parentId` equal to that cOID.
+  children. The parent and each child receive distinct Client Portal `cOID`
+  values; each child also receives `parentId` equal to the parent's `cOID`.
 - **OTO** sends the executable parent followed by its one attached child, with
-  the same cOID/`parentId` relationship.
+  the same distinct-child-`cOID` and parent-`parentId` relationship.
 - **OCO** does not send the conceptual LumiBot parent. It sends exactly the two
   executable children as an IBKR single-group/OCA package (`isSingleGroup`).
   Each child receives a unique `cOID` so acknowledgements can be correlated if
@@ -36,10 +36,22 @@ BRACKET and OTO, the tracked parent uses the broker ID as the children's
 `parent_identifier`. For OCO, children retain the local container's identifier;
 the local parent has no broker order ID.
 
-IBKR's documented OCA example returns tickets in a different order from the
-request. LumiBot therefore uses response `local_order_id` values to correlate
-OCO acknowledgements. If the complete mapping remains ambiguous, submission
-fails closed and every acknowledged broker ID receives a cancellation attempt.
+Client Portal does not guarantee one immediate acknowledgement row per submitted
+advanced-order ticket. IBKR's published bracket example submits three tickets
+but shows two immediate response rows, while its OCA example returns tickets in
+a different order. LumiBot therefore uses client-order correlation values and a
+bounded account-order poll to reconcile an incomplete BRACKET or OTO response;
+OCO responses use `local_order_id` correlation. The adapter tracks a package
+only after every expected executable ticket resolves to a distinct positive
+broker ID. If the complete mapping remains missing or ambiguous, submission
+fails closed and every broker ID discovered in either the response or the
+bounded reconciliation receives a cancellation attempt.
+
+This behavior follows IBKR's
+[published bracket response example](https://ibkrcampus.com/campus/ibkr-quant-news/how-to-code-a-bracket-order-in-the-web-api/),
+[current complex-order lesson](https://ibkrcampus.com/campus/trading-lessons/complex-orders/),
+and the documented `order_ref` field returned by
+[live-order monitoring](https://ibkrcampus.com/campus/ibkr-api-page/webapi-doc/#monitoring-live-orders).
 
 Strategies should use the current generic parameter names when constructing
 packages, for example:
@@ -62,6 +74,11 @@ time-in-force, and exchange. Automatically generated children may inherit the
 parent exchange for REST contract resolution without mutating the generic
 `Order` objects.
 
+For Client Portal REST price fields, a `stop` (`STP`) ticket serializes its
+trigger as `price`; it does not send `auxPrice`. A `stop_limit` (`STP LMT`)
+ticket serializes its limit as `price` and its trigger as `auxPrice`. This
+matches IBKR's published Web API bracket field definitions.
+
 ## Cancellation and polling
 
 Canceling a BRACKET or OTO parent attempts cancellation for the broker-backed
@@ -77,6 +94,12 @@ erase known child relationships, and the OCO local container remains connected
 to its tracked children. Reconstruction of an advanced package submitted
 before process startup is not claimed: it would require a tested, reliable
 relationship field in the broker response.
+
+The bounded acknowledgement poll uses a single-attempt account-order read and
+never enters the adapter's normal retry-until-available polling loop. A deletion
+error response is logged as a cancellation failure, not as a successful
+cancellation. An "order does not exist" result can mean a rejected or already
+inactive ticket, but it is not reported as proof that IBKR accepted a cancel.
 
 ## GTD limitation
 

--- a/docs/IBKR_REST_ORDER_SEMANTICS.md
+++ b/docs/IBKR_REST_ORDER_SEMANTICS.md
@@ -94,3 +94,45 @@ or other broker behavior. See IBKR's [Web API order documentation](https://ibkrc
 [new-order endpoint reference](https://ibkrcampus.com/docs/web-api/api-reference/trading/trading-orders/submit-new-order),
 and [TWS API documentation](https://www.interactivebrokers.com/docs/tws-api/doc/introduction)
 for the separate provider contracts.
+
+## Authorized paper-validation runbook
+
+The repository's IBKR REST paper suites are real broker API tests. A paper
+account limits the financial impact; it does not make the tests unit tests or
+safe for an unattended production session. They are marked ``apitest`` and
+``ibkr`` and are excluded from ordinary CI (the normal CI policy excludes
+``apitest`` tests).
+
+An explicitly authorized maintainer must use a dedicated IBKR paper username
+and an already authenticated paper Client Portal gateway. Configure the
+existing LumiBot IBKR settings without recording their values anywhere in the
+repository. ``IB_USE_PAPER_ACCOUNT`` must be explicitly set to ``true``;
+never use a production account for these tests. The fixture then verifies that
+the authenticated selected account has the
+paper ``DU`` identity convention and, when supplied, matches
+``IB_ACCOUNT_ID``. An external ``IB_API_URL`` gateway must already be
+authenticated to the paper account: the local paper flag does not convert an
+external live session. Missing configuration or an unavailable gateway skips
+the suite; a configured live-style account fails before an order request.
+
+Run only the focused modules, from the `lumibot-dev` environment, after
+confirming that the gateway is the intended paper session:
+
+```bash
+conda run -n lumibot-dev python -m pytest -q -m "apitest and ibkr" tests/test_ibkr_rest_advanced_orders_paper_apitest.py
+conda run -n lumibot-dev python -m pytest -q -m "apitest and ibkr" tests/test_ibkr_rest_gtd_paper_apitest.py
+```
+
+The advanced-order suite obtains a current reference price, submits deliberately
+non-marketable BRACKET/OTO/OCO tickets, and always attempts cancellation in
+cleanup. The GTD module is a separate, read-only capability probe: it uses
+only `/orders/whatif` and does not enable production GTD serialization. The
+probe's result is evidence for a separate reviewed implementation decision;
+passing it does not prove production OAuth readiness or authorize production
+order testing.
+
+Only masked account suffixes may appear in output. Never copy usernames,
+passwords, account identifiers, cookies, tokens, gateway session material, or
+raw broker responses into logs or issue reports. Process termination can still
+interrupt a `finally` cleanup; after any interrupted run, the maintainer must
+inspect the paper account and confirm that no test orders remain working.

--- a/docs/IBKR_REST_ORDER_SEMANTICS.md
+++ b/docs/IBKR_REST_ORDER_SEMANTICS.md
@@ -1,0 +1,87 @@
+# IBKR REST Order Semantics
+
+Contributor and user reference for advanced orders submitted through the IBKR Client Portal REST adapter.
+
+Last Updated: 2026-08-29
+
+Status: Current behavior
+
+Audience: LumiBot users and contributors
+
+## Overview
+
+LumiBot's `Order` entity is provider-generic. `InteractiveBrokersREST` owns the
+translation from that order tree to Interactive Brokers Client Portal tickets;
+IBKR-specific fields and lifecycle rules do not belong in the generic order
+API. This document describes the supported REST behavior and its deliberate
+boundaries.
+
+## Advanced order packages
+
+The adapter sends each advanced package in one `execute_order()` request:
+
+- **BRACKET** sends the executable parent followed by one or two attached
+  children. The parent receives a Client Portal `cOID`; each child receives
+  `parentId` equal to that cOID.
+- **OTO** sends the executable parent followed by its one attached child, with
+  the same cOID/`parentId` relationship.
+- **OCO** does not send the conceptual LumiBot parent. It sends exactly the two
+  executable children as an IBKR single-group/OCA package (`isSingleGroup`).
+  The conceptual parent remains a local container.
+
+Each executable native leg receives and tracks its own broker order ID. For
+BRACKET and OTO, the tracked parent uses the broker ID as the children's
+`parent_identifier`. For OCO, children retain the local container's identifier;
+the local parent has no broker order ID.
+
+Strategies should use the current generic parameter names when constructing
+packages, for example:
+
+```python
+entry = strategy.create_order(
+    asset,
+    quantity=10,
+    side="buy",
+    order_type="limit",
+    limit_price=100,
+    secondary_limit_price=110,
+    secondary_stop_price=95,
+)
+```
+
+The REST adapter preserves explicit child quantity, side, order type, prices,
+time-in-force, and exchange. Automatically generated children may inherit the
+parent exchange for REST contract resolution without mutating the generic
+`Order` objects.
+
+## Cancellation and polling
+
+Canceling a BRACKET or OTO parent attempts cancellation for the broker-backed
+parent and every known broker-backed child. Canceling an OCO parent attempts
+both executable children and never sends the local container ID to IBKR. An
+explicit child cancellation remains scoped to that child. Requests are
+deduplicated and remaining members are still attempted if one cancellation
+fails; local terminal status does not suppress an explicit broker request.
+
+Polling normalizes IBKR identifiers across integer and string representations
+and updates already-tracked native legs in place. Flat broker responses do not
+erase known child relationships, and the OCO local container remains connected
+to its tracked children. Reconstruction of an advanced package submitted
+before process startup is not claimed: it would require a tested, reliable
+relationship field in the broker response.
+
+## GTD limitation
+
+The Client Portal REST order schema does not document a verified exact-date
+expiration field equivalent to the Legacy socket API's `goodTillDate`. For
+that reason, REST submission explicitly rejects `time_in_force="gtd"` and any
+`good_till_date` supplied with another time-in-force value before contract
+lookup or order execution. This prevents an expiration from being silently
+discarded. Responses for orders created through another interface may still
+contain and be parsed from `goodTillDate`.
+
+Exact-date GTD remains separately supported by the Legacy IBKR socket adapter;
+this REST limitation does not change generic `Order`, backtesting, Polymarket,
+or other broker behavior. See the [IBKR Client Portal API documentation](https://ibkrcampus.com/campus/ibkr-api-page/cpapi-v1/)
+and [IBKR TWS API order documentation](https://ibkrcampus.com/campus/ibkr-api-page/twsapi-doc/)
+for provider documentation.

--- a/docs/IBKR_REST_PAPER_TEST_RUNBOOK.md
+++ b/docs/IBKR_REST_PAPER_TEST_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 Credential-free procedure for authorized IBKR REST paper-order validation.
 
-**Last Updated:** 2026-08-30
+**Last Updated:** 2026-08-31
 **Status:** Active operator runbook
 **Audience:** Authorized LumiBot maintainers
 
@@ -98,10 +98,10 @@ with a sanitized reason. A passing probe is evidence for a separate reviewed
 implementation decision; it does not enable production GTD support.
 
 LumiBot's legacy IBKR socket adapter has separate GTD support. REST exact-date
-GTD serialization remains disabled. The authorized paper probe on 2026-08-30
-rejected the candidate REST `tif=GTD` and `goodTillDate` request. That probe was
-run on a Sunday outside US regular trading hours, so advanced-order observations
-from that session are preliminary pending a market-hours retest.
+GTD serialization remains disabled. The 2026-08-30 Sunday probe rejected the
+candidate REST `tif=GTD` and `goodTillDate` request; an authorized 2026-08-31
+US regular-trading-hours probe rejected the same candidate. This is current
+evidence that the configured Client Portal REST API does not accept it.
 
 ## Advanced-order paper smoke suite
 

--- a/docs/IBKR_REST_PAPER_TEST_RUNBOOK.md
+++ b/docs/IBKR_REST_PAPER_TEST_RUNBOOK.md
@@ -127,6 +127,28 @@ suffixes may appear in test output.
 - Do not interpret a passing paper run as proof of production OAuth readiness
   or authorization for production testing.
 
+## Advanced-order acknowledgement diagnostics
+
+Client Portal can return fewer immediate acknowledgement rows than the number
+of BRACKET or OTO tickets submitted. That alone is not a failed package: LumiBot
+uses distinct client order IDs and bounded polling to reconcile every expected
+native ticket. The smoke test passes only when the complete set of distinct,
+positive broker IDs is resolved and tracked. If reconciliation stays partial,
+the test fails and cleanup attempts every broker ID discovered so far.
+
+On a failed submission, the paper test prints a sanitized response-shape summary.
+It identifies only whether each response entry had a positive, placeholder, or
+missing ID and whether correlation, parent, error, message, or warning fields
+were present. If a warning value is exactly a short numeric IBKR code, that code
+is shown; otherwise it is reported only as ``non_numeric_warning``. It also
+reports bounded reconciliation poll and match counts. It never prints order IDs,
+account identifiers, or raw broker response text.
+
+A cleanup response saying that an order does not exist is not evidence that a
+working order was canceled. It may indicate that the ticket was rejected or is
+already inactive. Always complete the post-run paper-account inspection; the
+adapter no longer reports an IBKR deletion error as a successful cancellation.
+
 ## Safety gates to expect
 
 - Missing local credentials or an unavailable gateway skips the API test.

--- a/docs/IBKR_REST_PAPER_TEST_RUNBOOK.md
+++ b/docs/IBKR_REST_PAPER_TEST_RUNBOOK.md
@@ -119,6 +119,12 @@ deliberately non-marketable BRACKET, OTO, and OCO packages. It polls order
 status and attempts cancellation in `finally` cleanup. Only masked account
 suffixes may appear in test output.
 
+Allow several minutes for an advanced-order run: the test waits only as long as
+needed for acknowledgement, bounded polling, cancellation, and cancellation
+verification. If it skips because the gateway did not provide a usable current
+reference price, no order was constructed or submitted; restore the paper
+gateway's market-data availability and run it again during market hours.
+
 ## After every run
 
 - Inspect the paper account directly and confirm no test orders remain working.

--- a/docs/IBKR_REST_PAPER_TEST_RUNBOOK.md
+++ b/docs/IBKR_REST_PAPER_TEST_RUNBOOK.md
@@ -1,0 +1,138 @@
+# IBKR REST Paper-Test Runbook
+
+Credential-free procedure for authorized IBKR REST paper-order validation.
+
+**Last Updated:** 2026-08-30
+**Status:** Active operator runbook
+**Audience:** Authorized LumiBot maintainers
+
+## Overview
+
+The IBKR REST paper suites are real broker API tests. The advanced-order suite
+creates real paper orders; it is not a unit-test suite. Never use a production
+account. These tests are marked `apitest` and `ibkr`, and normal CI excludes
+them.
+
+## Before running
+
+- Use a dedicated IBKR paper username and paper account.
+- Store credentials only in an untracked secret manager or untracked `<repo>/.env`.
+- Never copy credentials, account identifiers, cookies, tokens, gateway-session
+  material, or raw IBKR responses into logs, tickets, or chat.
+- Close other trading-enabled sessions using the dedicated username when they
+  could displace the Client Portal session.
+
+## Location and environment
+
+Run commands from the repository root, represented as `<repo>`, containing
+`lumibot/`, `tests/`, and `setup.py`.
+
+```powershell
+cd <repo>
+# If using Conda, activate your existing LumiBot test environment:
+conda activate <your-lumibot-environment>
+```
+
+For pytest, use the untracked configuration file `<repo>/.env`.
+
+## Gateway choice
+
+### Local IBeam gateway
+
+Use this mode only when LumiBot may manage a local IBeam container. Do not set
+`IB_API_URL`. Docker must be installed and running; on Windows, start Docker
+Desktop and wait until its engine is running.
+
+The untracked configuration needs the existing settings, using only paper
+values:
+
+```dotenv
+IB_USERNAME=<paper-username>
+IB_PASSWORD=<paper-password>
+IB_ACCOUNT_ID=<paper-account-id>
+IB_USE_PAPER_ACCOUNT=true
+```
+
+LumiBot starts local IBeam and waits for Client Portal authentication and any
+required 2FA. Complete authentication only for the intended paper session.
+
+Within one pytest invocation, the paper suite reuses one authenticated gateway
+and data source. Do not run these paper modules concurrently from separate
+terminals. If an interrupted or older run left a `lumibot-client-portal-*`
+container behind, stop and remove it in Docker Desktop before starting a new
+run.
+
+### Externally managed gateway
+
+Use this mode only when an approved Client Portal REST gateway is already
+running and authenticated to the intended paper account:
+
+```dotenv
+IB_API_URL=https://<your-paper-gateway>
+IB_ACCOUNT_ID=<paper-account-id>
+IB_USE_PAPER_ACCOUNT=true
+```
+
+`IB_USE_PAPER_ACCOUNT=true` does not convert an external live session into a
+paper session.
+
+## Preflight collection
+
+This command only collects tests; it does not start a gateway or contact IBKR:
+
+```powershell
+python -m pytest --collect-only -q tests/test_ibkr_rest_advanced_orders_paper_apitest.py tests/test_ibkr_rest_gtd_paper_apitest.py
+```
+
+## GTD capability probe
+
+Run the GTD probe before advanced submissions:
+
+```powershell
+python -m pytest -q --tb=no -r f -m "apitest and ibkr" tests/test_ibkr_rest_gtd_paper_apitest.py
+```
+
+It authenticates to the paper gateway and uses only `/orders/whatif`; it never
+calls the order-submission endpoint. A rejection intentionally fails the test
+with a sanitized reason. A passing probe is evidence for a separate reviewed
+implementation decision; it does not enable production GTD support.
+
+LumiBot's legacy IBKR socket adapter has separate GTD support. REST exact-date
+GTD serialization remains disabled. The authorized paper probe on 2026-08-30
+rejected the candidate REST `tif=GTD` and `goodTillDate` request. That probe was
+run on a Sunday outside US regular trading hours, so advanced-order observations
+from that session are preliminary pending a market-hours retest.
+
+## Advanced-order paper smoke suite
+
+Run this order-submission suite only during US regular trading hours on a
+market day, preferably 10:00–15:30 America/New_York. It does not enable
+outside-regular-trading-hours execution. Confirm the paper gateway and account,
+then run it once:
+
+```powershell
+python -m pytest -q --tb=no -r f -m "apitest and ibkr" tests/test_ibkr_rest_advanced_orders_paper_apitest.py
+```
+
+The suite uses the public LumiBot order-submission path for one-share,
+deliberately non-marketable BRACKET, OTO, and OCO packages. It polls order
+status and attempts cancellation in `finally` cleanup. Only masked account
+suffixes may appear in test output.
+
+## After every run
+
+- Inspect the paper account directly and confirm no test orders remain working.
+- Inspect it especially after a timeout, failure, terminal interruption, or
+  computer sleep: process termination can interrupt cleanup.
+- Do not interpret a passing paper run as proof of production OAuth readiness
+  or authorization for production testing.
+
+## Safety gates to expect
+
+- Missing local credentials or an unavailable gateway skips the API test.
+- `IB_USE_PAPER_ACCOUNT` must be explicitly `true` for order-changing tests.
+- The authenticated selected account must follow the paper-account `DU`
+  convention.
+- When configured, `IB_ACCOUNT_ID` must match the authenticated selected
+  account.
+- A non-paper account fails before the test constructs or submits an order.

--- a/docs/LEGACY_IB_GATEWAY_ORDER_SEMANTICS.md
+++ b/docs/LEGACY_IB_GATEWAY_ORDER_SEMANTICS.md
@@ -1,0 +1,22 @@
+# Legacy IB Gateway Order Semantics
+
+Legacy Interactive Brokers Gateway order-duration behavior and backtesting parity.
+
+Last Updated: 2026-08-29
+
+Status: Active
+
+Audience: LumiBot contributors and maintainers
+
+## Overview
+
+The deprecated socket-based Interactive Brokers adapter must preserve an
+order's ``time_in_force`` and ``good_till_date`` on every native leg it creates
+for bracket, OTO, and OCO orders. Automatically generated advanced-order
+children inherit the same values so BacktestingBroker's existing DAY and GTD
+expiry rules model the same intent. This is intentionally centralized in the
+order entity and the legacy adapter; provider-generic strategy APIs remain
+unchanged.
+
+When a live last-price tick is unavailable, the legacy adapter may use the
+previous-close tick only when no last price has already been received.

--- a/docsrc/brokers.interactive_brokers.rst
+++ b/docsrc/brokers.interactive_brokers.rst
@@ -118,9 +118,10 @@ The LumiBot ``Order`` entity is provider-generic. The
 ``InteractiveBrokersREST`` adapter performs the IBKR-specific translation:
 
 * **BRACKET** sends one atomic request containing the executable parent and
-  one or two attached children.
+  one or two attached children. Every ticket receives a distinct client order
+  ID, while each child references the parent's client order ID.
 * **OTO** sends one atomic request containing the executable parent and its
-  single attached child.
+  single attached child, using the same client-order relationship.
 * **OCO** sends only its two executable children as an IBKR single-group/OCA
   package. Each child receives a unique IBKR client order ID so responses can
   be correlated even when IBKR returns them out of request order. Its LumiBot
@@ -131,6 +132,17 @@ a BRACKET or OTO parent attempts all known broker-backed members; canceling an
 OCO parent attempts both executable children. A direct child cancellation is
 limited to that child. The adapter continues attempting remaining members if
 one cancellation fails.
+
+IBKR may return fewer immediate acknowledgement rows than the number of tickets
+in a BRACKET or OTO request. LumiBot does not infer missing broker IDs from row
+position. It performs a bounded reconciliation using the distinct client order
+IDs and tracks the package only when every executable ticket has a distinct
+positive broker ID. Otherwise, it fails closed and attempts cancellation for
+every broker ID discovered during submission or reconciliation.
+
+For Client Portal REST, a ``stop`` order uses its trigger as the ``price``
+field. A ``stop_limit`` order uses ``price`` for its limit and ``auxPrice`` for
+its trigger.
 
 For example, advanced orders use the current generic names
 ``secondary_limit_price`` and ``secondary_stop_price``:

--- a/docsrc/brokers.interactive_brokers.rst
+++ b/docsrc/brokers.interactive_brokers.rst
@@ -202,6 +202,26 @@ IBKR paper-account ``DU`` convention and that it matches an explicitly supplied
 ``IB_ACCOUNT_ID``. Test output masks account identifiers; do not add credentials
 or account identifiers to test logs.
 
+.. warning::
+
+   The opt-in IBKR REST paper suites are real broker API tests, even though
+   they use a paper account, and are excluded from ordinary CI. An authorized
+   maintainer must use a dedicated paper username with an already authenticated
+   paper gateway and set ``IB_USE_PAPER_ACCOUNT=true`` explicitly; never use a
+   production account for these tests. The
+   authenticated selected account must pass the paper ``DU`` identity gate.
+   For an external ``IB_API_URL`` gateway, the session must already be the
+   paper session; the local flag cannot convert a live session. The advanced
+   suite submits deliberately non-marketable orders and attempts cancellation,
+   but process termination can interrupt cleanup, so inspect the paper account
+   afterward. Only masked account suffixes may be shown in output. Passing
+   these tests does not establish production OAuth readiness.
+
+   The GTD capability probe is separate from advanced-order submission tests
+   and uses only the non-ordering ``/orders/whatif`` endpoint. It does not
+   enable production GTD behavior; any production implementation requires a
+   separate reviewed decision.
+
 Example Strategy
 ----------------
 

--- a/docsrc/brokers.interactive_brokers.rst
+++ b/docsrc/brokers.interactive_brokers.rst
@@ -111,6 +111,46 @@ Use the Legacy Interactive Brokers Gateway adapter when your strategy requires
 exact-date GTD orders. Orders created through another IBKR interface can still
 be read by the REST adapter.
 
+REST advanced orders
+--------------------
+
+The LumiBot ``Order`` entity is provider-generic. The
+``InteractiveBrokersREST`` adapter performs the IBKR-specific translation:
+
+* **BRACKET** sends one atomic request containing the executable parent and
+  one or two attached children.
+* **OTO** sends one atomic request containing the executable parent and its
+  single attached child.
+* **OCO** sends only its two executable children as an IBKR single-group/OCA
+  package. Its LumiBot parent is a local container and is never sent to IBKR.
+
+Each executable leg receives and tracks a separate broker order ID. Canceling
+a BRACKET or OTO parent attempts all known broker-backed members; canceling an
+OCO parent attempts both executable children. A direct child cancellation is
+limited to that child. The adapter continues attempting remaining members if
+one cancellation fails.
+
+For example, advanced orders use the current generic names
+``secondary_limit_price`` and ``secondary_stop_price``:
+
+.. code-block:: python
+
+   order = strategy.create_order(
+       asset,
+       quantity=10,
+       side="buy",
+       order_type="limit",
+       limit_price=100,
+       secondary_limit_price=110,
+       secondary_stop_price=95,
+   )
+
+REST polling updates the already-tracked native legs and preserves their
+parent/child relationships across IBKR integer or string identifier formats.
+Reconstruction of an advanced package submitted before process startup is not
+claimed. See the `IBKR Client Portal API documentation
+<https://ibkrcampus.com/campus/ibkr-api-page/cpapi-v1/>`_ for provider details.
+
 Strategy Setup
 --------------
 

--- a/docsrc/brokers.interactive_brokers.rst
+++ b/docsrc/brokers.interactive_brokers.rst
@@ -191,6 +191,17 @@ Add these variables to a `.env` file in the same directory as your strategy:
     - (Optional) Maximum authentication wait in seconds.
     - `300`
 
+REST Paper-Order Test Safety
+----------------------------
+
+LumiBot's repository-only IBKR REST paper-order API-test fixture requires
+``IB_USE_PAPER_ACCOUNT=true`` to be explicitly present, even though the local
+IBeam configuration defaults to paper mode. Before an order test constructs an
+order, the fixture verifies that the authenticated selected account uses the
+IBKR paper-account ``DU`` convention and that it matches an explicitly supplied
+``IB_ACCOUNT_ID``. Test output masks account identifiers; do not add credentials
+or account identifiers to test logs.
+
 Example Strategy
 ----------------
 

--- a/docsrc/brokers.interactive_brokers.rst
+++ b/docsrc/brokers.interactive_brokers.rst
@@ -70,7 +70,7 @@ Two-Factor Authentication (2FA)
 
 Interactive Brokers requires two-factor authentication for Client Portal Gateway users. Individual users must authenticate in a browser on the same machine as the gateway and reauthenticate at least daily. LumiBot does not provide a supported way to bypass this requirement.
 
-See `IBKR Client Portal Gateway requirements <https://ibkrcampus.com/campus/ibkr-api-page/cpapi-v1/>`_.
+See `IBKR Web API documentation <https://ibkrcampus.com/campus/ibkr-api-page/webapi-doc/>`_.
 
 .. warning::
 
@@ -122,7 +122,9 @@ The LumiBot ``Order`` entity is provider-generic. The
 * **OTO** sends one atomic request containing the executable parent and its
   single attached child.
 * **OCO** sends only its two executable children as an IBKR single-group/OCA
-  package. Its LumiBot parent is a local container and is never sent to IBKR.
+  package. Each child receives a unique IBKR client order ID so responses can
+  be correlated even when IBKR returns them out of request order. Its LumiBot
+  parent is a local container and is never sent to IBKR.
 
 Each executable leg receives and tracks a separate broker order ID. Canceling
 a BRACKET or OTO parent attempts all known broker-backed members; canceling an
@@ -140,6 +142,7 @@ For example, advanced orders use the current generic names
        quantity=10,
        side="buy",
        order_type="limit",
+       order_class="bracket",
        limit_price=100,
        secondary_limit_price=110,
        secondary_stop_price=95,
@@ -149,7 +152,10 @@ REST polling updates the already-tracked native legs and preserves their
 parent/child relationships across IBKR integer or string identifier formats.
 Reconstruction of an advanced package submitted before process startup is not
 claimed. See the `IBKR Client Portal API documentation
-<https://ibkrcampus.com/campus/ibkr-api-page/cpapi-v1/>`_ for provider details.
+<https://ibkrcampus.com/campus/ibkr-api-page/webapi-doc/#orders>`_ and the
+`new-order endpoint reference
+<https://ibkrcampus.com/docs/web-api/api-reference/trading/trading-orders/submit-new-order>`_
+for provider details.
 
 Strategy Setup
 --------------

--- a/docsrc/brokers.interactive_brokers.rst
+++ b/docsrc/brokers.interactive_brokers.rst
@@ -201,6 +201,8 @@ order, the fixture verifies that the authenticated selected account uses the
 IBKR paper-account ``DU`` convention and that it matches an explicitly supplied
 ``IB_ACCOUNT_ID``. Test output masks account identifiers; do not add credentials
 or account identifiers to test logs.
+Within one pytest invocation, the fixture reuses one authenticated data source
+so individual paper tests do not start competing local IBeam containers.
 
 .. warning::
 

--- a/docsrc/brokers.interactive_brokers.rst
+++ b/docsrc/brokers.interactive_brokers.rst
@@ -100,6 +100,17 @@ When using a paper trading account, log in with your paper trading username and 
 
 **Note:** The paper trading account is separate from your live account. Ensure you're using the correct credentials for each environment to avoid any login conflicts.
 
+Client Portal REST order-expiry limitation
+------------------------------------------
+
+The Interactive Brokers Client Portal REST adapter supports the currently
+documented time-in-force values such as ``day`` and ``gtc``. It rejects
+``time_in_force="gtd"`` and any ``good_till_date`` because IBKR's Client
+Portal order schema does not document a verified exact-date expiration field.
+Use the Legacy Interactive Brokers Gateway adapter when your strategy requires
+exact-date GTD orders. Orders created through another IBKR interface can still
+be read by the REST adapter.
+
 Strategy Setup
 --------------
 

--- a/docsrc/brokers.interactive_brokers_legacy.rst
+++ b/docsrc/brokers.interactive_brokers_legacy.rst
@@ -45,3 +45,13 @@ Set up your entry point file as above, except using Interactive Brokers. Here is
     trader.run_all()
 
 You can also see the file simple_start_ib.py for a working bot here: https://github.com/Lumiwealth/lumibot/blob/master/getting_started/simple_start_ib.py
+
+Order duration
+--------------
+
+The legacy Gateway adapter forwards ``time_in_force`` for simple and advanced
+orders. For ``time_in_force="gtd"``, also provide ``good_till_date`` as a
+``datetime``; LumiBot sends that date to every native order in a bracket, OTO,
+or OCO group. Backtesting preserves the same duration for automatically created
+advanced-order children, so ``day`` and ``gtd`` expiration behavior remains
+consistent with the legacy Gateway path.

--- a/lumibot/brokers/interactive_brokers.py
+++ b/lumibot/brokers/interactive_brokers.py
@@ -716,7 +716,7 @@ class IBWrapper(EWrapper):
 
         # If the last price is not available, then use yesterday's closing price
         # This can happen if the market is closed
-        if tickType == 9 and self.tick is None and self.should_use_last_close:
+        if tickType == 9 and self.price is None and self.should_use_last_close:
             self.price = price
             self.tick_type_used = tickType
 
@@ -1513,6 +1513,12 @@ class IBApp(IBWrapper, IBClient):
 
         return contract
 
+    @staticmethod
+    def _apply_time_in_force(ib_order, order):
+        """Copy LumiBot duration fields to every native order in an advanced order."""
+        ib_order.tif = order.time_in_force.upper()
+        ib_order.goodTillDate = order.good_till_date.strftime("%Y%m%d %H:%M:%S") if order.good_till_date else ""
+
     def create_order(self, order):
         ib_order = Order()
         if order.order_class == "bracket":
@@ -1529,6 +1535,7 @@ class IBApp(IBWrapper, IBClient):
             parent.totalQuantity = order.quantity
             parent.lmtPrice = order.limit_price
             parent.transmit = False
+            self._apply_time_in_force(parent, order)
 
             takeProfit = Order()
             takeProfit.orderId = self.nextOrderId()
@@ -1538,6 +1545,7 @@ class IBApp(IBWrapper, IBClient):
             takeProfit.lmtPrice = order.limit_price
             takeProfit.parentId = parent.orderId
             takeProfit.transmit = False
+            self._apply_time_in_force(takeProfit, order)
 
             stopLoss = Order()
             stopLoss.orderId = self.nextOrderId()
@@ -1547,6 +1555,7 @@ class IBApp(IBWrapper, IBClient):
             stopLoss.totalQuantity = order.quantity
             stopLoss.parentId = parent.orderId
             stopLoss.transmit = True
+            self._apply_time_in_force(stopLoss, order)
 
             bracketOrder = [parent, takeProfit, stopLoss]
 
@@ -1567,6 +1576,7 @@ class IBApp(IBWrapper, IBClient):
             parent.totalQuantity = order.quantity
             parent.lmtPrice = order.limit_price
             parent.transmit = False
+            self._apply_time_in_force(parent, order)
 
             if order.limit_price:
                 takeProfit = Order()
@@ -1577,6 +1587,7 @@ class IBApp(IBWrapper, IBClient):
                 takeProfit.lmtPrice = order.limit_price
                 takeProfit.parentId = parent.orderId
                 takeProfit.transmit = True
+                self._apply_time_in_force(takeProfit, order)
                 return [parent, takeProfit]
 
             elif order.stop_price:
@@ -1588,6 +1599,7 @@ class IBApp(IBWrapper, IBClient):
                 stopLoss.totalQuantity = order.quantity
                 stopLoss.parentId = parent.orderId
                 stopLoss.transmit = True
+                self._apply_time_in_force(stopLoss, order)
                 return [parent, stopLoss]
 
         elif order.order_class == "oco":
@@ -1598,6 +1610,7 @@ class IBApp(IBWrapper, IBClient):
             takeProfit.totalQuantity = order.quantity
             takeProfit.lmtPrice = order.limit_price
             takeProfit.transmit = False
+            self._apply_time_in_force(takeProfit, order)
 
             oco_Group = f"oco_{takeProfit.orderId}"
             takeProfit.ocaGroup = oco_Group
@@ -1610,6 +1623,7 @@ class IBApp(IBWrapper, IBClient):
             stopLoss.totalQuantity = order.quantity
             stopLoss.auxPrice = order.stop_price
             stopLoss.transmit = True
+            self._apply_time_in_force(stopLoss, order)
 
             stopLoss.ocaGroup = oco_Group
             stopLoss.ocaType = 1
@@ -1625,8 +1639,7 @@ class IBApp(IBWrapper, IBClient):
             if order.trail_price:
                 ib_order.auxPrice = order.trail_price
             ib_order.orderId = order.identifier if order.identifier else self.nextOrderId()
-            ib_order.tif = order.time_in_force.upper()
-            ib_order.goodTillDate = order.good_till_date.strftime("%Y%m%d %H:%M:%S") if order.good_till_date else ""
+            self._apply_time_in_force(ib_order, order)
             return [ib_order]
 
     def _create_multileg_order(self, order, exchange=None, **kwargs):
@@ -1684,8 +1697,7 @@ class IBApp(IBWrapper, IBClient):
         combo_order.action = "BUY" # TODO: This is a placeholder. This should be set based on the order side
         combo_order.orderId = combo_order_id
         combo_order.orderType = ORDERTYPE_MAPPING[order.order_type]
-        combo_order.tif = order.time_in_force.upper()
-        combo_order.goodTillDate = order.good_till_date if order.good_till_date else ""
+        self._apply_time_in_force(combo_order, order)
         combo_order.totalQuantity = min([child_order.quantity for child_order in order.child_orders])
 
         # Set the limit price if this is a limit order and a price is provided

--- a/lumibot/brokers/interactive_brokers_rest.py
+++ b/lumibot/brokers/interactive_brokers_rest.py
@@ -836,6 +836,11 @@ class InteractiveBrokersREST(Broker):
             self._safe_stream_dispatch(self.NEW_ORDER, order=native_order)
 
     def _submit_order(self, order: Order) -> Order:
+        # Validate before the futures fallback can perform a conid lookup.  The
+        # Client Portal schema does not document an exact-date GTD field, so a
+        # REST submission must never silently discard LumiBot's expiration.
+        self._validate_rest_order_time_in_force([order, *order.child_orders])
+
         # Ensure futures orders have expiration set
         if (
             hasattr(order.asset, "asset_type")
@@ -894,6 +899,8 @@ class InteractiveBrokersREST(Broker):
         duration: str = "day",
         price=None,
     ):
+        self._validate_rest_order_time_in_force(orders, duration=duration)
+
         try:
             if is_multileg:
                 if order_type == "credit":
@@ -1073,6 +1080,35 @@ class InteractiveBrokersREST(Broker):
 
         return f"lumibot-{sha256(identifier.encode('utf-8')).hexdigest()[:56]}"
 
+    @staticmethod
+    def _validate_rest_order_time_in_force(orders: list[Order], duration: str | None = None) -> None:
+        """Reject unverified Client Portal exact-date GTD submissions.
+
+        IBKR's socket API supports ``goodTillDate``, but Client Portal's order
+        schema does not document an equivalent field.  Keeping this check in
+        the REST adapter prevents the generic Order's ``good_till_date`` from
+        being silently omitted from either a single ticket or an order package.
+        """
+        if duration is not None and str(duration).upper() == "GTD":
+            raise NotImplementedError(
+                "IBKR REST exact-date GTD submission is not supported because "
+                "the Client Portal expiration field is not verified."
+            )
+
+        for order in orders:
+            time_in_force = str(getattr(order, "time_in_force", "") or "").upper()
+            good_till_date = getattr(order, "good_till_date", None)
+            if time_in_force == "GTD":
+                raise NotImplementedError(
+                    "IBKR REST exact-date GTD submission is not supported because "
+                    "the Client Portal expiration field is not verified."
+                )
+            if good_till_date is not None:
+                raise ValueError(
+                    "IBKR REST good_till_date requires time_in_force='gtd'; "
+                    f"received time_in_force={getattr(order, 'time_in_force', None)!r}."
+                )
+
     def _get_order_data_for_submission(self, order):
         order_data, _ = self._build_order_submission(order)
         return order_data
@@ -1086,6 +1122,7 @@ class InteractiveBrokersREST(Broker):
         returned native-order list is in exactly the same order as the REST
         tickets so acknowledgements can be mapped without inference.
         """
+        self._validate_rest_order_time_in_force([order, *order.child_orders])
         order_class = order.order_class
 
         if order_class is Order.OrderClass.SIMPLE:
@@ -1162,6 +1199,8 @@ class InteractiveBrokersREST(Broker):
         parent_id: str | None = None,
         is_single_group: bool | None = None,
     ):
+        self._validate_rest_order_time_in_force([order])
+
         try:
             conid = None
             side = None
@@ -1271,6 +1310,7 @@ class InteractiveBrokersREST(Broker):
         dict
             A dictionary containing the order data for the multileg order.
         """
+        self._validate_rest_order_time_in_force(orders, duration=duration)
 
         # Initialize the order data dictionary
         order_data = {"orders": []}

--- a/lumibot/brokers/interactive_brokers_rest.py
+++ b/lumibot/brokers/interactive_brokers_rest.py
@@ -726,19 +726,19 @@ class InteractiveBrokersREST(Broker):
                     )
                 )
 
-    @staticmethod
-    def _get_acknowledged_order_ids(response) -> list[str]:
+    @classmethod
+    def _get_acknowledged_order_ids(cls, response) -> list[str]:
         """Collect every usable broker ID from a response for cleanup purposes."""
         entries = response if isinstance(response, list) else [response]
         acknowledged_ids = []
         for entry in entries:
             if not isinstance(entry, dict):
                 continue
-            order_id = entry.get("order_id")
-            if isinstance(order_id, bool) or not isinstance(order_id, (str, int)):
-                continue
-            order_id = str(order_id).strip()
-            if order_id:
+            # Client Portal can return placeholders such as ``-1`` for an
+            # unaccepted package member. Only a positive numeric ID identifies
+            # a ticket that can be compensated, polled, or canceled.
+            order_id = cls._normalize_broker_order_id(entry.get("order_id"))
+            if order_id is not None:
                 acknowledged_ids.append(order_id)
         return acknowledged_ids
 
@@ -769,12 +769,8 @@ class InteractiveBrokersREST(Broker):
             if "error" in entry or "message" in entry:
                 errors.append(f"entry {index} contains an error or message instead of a clean acknowledgement")
 
-            order_id = entry.get("order_id")
-            if isinstance(order_id, bool) or not isinstance(order_id, (str, int)):
-                errors.append(f"entry {index} is missing a valid order_id")
-                continue
-            order_id = str(order_id).strip()
-            if not order_id:
+            order_id = self._normalize_broker_order_id(entry.get("order_id"))
+            if order_id is None:
                 errors.append(f"entry {index} is missing a valid order_id")
                 continue
             acknowledgements.append((order_id, entry))

--- a/lumibot/brokers/interactive_brokers_rest.py
+++ b/lumibot/brokers/interactive_brokers_rest.py
@@ -222,6 +222,10 @@ class InteractiveBrokersREST(Broker):
         """Parse a broker order representation
         to an order object"""
 
+        order_id = self._normalize_ibkr_order_identifier(response.get("orderId"))
+        if order_id is None:
+            raise ValueError("IBKR REST order response is missing a valid orderId.")
+
         asset_type = [k for k, v in TYPE_MAP.items() if v == response["secType"]][0]
         totalQuantity = response["totalSize"]
 
@@ -233,7 +237,7 @@ class InteractiveBrokersREST(Broker):
             order.quantity = totalQuantity
             order.asset = Asset(symbol=response['ticker'], asset_type="multileg")
             order.side = response['side']
-            order.identifier = response['orderId']
+            order.identifier = order_id
 
             order.child_orders = []
 
@@ -263,7 +267,7 @@ class InteractiveBrokersREST(Broker):
             )
 
         order._transmitted = True
-        order.set_identifier(response["orderId"])
+        order.set_identifier(order_id)
         # Map IB order status to Lumibot status
         order.status = response["status"].lower()
 
@@ -372,7 +376,9 @@ class InteractiveBrokersREST(Broker):
                 if isinstance(order, dict)
                 else getattr(order, "orderId", None)
             )
-            if order_id is not None and str(order_id) == str(identifier):
+            normalized_order_id = self._normalize_ibkr_order_identifier(order_id)
+            normalized_identifier = self._normalize_ibkr_order_identifier(identifier)
+            if normalized_order_id is not None and normalized_order_id == normalized_identifier:
                 return order
 
         logger.warning(
@@ -974,11 +980,19 @@ class InteractiveBrokersREST(Broker):
             logger.error(colored("Error details:", "red"), exc_info=True)
 
     @staticmethod
-    def _normalize_broker_order_id(identifier) -> str | None:
-        """Return a usable Client Portal order ID, excluding local identifiers."""
+    def _normalize_ibkr_order_identifier(identifier) -> str | None:
+        """Normalize Client Portal IDs across integer and string responses."""
         if isinstance(identifier, bool) or not isinstance(identifier, (str, int)):
             return None
         order_id = str(identifier).strip()
+        return order_id or None
+
+    @classmethod
+    def _normalize_broker_order_id(cls, identifier) -> str | None:
+        """Return a usable Client Portal order ID, excluding local identifiers."""
+        order_id = cls._normalize_ibkr_order_identifier(identifier)
+        if order_id is None:
+            return None
         if not re.fullmatch(r"[0-9]+", order_id) or int(order_id) <= 0:
             return None
         return order_id
@@ -1487,7 +1501,11 @@ class InteractiveBrokersREST(Broker):
 
         # Get current orders from IB and dispatch them to the stream for processing
         raw_orders = self.data_source.get_broker_all_orders()
-        stored_orders = {x.identifier: x for x in self.get_all_orders()}
+        stored_orders = {}
+        for stored_order in self.get_all_orders():
+            order_id = self._normalize_ibkr_order_identifier(stored_order.identifier)
+            if order_id is not None:
+                stored_orders[order_id] = stored_order
 
         for order_raw in raw_orders:
             order = self._parse_broker_order(order_raw, self._strategy_name)
@@ -1497,8 +1515,12 @@ class InteractiveBrokersREST(Broker):
 
             # Process all parent and child orders
             for order in all_orders:
+                order_id = self._normalize_ibkr_order_identifier(order.identifier)
+                if order_id is None:
+                    logger.warning("Ignoring IBKR REST poll order without a valid order identifier.")
+                    continue
                 # First time seeing this order
-                if order.identifier not in stored_orders:
+                if order_id not in stored_orders:
                     if self._first_iteration:
                         # Process existing orders on first poll
                         if order.status == Order.OrderStatus.FILLED:
@@ -1520,27 +1542,34 @@ class InteractiveBrokersREST(Broker):
                         self._process_new_order(order)
                 else:
                     # Update existing order
-                    stored_order = stored_orders[order.identifier]
+                    stored_order = stored_orders[order_id]
                     stored_order.quantity = order.quantity
-                    stored_children = [stored_orders[o.identifier] if o.identifier in stored_orders else o
-                                    for o in order.child_orders]
+                    stored_order.avg_fill_price = order.avg_fill_price
+                    stored_order.update_raw(order._raw)
 
-                    if stored_children:
+                    # Flat Client Portal responses for a known native child do
+                    # not describe its LumiBot parent tree.  Only replace child
+                    # links when IBKR actually returned nested child data.
+                    if order.child_orders:
+                        stored_children = []
+                        for child_order in order.child_orders:
+                            child_id = self._normalize_ibkr_order_identifier(child_order.identifier)
+                            stored_children.append(stored_orders.get(child_id, child_order))
                         stored_order.child_orders = stored_children
 
                     # Handle status changes
                     if not order.equivalent_status(stored_order):
                         match order.status.lower():
-                            case "submitted" | "open":
+                            case "submitted" | "open" | "new":
                                 self._safe_stream_dispatch(self.NEW_ORDER, order=stored_order)
-                            case "fill":
+                            case "fill" | "filled":
                                 self._safe_stream_dispatch(
                                     self.FILLED_ORDER,
                                     order=stored_order,
                                     price=order.avg_fill_price,
                                     filled_quantity=order.quantity
                                 )
-                            case "canceled":
+                            case "cancel" | "canceled" | "cancelled":
                                 self._safe_stream_dispatch(self.CANCELED_ORDER, order=stored_order)
                             case "error":
                                 msg = f"IB encountered an error with order {order.identifier}"
@@ -1549,7 +1578,11 @@ class InteractiveBrokersREST(Broker):
                         stored_order.status = order.status
 
         # Check for disappeared orders
-        tracked_orders = {x.identifier: x for x in self.get_tracked_orders()}
+        tracked_orders = {}
+        for tracked_order in self.get_tracked_orders():
+            order_id = self._normalize_ibkr_order_identifier(tracked_order.identifier)
+            if order_id is not None:
+                tracked_orders[order_id] = tracked_order
         broker_ids = self._get_broker_id_from_raw_orders(raw_orders)
         for order_id, order in tracked_orders.items():
             if order_id not in broker_ids:
@@ -1569,9 +1602,13 @@ class InteractiveBrokersREST(Broker):
         ids = []
         for o in raw_orders:
             if "orderId" in o:
-                ids.append(str(o["orderId"]))
+                order_id = self._normalize_ibkr_order_identifier(o["orderId"])
+                if order_id is not None:
+                    ids.append(order_id)
             if "leg" in o and isinstance(o["leg"], list):
                 for leg in o["leg"]:
                     if "orderId" in leg:
-                        ids.append(str(leg["orderId"]))
+                        order_id = self._normalize_ibkr_order_identifier(leg["orderId"])
+                        if order_id is not None:
+                            ids.append(order_id)
         return ids

--- a/lumibot/brokers/interactive_brokers_rest.py
+++ b/lumibot/brokers/interactive_brokers_rest.py
@@ -973,8 +973,51 @@ class InteractiveBrokersREST(Broker):
 
             logger.error(colored("Error details:", "red"), exc_info=True)
 
+    @staticmethod
+    def _normalize_broker_order_id(identifier) -> str | None:
+        """Return a usable Client Portal order ID, excluding local identifiers."""
+        if isinstance(identifier, bool) or not isinstance(identifier, (str, int)):
+            return None
+        order_id = str(identifier).strip()
+        if not re.fullmatch(r"[0-9]+", order_id) or int(order_id) <= 0:
+            return None
+        return order_id
+
+    def _get_cancel_order_targets(self, order: Order) -> list[Order]:
+        """Return unique broker-backed cancellation targets in dependency order."""
+        if order.order_class is Order.OrderClass.OCO:
+            # An OCO parent is a LumiBot-only container and must never be sent
+            # to Client Portal, even if its local identifier looks numeric.
+            candidates = list(order.child_orders)
+        elif order.order_class in (Order.OrderClass.BRACKET, Order.OrderClass.OTO):
+            candidates = [order, *order.child_orders]
+        else:
+            # Explicit cancellation of an individual child remains scoped to
+            # that child because children are SIMPLE Order objects.
+            candidates = [order]
+
+        targets = []
+        seen_order_ids = set()
+        for candidate in candidates:
+            order_id = self._normalize_broker_order_id(candidate.identifier)
+            if order_id is None or order_id in seen_order_ids:
+                continue
+            seen_order_ids.add(order_id)
+            targets.append(candidate)
+        return targets
+
     def cancel_order(self, order: Order) -> None:
-        self.data_source.delete_order(order)
+        """Cancel every known native IBKR order represented by a LumiBot Order."""
+        for target in self._get_cancel_order_targets(order):
+            try:
+                # An explicit broker cancellation must not be suppressed by
+                # local LumiBot status. Let IBKR accept or reject each request.
+                self.data_source.delete_order(target)
+            except Exception:
+                logger.error(
+                    f"Failed to cancel IBKR REST order {target.identifier}; continuing package cancellation.",
+                    exc_info=True,
+                )
 
     def _modify_order(self, order: Order, limit_price: Union[float, None] = None,
                       stop_price: Union[float, None] = None):

--- a/lumibot/brokers/interactive_brokers_rest.py
+++ b/lumibot/brokers/interactive_brokers_rest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import time
 from hashlib import sha256
 from math import gcd
 
@@ -66,6 +67,9 @@ ORDERTYPE_MAPPING = dict(
     stop_limit="STP LMT",
     trailing_stop="TRAIL",
 )
+
+_ADVANCED_ACK_RECONCILIATION_SECONDS = 10.0
+_ADVANCED_ACK_POLL_INTERVAL_SECONDS = 0.5
 
 SPREAD_CONID_MAP = {
     "AUD": 61227077,
@@ -738,7 +742,7 @@ class InteractiveBrokersREST(Broker):
             # unaccepted package member. Only a positive numeric ID identifies
             # a ticket that can be compensated, polled, or canceled.
             order_id = cls._normalize_broker_order_id(entry.get("order_id"))
-            if order_id is not None:
+            if order_id is not None and order_id not in acknowledged_ids:
                 acknowledged_ids.append(order_id)
         return acknowledged_ids
 
@@ -808,7 +812,7 @@ class InteractiveBrokersREST(Broker):
             ]
             if require_unambiguous_correlation and len(open_indexes) > 1:
                 errors.append(
-                    "response does not identify enough OCO acknowledgements by local_order_id"
+                    "response does not identify enough acknowledgements by local_order_id"
                 )
             elif len(open_indexes) != len(uncorrelated):
                 errors.append("response acknowledgement correlation is inconsistent")
@@ -820,6 +824,115 @@ class InteractiveBrokersREST(Broker):
         if errors:
             raise ValueError("Invalid IBKR REST order acknowledgement package: " + "; ".join(errors))
         return acknowledgements
+
+    @staticmethod
+    def _get_order_correlation_id(record: dict) -> str | None:
+        """Read a Client Portal client-order correlation value without logging it."""
+        for field in ("local_order_id", "order_ref", "orderRef", "cOID"):
+            value = record.get(field)
+            if value is not None and str(value).strip():
+                return str(value).strip()
+        return None
+
+    def _reconcile_advanced_order_acknowledgements(
+        self,
+        response,
+        submitted_tickets: list[dict],
+        acknowledged_ids: list[str],
+    ) -> list[tuple[str, dict]]:
+        """Resolve an incomplete BRACKET/OTO response through bounded polling.
+
+        Client Portal can submit three bracket tickets while returning fewer
+        immediate acknowledgement rows.  Every native ticket has a unique cOID,
+        so account-order polling can complete the mapping without relying on
+        response position or accidentally adopting another account order.
+        """
+        entries = response if isinstance(response, list) else []
+        if not isinstance(response, list):
+            raise ValueError(
+                "Invalid IBKR REST order acknowledgement package: "
+                f"response must be a list, received {type(response).__name__}"
+            )
+        if any(
+            not isinstance(entry, dict) or "error" in entry or "message" in entry
+            for entry in entries
+        ):
+            raise ValueError(
+                "Invalid IBKR REST order acknowledgement package: "
+                "response contains a malformed entry, error, or message"
+            )
+
+        ticket_indexes_by_coid = {
+            str(ticket["cOID"]): index
+            for index, ticket in enumerate(submitted_tickets)
+            if ticket.get("cOID") is not None
+        }
+        expected_count = len(submitted_tickets)
+        if len(entries) > expected_count:
+            raise ValueError(
+                "Invalid IBKR REST order acknowledgement package: "
+                f"received {len(entries)} entries for {expected_count} native tickets"
+            )
+        if len(ticket_indexes_by_coid) != expected_count:
+            raise ValueError(
+                "Invalid IBKR REST order acknowledgement package: "
+                "advanced tickets do not have unique client order IDs"
+            )
+
+        correlated: list[tuple[str, dict] | None] = [None] * expected_count
+
+        def collect(records, *, polled: bool) -> None:
+            for record in records:
+                if not isinstance(record, dict):
+                    continue
+                raw_order_id = record.get("orderId") if polled else record.get("order_id")
+                order_id = self._normalize_broker_order_id(raw_order_id)
+                correlation_id = self._get_order_correlation_id(record)
+                ticket_index = ticket_indexes_by_coid.get(correlation_id)
+                if order_id is None or ticket_index is None:
+                    continue
+                current = correlated[ticket_index]
+                if current is not None and current[0] != order_id:
+                    raise ValueError(
+                        "Invalid IBKR REST order acknowledgement package: "
+                        "one client order ID resolved to multiple broker IDs"
+                    )
+                correlated[ticket_index] = (order_id, record)
+                if order_id not in acknowledged_ids:
+                    acknowledged_ids.append(order_id)
+
+        collect(entries, polled=False)
+        deadline = time.monotonic() + _ADVANCED_ACK_RECONCILIATION_SECONDS
+        while any(acknowledgement is None for acknowledgement in correlated):
+            collect(self.data_source.get_broker_all_orders_once(), polled=True)
+            if all(acknowledgement is not None for acknowledgement in correlated):
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(_ADVANCED_ACK_POLL_INTERVAL_SECONDS, remaining))
+
+        resolved_count = sum(acknowledgement is not None for acknowledgement in correlated)
+        if resolved_count != expected_count:
+            raise ValueError(
+                "Invalid IBKR REST order acknowledgement package: "
+                f"resolved {resolved_count} of {expected_count} native tickets "
+                "within the bounded reconciliation window"
+            )
+
+        resolved = [acknowledgement for acknowledgement in correlated if acknowledgement is not None]
+        resolved_ids = [order_id for order_id, _ in resolved]
+        if len(set(resolved_ids)) != expected_count:
+            raise ValueError(
+                "Invalid IBKR REST order acknowledgement package: "
+                "reconciliation returned duplicate broker IDs"
+            )
+        if set(acknowledged_ids) != set(resolved_ids):
+            raise ValueError(
+                "Invalid IBKR REST order acknowledgement package: "
+                "submission returned a broker ID outside the reconciled package"
+            )
+        return resolved
 
     def _cancel_acknowledged_order_ids(self, package_order, acknowledged_ids: list[str]) -> None:
         """Best-effort compensation for a package that IBKR only partly acknowledged."""
@@ -913,12 +1026,28 @@ class InteractiveBrokersREST(Broker):
                     expected_count=len(native_orders),
                     submitted_tickets=order_data["orders"],
                     require_unambiguous_correlation=(
-                        order.order_class is Order.OrderClass.OCO
+                        order.order_class
+                        in (
+                            Order.OrderClass.BRACKET,
+                            Order.OrderClass.OTO,
+                            Order.OrderClass.OCO,
+                        )
                     ),
                 )
             except Exception:
-                self._cancel_acknowledged_order_ids(order, acknowledged_ids)
-                raise
+                if order.order_class in (Order.OrderClass.BRACKET, Order.OrderClass.OTO):
+                    try:
+                        acknowledgements = self._reconcile_advanced_order_acknowledgements(
+                            response,
+                            order_data["orders"],
+                            acknowledged_ids,
+                        )
+                    except Exception:
+                        self._cancel_acknowledged_order_ids(order, acknowledged_ids)
+                        raise
+                else:
+                    self._cancel_acknowledged_order_ids(order, acknowledged_ids)
+                    raise
 
             try:
                 self._track_acknowledged_order_package(order, native_orders, acknowledgements)
@@ -1183,7 +1312,14 @@ class InteractiveBrokersREST(Broker):
             native_orders = [order, *children]
             tickets = [(order, None, parent_coid, None, None)]
             tickets.extend(
-                (child, order.exchange, None, parent_coid, None) for child in children
+                (
+                    child,
+                    order.exchange,
+                    self._get_ibkr_client_order_id(child),
+                    parent_coid,
+                    None,
+                )
+                for child in children
             )
         elif order_class is Order.OrderClass.OTO:
             if len(children) != 1:
@@ -1195,7 +1331,13 @@ class InteractiveBrokersREST(Broker):
             native_orders = [order, children[0]]
             tickets = [
                 (order, None, parent_coid, None, None),
-                (children[0], order.exchange, None, parent_coid, None),
+                (
+                    children[0],
+                    order.exchange,
+                    self._get_ibkr_client_order_id(children[0]),
+                    parent_coid,
+                    None,
+                ),
             ]
         elif order_class is Order.OrderClass.OCO:
             if len(children) != 2:
@@ -1224,6 +1366,12 @@ class InteractiveBrokersREST(Broker):
         else:
             raise ValueError(
                 f"IBKR REST advanced-order package construction does not support {order_class!r}."
+            )
+
+        package_coids = [ticket[2] for ticket in tickets if ticket[2] is not None]
+        if len(set(package_coids)) != len(package_coids):
+            raise ValueError(
+                "IBKR REST advanced-order tickets must have distinct identifiers for cOID correlation."
             )
 
         order_data = {"orders": []}
@@ -1292,8 +1440,28 @@ class InteractiveBrokersREST(Broker):
 
             rules = self.data_source.get_contract_rules(conid)
             increment = rules['rules']['increment'] # 0.05 for example
-            price = (order.limit_price // increment) * increment if order.limit_price is not None else None
-            aux_price = (order.stop_price // increment) * increment if order.stop_price is not None else None
+            limit_price = (
+                (order.limit_price // increment) * increment
+                if order.limit_price is not None
+                else None
+            )
+            stop_price = (
+                (order.stop_price // increment) * increment
+                if order.stop_price is not None
+                else None
+            )
+            # Client Portal REST uses ``price`` for an STP trigger. ``auxPrice``
+            # is the trigger only for STP LMT; sending an STP trigger as auxPrice
+            # can produce a placeholder acknowledgement instead of a ticket.
+            if order.order_type == Order.OrderType.STOP:
+                price = stop_price
+                aux_price = None
+            elif order.order_type == Order.OrderType.STOP_LIMIT:
+                price = limit_price
+                aux_price = stop_price
+            else:
+                price = limit_price
+                aux_price = None
 
             data = {
                 "conid": conid,

--- a/lumibot/brokers/interactive_brokers_rest.py
+++ b/lumibot/brokers/interactive_brokers_rest.py
@@ -720,6 +720,115 @@ class InteractiveBrokersREST(Broker):
                     )
                 )
 
+    @staticmethod
+    def _get_acknowledged_order_ids(response) -> list[str]:
+        """Collect every usable broker ID from a response for cleanup purposes."""
+        entries = response if isinstance(response, list) else [response]
+        acknowledged_ids = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            order_id = entry.get("order_id")
+            if isinstance(order_id, bool) or not isinstance(order_id, (str, int)):
+                continue
+            order_id = str(order_id).strip()
+            if order_id:
+                acknowledged_ids.append(order_id)
+        return acknowledged_ids
+
+    def _validate_order_acknowledgements(self, response, expected_count: int) -> list[tuple[str, dict]]:
+        """Validate an atomic Client Portal acknowledgement package."""
+        errors = []
+        if not isinstance(response, list):
+            errors.append(f"response must be a list, received {type(response).__name__}")
+            entries = []
+        else:
+            entries = response
+            if len(entries) != expected_count:
+                errors.append(
+                    f"expected {expected_count} acknowledgement entries, received {len(entries)}"
+                )
+
+        acknowledgements = []
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                errors.append(f"entry {index} must be an object")
+                continue
+            if "error" in entry or "message" in entry:
+                errors.append(f"entry {index} contains an error or message instead of a clean acknowledgement")
+
+            order_id = entry.get("order_id")
+            if isinstance(order_id, bool) or not isinstance(order_id, (str, int)):
+                errors.append(f"entry {index} is missing a valid order_id")
+                continue
+            order_id = str(order_id).strip()
+            if not order_id:
+                errors.append(f"entry {index} is missing a valid order_id")
+                continue
+            acknowledgements.append((order_id, entry))
+
+        acknowledged_ids = [order_id for order_id, _ in acknowledgements]
+        if len(set(acknowledged_ids)) != len(acknowledged_ids):
+            errors.append("response contains duplicate order_id acknowledgements")
+
+        if errors:
+            raise ValueError("Invalid IBKR REST order acknowledgement package: " + "; ".join(errors))
+        return acknowledgements
+
+    def _cancel_acknowledged_order_ids(self, package_order, acknowledged_ids: list[str]) -> None:
+        """Best-effort compensation for a package that IBKR only partly acknowledged."""
+        for order_id in acknowledged_ids:
+            cleanup_order = Order(strategy=package_order.strategy, identifier=order_id)
+            try:
+                self.cancel_order(cleanup_order)
+            except Exception:
+                logger.error(
+                    f"Failed to cancel acknowledged IBKR REST order {order_id} during package cleanup.",
+                    exc_info=True,
+                )
+
+    def _mark_order_package_error(self, order, message: str) -> None:
+        """Mark a failed local order tree without generating per-leg error callbacks."""
+        affected_orders = [order, *order.child_orders]
+        seen = set()
+        for affected_order in affected_orders:
+            object_id = id(affected_order)
+            if object_id in seen:
+                continue
+            seen.add(object_id)
+            affected_order.set_error(message)
+
+        self._log_order_status(order, "failed", success=False)
+        self._safe_stream_dispatch(self.ERROR_ORDER, order=order, error_msg=message)
+
+    def _track_acknowledged_order_package(self, order, native_orders, acknowledgements) -> None:
+        """Apply broker acknowledgements and register every native order exactly once."""
+        for native_order, (order_id, raw_response) in zip(native_orders, acknowledgements):
+            native_order.identifier = order_id
+            native_order.update_raw(raw_response)
+            native_order.status = Order.OrderStatus.SUBMITTED
+
+        if order.order_class in (Order.OrderClass.BRACKET, Order.OrderClass.OTO):
+            broker_parent_id = native_orders[0].identifier
+            for child_order in order.child_orders:
+                child_order.parent_identifier = broker_parent_id
+        elif order.order_class is Order.OrderClass.OCO:
+            local_parent_id = order.identifier
+            for child_order in order.child_orders:
+                child_order.parent_identifier = local_parent_id
+            order.status = Order.OrderStatus.SUBMITTED
+            self._unprocessed_orders.append(order)
+
+        # Add the complete package before dispatching events so callbacks cannot
+        # observe a partially registered native order tree.
+        for native_order in native_orders:
+            self._unprocessed_orders.append(native_order)
+
+        if order.order_class is Order.OrderClass.OCO:
+            self._safe_stream_dispatch(self.PLACEHOLDER_ORDER, order=order)
+        for native_order in native_orders:
+            self._safe_stream_dispatch(self.NEW_ORDER, order=native_order)
+
     def _submit_order(self, order: Order) -> Order:
         # Ensure futures orders have expiration set
         if (
@@ -743,29 +852,32 @@ class InteractiveBrokersREST(Broker):
                     logger.info(colored(f"Auto-filled expiration for {order.asset.symbol}: {order.asset.expiration}", "yellow"))
 
         try:
-            order_data = self._get_order_data_for_submission(order)
-            response = self.data_source.execute_order(order_data)
+            order_data, native_orders = self._build_order_submission(order)
+            response = self.data_source.execute_order(order_data, return_raw_response=True)
 
-            if response is None:
-                self._log_order_status(order, "failed", success=False)
-                msg = "Broker returned no response"
-                self._safe_stream_dispatch(self.ERROR_ORDER, order=order, error_msg=msg)
-                return order
+            acknowledged_ids = self._get_acknowledged_order_ids(response)
+            try:
+                acknowledgements = self._validate_order_acknowledgements(
+                    response,
+                    expected_count=len(native_orders),
+                )
+            except Exception:
+                self._cancel_acknowledged_order_ids(order, acknowledged_ids)
+                raise
+
+            try:
+                self._track_acknowledged_order_package(order, native_orders, acknowledgements)
+            except Exception:
+                self._cancel_acknowledged_order_ids(order, acknowledged_ids)
+                raise
 
             self._log_order_status(order, "executed", success=True)
-
-            order.identifier = response[0]["order_id"]
-            self._unprocessed_orders.append(order)
-            order.status=Order.OrderStatus.SUBMITTED
-
-            self._safe_stream_dispatch(self.NEW_ORDER, order=order)
-
             return order
 
         except Exception as e:
-            msg = colored(f"Error submitting order {order}: {e}", color="red")
+            msg = f"Error submitting IBKR REST order package {order}: {e}"
             logger.error(colored("Error details:", "red"), exc_info=True)
-            self._safe_stream_dispatch(self.ERROR_ORDER, order=order, error_msg=msg)
+            self._mark_order_package_error(order, msg)
             return order
 
     def _submit_orders(
@@ -905,16 +1017,22 @@ class InteractiveBrokersREST(Broker):
         return f"lumibot-{sha256(identifier.encode('utf-8')).hexdigest()[:56]}"
 
     def _get_order_data_for_submission(self, order):
+        order_data, _ = self._build_order_submission(order)
+        return order_data
+
+    def _build_order_submission(self, order):
         """Build one atomic Client Portal order-ticket package for an Order tree.
 
         The generic Order tree models the relationships.  This adapter maps
         those relationships to the Client Portal-specific cOID, parentId, and
-        isSingleGroup ticket fields without changing the Order API.
+        isSingleGroup ticket fields without changing the Order API.  The
+        returned native-order list is in exactly the same order as the REST
+        tickets so acknowledgements can be mapped without inference.
         """
         order_class = order.order_class
 
         if order_class is Order.OrderClass.SIMPLE:
-            return self.get_order_data_from_orders([order])
+            return self.get_order_data_from_orders([order]), [order]
 
         children = list(order.child_orders)
         if order_class is Order.OrderClass.BRACKET:
@@ -924,6 +1042,7 @@ class InteractiveBrokersREST(Broker):
                     f"Found {len(children)}."
                 )
             parent_coid = self._get_ibkr_client_order_id(order)
+            native_orders = [order, *children]
             tickets = [(order, None, parent_coid, None, None)]
             tickets.extend(
                 (child, order.exchange, None, parent_coid, None) for child in children
@@ -935,6 +1054,7 @@ class InteractiveBrokersREST(Broker):
                     f"Found {len(children)}."
                 )
             parent_coid = self._get_ibkr_client_order_id(order)
+            native_orders = [order, children[0]]
             tickets = [
                 (order, None, parent_coid, None, None),
                 (children[0], order.exchange, None, parent_coid, None),
@@ -947,6 +1067,7 @@ class InteractiveBrokersREST(Broker):
                 )
             # The LumiBot OCO parent is conceptual; IBKR receives only its
             # two executable children as one single-group package.
+            native_orders = children
             tickets = [
                 (child, order.exchange, None, None, True) for child in children
             ]
@@ -973,7 +1094,7 @@ class InteractiveBrokersREST(Broker):
                 )
             order_data["orders"].append(ticket)
 
-        return order_data
+        return order_data, native_orders
 
     def get_order_data_from_order(
         self,
@@ -1219,6 +1340,17 @@ class InteractiveBrokersREST(Broker):
                 broker._process_trade_event(
                     order,
                     broker.NEW_ORDER,
+                )
+                return True
+            except:
+                logger.error(_format_exc())
+
+        @broker.stream.add_action(broker.PLACEHOLDER_ORDER)
+        def on_trade_event_placeholder(order):
+            try:
+                broker._process_trade_event(
+                    order,
+                    broker.PLACEHOLDER_ORDER,
                 )
                 return True
             except:

--- a/lumibot/brokers/interactive_brokers_rest.py
+++ b/lumibot/brokers/interactive_brokers_rest.py
@@ -742,7 +742,13 @@ class InteractiveBrokersREST(Broker):
                 acknowledged_ids.append(order_id)
         return acknowledged_ids
 
-    def _validate_order_acknowledgements(self, response, expected_count: int) -> list[tuple[str, dict]]:
+    def _validate_order_acknowledgements(
+        self,
+        response,
+        expected_count: int,
+        submitted_tickets: list[dict] | None = None,
+        require_unambiguous_correlation: bool = False,
+    ) -> list[tuple[str, dict]]:
         """Validate an atomic Client Portal acknowledgement package."""
         errors = []
         if not isinstance(response, list):
@@ -776,6 +782,44 @@ class InteractiveBrokersREST(Broker):
         acknowledged_ids = [order_id for order_id, _ in acknowledgements]
         if len(set(acknowledged_ids)) != len(acknowledged_ids):
             errors.append("response contains duplicate order_id acknowledgements")
+
+        if not errors and submitted_tickets is not None:
+            ticket_indexes_by_coid = {
+                str(ticket["cOID"]): index
+                for index, ticket in enumerate(submitted_tickets)
+                if ticket.get("cOID") is not None
+            }
+            correlated = [None] * expected_count
+            uncorrelated = []
+            for acknowledgement in acknowledgements:
+                local_order_id = acknowledgement[1].get("local_order_id")
+                local_order_id = (
+                    str(local_order_id) if local_order_id is not None else None
+                )
+                ticket_index = ticket_indexes_by_coid.get(local_order_id)
+                if ticket_index is None:
+                    uncorrelated.append(acknowledgement)
+                elif correlated[ticket_index] is not None:
+                    errors.append(
+                        f"response contains duplicate local_order_id {local_order_id!r}"
+                    )
+                else:
+                    correlated[ticket_index] = acknowledgement
+
+            open_indexes = [
+                index for index, acknowledgement in enumerate(correlated)
+                if acknowledgement is None
+            ]
+            if require_unambiguous_correlation and len(open_indexes) > 1:
+                errors.append(
+                    "response does not identify enough OCO acknowledgements by local_order_id"
+                )
+            elif len(open_indexes) != len(uncorrelated):
+                errors.append("response acknowledgement correlation is inconsistent")
+            else:
+                for ticket_index, acknowledgement in zip(open_indexes, uncorrelated):
+                    correlated[ticket_index] = acknowledgement
+                acknowledgements = correlated
 
         if errors:
             raise ValueError("Invalid IBKR REST order acknowledgement package: " + "; ".join(errors))
@@ -871,6 +915,10 @@ class InteractiveBrokersREST(Broker):
                 acknowledgements = self._validate_order_acknowledgements(
                     response,
                     expected_count=len(native_orders),
+                    submitted_tickets=order_data["orders"],
+                    require_unambiguous_correlation=(
+                        order.order_class is Order.OrderClass.OCO
+                    ),
                 )
             except Exception:
                 self._cancel_acknowledged_order_ids(order, acknowledged_ids)
@@ -1162,8 +1210,20 @@ class InteractiveBrokersREST(Broker):
             # The LumiBot OCO parent is conceptual; IBKR receives only its
             # two executable children as one single-group package.
             native_orders = children
+            child_coids = [self._get_ibkr_client_order_id(child) for child in children]
+            if len(set(child_coids)) != len(child_coids):
+                raise ValueError(
+                    "IBKR REST OCO child orders must have distinct identifiers for cOID correlation."
+                )
             tickets = [
-                (child, order.exchange, None, None, True) for child in children
+                (
+                    child,
+                    order.exchange,
+                    child_coid,
+                    None,
+                    True,
+                )
+                for child, child_coid in zip(children, child_coids)
             ]
         else:
             raise ValueError(

--- a/lumibot/brokers/interactive_brokers_rest.py
+++ b/lumibot/brokers/interactive_brokers_rest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+from hashlib import sha256
 from math import gcd
 
 from lumibot._lazy_imports import LazyLogger, LazyModule, lazy_class
@@ -742,7 +743,7 @@ class InteractiveBrokersREST(Broker):
                     logger.info(colored(f"Auto-filled expiration for {order.asset.symbol}: {order.asset.expiration}", "yellow"))
 
         try:
-            order_data = self.get_order_data_from_orders([order])
+            order_data = self._get_order_data_for_submission(order)
             response = self.data_source.execute_order(order_data)
 
             if response is None:
@@ -885,11 +886,109 @@ class InteractiveBrokersREST(Broker):
 
         return legs_dict
 
-    def get_order_data_from_order(self, order):
+    def _get_ibkr_client_order_id(self, order) -> str:
+        """Return an IBKR-safe, stable client order ID for a parent ticket.
+
+        LumiBot identifiers are UUIDs by default, so they can normally be sent
+        directly.  A caller may supply a different identifier, however, and
+        Client Portal requires a cOID no longer than 64 characters.  Hashing
+        non-safe identifiers keeps the REST-only requirement out of Order
+        while preserving a stable link for this submission.
+        """
+        identifier = str(getattr(order, "identifier", "") or "")
+        if not identifier:
+            raise ValueError("IBKR REST advanced-order parent is missing an identifier for cOID.")
+
+        if re.fullmatch(r"[A-Za-z0-9_-]{1,64}", identifier):
+            return identifier
+
+        return f"lumibot-{sha256(identifier.encode('utf-8')).hexdigest()[:56]}"
+
+    def _get_order_data_for_submission(self, order):
+        """Build one atomic Client Portal order-ticket package for an Order tree.
+
+        The generic Order tree models the relationships.  This adapter maps
+        those relationships to the Client Portal-specific cOID, parentId, and
+        isSingleGroup ticket fields without changing the Order API.
+        """
+        order_class = order.order_class
+
+        if order_class is Order.OrderClass.SIMPLE:
+            return self.get_order_data_from_orders([order])
+
+        children = list(order.child_orders)
+        if order_class is Order.OrderClass.BRACKET:
+            if len(children) not in (1, 2):
+                raise ValueError(
+                    "IBKR REST BRACKET orders must contain one or two child orders. "
+                    f"Found {len(children)}."
+                )
+            parent_coid = self._get_ibkr_client_order_id(order)
+            tickets = [(order, None, parent_coid, None, None)]
+            tickets.extend(
+                (child, order.exchange, None, parent_coid, None) for child in children
+            )
+        elif order_class is Order.OrderClass.OTO:
+            if len(children) != 1:
+                raise ValueError(
+                    "IBKR REST OTO orders must contain exactly one child order. "
+                    f"Found {len(children)}."
+                )
+            parent_coid = self._get_ibkr_client_order_id(order)
+            tickets = [
+                (order, None, parent_coid, None, None),
+                (children[0], order.exchange, None, parent_coid, None),
+            ]
+        elif order_class is Order.OrderClass.OCO:
+            if len(children) != 2:
+                raise ValueError(
+                    "IBKR REST OCO orders must contain exactly two child orders. "
+                    f"Found {len(children)}."
+                )
+            # The LumiBot OCO parent is conceptual; IBKR receives only its
+            # two executable children as one single-group package.
+            tickets = [
+                (child, order.exchange, None, None, True) for child in children
+            ]
+        else:
+            raise ValueError(
+                f"IBKR REST advanced-order package construction does not support {order_class!r}."
+            )
+
+        order_data = {"orders": []}
+        for index, (ticket_order, inherited_exchange, c_oid, parent_id, is_single_group) in enumerate(tickets):
+            effective_exchange = ticket_order.exchange or inherited_exchange
+            ticket = self.get_order_data_from_order(
+                ticket_order,
+                exchange=effective_exchange,
+                c_oid=c_oid,
+                parent_id=parent_id,
+                is_single_group=is_single_group,
+            )
+            if ticket is None:
+                role = "parent" if index == 0 and order_class is not Order.OrderClass.OCO else "child"
+                raise ValueError(
+                    f"Unable to serialize IBKR REST {order_class.value} {role} ticket; "
+                    "the complete order package was not built."
+                )
+            order_data["orders"].append(ticket)
+
+        return order_data
+
+    def get_order_data_from_order(
+        self,
+        order,
+        *,
+        exchange=None,
+        c_oid: str | None = None,
+        parent_id: str | None = None,
+        is_single_group: bool | None = None,
+    ):
         try:
             conid = None
             side = None
             orderType = None
+            effective_exchange = order.exchange if exchange is None else exchange
 
             if order.is_buy_order():
                 side = "BUY"
@@ -901,7 +1000,7 @@ class InteractiveBrokersREST(Broker):
 
             orderType = ORDERTYPE_MAPPING[order.order_type]
 
-            conid = self.data_source.get_conid_from_asset(order.asset, exchange=order.exchange)
+            conid = self.data_source.get_conid_from_asset(order.asset, exchange=effective_exchange)
 
             if conid is None:
                 asset_type = order.asset.asset_type
@@ -931,7 +1030,7 @@ class InteractiveBrokersREST(Broker):
                 "tif": order.time_in_force.upper(),
                 "price": price,
                 "auxPrice": aux_price,
-                "listingExchange": order.exchange,
+                "listingExchange": effective_exchange,
             }
 
             if order.trail_percent:
@@ -941,6 +1040,13 @@ class InteractiveBrokersREST(Broker):
             if order.trail_price:
                 data["trailingType"] = "amt"
                 data["trailingAmt"] = order.trail_price
+
+            if c_oid is not None:
+                data["cOID"] = c_oid
+            if parent_id is not None:
+                data["parentId"] = parent_id
+            if is_single_group is not None:
+                data["isSingleGroup"] = is_single_group
 
             # Remove items with value None from order_data
             data = {k: v for k, v in data.items() if v is not None}

--- a/lumibot/data_sources/interactive_brokers_rest_data.py
+++ b/lumibot/data_sources/interactive_brokers_rest_data.py
@@ -613,6 +613,29 @@ class InteractiveBrokersRESTData(DataSource):
 
         return []
 
+    def get_broker_all_orders_once(self):
+        """Fetch the selected account's orders once without an unbounded retry.
+
+        Advanced-order acknowledgement reconciliation runs after the submission
+        request has already authenticated the brokerage session.  It must not
+        enter the normal polling method's retry-until-available behavior while
+        an incompletely acknowledged package may still need compensation.
+        """
+        url = (
+            f"{self.base_url}/iserver/account/orders?force=true"
+            f"&accountId={self.account_id}"
+        )
+        response = self.get_from_endpoint(
+            url,
+            "Reconciling submitted orders",
+            allow_fail=True,
+            silent=True,
+            max_retries=0,
+        )
+        if isinstance(response, dict) and isinstance(response.get("orders"), list):
+            return response["orders"]
+        return []
+
     def get_order_info(self, orderid):
         self.ping_iserver()
 
@@ -660,12 +683,14 @@ class InteractiveBrokersRESTData(DataSource):
         orderId = order.identifier
         url = f"{self.base_url}/iserver/account/{self.account_id}/order/{orderId}"
         status = self.delete_to_endpoint(url, description=f"Deleting order {orderId}")
-        if status:
+        if status and not (isinstance(status, dict) and status.get("error")):
             logger.info(
                 colored(f"Order with ID {orderId} canceled successfully.", "green")
             )
+            return True
         else:
             logger.error(colored(f"Failed to delete order with ID {orderId}.", "red"))
+            return False
 
     def get_positions(self):
         """

--- a/lumibot/data_sources/interactive_brokers_rest_data.py
+++ b/lumibot/data_sources/interactive_brokers_rest_data.py
@@ -620,7 +620,7 @@ class InteractiveBrokersRESTData(DataSource):
         response = self.get_from_endpoint(url, "Getting Order Info", allow_fail=False, silent=True)
         return response
 
-    def execute_order(self, order_data):
+    def execute_order(self, order_data, return_raw_response=False):
         if order_data is None:
             logger.debug(colored("Failed to get order data.", "red"))
             return None
@@ -629,6 +629,12 @@ class InteractiveBrokersRESTData(DataSource):
 
         url = f"{self.base_url}/iserver/account/{self.account_id}/orders"
         response = self.post_to_endpoint(url, order_data, description="Executing order")
+
+        # Atomic order packages need the complete broker response so the
+        # broker adapter can validate every acknowledgement and compensate for
+        # partial acceptance. Confirmation handling remains in post_to_endpoint.
+        if return_raw_response:
+            return response
 
         if isinstance(response, list) and "order_id" in response[0]:
             # success

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -959,6 +959,8 @@ class Order:
                     limit_price=self.limit_price,
                     order_type=Order.OrderType.LIMIT,
                     quote=self.quote,
+                    time_in_force=self.time_in_force,
+                    good_till_date=self.good_till_date,
                 )
                 stop_order = Order(
                     # Stop Type will be filled in automatically for child based on the Stop Modifiers
@@ -971,6 +973,8 @@ class Order:
                     trail_price=self.trail_price,
                     trail_percent=self.trail_percent,
                     quote=self.quote,
+                    time_in_force=self.time_in_force,
+                    good_till_date=self.good_till_date,
                 )
                 # Set dependencies so that the two orders will cancel the other in BackTesting
                 limit_order.dependent_order = stop_order
@@ -1006,6 +1010,8 @@ class Order:
                             limit_price=secondary_limit_price,
                             order_type=Order.OrderType.LIMIT,
                             quote=self.quote,
+                            time_in_force=self.time_in_force,
+                            good_till_date=self.good_till_date,
                         )
                     )
                 if secondary_stop_price is not None:
@@ -1021,6 +1027,8 @@ class Order:
                             trail_price=secondary_trail_price,
                             trail_percent=secondary_trail_percent,
                             quote=self.quote,
+                            time_in_force=self.time_in_force,
+                            good_till_date=self.good_till_date,
                         )
                     )
 
@@ -1059,6 +1067,8 @@ class Order:
                             limit_price=secondary_limit_price,
                             order_type=Order.OrderType.LIMIT,
                             quote=self.quote,
+                            time_in_force=self.time_in_force,
+                            good_till_date=self.good_till_date,
                         )
                     )
                 elif secondary_stop_price is not None:
@@ -1074,6 +1084,8 @@ class Order:
                             trail_price=secondary_trail_price,
                             trail_percent=secondary_trail_percent,
                             quote=self.quote,
+                            time_in_force=self.time_in_force,
+                            good_till_date=self.good_till_date,
                         )
                     )
             elif len(self.child_orders) == 1:

--- a/tests/ibkr_rest_paper_order_safety.py
+++ b/tests/ibkr_rest_paper_order_safety.py
@@ -1,0 +1,147 @@
+"""Safety gates shared by IBKR REST paper-order API tests.
+
+These helpers intentionally live in ``tests``.  They protect tests that can
+change broker state without changing the runtime broker contract.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+import pytest
+
+
+def _as_bool(value: object) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def mask_ibkr_account_id(account_id: object) -> str:
+    """Return an account identifier's suffix without exposing the identifier."""
+    value = str(account_id or "").strip()
+    if not value:
+        return "<missing>"
+    if len(value) <= 4:
+        return "****"
+    return f"****{value[-4:]}"
+
+
+def require_explicit_ibkr_rest_paper_configuration(
+    config: Mapping[str, object],
+    environment: Mapping[str, str] | None = None,
+) -> None:
+    """Skip unavailable test setups and reject a non-explicit paper selection.
+
+    ``INTERACTIVE_BROKERS_REST_CONFIG`` defaults ``USE_PAPER_ACCOUNT`` to
+    ``true``.  An order-changing test must instead see an explicit raw
+    ``IB_USE_PAPER_ACCOUNT=true`` environment setting.
+    """
+    environment = os.environ if environment is None else environment
+    external_gateway = bool(str(config.get("API_URL") or "").strip()) or _as_bool(
+        config.get("RUNNING_ON_SERVER")
+    )
+    if not external_gateway and not (
+        str(config.get("IB_USERNAME") or "").strip()
+        and str(config.get("IB_PASSWORD") or "").strip()
+    ):
+        pytest.skip("IBKR REST paper-order test requires configured gateway credentials")
+
+    paper_setting = environment.get("IB_USE_PAPER_ACCOUNT")
+    if paper_setting is None or not str(paper_setting).strip():
+        pytest.skip(
+            "IBKR REST paper-order test requires explicit IB_USE_PAPER_ACCOUNT=true"
+        )
+    if str(paper_setting).strip().lower() != "true":
+        pytest.fail(
+            "IBKR REST paper-order test refuses to run unless "
+            "IB_USE_PAPER_ACCOUNT is explicitly true"
+        )
+
+
+def require_ibkr_rest_paper_account(
+    *,
+    configured_account_id: object,
+    authenticated_account_id: object,
+    data_source_account_id: object | None = None,
+) -> str:
+    """Reject non-paper or ambiguous account selections before order creation."""
+    authenticated = str(authenticated_account_id or "").strip()
+    if not authenticated:
+        pytest.fail("IBKR REST paper-order test could not determine an authenticated account")
+    if not authenticated.upper().startswith("DU"):
+        pytest.fail(
+            "IBKR REST paper-order test refuses non-paper account "
+            f"{mask_ibkr_account_id(authenticated)}; expected the DU paper-account prefix"
+        )
+
+    configured = str(configured_account_id or "").strip()
+    if configured and configured != authenticated:
+        pytest.fail(
+            "Configured IB_ACCOUNT_ID does not match the authenticated IBKR account "
+            f"(configured {mask_ibkr_account_id(configured)}, "
+            f"authenticated {mask_ibkr_account_id(authenticated)})"
+        )
+
+    selected_by_data_source = str(data_source_account_id or "").strip()
+    if selected_by_data_source and selected_by_data_source != authenticated:
+        pytest.fail(
+            "InteractiveBrokersRESTData selected a different account than the "
+            f"authenticated account (selected {mask_ibkr_account_id(selected_by_data_source)}, "
+            f"authenticated {mask_ibkr_account_id(authenticated)})"
+        )
+    return authenticated
+
+
+def _authenticated_selected_account_id(data_source) -> str:
+    """Read the authenticated selection without logging the response payload."""
+    try:
+        response = data_source.http_client.get(
+            f"{data_source.base_url}/iserver/accounts",
+            verify=data_source.verify_ssl,
+            timeout=data_source.request_timeout,
+        )
+        if not 200 <= response.status_code < 300:
+            pytest.skip("IBKR REST gateway is unavailable for the paper-order test")
+        payload = response.json()
+    except Exception:
+        pytest.skip("IBKR REST gateway is unavailable for the paper-order test")
+
+    selected_account_id = payload.get("selectedAccount") if isinstance(payload, dict) else None
+    if not isinstance(selected_account_id, str) or not selected_account_id.strip():
+        pytest.skip("IBKR REST gateway did not expose an authenticated selected account")
+    return selected_account_id
+
+
+def require_authenticated_ibkr_rest_paper_account(
+    data_source,
+    config: Mapping[str, object],
+) -> str:
+    """Verify the post-authentication account before an API test creates an order."""
+    authenticated_account_id = _authenticated_selected_account_id(data_source)
+    return require_ibkr_rest_paper_account(
+        configured_account_id=config.get("IB_ACCOUNT_ID"),
+        authenticated_account_id=authenticated_account_id,
+        data_source_account_id=data_source.account_id,
+    )
+
+
+@pytest.fixture
+def ibkr_rest_paper_order_data_source():
+    """Yield an authenticated, verified paper data source for order API tests."""
+    from lumibot.credentials import INTERACTIVE_BROKERS_REST_CONFIG
+    from lumibot.data_sources import InteractiveBrokersRESTData
+
+    config = dict(INTERACTIVE_BROKERS_REST_CONFIG)
+    require_explicit_ibkr_rest_paper_configuration(config)
+    data_source = None
+    try:
+        data_source = InteractiveBrokersRESTData(config)
+    except Exception:
+        pytest.skip("IBKR REST gateway is unavailable for the paper-order test")
+
+    try:
+        require_authenticated_ibkr_rest_paper_account(data_source, config)
+        yield data_source
+    finally:
+        if data_source is not None:
+            data_source.stop()

--- a/tests/ibkr_rest_paper_order_safety.py
+++ b/tests/ibkr_rest_paper_order_safety.py
@@ -125,8 +125,20 @@ def require_authenticated_ibkr_rest_paper_account(
     )
 
 
+def _construct_paper_test_data_source(data_source_type, config, monkeypatch):
+    """Construct the test data source without changing IBKR warning settings.
+
+    ``InteractiveBrokersRESTData.start()`` normally suppresses selected IBKR
+    warnings after authentication.  A paper safety fixture must not make that
+    session-changing request before it has verified the authenticated account,
+    and paper tests should observe warnings rather than suppress them.
+    """
+    monkeypatch.setattr(data_source_type, "suppress_warnings", lambda _self: None)
+    return data_source_type(config)
+
+
 @pytest.fixture
-def ibkr_rest_paper_order_data_source():
+def ibkr_rest_paper_order_data_source(monkeypatch):
     """Yield an authenticated, verified paper data source for order API tests."""
     from lumibot.credentials import INTERACTIVE_BROKERS_REST_CONFIG
     from lumibot.data_sources import InteractiveBrokersRESTData
@@ -135,7 +147,11 @@ def ibkr_rest_paper_order_data_source():
     require_explicit_ibkr_rest_paper_configuration(config)
     data_source = None
     try:
-        data_source = InteractiveBrokersRESTData(config)
+        data_source = _construct_paper_test_data_source(
+            InteractiveBrokersRESTData,
+            config,
+            monkeypatch,
+        )
     except Exception:
         pytest.skip("IBKR REST gateway is unavailable for the paper-order test")
 

--- a/tests/ibkr_rest_paper_order_safety.py
+++ b/tests/ibkr_rest_paper_order_safety.py
@@ -8,12 +8,41 @@ from __future__ import annotations
 
 import os
 from collections.abc import Mapping
+from unittest.mock import patch
 
 import pytest
 
 
 def _as_bool(value: object) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def ibkr_rest_paper_test_config(
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, str | None]:
+    """Build the established REST configuration without importing credentials.
+
+    Importing ``lumibot.credentials`` may auto-select and start a broker when
+    IBKR credentials are present. Paper API tests must run their explicit-paper
+    gate before any gateway construction, so they read the same public IBKR
+    environment variables directly instead.
+    """
+    environment = os.environ if environment is None else environment
+    return {
+        "IB_USERNAME": environment.get("IB_USERNAME"),
+        "IB_PASSWORD": environment.get("IB_PASSWORD"),
+        "IB_ACCOUNT_ID": environment.get("IB_ACCOUNT_ID"),
+        "API_URL": environment.get("IB_API_URL"),
+        "RUNNING_ON_SERVER": environment.get("RUNNING_ON_SERVER"),
+        "GATEWAY_PORT": environment.get("IB_GATEWAY_PORT"),
+        "GATEWAY_INSTANCE_ID": environment.get("IB_GATEWAY_INSTANCE_ID"),
+        "USE_PAPER_ACCOUNT": environment.get("IB_USE_PAPER_ACCOUNT", "true"),
+        "IBEAM_DOCKER_TAG": environment.get("IBEAM_DOCKER_TAG"),
+        "AUTH_TIMEOUT": environment.get("IB_AUTH_TIMEOUT"),
+        "AUTH_POLL_INTERVAL": environment.get("IB_AUTH_POLL_INTERVAL"),
+        "REQUEST_TIMEOUT": environment.get("IB_REQUEST_TIMEOUT"),
+        "VERIFY_SSL": environment.get("IB_VERIFY_SSL"),
+    }
 
 
 def mask_ibkr_account_id(account_id: object) -> str:
@@ -137,21 +166,23 @@ def _construct_paper_test_data_source(data_source_type, config, monkeypatch):
     return data_source_type(config)
 
 
-@pytest.fixture
-def ibkr_rest_paper_order_data_source(monkeypatch):
+@pytest.fixture(scope="session")
+def ibkr_rest_paper_order_data_source():
     """Yield an authenticated, verified paper data source for order API tests."""
-    from lumibot.credentials import INTERACTIVE_BROKERS_REST_CONFIG
     from lumibot.data_sources import InteractiveBrokersRESTData
 
-    config = dict(INTERACTIVE_BROKERS_REST_CONFIG)
+    config = ibkr_rest_paper_test_config()
     require_explicit_ibkr_rest_paper_configuration(config)
     data_source = None
     try:
-        data_source = _construct_paper_test_data_source(
+        # Keep this patch scoped to construction: the safety gate must inspect
+        # the authenticated account before a paper test can change server state.
+        with patch.object(
             InteractiveBrokersRESTData,
-            config,
-            monkeypatch,
-        )
+            "suppress_warnings",
+            lambda _self: None,
+        ):
+            data_source = InteractiveBrokersRESTData(config)
     except Exception:
         pytest.skip("IBKR REST gateway is unavailable for the paper-order test")
 

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -474,7 +474,12 @@ def test_ibkr_rest_submit_order_without_stream_does_not_crash(monkeypatch):
     from lumibot.entities import Asset, Order
 
     monkeypatch.setattr(broker_module.Broker, "_start_orders_thread", lambda self: None)
-    data_source = SimpleNamespace(execute_order=lambda order_data: [{"order_id": "ib-1"}])
+    # The REST broker requests the complete response so atomic packages can
+    # validate every native acknowledgement. Keep this fake aligned with the
+    # production data-source interface introduced for that safety invariant.
+    data_source = SimpleNamespace(
+        execute_order=lambda order_data, return_raw_response=False: [{"order_id": "ib-1"}]
+    )
     broker = InteractiveBrokersREST(config={"MARKET": "NYSE"}, data_source=data_source, connect_stream=False)
     broker.get_order_data_from_orders = lambda orders: {"orders": []}
     broker._log_order_status = lambda *args, **kwargs: None

--- a/tests/test_ibkr_rest_advanced_orders_paper_apitest.py
+++ b/tests/test_ibkr_rest_advanced_orders_paper_apitest.py
@@ -14,7 +14,10 @@ import pytest
 
 from lumibot.brokers.interactive_brokers_rest import InteractiveBrokersREST
 from lumibot.entities import Asset, Order
-from tests.ibkr_rest_paper_order_safety import ibkr_rest_paper_order_data_source
+from tests.ibkr_rest_paper_order_safety import (
+    ibkr_rest_paper_order_data_source,
+    ibkr_rest_paper_test_config,
+)
 
 
 pytestmark = [pytest.mark.apitest, pytest.mark.ibkr]
@@ -132,11 +135,12 @@ class _BrokerTrafficProbe:
                 for entry in entries:
                     if not isinstance(entry, dict):
                         continue
-                    order_id = entry.get("order_id")
-                    if isinstance(order_id, bool) or not isinstance(order_id, (str, int)):
-                        continue
-                    normalized = str(order_id).strip()
-                    if normalized:
+                    # ``-1`` and other non-positive/non-numeric values are
+                    # Client Portal placeholders, not broker-backed tickets.
+                    normalized = InteractiveBrokersREST._normalize_broker_order_id(
+                        entry.get("order_id")
+                    )
+                    if normalized is not None:
                         # Confirmation calls can be nested inside the outer
                         # execute call. Capture each ID as that call returns so
                         # a later confirmation failure cannot orphan an ID.
@@ -506,12 +510,10 @@ def test_ibkr_rest_advanced_orders_on_verified_paper_account(
     request,
 ):
     """Exercise real broker submission, polling, tracking, and cleanup on paper."""
-    from lumibot.credentials import INTERACTIVE_BROKERS_REST_CONFIG
-
     data_source = ibkr_rest_paper_order_data_source
     probe = _BrokerTrafficProbe(data_source, monkeypatch)
     broker = InteractiveBrokersREST(
-        dict(INTERACTIVE_BROKERS_REST_CONFIG),
+        ibkr_rest_paper_test_config(),
         data_source=data_source,
         connect_stream=False,
     )

--- a/tests/test_ibkr_rest_advanced_orders_paper_apitest.py
+++ b/tests/test_ibkr_rest_advanced_orders_paper_apitest.py
@@ -37,9 +37,36 @@ _FILLED_STATUSES = {"fill", "filled"}
 @dataclass
 class _ScenarioRecord:
     name: str
+    expected_native_count: int
     acknowledged_ids: list[str] = field(default_factory=list)
+    response_entry_count: int = 0
+    cleanup_attempted_ids: set[str] = field(default_factory=set)
     confirmation_count_before: int = 0
     cancellation_count_before: int = 0
+    polling_outcome: str = "not_reached"
+    cancellation_outcome: str = "not_reached"
+
+    @property
+    def acceptance_outcome(self) -> str:
+        acknowledged_count = len(self.acknowledged_ids)
+        if acknowledged_count == 0:
+            return "no_order_accepted"
+        if acknowledged_count == self.expected_native_count:
+            return "package_fully_accepted"
+        if acknowledged_count < self.expected_native_count:
+            return "package_partially_acknowledged"
+        return "unexpected_acknowledgement_count"
+
+    def sanitized_diagnostic(self) -> str:
+        return (
+            f"acceptance={self.acceptance_outcome}, "
+            f"expected_native={self.expected_native_count}, "
+            f"response_entries={self.response_entry_count}, "
+            f"acknowledged_unique={len(self.acknowledged_ids)}, "
+            f"polling={self.polling_outcome}, "
+            f"cancellation={self.cancellation_outcome}, "
+            f"cleanup_attempted_unique={len(self.cleanup_attempted_ids)}"
+        )
 
 
 class _BrokerTrafficProbe:
@@ -95,6 +122,7 @@ class _BrokerTrafficProbe:
             )
             if description == "Executing order" and self.current_scenario is not None:
                 entries = response if isinstance(response, list) else [response]
+                self.current_scenario.response_entry_count = len(entries)
                 for entry in entries:
                     if not isinstance(entry, dict):
                         continue
@@ -105,7 +133,8 @@ class _BrokerTrafficProbe:
                     if normalized:
                         # Record immediately after the real acknowledgement,
                         # before the broker maps or validates the package.
-                        self.current_scenario.acknowledged_ids.append(normalized)
+                        if normalized not in self.current_scenario.acknowledged_ids:
+                            self.current_scenario.acknowledged_ids.append(normalized)
             return response
 
         def bounded_delete(
@@ -132,9 +161,10 @@ class _BrokerTrafficProbe:
         monkeypatch.setattr(data_source, "delete_to_endpoint", bounded_delete)
         monkeypatch.setattr(data_source, "delete_order", delete_order_and_record)
 
-    def begin(self, name: str) -> _ScenarioRecord:
+    def begin(self, name: str, expected_native_count: int) -> _ScenarioRecord:
         record = _ScenarioRecord(
             name=name,
+            expected_native_count=expected_native_count,
             confirmation_count_before=self.confirmation_count,
             cancellation_count_before=len(self.cancellation_targets),
         )
@@ -294,10 +324,15 @@ def _assert_acknowledgement_and_tracking(
     native_orders: list[Order],
 ) -> list[str]:
     expected_count = len(native_orders)
-    if len(record.acknowledged_ids) != expected_count:
+    if record.response_entry_count != expected_count:
         pytest.fail(
             f"IBKR {record.name} response cardinality mismatch: expected {expected_count} "
-            f"native acknowledgements, received {len(record.acknowledged_ids)}"
+            f"native acknowledgement entries, received {record.response_entry_count}"
+        )
+    if len(record.acknowledged_ids) != expected_count:
+        pytest.fail(
+            f"IBKR {record.name} acknowledged {len(record.acknowledged_ids)} unique native IDs "
+            f"but expected {expected_count}"
         )
 
     native_ids = [str(order.identifier) for order in native_orders]
@@ -331,6 +366,9 @@ def _cleanup_scenario(
 ) -> list[str]:
     cleanup_errors = []
     cancellation_start = len(probe.cancellation_targets)
+    # The acknowledgement ledger is ordered and deduplicated at capture time.
+    # Repeating cancellation here is intentional: cleanup must be idempotent
+    # even when the scenario already canceled through a package parent.
     for order_id in record.acknowledged_ids:
         try:
             broker.cancel_order(Order(strategy=_STRATEGY_NAME, identifier=order_id))
@@ -338,6 +376,9 @@ def _cleanup_scenario(
             cleanup_errors.append(type(exc).__name__)
 
     attempted = probe.cancellation_targets[cancellation_start:]
+    record.cleanup_attempted_ids.update(
+        order_id for order_id in attempted if order_id in record.acknowledged_ids
+    )
     missing_attempts = Counter(record.acknowledged_ids) - Counter(attempted)
     if missing_attempts:
         cleanup_errors.append(
@@ -361,9 +402,11 @@ def _run_scenario(
     package_order: Order,
     expected_native_orders,
     assertions,
+    cancellation_assertions,
     record_property,
 ) -> None:
-    record = probe.begin(name)
+    native_orders = expected_native_orders(package_order)
+    record = probe.begin(name, expected_native_count=len(native_orders))
     scenario_error: BaseException | None = None
     try:
         result = broker.submit_order(package_order)
@@ -376,11 +419,18 @@ def _run_scenario(
             native_orders,
         )
         assertions(package_order, native_orders, native_ids, record)
-        _wait_until_native_tickets_are_retrievable(data_source, native_ids)
+        record.polling_outcome = "in_progress"
+        try:
+            _wait_until_native_tickets_are_retrievable(data_source, native_ids)
+        except BaseException:
+            record.polling_outcome = "failed"
+            raise
+        record.polling_outcome = "all_native_tickets_retrievable"
         assert all(
             broker.get_order(order_id) is native_order
             for order_id, native_order in zip(native_ids, native_orders)
         ), f"IBKR {name} lifecycle polling lost or duplicated a tracked native order"
+        cancellation_assertions(package_order, native_orders, native_ids, record)
     except BaseException as exc:
         scenario_error = exc
     finally:
@@ -390,13 +440,27 @@ def _run_scenario(
             f"ibkr_{name.lower()}_confirmation_path",
             probe.confirmation_occurred(record),
         )
+        record_property(f"ibkr_{name.lower()}_acceptance", record.acceptance_outcome)
+        record_property(
+            f"ibkr_{name.lower()}_acknowledged_unique",
+            len(record.acknowledged_ids),
+        )
+        record_property(
+            f"ibkr_{name.lower()}_cleanup_attempted_unique",
+            len(record.cleanup_attempted_ids),
+        )
+        record_property(f"ibkr_{name.lower()}_polling", record.polling_outcome)
 
     if scenario_error is not None:
+        scenario_error.add_note("Sanitized IBKR paper diagnostic: " + record.sanitized_diagnostic())
         if cleanup_errors:
             scenario_error.add_note("Cleanup: " + "; ".join(cleanup_errors))
         raise scenario_error
     if cleanup_errors:
-        pytest.fail(f"IBKR {name} cleanup failed: {'; '.join(cleanup_errors)}")
+        pytest.fail(
+            f"IBKR {name} cleanup failed ({record.sanitized_diagnostic()}): "
+            f"{'; '.join(cleanup_errors)}"
+        )
 
 
 def test_ibkr_rest_advanced_orders_on_verified_paper_account(
@@ -455,12 +519,68 @@ def test_ibkr_rest_advanced_orders_on_verified_paper_account(
         assert local_parent_id not in native_ids
         assert all(child.parent_identifier == local_parent_id for child in native_orders)
 
+    def assert_exact_cancellation_targets(start, expected_ids, label):
+        contacted_ids = probe.cancellation_targets[start:]
+        assert Counter(contacted_ids) == Counter(expected_ids), (
+            f"IBKR {label} cancellation contacted an unexpected set of native IDs"
+        )
+
+    def cancel_bracket(parent, native_orders, native_ids, record):
+        record.cancellation_outcome = "in_progress"
+        direct_child = native_orders[-1]
+        direct_child_id = native_ids[-1]
+
+        # Explicit cancellation must reach IBKR regardless of local workflow
+        # state, and repeating the exact child cancellation must remain safe.
+        for local_status in (Order.OrderStatus.CANCELLING, Order.OrderStatus.CANCELED):
+            direct_child.status = local_status
+            cancellation_start = len(probe.cancellation_targets)
+            broker.cancel_order(direct_child)
+            assert_exact_cancellation_targets(
+                cancellation_start,
+                [direct_child_id],
+                f"BRACKET direct child in {local_status.value}",
+            )
+
         cancellation_start = len(probe.cancellation_targets)
         broker.cancel_order(parent)
-        parent_cancel_targets = probe.cancellation_targets[cancellation_start:]
-        assert Counter(parent_cancel_targets) == Counter(native_ids)
-        assert local_parent_id not in parent_cancel_targets
+        assert_exact_cancellation_targets(
+            cancellation_start,
+            native_ids,
+            "BRACKET parent",
+        )
+        _wait_until_orders_are_not_working(data_source, native_ids)
+        record.cancellation_outcome = "all_native_tickets_inactive"
+
+    def cancel_oto(parent, _native_orders, native_ids, record):
+        record.cancellation_outcome = "in_progress"
+        # Two parent-level attempts prove both local terminal-ish states still
+        # contact every broker-backed member and that cancellation is idempotent.
+        for local_status in (Order.OrderStatus.CANCELLING, Order.OrderStatus.CANCELED):
+            parent.status = local_status
+            cancellation_start = len(probe.cancellation_targets)
+            broker.cancel_order(parent)
+            assert_exact_cancellation_targets(
+                cancellation_start,
+                native_ids,
+                f"OTO parent in {local_status.value}",
+            )
+        _wait_until_orders_are_not_working(data_source, native_ids)
+        record.cancellation_outcome = "all_native_tickets_inactive"
+
+    def cancel_oco(parent, _native_orders, native_ids, record):
+        local_parent_id = str(parent.identifier)
+        record.cancellation_outcome = "in_progress"
+        for local_status in (Order.OrderStatus.CANCELLING, Order.OrderStatus.CANCELED):
+            parent.status = local_status
+            cancellation_start = len(probe.cancellation_targets)
+            broker.cancel_order(parent)
+            parent_cancel_targets = probe.cancellation_targets[cancellation_start:]
+            assert Counter(parent_cancel_targets) == Counter(native_ids)
+            assert local_parent_id not in parent_cancel_targets
         assert local_parent_id not in probe.scenario_cancellation_targets(record)
+        _wait_until_orders_are_not_working(data_source, native_ids)
+        record.cancellation_outcome = "all_native_tickets_inactive"
 
     try:
         _run_scenario(
@@ -483,6 +603,7 @@ def test_ibkr_rest_advanced_orders_on_verified_paper_account(
             ),
             expected_native_orders=lambda parent: [parent, *parent.child_orders],
             assertions=assert_bracket,
+            cancellation_assertions=cancel_bracket,
             record_property=record_property,
         )
 
@@ -505,6 +626,7 @@ def test_ibkr_rest_advanced_orders_on_verified_paper_account(
             ),
             expected_native_orders=lambda parent: [parent, *parent.child_orders],
             assertions=assert_oto,
+            cancellation_assertions=cancel_oto,
             record_property=record_property,
         )
 
@@ -526,6 +648,7 @@ def test_ibkr_rest_advanced_orders_on_verified_paper_account(
             ),
             expected_native_orders=lambda parent: list(parent.child_orders),
             assertions=assert_oco,
+            cancellation_assertions=cancel_oco,
             record_property=record_property,
         )
     finally:

--- a/tests/test_ibkr_rest_advanced_orders_paper_apitest.py
+++ b/tests/test_ibkr_rest_advanced_orders_paper_apitest.py
@@ -24,8 +24,11 @@ pytestmark = [pytest.mark.apitest, pytest.mark.ibkr]
 
 _STRATEGY_NAME = "ibkr_rest_advanced_orders_paper_apitest"
 _POLL_INTERVAL_SECONDS = 0.5
-_MARKET_DATA_ATTEMPTS = 3
-_MARKET_DATA_RETRY_SECONDS = 0.25
+# Client Portal snapshots often need a brief warm-up request before field 31 is
+# populated. Keep order construction bounded while allowing a healthy gateway
+# time to return the reference price needed for non-marketable limits.
+_MARKET_DATA_ATTEMPTS = 6
+_MARKET_DATA_RETRY_SECONDS = 1.0
 _VISIBLE_TIMEOUT_SECONDS = 20.0
 _CANCEL_TIMEOUT_SECONDS = 30.0
 _TERMINAL_STATUSES = {

--- a/tests/test_ibkr_rest_advanced_orders_paper_apitest.py
+++ b/tests/test_ibkr_rest_advanced_orders_paper_apitest.py
@@ -18,17 +18,16 @@ from tests.ibkr_rest_paper_order_safety import (
     ibkr_rest_paper_order_data_source,
     ibkr_rest_paper_test_config,
 )
+from tests.test_ibkr_rest_gtd_paper_apitest import (
+    _contract_conid as _paper_contract_conid,
+    _reference_price as _paper_reference_price,
+)
 
 
 pytestmark = [pytest.mark.apitest, pytest.mark.ibkr]
 
 _STRATEGY_NAME = "ibkr_rest_advanced_orders_paper_apitest"
 _POLL_INTERVAL_SECONDS = 0.5
-# Client Portal snapshots often need a brief warm-up request before field 31 is
-# populated. Keep order construction bounded while allowing a healthy gateway
-# time to return the reference price needed for non-marketable limits.
-_MARKET_DATA_ATTEMPTS = 6
-_MARKET_DATA_RETRY_SECONDS = 1.0
 _VISIBLE_TIMEOUT_SECONDS = 20.0
 _CANCEL_TIMEOUT_SECONDS = 30.0
 _TERMINAL_STATUSES = {
@@ -42,12 +41,57 @@ _TERMINAL_STATUSES = {
 _FILLED_STATUSES = {"fill", "filled"}
 
 
+def _sanitized_warning_category(value) -> str:
+    """Return only an exact short numeric IBKR warning code, never warning text."""
+    if isinstance(value, bool) or value is None:
+        return "absent"
+    if isinstance(value, int) and 0 <= value <= 99999:
+        return f"code={value}"
+    if isinstance(value, str):
+        candidate = value.strip()
+        if candidate.isascii() and candidate.isdecimal() and 1 <= len(candidate) <= 5:
+            return f"code={candidate}"
+    return "non_numeric_warning"
+
+
+def _sanitized_submission_entry_shape(entry) -> str:
+    """Describe an order response entry without retaining any broker content."""
+    if not isinstance(entry, dict):
+        return "entry=non_object"
+
+    raw_order_id = entry.get("order_id")
+    normalized_order_id = InteractiveBrokersREST._normalize_broker_order_id(raw_order_id)
+    if normalized_order_id is not None:
+        id_state = "positive"
+    elif raw_order_id is None:
+        id_state = "missing"
+    elif isinstance(raw_order_id, (int, str)) and not isinstance(raw_order_id, bool):
+        id_state = "placeholder_or_nonpositive"
+    else:
+        id_state = "invalid"
+
+    return (
+        f"id={id_state}, "
+        f"local_order_id={'present' if entry.get('local_order_id') is not None else 'absent'}, "
+        f"parent_order_id={'present' if entry.get('parent_order_id') is not None else 'absent'}, "
+        f"error={'present' if 'error' in entry else 'absent'}, "
+        f"message={'present' if 'message' in entry else 'absent'}, "
+        f"warning={_sanitized_warning_category(entry.get('warning_message'))}"
+    )
+
+
 @dataclass
 class _ScenarioRecord:
     name: str
     expected_native_count: int
+    expected_coids: set[str] = field(default_factory=set)
     acknowledged_ids: list[str] = field(default_factory=list)
     response_entry_count: int = 0
+    response_entry_shapes: list[str] = field(default_factory=list)
+    reconciliation_poll_count: int = 0
+    reconciliation_order_row_count: int = 0
+    reconciled_ticket_count: int = 0
+    reconciled_coids: set[str] = field(default_factory=set)
     cleanup_attempted_ids: set[str] = field(default_factory=set)
     confirmation_count_before: int = 0
     cancellation_count_before: int = 0
@@ -70,7 +114,11 @@ class _ScenarioRecord:
             f"acceptance={self.acceptance_outcome}, "
             f"expected_native={self.expected_native_count}, "
             f"response_entries={self.response_entry_count}, "
+            f"response_shapes=[{' | '.join(self.response_entry_shapes) or 'none'}], "
             f"acknowledged_unique={len(self.acknowledged_ids)}, "
+            f"reconciliation_polls={self.reconciliation_poll_count}, "
+            f"reconciliation_order_rows={self.reconciliation_order_row_count}, "
+            f"reconciled_tickets={self.reconciled_ticket_count}, "
             f"polling={self.polling_outcome}, "
             f"cancellation={self.cancellation_outcome}, "
             f"cleanup_attempted_unique={len(self.cleanup_attempted_ids)}"
@@ -102,13 +150,38 @@ class _BrokerTrafficProbe:
             allow_fail=True,
             max_retries=None,
         ):
-            return original_get(
+            response = original_get(
                 url,
                 description=description,
                 silent=silent,
                 allow_fail=allow_fail,
                 max_retries=0 if max_retries is None else max_retries,
             )
+            if self.current_scenario is not None and description == "Reconciling submitted orders":
+                record = self.current_scenario
+                record.reconciliation_poll_count += 1
+                entries = response.get("orders") if isinstance(response, dict) else None
+                if isinstance(entries, list):
+                    record.reconciliation_order_row_count += len(entries)
+                else:
+                    entries = []
+                for entry in entries:
+                    if not isinstance(entry, dict):
+                        continue
+                    correlation_id = InteractiveBrokersREST._get_order_correlation_id(entry)
+                    order_id = InteractiveBrokersREST._normalize_broker_order_id(
+                        entry.get("orderId")
+                    )
+                    if (
+                        correlation_id in self.current_scenario.expected_coids
+                        and order_id is not None
+                        and order_id not in record.acknowledged_ids
+                    ):
+                        record.acknowledged_ids.append(order_id)
+                    if correlation_id in record.expected_coids and correlation_id not in record.reconciled_coids:
+                        record.reconciled_coids.add(correlation_id)
+                        record.reconciled_ticket_count = len(record.reconciled_coids)
+            return response
 
         def bounded_post(
             url,
@@ -135,6 +208,9 @@ class _BrokerTrafficProbe:
                 entries = response if isinstance(response, list) else [response]
                 if description == "Executing order":
                     self.current_scenario.response_entry_count = len(entries)
+                    self.current_scenario.response_entry_shapes = [
+                        _sanitized_submission_entry_shape(entry) for entry in entries
+                    ]
                 for entry in entries:
                     if not isinstance(entry, dict):
                         continue
@@ -175,10 +251,20 @@ class _BrokerTrafficProbe:
         monkeypatch.setattr(data_source, "delete_to_endpoint", bounded_delete)
         monkeypatch.setattr(data_source, "delete_order", delete_order_and_record)
 
-    def begin(self, name: str, expected_native_count: int) -> _ScenarioRecord:
+    def begin(
+        self,
+        name: str,
+        native_orders: list[Order] | None = None,
+        *,
+        expected_native_count: int | None = None,
+    ) -> _ScenarioRecord:
+        native_orders = native_orders or []
+        if expected_native_count is None:
+            expected_native_count = len(native_orders)
         record = _ScenarioRecord(
             name=name,
             expected_native_count=expected_native_count,
+            expected_coids={str(order.identifier) for order in native_orders},
             confirmation_count_before=self.confirmation_count,
             cancellation_count_before=len(self.cancellation_targets),
         )
@@ -217,32 +303,20 @@ def _order_id(payload) -> str | None:
 
 
 def _bounded_reference_price(data_source, asset: Asset) -> float | None:
-    """Read a current price through the configured data source with short bounds."""
-    conid = data_source.get_conid_from_asset(asset, exchange="SMART")
-    if conid is None:
-        return None
-
-    path = f"{data_source.base_url}/iserver/marketdata/snapshot?conids={conid}&fields=31"
-    for attempt in range(_MARKET_DATA_ATTEMPTS):
-        payload = data_source.get_from_endpoint(
-            path,
-            description="Getting bounded paper-test reference price",
-            silent=True,
-            max_retries=0,
-        )
-        if isinstance(payload, list) and payload and isinstance(payload[0], dict):
-            raw_price = payload[0].get("31")
-            if isinstance(raw_price, str) and raw_price.startswith("C"):
-                raw_price = raw_price[1:].strip()
-            try:
-                price = float(raw_price)
-            except (TypeError, ValueError):
-                price = 0.0
-            if price > 0:
-                return price
-        if attempt + 1 < _MARKET_DATA_ATTEMPTS:
-            time.sleep(_MARKET_DATA_RETRY_SECONDS)
-    return None
+    """Read a price through the same bounded REST snapshot path as the GTD probe."""
+    symbol = asset.symbol
+    skip_context = "advanced paper-order test"
+    conid = _paper_contract_conid(
+        data_source,
+        symbol=symbol,
+        skip_context=skip_context,
+    )
+    return _paper_reference_price(
+        data_source,
+        conid,
+        symbol=symbol,
+        skip_context=skip_context,
+    )
 
 
 def _poll_account_orders(data_source) -> tuple[bool, dict[str, str | None]]:
@@ -367,18 +441,20 @@ def _assert_acknowledgement_and_tracking(
     native_orders: list[Order],
 ) -> list[str]:
     expected_count = len(native_orders)
-    if record.response_entry_count != expected_count:
-        pytest.fail(
-            f"IBKR {record.name} response cardinality mismatch: expected {expected_count} "
-            f"native acknowledgement entries, received {record.response_entry_count}"
-        )
+    native_ids = [str(order.identifier) for order in native_orders]
+    # Client Portal may return fewer immediate rows than submitted bracket
+    # tickets. Successful bounded reconciliation is authoritative, and these
+    # broker-backed IDs must enter the outer finally-cleanup ledger at once.
+    for order_id in native_ids:
+        normalized = InteractiveBrokersREST._normalize_broker_order_id(order_id)
+        if normalized is not None and normalized not in record.acknowledged_ids:
+            record.acknowledged_ids.append(normalized)
     if len(record.acknowledged_ids) != expected_count:
         pytest.fail(
             f"IBKR {record.name} acknowledged {len(record.acknowledged_ids)} unique native IDs "
             f"but expected {expected_count}"
         )
 
-    native_ids = [str(order.identifier) for order in native_orders]
     assert len(set(native_ids)) == expected_count, (
         f"IBKR {record.name} native tickets did not receive distinct broker IDs"
     )
@@ -449,7 +525,7 @@ def _run_scenario(
     record_property,
 ) -> None:
     native_orders = expected_native_orders(package_order)
-    record = probe.begin(name, expected_native_count=len(native_orders))
+    record = probe.begin(name, native_orders)
     scenario_error: BaseException | None = None
     try:
         result = broker.submit_order(package_order)
@@ -487,6 +563,14 @@ def _run_scenario(
         record_property(
             f"ibkr_{name.lower()}_acknowledged_unique",
             len(record.acknowledged_ids),
+        )
+        record_property(
+            f"ibkr_{name.lower()}_response_shapes",
+            " | ".join(record.response_entry_shapes) or "none",
+        )
+        record_property(
+            f"ibkr_{name.lower()}_reconciled_tickets",
+            record.reconciled_ticket_count,
         )
         record_property(
             f"ibkr_{name.lower()}_cleanup_attempted_unique",

--- a/tests/test_ibkr_rest_advanced_orders_paper_apitest.py
+++ b/tests/test_ibkr_rest_advanced_orders_paper_apitest.py
@@ -21,6 +21,8 @@ pytestmark = [pytest.mark.apitest, pytest.mark.ibkr]
 
 _STRATEGY_NAME = "ibkr_rest_advanced_orders_paper_apitest"
 _POLL_INTERVAL_SECONDS = 0.5
+_MARKET_DATA_ATTEMPTS = 3
+_MARKET_DATA_RETRY_SECONDS = 0.25
 _VISIBLE_TIMEOUT_SECONDS = 20.0
 _CANCEL_TIMEOUT_SECONDS = 30.0
 _TERMINAL_STATUSES = {
@@ -120,9 +122,13 @@ class _BrokerTrafficProbe:
                 allow_fail=allow_fail,
                 max_retries=0 if max_retries is None else max_retries,
             )
-            if description == "Executing order" and self.current_scenario is not None:
+            if self.current_scenario is not None and description in {
+                "Executing order",
+                "Confirming Order",
+            }:
                 entries = response if isinstance(response, list) else [response]
-                self.current_scenario.response_entry_count = len(entries)
+                if description == "Executing order":
+                    self.current_scenario.response_entry_count = len(entries)
                 for entry in entries:
                     if not isinstance(entry, dict):
                         continue
@@ -131,8 +137,9 @@ class _BrokerTrafficProbe:
                         continue
                     normalized = str(order_id).strip()
                     if normalized:
-                        # Record immediately after the real acknowledgement,
-                        # before the broker maps or validates the package.
+                        # Confirmation calls can be nested inside the outer
+                        # execute call. Capture each ID as that call returns so
+                        # a later confirmation failure cannot orphan an ID.
                         if normalized not in self.current_scenario.acknowledged_ids:
                             self.current_scenario.acknowledged_ids.append(normalized)
             return response
@@ -200,6 +207,35 @@ def _order_id(payload) -> str | None:
         return None
     normalized = str(value).strip()
     return normalized or None
+
+
+def _bounded_reference_price(data_source, asset: Asset) -> float | None:
+    """Read a current price through the configured data source with short bounds."""
+    conid = data_source.get_conid_from_asset(asset, exchange="SMART")
+    if conid is None:
+        return None
+
+    path = f"{data_source.base_url}/iserver/marketdata/snapshot?conids={conid}&fields=31"
+    for attempt in range(_MARKET_DATA_ATTEMPTS):
+        payload = data_source.get_from_endpoint(
+            path,
+            description="Getting bounded paper-test reference price",
+            silent=True,
+            max_retries=0,
+        )
+        if isinstance(payload, list) and payload and isinstance(payload[0], dict):
+            raw_price = payload[0].get("31")
+            if isinstance(raw_price, str) and raw_price.startswith("C"):
+                raw_price = raw_price[1:].strip()
+            try:
+                price = float(raw_price)
+            except (TypeError, ValueError):
+                price = 0.0
+            if price > 0:
+                return price
+        if attempt + 1 < _MARKET_DATA_ATTEMPTS:
+            time.sleep(_MARKET_DATA_RETRY_SECONDS)
+    return None
 
 
 def _poll_account_orders(data_source) -> tuple[bool, dict[str, str | None]]:
@@ -489,7 +525,7 @@ def test_ibkr_rest_advanced_orders_on_verified_paper_account(
     request.addfinalizer(stop_broker_threads)
 
     asset = Asset("SPY", asset_type=Asset.AssetType.STOCK)
-    reference_price = broker.get_last_price(asset, exchange="SMART")
+    reference_price = _bounded_reference_price(data_source, asset)
     if reference_price is None or float(reference_price) <= 0:
         pytest.skip("IBKR paper gateway did not provide a usable current SPY reference price")
 

--- a/tests/test_ibkr_rest_advanced_orders_paper_apitest.py
+++ b/tests/test_ibkr_rest_advanced_orders_paper_apitest.py
@@ -1,0 +1,532 @@
+"""Opt-in paper test for IBKR REST BRACKET, OTO, and OCO order lifecycles.
+
+This module is excluded from ordinary CI by the existing ``apitest`` marker.
+It must never be run without the test-scoped paper-account fixture below.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+
+import pytest
+
+from lumibot.brokers.interactive_brokers_rest import InteractiveBrokersREST
+from lumibot.entities import Asset, Order
+from tests.ibkr_rest_paper_order_safety import ibkr_rest_paper_order_data_source
+
+
+pytestmark = [pytest.mark.apitest, pytest.mark.ibkr]
+
+_STRATEGY_NAME = "ibkr_rest_advanced_orders_paper_apitest"
+_POLL_INTERVAL_SECONDS = 0.5
+_VISIBLE_TIMEOUT_SECONDS = 20.0
+_CANCEL_TIMEOUT_SECONDS = 30.0
+_TERMINAL_STATUSES = {
+    "apicancelled",
+    "cancelled",
+    "canceled",
+    "expired",
+    "inactive",
+    "rejected",
+}
+_FILLED_STATUSES = {"fill", "filled"}
+
+
+@dataclass
+class _ScenarioRecord:
+    name: str
+    acknowledged_ids: list[str] = field(default_factory=list)
+    confirmation_count_before: int = 0
+    cancellation_count_before: int = 0
+
+
+class _BrokerTrafficProbe:
+    """Record only sanitized lifecycle facts while delegating every real call."""
+
+    def __init__(self, data_source, monkeypatch):
+        self.data_source = data_source
+        self.confirmation_count = 0
+        self.cancellation_targets: list[str] = []
+        self.current_scenario: _ScenarioRecord | None = None
+
+        # Keep every network operation bounded. These wrappers still use the
+        # configured real transport and do not mock an IBKR response.
+        data_source.request_timeout = min(float(data_source.request_timeout), 5.0)
+
+        original_get = data_source.get_from_endpoint
+        original_post = data_source.post_to_endpoint
+        original_delete = data_source.delete_to_endpoint
+        original_delete_order = data_source.delete_order
+
+        def bounded_get(
+            url,
+            description="",
+            silent=False,
+            allow_fail=True,
+            max_retries=None,
+        ):
+            return original_get(
+                url,
+                description=description,
+                silent=silent,
+                allow_fail=allow_fail,
+                max_retries=0 if max_retries is None else max_retries,
+            )
+
+        def bounded_post(
+            url,
+            json,
+            description="",
+            silent=False,
+            allow_fail=True,
+            max_retries=None,
+        ):
+            if description == "Confirming Order":
+                self.confirmation_count += 1
+            response = original_post(
+                url,
+                json,
+                description=description,
+                silent=silent,
+                allow_fail=allow_fail,
+                max_retries=0 if max_retries is None else max_retries,
+            )
+            if description == "Executing order" and self.current_scenario is not None:
+                entries = response if isinstance(response, list) else [response]
+                for entry in entries:
+                    if not isinstance(entry, dict):
+                        continue
+                    order_id = entry.get("order_id")
+                    if isinstance(order_id, bool) or not isinstance(order_id, (str, int)):
+                        continue
+                    normalized = str(order_id).strip()
+                    if normalized:
+                        # Record immediately after the real acknowledgement,
+                        # before the broker maps or validates the package.
+                        self.current_scenario.acknowledged_ids.append(normalized)
+            return response
+
+        def bounded_delete(
+            url,
+            description="",
+            silent=False,
+            allow_fail=True,
+            max_retries=None,
+        ):
+            return original_delete(
+                url,
+                description=description,
+                silent=silent,
+                allow_fail=allow_fail,
+                max_retries=0 if max_retries is None else max_retries,
+            )
+
+        def delete_order_and_record(order):
+            self.cancellation_targets.append(str(order.identifier))
+            return original_delete_order(order)
+
+        monkeypatch.setattr(data_source, "get_from_endpoint", bounded_get)
+        monkeypatch.setattr(data_source, "post_to_endpoint", bounded_post)
+        monkeypatch.setattr(data_source, "delete_to_endpoint", bounded_delete)
+        monkeypatch.setattr(data_source, "delete_order", delete_order_and_record)
+
+    def begin(self, name: str) -> _ScenarioRecord:
+        record = _ScenarioRecord(
+            name=name,
+            confirmation_count_before=self.confirmation_count,
+            cancellation_count_before=len(self.cancellation_targets),
+        )
+        self.current_scenario = record
+        return record
+
+    def finish(self) -> None:
+        self.current_scenario = None
+
+    def confirmation_occurred(self, record: _ScenarioRecord) -> bool:
+        return self.confirmation_count > record.confirmation_count_before
+
+    def scenario_cancellation_targets(self, record: _ScenarioRecord) -> list[str]:
+        return self.cancellation_targets[record.cancellation_count_before :]
+
+
+def _status(payload) -> str | None:
+    if isinstance(payload, list) and payload:
+        payload = payload[0]
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("status")
+    if value is None:
+        value = payload.get("order_status", payload.get("orderStatus"))
+    return str(value).strip().lower().replace("_", "").replace(" ", "") if value else None
+
+
+def _order_id(payload) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("orderId", payload.get("order_id"))
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _poll_account_orders(data_source) -> tuple[bool, dict[str, str | None]]:
+    """Poll the configured account once without retaining or logging raw data."""
+    data_source.get_from_endpoint(
+        f"{data_source.base_url}/iserver/account/orders?force=true",
+        description="Refreshing paper order test state",
+        silent=True,
+        max_retries=0,
+    )
+    payload = data_source.get_from_endpoint(
+        f"{data_source.base_url}/iserver/account/orders?accountId={data_source.account_id}",
+        description="Polling paper order test state",
+        silent=True,
+        max_retries=0,
+    )
+    if not isinstance(payload, dict) or not isinstance(payload.get("orders"), list):
+        return False, {}
+
+    statuses: dict[str, str | None] = {}
+    for raw_order in payload["orders"]:
+        order_id = _order_id(raw_order)
+        if order_id is not None:
+            statuses[order_id] = _status(raw_order)
+        if isinstance(raw_order, dict) and isinstance(raw_order.get("leg"), list):
+            for raw_leg in raw_order["leg"]:
+                leg_id = _order_id(raw_leg)
+                if leg_id is not None:
+                    statuses[leg_id] = _status(raw_leg)
+    return True, statuses
+
+
+def _poll_order_status(data_source, order_id: str) -> tuple[bool, str | None]:
+    payload = data_source.get_from_endpoint(
+        f"{data_source.base_url}/iserver/account/order/status/{order_id}",
+        description="Retrieving paper order test state",
+        silent=True,
+        max_retries=0,
+    )
+    if payload is None or (
+        isinstance(payload, dict) and ("error" in payload or "message" in payload)
+    ):
+        return False, None
+    status = _status(payload)
+    returned_order_id = _order_id(payload)
+    if returned_order_id is not None and returned_order_id != order_id:
+        return False, None
+    return status is not None, status
+
+
+def _wait_until_native_tickets_are_retrievable(
+    data_source,
+    expected_ids: list[str],
+) -> None:
+    deadline = time.monotonic() + _VISIBLE_TIMEOUT_SECONDS
+    missing = set(expected_ids)
+    while missing and time.monotonic() < deadline:
+        account_poll_succeeded, visible = _poll_account_orders(data_source)
+        if account_poll_succeeded:
+            missing.difference_update(visible)
+
+        for order_id in list(missing):
+            retrieved, _ = _poll_order_status(data_source, order_id)
+            if retrieved:
+                missing.remove(order_id)
+
+        if missing:
+            time.sleep(_POLL_INTERVAL_SECONDS)
+
+    if missing:
+        pytest.fail(
+            f"IBKR did not expose {len(missing)} of {len(expected_ids)} acknowledged native tickets "
+            f"within {_VISIBLE_TIMEOUT_SECONDS:g} seconds"
+        )
+
+
+def _wait_until_orders_are_not_working(data_source, order_ids: list[str]) -> None:
+    deadline = time.monotonic() + _CANCEL_TIMEOUT_SECONDS
+    pending = set(order_ids)
+    filled: set[str] = set()
+
+    while pending and time.monotonic() < deadline:
+        account_poll_succeeded, visible = _poll_account_orders(data_source)
+        for order_id in list(pending):
+            visible_status = visible.get(order_id)
+            if visible_status in _FILLED_STATUSES:
+                filled.add(order_id)
+                pending.remove(order_id)
+                continue
+            if visible_status in _TERMINAL_STATUSES:
+                pending.remove(order_id)
+                continue
+            if account_poll_succeeded and order_id not in visible:
+                pending.remove(order_id)
+                continue
+
+            retrieved, retrieved_status = _poll_order_status(data_source, order_id)
+            if retrieved_status in _FILLED_STATUSES:
+                filled.add(order_id)
+                pending.remove(order_id)
+            elif retrieved_status in _TERMINAL_STATUSES:
+                pending.remove(order_id)
+            elif not retrieved and account_poll_succeeded and order_id not in visible:
+                pending.remove(order_id)
+
+        if pending:
+            time.sleep(_POLL_INTERVAL_SECONDS)
+
+    if filled:
+        pytest.fail(f"{len(filled)} supposedly non-marketable paper orders filled during cleanup")
+    if pending:
+        pytest.fail(
+            f"{len(pending)} acknowledged paper orders were still working after "
+            f"{_CANCEL_TIMEOUT_SECONDS:g} seconds"
+        )
+
+
+def _assert_acknowledgement_and_tracking(
+    broker: InteractiveBrokersREST,
+    record: _ScenarioRecord,
+    package_order: Order,
+    native_orders: list[Order],
+) -> list[str]:
+    expected_count = len(native_orders)
+    if len(record.acknowledged_ids) != expected_count:
+        pytest.fail(
+            f"IBKR {record.name} response cardinality mismatch: expected {expected_count} "
+            f"native acknowledgements, received {len(record.acknowledged_ids)}"
+        )
+
+    native_ids = [str(order.identifier) for order in native_orders]
+    assert len(set(native_ids)) == expected_count, (
+        f"IBKR {record.name} native tickets did not receive distinct broker IDs"
+    )
+    assert Counter(record.acknowledged_ids) == Counter(native_ids), (
+        f"IBKR {record.name} acknowledgement mapping did not cover every native ticket"
+    )
+    assert all(order.was_transmitted() for order in native_orders)
+    assert package_order.status != Order.OrderStatus.ERROR, (
+        f"IBKR {record.name} package failed during submission or acknowledgement mapping"
+    )
+
+    tracked = broker.get_all_orders()
+    expected_local_orders = [package_order, *package_order.child_orders]
+    assert all(sum(candidate is expected for candidate in tracked) == 1 for expected in expected_local_orders), (
+        f"IBKR {record.name} created a duplicate or omitted LumiBot order"
+    )
+    assert all(sum(str(candidate.identifier) == order_id for candidate in tracked) == 1 for order_id in native_ids), (
+        f"IBKR {record.name} created duplicate tracked broker IDs"
+    )
+    return native_ids
+
+
+def _cleanup_scenario(
+    broker: InteractiveBrokersREST,
+    data_source,
+    probe: _BrokerTrafficProbe,
+    record: _ScenarioRecord,
+) -> list[str]:
+    cleanup_errors = []
+    cancellation_start = len(probe.cancellation_targets)
+    for order_id in record.acknowledged_ids:
+        try:
+            broker.cancel_order(Order(strategy=_STRATEGY_NAME, identifier=order_id))
+        except Exception as exc:
+            cleanup_errors.append(type(exc).__name__)
+
+    attempted = probe.cancellation_targets[cancellation_start:]
+    missing_attempts = Counter(record.acknowledged_ids) - Counter(attempted)
+    if missing_attempts:
+        cleanup_errors.append(
+            f"no broker cancellation attempt for {sum(missing_attempts.values())} acknowledged IDs"
+        )
+
+    if record.acknowledged_ids:
+        try:
+            _wait_until_orders_are_not_working(data_source, record.acknowledged_ids)
+        except BaseException as exc:
+            cleanup_errors.append(str(exc))
+    return cleanup_errors
+
+
+def _run_scenario(
+    *,
+    name: str,
+    broker: InteractiveBrokersREST,
+    data_source,
+    probe: _BrokerTrafficProbe,
+    package_order: Order,
+    expected_native_orders,
+    assertions,
+    record_property,
+) -> None:
+    record = probe.begin(name)
+    scenario_error: BaseException | None = None
+    try:
+        result = broker.submit_order(package_order)
+        assert result is package_order
+        native_orders = expected_native_orders(package_order)
+        native_ids = _assert_acknowledgement_and_tracking(
+            broker,
+            record,
+            package_order,
+            native_orders,
+        )
+        assertions(package_order, native_orders, native_ids, record)
+        _wait_until_native_tickets_are_retrievable(data_source, native_ids)
+        assert all(
+            broker.get_order(order_id) is native_order
+            for order_id, native_order in zip(native_ids, native_orders)
+        ), f"IBKR {name} lifecycle polling lost or duplicated a tracked native order"
+    except BaseException as exc:
+        scenario_error = exc
+    finally:
+        cleanup_errors = _cleanup_scenario(broker, data_source, probe, record)
+        probe.finish()
+        record_property(
+            f"ibkr_{name.lower()}_confirmation_path",
+            probe.confirmation_occurred(record),
+        )
+
+    if scenario_error is not None:
+        if cleanup_errors:
+            scenario_error.add_note("Cleanup: " + "; ".join(cleanup_errors))
+        raise scenario_error
+    if cleanup_errors:
+        pytest.fail(f"IBKR {name} cleanup failed: {'; '.join(cleanup_errors)}")
+
+
+def test_ibkr_rest_advanced_orders_on_verified_paper_account(
+    ibkr_rest_paper_order_data_source,
+    monkeypatch,
+    record_property,
+    request,
+):
+    """Exercise real broker submission, polling, tracking, and cleanup on paper."""
+    from lumibot.credentials import INTERACTIVE_BROKERS_REST_CONFIG
+
+    data_source = ibkr_rest_paper_order_data_source
+    probe = _BrokerTrafficProbe(data_source, monkeypatch)
+    broker = InteractiveBrokersREST(
+        dict(INTERACTIVE_BROKERS_REST_CONFIG),
+        data_source=data_source,
+        connect_stream=False,
+    )
+    broker._strategy_name = _STRATEGY_NAME
+
+    def stop_broker_threads():
+        broker._stop_event.set()
+        if broker._orders_thread is not None:
+            broker._orders_thread.join(timeout=1)
+
+    request.addfinalizer(stop_broker_threads)
+
+    asset = Asset("SPY", asset_type=Asset.AssetType.STOCK)
+    reference_price = broker.get_last_price(asset, exchange="SMART")
+    if reference_price is None or float(reference_price) <= 0:
+        pytest.skip("IBKR paper gateway did not provide a usable current SPY reference price")
+
+    reference_price = float(reference_price)
+    lower_limit = round(reference_price * 0.95, 2)
+    lower_stop = round(reference_price * 0.90, 2)
+    upper_trigger = round(reference_price * 1.05, 2)
+
+    def assert_bracket(parent, native_orders, native_ids, _record):
+        assert len(parent.child_orders) == 2
+        assert native_orders == [parent, *parent.child_orders]
+        assert all(child.parent_identifier == parent.identifier for child in parent.child_orders)
+        assert parent.identifier == native_ids[0]
+
+    def assert_oto(parent, native_orders, native_ids, _record):
+        assert len(parent.child_orders) == 1
+        assert native_orders == [parent, parent.child_orders[0]]
+        assert parent.child_orders[0].parent_identifier == parent.identifier
+        assert parent.identifier == native_ids[0]
+
+    def assert_oco(parent, native_orders, native_ids, record):
+        local_parent_id = str(parent.identifier)
+        assert native_orders == parent.child_orders
+        assert len(native_orders) == 2
+        assert all(child.side == Order.OrderSide.BUY for child in native_orders)
+        assert not parent.was_transmitted()
+        assert local_parent_id not in native_ids
+        assert all(child.parent_identifier == local_parent_id for child in native_orders)
+
+        cancellation_start = len(probe.cancellation_targets)
+        broker.cancel_order(parent)
+        parent_cancel_targets = probe.cancellation_targets[cancellation_start:]
+        assert Counter(parent_cancel_targets) == Counter(native_ids)
+        assert local_parent_id not in parent_cancel_targets
+        assert local_parent_id not in probe.scenario_cancellation_targets(record)
+
+    try:
+        _run_scenario(
+            name="BRACKET",
+            broker=broker,
+            data_source=data_source,
+            probe=probe,
+            package_order=Order(
+                strategy=_STRATEGY_NAME,
+                asset=asset,
+                quantity=1,
+                side=Order.OrderSide.BUY,
+                limit_price=lower_limit,
+                order_type=Order.OrderType.LIMIT,
+                order_class=Order.OrderClass.BRACKET,
+                secondary_limit_price=upper_trigger,
+                secondary_stop_price=lower_stop,
+                time_in_force="day",
+                exchange="SMART",
+            ),
+            expected_native_orders=lambda parent: [parent, *parent.child_orders],
+            assertions=assert_bracket,
+            record_property=record_property,
+        )
+
+        _run_scenario(
+            name="OTO",
+            broker=broker,
+            data_source=data_source,
+            probe=probe,
+            package_order=Order(
+                strategy=_STRATEGY_NAME,
+                asset=asset,
+                quantity=1,
+                side=Order.OrderSide.BUY,
+                limit_price=lower_limit,
+                order_type=Order.OrderType.LIMIT,
+                order_class=Order.OrderClass.OTO,
+                secondary_limit_price=upper_trigger,
+                time_in_force="day",
+                exchange="SMART",
+            ),
+            expected_native_orders=lambda parent: [parent, *parent.child_orders],
+            assertions=assert_oto,
+            record_property=record_property,
+        )
+
+        _run_scenario(
+            name="OCO",
+            broker=broker,
+            data_source=data_source,
+            probe=probe,
+            package_order=Order(
+                strategy=_STRATEGY_NAME,
+                asset=asset,
+                quantity=1,
+                side=Order.OrderSide.BUY,
+                limit_price=lower_limit,
+                stop_price=upper_trigger,
+                order_class=Order.OrderClass.OCO,
+                time_in_force="day",
+                exchange="SMART",
+            ),
+            expected_native_orders=lambda parent: list(parent.child_orders),
+            assertions=assert_oco,
+            record_property=record_property,
+        )
+    finally:
+        stop_broker_threads()

--- a/tests/test_ibkr_rest_gtd_paper_apitest.py
+++ b/tests/test_ibkr_rest_gtd_paper_apitest.py
@@ -1,0 +1,308 @@
+"""Opt-in IBKR REST GTD capability probe using only the what-if endpoint.
+
+This module is excluded from ordinary CI by the existing ``apitest`` marker.
+It probes one candidate Client Portal field without changing LumiBot's
+production GTD serialization guard.  A successful paper result is evidence
+only: enabling production GTD requires a separate reviewed implementation
+decision after an authorized paper probe result is available.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from tests.ibkr_rest_paper_order_safety import ibkr_rest_paper_order_data_source
+
+
+pytestmark = [pytest.mark.apitest, pytest.mark.ibkr]
+
+_SYMBOL = "SPY"
+_REQUEST_TIMEOUT_SECONDS = 5.0
+_MARKET_DATA_ATTEMPTS = 3
+_MARKET_DATA_RETRY_SECONDS = 0.25
+_MARGIN_RESPONSE_FIELDS = {
+    "amount",
+    "equity",
+    "initial",
+    "maintenance",
+    "position",
+}
+_TIF_CAPABILITY_KEYS = {
+    "tif",
+    "tifs",
+    "tiftypes",
+    "timeinforce",
+    "timeinforcetypes",
+    "timeinforcevalues",
+}
+
+
+@dataclass(frozen=True)
+class _WhatIfClassification:
+    outcome: str
+    diagnostic: str
+
+
+def _request_timeout(data_source) -> float:
+    """Keep each live capability request bounded without changing transport safeguards."""
+    return min(float(data_source.request_timeout), _REQUEST_TIMEOUT_SECONDS)
+
+
+def _request_json(data_source, method: str, path: str, payload: dict | None = None):
+    """Use the authenticated data source client without logging response content.
+
+    Calling the configured client's HTTP methods preserves its authenticated
+    session and TLS verification settings.  This test deliberately does not
+    use ``post_to_endpoint`` for what-if requests because its order-confirm
+    handling can POST to ``/iserver/reply``; this probe must contact only the
+    non-ordering what-if endpoint for its order-shaped request.
+    """
+    url = f"{data_source.base_url}{path}"
+    request = data_source.http_client.get if method == "GET" else data_source.http_client.post
+    try:
+        if method == "GET":
+            response = request(
+                url,
+                verify=data_source.verify_ssl,
+                timeout=_request_timeout(data_source),
+            )
+        else:
+            response = request(
+                url,
+                json=payload,
+                verify=data_source.verify_ssl,
+                timeout=_request_timeout(data_source),
+            )
+        try:
+            response_payload = response.json()
+        except ValueError:
+            response_payload = None
+    except Exception:
+        pytest.skip("IBKR REST gateway is unavailable for the GTD paper capability probe")
+    return response.status_code, response_payload
+
+
+def _contract_conid(data_source) -> int:
+    status_code, payload = _request_json(
+        data_source,
+        "GET",
+        f"/iserver/secdef/search?symbol={_SYMBOL}",
+    )
+    if not 200 <= status_code < 300 or not isinstance(payload, list):
+        pytest.skip("IBKR REST gateway did not provide a usable SPY contract for the GTD probe")
+
+    for candidate in payload:
+        if not isinstance(candidate, dict):
+            continue
+        conid = candidate.get("conid")
+        if isinstance(conid, bool):
+            continue
+        try:
+            return int(conid)
+        except (TypeError, ValueError):
+            continue
+    pytest.skip("IBKR REST gateway did not provide a usable SPY contract for the GTD probe")
+
+
+def _reference_price(data_source, conid: int) -> float:
+    path = f"/iserver/marketdata/snapshot?conids={conid}&fields=31"
+    for attempt in range(_MARKET_DATA_ATTEMPTS):
+        status_code, payload = _request_json(data_source, "GET", path)
+        if 200 <= status_code < 300 and isinstance(payload, list) and payload:
+            raw_price = payload[0].get("31") if isinstance(payload[0], dict) else None
+            if isinstance(raw_price, str) and raw_price.startswith("C"):
+                raw_price = raw_price[1:].strip()
+            try:
+                price = float(raw_price)
+            except (TypeError, ValueError):
+                price = 0.0
+            if price > 0:
+                return price
+        if attempt + 1 < _MARKET_DATA_ATTEMPTS:
+            time.sleep(_MARKET_DATA_RETRY_SECONDS)
+    pytest.skip("IBKR REST gateway did not provide a usable SPY reference price for the GTD probe")
+
+
+def _tif_tokens(value: Any) -> set[str]:
+    if isinstance(value, str):
+        return {token.upper() for token in re.split(r"[\s,;|]+", value) if token}
+    if isinstance(value, (list, tuple, set)):
+        return {
+            str(item).strip().upper()
+            for item in value
+            if isinstance(item, (str, int)) and str(item).strip()
+        }
+    return set()
+
+
+def _gtd_tif_capability(rules: Any) -> bool | None:
+    """Return only the GTD capability fact, never the contract response itself."""
+    found_tif_field = False
+
+    def walk(value: Any) -> bool:
+        nonlocal found_tif_field
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                normalized_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
+                if normalized_key in _TIF_CAPABILITY_KEYS:
+                    found_tif_field = True
+                    if "GTD" in _tif_tokens(nested):
+                        return True
+                if walk(nested):
+                    return True
+        elif isinstance(value, list):
+            return any(walk(item) for item in value)
+        return False
+
+    return True if walk(rules) else (False if found_tif_field else None)
+
+
+def _candidate_good_till_date() -> str:
+    """Serialize a timezone-aware UTC datetime in IBKR's UTC GTD candidate format."""
+    future = (datetime.now(timezone.utc) + timedelta(days=7)).replace(microsecond=0)
+    return future.strftime("%Y%m%d-%H:%M:%S")
+
+
+def _candidate_whatif_payload(conid: int, reference_price: float) -> dict:
+    # A buy limit five percent below the just-read reference price is designed
+    # to remain non-marketable while still being a conventional one-share ticket.
+    non_marketable_limit = max(0.01, round(reference_price * 0.95, 2))
+    return {
+        "orders": [
+            {
+                "conid": conid,
+                "quantity": 1,
+                "orderType": "LMT",
+                "side": "BUY",
+                "tif": "GTD",
+                "price": non_marketable_limit,
+                "listingExchange": "SMART",
+                "goodTillDate": _candidate_good_till_date(),
+            }
+        ]
+    }
+
+
+def _contains_order_id(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if str(key).replace("_", "").lower() == "orderid" and nested not in (None, ""):
+                return True
+            if _contains_order_id(nested):
+                return True
+    elif isinstance(value, list):
+        return any(_contains_order_id(item) for item in value)
+    return False
+
+
+def _rejection_diagnostic(status_code: int, payload: Any) -> str:
+    """Classify a rejection without exposing account data or raw broker text."""
+    messages: list[str] = []
+    if isinstance(payload, dict):
+        for key in ("error", "message", "detail", "warn"):
+            value = payload.get(key)
+            if isinstance(value, str):
+                messages.append(value.lower())
+    text = " ".join(messages)
+    terms = []
+    if "gtd" in text:
+        terms.append("GTD")
+    if "goodtilldate" in text or "good till date" in text:
+        terms.append("goodTillDate")
+    if "time in force" in text or "tif" in text:
+        terms.append("tif")
+    return (
+        f"http_status={status_code}, "
+        f"reason_mentions={','.join(terms) if terms else 'no_gtd_field_or_tif_term'}"
+    )
+
+
+def _classify_whatif_response(status_code: int, payload: Any) -> _WhatIfClassification:
+    if _contains_order_id(payload):
+        return _WhatIfClassification(
+            "ambiguous",
+            f"http_status={status_code}, response_contains_order_id",
+        )
+
+    if not 200 <= status_code < 300:
+        return _WhatIfClassification("rejected", _rejection_diagnostic(status_code, payload))
+
+    if not isinstance(payload, dict):
+        return _WhatIfClassification("ambiguous", f"http_status={status_code}, non_object_response")
+
+    if payload.get("error") not in (None, ""):
+        return _WhatIfClassification("rejected", _rejection_diagnostic(status_code, payload))
+
+    # A warning requires manual review.  It must not become positive GTD
+    # evidence merely because a gateway revision emits a new warning category.
+    if payload.get("warn") not in (None, ""):
+        return _WhatIfClassification("ambiguous", f"http_status={status_code}, warning_response")
+
+    if _MARGIN_RESPONSE_FIELDS.intersection(payload):
+        return _WhatIfClassification("accepted", f"http_status={status_code}, margin_preview")
+    return _WhatIfClassification("ambiguous", f"http_status={status_code}, non_preview_response")
+
+
+def test_ibkr_rest_gtd_tif_capability_on_verified_paper_account(
+    ibkr_rest_paper_order_data_source,
+    record_property,
+):
+    """Record the TIF capability fact from info-and-rules without logging it."""
+    data_source = ibkr_rest_paper_order_data_source
+    conid = _contract_conid(data_source)
+    status_code, rules = _request_json(
+        data_source,
+        "GET",
+        f"/iserver/contract/{conid}/info-and-rules",
+    )
+    if not 200 <= status_code < 300:
+        pytest.fail(f"IBKR GTD info-and-rules probe failed: http_status={status_code}")
+
+    capability = _gtd_tif_capability(rules)
+    record_property(
+        "ibkr_gtd_tif_capability",
+        "advertised" if capability is True else "not_advertised" if capability is False else "not_exposed",
+    )
+
+
+def test_ibkr_rest_good_till_date_whatif_on_verified_paper_account(
+    ibkr_rest_paper_order_data_source,
+    record_property,
+):
+    """Probe only ``/orders/whatif``; it never calls the order-submission endpoint."""
+    data_source = ibkr_rest_paper_order_data_source
+    conid = _contract_conid(data_source)
+    reference_price = _reference_price(data_source, conid)
+    payload = _candidate_whatif_payload(conid, reference_price)
+
+    # This is intentionally the sole order-shaped request in the module.
+    status_code, response = _request_json(
+        data_source,
+        "POST",
+        f"/iserver/account/{data_source.account_id}/orders/whatif",
+        payload,
+    )
+    classification = _classify_whatif_response(status_code, response)
+    record_property("ibkr_gtd_whatif_result", classification.outcome)
+    record_property("ibkr_gtd_whatif_diagnostic", classification.diagnostic)
+    record_property("ibkr_gtd_candidate_format", "UTC_YYYYMMDD-HHMMSS")
+
+    assert classification.outcome in {"accepted", "rejected"}, (
+        "IBKR GTD what-if response was ambiguous; it is not evidence that "
+        "goodTillDate is supported"
+    )
+    if classification.outcome == "rejected":
+        pytest.fail(
+            "IBKR GTD what-if rejected the goodTillDate candidate "
+            f"({classification.diagnostic}); production GTD remains disabled"
+        )
+
+    assert not _contains_order_id(response), "what-if response must not acknowledge a working order"
+    assert isinstance(response, dict)
+    assert _MARGIN_RESPONSE_FIELDS.intersection(response), "accepted GTD probe must return a margin preview"

--- a/tests/test_ibkr_rest_gtd_paper_apitest.py
+++ b/tests/test_ibkr_rest_gtd_paper_apitest.py
@@ -25,9 +25,9 @@ pytestmark = [pytest.mark.apitest, pytest.mark.ibkr]
 _SYMBOL = "SPY"
 _REQUEST_TIMEOUT_SECONDS = 5.0
 # Client Portal snapshots often need a brief warm-up request before field 31 is
-# populated. Keep the paper probe bounded while allowing that subscription to
-# become usable on an otherwise healthy, authenticated gateway.
-_MARKET_DATA_ATTEMPTS = 6
+# populated. Keep the paper probe bounded to a 15-second warm-up while allowing
+# that subscription to become usable on an otherwise healthy, authenticated gateway.
+_MARKET_DATA_ATTEMPTS = 16
 _MARKET_DATA_RETRY_SECONDS = 1.0
 _MARGIN_RESPONSE_FIELDS = {
     "amount",
@@ -98,14 +98,21 @@ def _request_json(data_source, method: str, path: str, payload: dict | None = No
     return response.status_code, response_payload
 
 
-def _contract_conid(data_source) -> int:
+def _contract_conid(
+    data_source,
+    *,
+    symbol: str = _SYMBOL,
+    skip_context: str = "GTD paper capability probe",
+) -> int:
     status_code, payload = _request_json(
         data_source,
         "GET",
-        f"/iserver/secdef/search?symbol={_SYMBOL}",
+        f"/iserver/secdef/search?symbol={symbol}",
     )
     if not 200 <= status_code < 300 or not isinstance(payload, list):
-        pytest.skip("IBKR REST gateway did not provide a usable SPY contract for the GTD probe")
+        pytest.skip(
+            f"IBKR REST gateway did not provide a usable {symbol} contract for the {skip_context}"
+        )
 
     for candidate in payload:
         if not isinstance(candidate, dict):
@@ -117,10 +124,18 @@ def _contract_conid(data_source) -> int:
             return int(conid)
         except (TypeError, ValueError):
             continue
-    pytest.skip("IBKR REST gateway did not provide a usable SPY contract for the GTD probe")
+    pytest.skip(
+        f"IBKR REST gateway did not provide a usable {symbol} contract for the {skip_context}"
+    )
 
 
-def _reference_price(data_source, conid: int) -> float:
+def _reference_price(
+    data_source,
+    conid: int,
+    *,
+    symbol: str = _SYMBOL,
+    skip_context: str = "GTD paper capability probe",
+) -> float:
     path = f"/iserver/marketdata/snapshot?conids={conid}&fields=31"
     for attempt in range(_MARKET_DATA_ATTEMPTS):
         status_code, payload = _request_json(data_source, "GET", path)
@@ -136,7 +151,9 @@ def _reference_price(data_source, conid: int) -> float:
                 return price
         if attempt + 1 < _MARKET_DATA_ATTEMPTS:
             time.sleep(_MARKET_DATA_RETRY_SECONDS)
-    pytest.skip("IBKR REST gateway did not provide a usable SPY reference price for the GTD probe")
+    pytest.skip(
+        f"IBKR REST gateway did not provide a usable {symbol} reference price for the {skip_context}"
+    )
 
 
 def _tif_tokens(value: Any) -> set[str]:

--- a/tests/test_ibkr_rest_gtd_paper_apitest.py
+++ b/tests/test_ibkr_rest_gtd_paper_apitest.py
@@ -24,8 +24,11 @@ pytestmark = [pytest.mark.apitest, pytest.mark.ibkr]
 
 _SYMBOL = "SPY"
 _REQUEST_TIMEOUT_SECONDS = 5.0
-_MARKET_DATA_ATTEMPTS = 3
-_MARKET_DATA_RETRY_SECONDS = 0.25
+# Client Portal snapshots often need a brief warm-up request before field 31 is
+# populated. Keep the paper probe bounded while allowing that subscription to
+# become usable on an otherwise healthy, authenticated gateway.
+_MARKET_DATA_ATTEMPTS = 6
+_MARKET_DATA_RETRY_SECONDS = 1.0
 _MARGIN_RESPONSE_FIELDS = {
     "amount",
     "equity",

--- a/tests/test_ibkr_rest_gtd_paper_apitest.py
+++ b/tests/test_ibkr_rest_gtd_paper_apitest.py
@@ -63,6 +63,13 @@ def _request_json(data_source, method: str, path: str, payload: dict | None = No
     handling can POST to ``/iserver/reply``; this probe must contact only the
     non-ordering what-if endpoint for its order-shaped request.
     """
+    if method not in {"GET", "POST"}:
+        pytest.fail("IBKR GTD capability probe permits only GET and POST requests")
+    if method == "POST":
+        expected_path = f"/iserver/account/{data_source.account_id}/orders/whatif"
+        if path != expected_path:
+            pytest.fail("IBKR GTD capability probe refuses POST outside /orders/whatif")
+
     url = f"{data_source.base_url}{path}"
     request = data_source.http_client.get if method == "GET" else data_source.http_client.post
     try:

--- a/tests/test_ibkr_rest_paper_order_safety.py
+++ b/tests/test_ibkr_rest_paper_order_safety.py
@@ -4,6 +4,8 @@ from lumibot.entities import Asset
 from tests.ibkr_rest_paper_order_safety import (
     _authenticated_selected_account_id,
     _construct_paper_test_data_source,
+    ibkr_rest_paper_order_data_source,
+    ibkr_rest_paper_test_config,
     mask_ibkr_account_id,
     require_explicit_ibkr_rest_paper_configuration,
     require_ibkr_rest_paper_account,
@@ -22,6 +24,39 @@ def _local_ibeam_config():
 def test_missing_ibkr_rest_configuration_skips_before_gateway_startup():
     with pytest.raises(pytest.skip.Exception):
         require_explicit_ibkr_rest_paper_configuration({}, {"IB_USE_PAPER_ACCOUNT": "true"})
+
+
+def test_paper_test_config_uses_existing_rest_environment_names_without_importing_credentials():
+    config = ibkr_rest_paper_test_config(
+        {
+            "IB_USERNAME": "test-user",
+            "IB_PASSWORD": "test-password",
+            "IB_ACCOUNT_ID": "DU1234567",
+            "IB_API_URL": "https://gateway.example",
+            "IB_USE_PAPER_ACCOUNT": "true",
+            "IB_GATEWAY_PORT": "4243",
+        }
+    )
+
+    assert config == {
+        "IB_USERNAME": "test-user",
+        "IB_PASSWORD": "test-password",
+        "IB_ACCOUNT_ID": "DU1234567",
+        "API_URL": "https://gateway.example",
+        "RUNNING_ON_SERVER": None,
+        "GATEWAY_PORT": "4243",
+        "GATEWAY_INSTANCE_ID": None,
+        "USE_PAPER_ACCOUNT": "true",
+        "IBEAM_DOCKER_TAG": None,
+        "AUTH_TIMEOUT": None,
+        "AUTH_POLL_INTERVAL": None,
+        "REQUEST_TIMEOUT": None,
+        "VERIFY_SSL": None,
+    }
+
+
+def test_paper_data_source_fixture_is_session_scoped_to_reuse_one_gateway():
+    assert ibkr_rest_paper_order_data_source._fixture_function_marker.scope == "session"
 
 
 def test_absent_explicit_paper_flag_skips_even_when_config_default_would_be_paper():
@@ -90,7 +125,7 @@ def test_confirmation_acknowledgement_is_ledged_before_outer_submission_returns(
                     self.probe.current_scenario.acknowledged_ids
                 )
                 return response
-            return [{"order_id": "broker-order-1"}]
+            return [{"order_id": "-1"}, {"order_id": "1001"}]
 
         def delete_to_endpoint(self, *_args, **_kwargs):
             return None
@@ -109,8 +144,8 @@ def test_confirmation_acknowledgement_is_ledged_before_outer_submission_returns(
         description="Executing order",
     )
 
-    assert data_source.ledger_seen_before_outer_return == ["broker-order-1"]
-    assert record.acknowledged_ids == ["broker-order-1"]
+    assert data_source.ledger_seen_before_outer_return == ["1001"]
+    assert record.acknowledged_ids == ["1001"]
 
 
 def test_advanced_paper_reference_price_uses_bounded_configured_snapshot():

--- a/tests/test_ibkr_rest_paper_order_safety.py
+++ b/tests/test_ibkr_rest_paper_order_safety.py
@@ -14,6 +14,8 @@ from tests.ibkr_rest_paper_order_safety import (
 from tests.test_ibkr_rest_advanced_orders_paper_apitest import (
     _BrokerTrafficProbe,
     _bounded_reference_price,
+    _sanitized_submission_entry_shape,
+    _sanitized_warning_category,
 )
 from tests.test_ibkr_rest_gtd_paper_apitest import _request_json
 
@@ -149,30 +151,63 @@ def test_confirmation_acknowledgement_is_ledged_before_outer_submission_returns(
     assert record.acknowledged_ids == ["1001"]
 
 
+def test_submission_response_diagnostic_masks_all_broker_values():
+    diagnostic = _sanitized_submission_entry_shape(
+        {
+            "order_id": "-1",
+            "local_order_id": "local-secret",
+            "parent_order_id": "1234567890",
+            "error": "private broker response",
+            "message": "private confirmation",
+            "warning_message": "private warning",
+        }
+    )
+
+    assert diagnostic == (
+        "id=placeholder_or_nonpositive, local_order_id=present, "
+        "parent_order_id=present, error=present, message=present, warning=non_numeric_warning"
+    )
+    assert "local-secret" not in diagnostic
+    assert "1234567890" not in diagnostic
+    assert "private" not in diagnostic
+
+
+def test_submission_warning_diagnostic_exposes_only_exact_short_numeric_codes():
+    assert _sanitized_warning_category("399") == "code=399"
+    assert _sanitized_warning_category(399) == "code=399"
+    assert _sanitized_warning_category("warning 399") == "non_numeric_warning"
+    assert _sanitized_warning_category("DU1234567") == "non_numeric_warning"
+    assert _sanitized_warning_category(None) == "absent"
+
+
 def test_advanced_paper_reference_price_uses_bounded_configured_snapshot():
+    class FakeResponse:
+        status_code = 200
+
+        def __init__(self, payload):
+            self.payload = payload
+
+        def json(self):
+            return self.payload
+
+    class FakeHttpClient:
+        def get(self, url, **_kwargs):
+            if url.endswith("/iserver/secdef/search?symbol=SPY"):
+                return FakeResponse([{"conid": 265598}])
+            assert url.endswith("/iserver/marketdata/snapshot?conids=265598&fields=31")
+            return FakeResponse([{"31": "C 100.25"}])
+
     class FakeDataSource:
         base_url = "https://gateway.example/v1/api"
-
-        def __init__(self):
-            self.snapshot_calls = 0
-
-        def get_conid_from_asset(self, asset, exchange=None):
-            assert asset.symbol == "SPY"
-            assert exchange == "SMART"
-            return 265598
-
-        def get_from_endpoint(self, url, **kwargs):
-            self.snapshot_calls += 1
-            assert url.endswith("/iserver/marketdata/snapshot?conids=265598&fields=31")
-            assert kwargs["max_retries"] == 0
-            return [{"31": "C 100.25"}]
+        verify_ssl = True
+        request_timeout = 1
+        http_client = FakeHttpClient()
 
     data_source = FakeDataSource()
 
     price = _bounded_reference_price(data_source, Asset("SPY"))
 
     assert price == 100.25
-    assert data_source.snapshot_calls == 1
 
 
 def test_gtd_paper_reference_price_allows_a_bounded_snapshot_warmup(monkeypatch):

--- a/tests/test_ibkr_rest_paper_order_safety.py
+++ b/tests/test_ibkr_rest_paper_order_safety.py
@@ -1,0 +1,81 @@
+import pytest
+
+from tests.ibkr_rest_paper_order_safety import (
+    _authenticated_selected_account_id,
+    mask_ibkr_account_id,
+    require_explicit_ibkr_rest_paper_configuration,
+    require_ibkr_rest_paper_account,
+)
+
+
+def _local_ibeam_config():
+    return {"IB_USERNAME": "test-user", "IB_PASSWORD": "test-password"}
+
+
+def test_missing_ibkr_rest_configuration_skips_before_gateway_startup():
+    with pytest.raises(pytest.skip.Exception):
+        require_explicit_ibkr_rest_paper_configuration({}, {"IB_USE_PAPER_ACCOUNT": "true"})
+
+
+def test_absent_explicit_paper_flag_skips_even_when_config_default_would_be_paper():
+    config = {"API_URL": "https://gateway.example", "USE_PAPER_ACCOUNT": "true"}
+
+    with pytest.raises(pytest.skip.Exception):
+        require_explicit_ibkr_rest_paper_configuration(config, {})
+
+
+def test_false_explicit_paper_flag_fails_before_account_or_order_handling():
+    with pytest.raises(pytest.fail.Exception, match="explicitly true"):
+        require_explicit_ibkr_rest_paper_configuration(
+            _local_ibeam_config(), {"IB_USE_PAPER_ACCOUNT": "false"}
+        )
+
+
+def test_unavailable_gateway_skips_without_constructing_a_data_source():
+    class UnavailableHttpClient:
+        def get(self, *_args, **_kwargs):
+            raise OSError("unavailable")
+
+    class FakeDataSource:
+        base_url = "https://gateway.example/v1/api"
+        verify_ssl = True
+        request_timeout = 1
+        http_client = UnavailableHttpClient()
+
+    with pytest.raises(pytest.skip.Exception):
+        _authenticated_selected_account_id(FakeDataSource())
+
+
+def test_live_style_account_identifier_fails():
+    with pytest.raises(pytest.fail.Exception, match="non-paper account"):
+        require_ibkr_rest_paper_account(
+            configured_account_id=None,
+            authenticated_account_id="U1234567",
+        )
+
+
+def test_paper_style_account_identifier_passes():
+    account_id = require_ibkr_rest_paper_account(
+        configured_account_id="DU1234567",
+        authenticated_account_id="DU1234567",
+        data_source_account_id="DU1234567",
+    )
+
+    assert account_id == "DU1234567"
+
+
+def test_configured_account_mismatch_fails():
+    with pytest.raises(pytest.fail.Exception, match="does not match"):
+        require_ibkr_rest_paper_account(
+            configured_account_id="DU1234567",
+            authenticated_account_id="DU7654321",
+        )
+
+
+def test_masked_account_identifier_never_reveals_the_full_identifier():
+    account_id = "DU1234567"
+    masked = mask_ibkr_account_id(account_id)
+
+    assert masked == "****4567"
+    assert account_id not in masked
+    assert mask_ibkr_account_id("DU12") == "****"

--- a/tests/test_ibkr_rest_paper_order_safety.py
+++ b/tests/test_ibkr_rest_paper_order_safety.py
@@ -1,6 +1,7 @@
 import pytest
 
 from lumibot.entities import Asset
+from tests import test_ibkr_rest_gtd_paper_apitest as gtd_paper_apitest
 from tests.ibkr_rest_paper_order_safety import (
     _authenticated_selected_account_id,
     _construct_paper_test_data_source,
@@ -172,6 +173,44 @@ def test_advanced_paper_reference_price_uses_bounded_configured_snapshot():
 
     assert price == 100.25
     assert data_source.snapshot_calls == 1
+
+
+def test_gtd_paper_reference_price_allows_a_bounded_snapshot_warmup(monkeypatch):
+    class FakeResponse:
+        status_code = 200
+
+        def __init__(self, payload):
+            self.payload = payload
+
+        def json(self):
+            return self.payload
+
+    class FakeHttpClient:
+        def __init__(self):
+            self.snapshot_calls = 0
+
+        def get(self, _url, **_kwargs):
+            self.snapshot_calls += 1
+            if self.snapshot_calls < gtd_paper_apitest._MARKET_DATA_ATTEMPTS:
+                return FakeResponse([])
+            return FakeResponse([{"31": "100.25"}])
+
+    class FakeDataSource:
+        base_url = "https://gateway.example/v1/api"
+        verify_ssl = True
+        request_timeout = 1
+        http_client = FakeHttpClient()
+
+    sleep_calls = []
+    monkeypatch.setattr(gtd_paper_apitest.time, "sleep", sleep_calls.append)
+
+    price = gtd_paper_apitest._reference_price(FakeDataSource(), 265598)
+
+    assert price == 100.25
+    assert FakeDataSource.http_client.snapshot_calls == gtd_paper_apitest._MARKET_DATA_ATTEMPTS
+    assert sleep_calls == [gtd_paper_apitest._MARKET_DATA_RETRY_SECONDS] * (
+        gtd_paper_apitest._MARKET_DATA_ATTEMPTS - 1
+    )
 
 
 def test_gtd_probe_refuses_post_outside_whatif(monkeypatch):

--- a/tests/test_ibkr_rest_paper_order_safety.py
+++ b/tests/test_ibkr_rest_paper_order_safety.py
@@ -1,11 +1,18 @@
 import pytest
 
+from lumibot.entities import Asset
 from tests.ibkr_rest_paper_order_safety import (
     _authenticated_selected_account_id,
+    _construct_paper_test_data_source,
     mask_ibkr_account_id,
     require_explicit_ibkr_rest_paper_configuration,
     require_ibkr_rest_paper_account,
 )
+from tests.test_ibkr_rest_advanced_orders_paper_apitest import (
+    _BrokerTrafficProbe,
+    _bounded_reference_price,
+)
+from tests.test_ibkr_rest_gtd_paper_apitest import _request_json
 
 
 def _local_ibeam_config():
@@ -44,6 +51,113 @@ def test_unavailable_gateway_skips_without_constructing_a_data_source():
 
     with pytest.raises(pytest.skip.Exception):
         _authenticated_selected_account_id(FakeDataSource())
+
+
+def test_paper_data_source_startup_does_not_suppress_session_warnings(monkeypatch):
+    class FakeDataSource:
+        def __init__(self, config):
+            self.config = config
+            self.warning_suppression_calls = 0
+            self.suppress_warnings()
+
+        def suppress_warnings(self):
+            self.warning_suppression_calls += 1
+
+    data_source = _construct_paper_test_data_source(
+        FakeDataSource,
+        {"IB_USERNAME": "test-user"},
+        monkeypatch,
+    )
+
+    assert data_source.warning_suppression_calls == 0
+
+
+def test_confirmation_acknowledgement_is_ledged_before_outer_submission_returns(monkeypatch):
+    class FakeDataSource:
+        request_timeout = 30
+
+        def get_from_endpoint(self, *_args, **_kwargs):
+            return None
+
+        def post_to_endpoint(self, _url, _json, description="", **_kwargs):
+            if description == "Executing order":
+                response = self.post_to_endpoint(
+                    "https://gateway.example/iserver/reply/fake",
+                    {"confirmed": True},
+                    description="Confirming Order",
+                )
+                self.ledger_seen_before_outer_return = list(
+                    self.probe.current_scenario.acknowledged_ids
+                )
+                return response
+            return [{"order_id": "broker-order-1"}]
+
+        def delete_to_endpoint(self, *_args, **_kwargs):
+            return None
+
+        def delete_order(self, _order):
+            return None
+
+    data_source = FakeDataSource()
+    probe = _BrokerTrafficProbe(data_source, monkeypatch)
+    data_source.probe = probe
+    record = probe.begin("confirmation", expected_native_count=1)
+
+    data_source.post_to_endpoint(
+        "https://gateway.example/iserver/account/paper/orders",
+        {"orders": [{}]},
+        description="Executing order",
+    )
+
+    assert data_source.ledger_seen_before_outer_return == ["broker-order-1"]
+    assert record.acknowledged_ids == ["broker-order-1"]
+
+
+def test_advanced_paper_reference_price_uses_bounded_configured_snapshot():
+    class FakeDataSource:
+        base_url = "https://gateway.example/v1/api"
+
+        def __init__(self):
+            self.snapshot_calls = 0
+
+        def get_conid_from_asset(self, asset, exchange=None):
+            assert asset.symbol == "SPY"
+            assert exchange == "SMART"
+            return 265598
+
+        def get_from_endpoint(self, url, **kwargs):
+            self.snapshot_calls += 1
+            assert url.endswith("/iserver/marketdata/snapshot?conids=265598&fields=31")
+            assert kwargs["max_retries"] == 0
+            return [{"31": "C 100.25"}]
+
+    data_source = FakeDataSource()
+
+    price = _bounded_reference_price(data_source, Asset("SPY"))
+
+    assert price == 100.25
+    assert data_source.snapshot_calls == 1
+
+
+def test_gtd_probe_refuses_post_outside_whatif(monkeypatch):
+    class UnexpectedHttpClient:
+        def post(self, *_args, **_kwargs):
+            pytest.fail("GTD safety guard allowed an unexpected POST")
+
+    class FakeDataSource:
+        account_id = "DU1234567"
+        base_url = "https://gateway.example/v1/api"
+        http_client = UnexpectedHttpClient()
+        request_timeout = 1
+        verify_ssl = True
+
+    with pytest.raises(pytest.fail.Exception, match="refuses POST outside /orders/whatif"):
+        _request_json(
+            FakeDataSource(),
+            "POST",
+            "/iserver/account/DU1234567/orders",
+            {"orders": [{}]},
+        )
 
 
 def test_live_style_account_identifier_fails():

--- a/tests/test_interactive_brokers_rest_order_semantics.py
+++ b/tests/test_interactive_brokers_rest_order_semantics.py
@@ -471,3 +471,157 @@ def test_cleanup_continues_after_an_earlier_cancel_fails(broker):
     assert [cleanup.identifier for cleanup in cleanup_orders] == ["6001", "6002", "6003"]
     assert parent.status == Order.OrderStatus.ERROR
     assert broker._on_new_order.call_count == 0
+
+
+def _set_broker_id(order, order_id):
+    order.identifier = str(order_id)
+    order.update_raw({"order_id": str(order_id)})
+
+
+def test_cancel_simple_order_contacts_ibkr(broker):
+    order = _order(limit_price=100.0, order_type=Order.OrderType.LIMIT)
+    _set_broker_id(order, 7001)
+
+    broker.cancel_order(order)
+
+    broker.data_source.delete_order.assert_called_once_with(order)
+
+
+def test_cancel_bracket_parent_attempts_parent_and_every_child(broker):
+    parent = _order(
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+        secondary_stop_price=95.0,
+    )
+    native_orders = [parent, *parent.child_orders]
+    for order_id, native_order in zip((7101, 7102, 7103), native_orders):
+        _set_broker_id(native_order, order_id)
+
+    broker.cancel_order(parent)
+
+    assert [args.args[0] for args in broker.data_source.delete_order.call_args_list] == native_orders
+
+
+def test_cancel_oto_parent_attempts_parent_and_child(broker):
+    parent = _order(
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.OTO,
+        secondary_limit_price=110.0,
+    )
+    native_orders = [parent, *parent.child_orders]
+    for order_id, native_order in zip((7201, 7202), native_orders):
+        _set_broker_id(native_order, order_id)
+
+    broker.cancel_order(parent)
+
+    assert [args.args[0] for args in broker.data_source.delete_order.call_args_list] == native_orders
+
+
+def test_cancel_oco_parent_excludes_local_container_id(broker):
+    parent = _order(
+        identifier="7300",
+        side=Order.OrderSide.SELL,
+        limit_price=110.0,
+        stop_price=95.0,
+        order_class=Order.OrderClass.OCO,
+    )
+    for order_id, child in zip((7301, 7302), parent.child_orders):
+        _set_broker_id(child, order_id)
+
+    broker.cancel_order(parent)
+
+    canceled_orders = [args.args[0] for args in broker.data_source.delete_order.call_args_list]
+    assert canceled_orders == parent.child_orders
+    assert all(canceled.identifier != parent.identifier for canceled in canceled_orders)
+
+
+def test_canceling_advanced_child_only_contacts_ibkr_for_that_child(broker):
+    parent = _order(
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+        secondary_stop_price=95.0,
+    )
+    _set_broker_id(parent, 7401)
+    _set_broker_id(parent.child_orders[0], 7402)
+    _set_broker_id(parent.child_orders[1], 7403)
+
+    broker.cancel_order(parent.child_orders[1])
+
+    broker.data_source.delete_order.assert_called_once_with(parent.child_orders[1])
+
+
+def test_cancel_deduplicates_broker_ids(broker):
+    parent = _order(
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+        secondary_stop_price=95.0,
+    )
+    _set_broker_id(parent, 7501)
+    _set_broker_id(parent.child_orders[0], 7501)
+    _set_broker_id(parent.child_orders[1], 7502)
+
+    broker.cancel_order(parent)
+
+    canceled_orders = [args.args[0] for args in broker.data_source.delete_order.call_args_list]
+    assert [canceled.identifier for canceled in canceled_orders] == ["7501", "7502"]
+
+
+@pytest.mark.parametrize(
+    "terminal_status",
+    [
+        Order.OrderStatus.CANCELLING,
+        Order.OrderStatus.CANCELED,
+        Order.OrderStatus.FILLED,
+        Order.OrderStatus.ERROR,
+    ],
+)
+def test_cancel_contacts_ibkr_regardless_of_terminal_local_status(broker, terminal_status):
+    order = _order(limit_price=100.0, order_type=Order.OrderType.LIMIT)
+    _set_broker_id(order, 7601)
+    order.status = terminal_status
+
+    broker.cancel_order(order)
+
+    broker.data_source.delete_order.assert_called_once_with(order)
+
+
+def test_cancel_skips_empty_local_and_malformed_identifiers(broker):
+    parent = _order(
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+        secondary_stop_price=95.0,
+    )
+    _set_broker_id(parent, 7701)
+    parent.child_orders[0].identifier = ""
+    parent.child_orders[1].identifier = "local-child-id"
+
+    broker.cancel_order(parent)
+
+    broker.data_source.delete_order.assert_called_once_with(parent)
+
+
+def test_cancel_continues_after_exception_and_rejection(broker):
+    parent = _order(
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+        secondary_stop_price=95.0,
+    )
+    native_orders = [parent, *parent.child_orders]
+    for order_id, native_order in zip((7801, 7802, 7803), native_orders):
+        _set_broker_id(native_order, order_id)
+    broker.data_source.delete_order.side_effect = [RuntimeError("cancel failed"), False, True]
+
+    broker.cancel_order(parent)
+
+    assert [args.args[0] for args in broker.data_source.delete_order.call_args_list] == native_orders

--- a/tests/test_interactive_brokers_rest_order_semantics.py
+++ b/tests/test_interactive_brokers_rest_order_semantics.py
@@ -1,0 +1,226 @@
+from unittest.mock import Mock, call
+
+import pytest
+
+import lumibot.brokers.interactive_brokers_rest as ibkr_rest_module
+from lumibot.brokers.interactive_brokers_rest import InteractiveBrokersREST
+from lumibot.entities import Asset, Order
+
+
+@pytest.fixture
+def broker(monkeypatch):
+    monkeypatch.setattr(ibkr_rest_module, "colored", lambda text, *args, **kwargs: text)
+    broker = InteractiveBrokersREST.__new__(InteractiveBrokersREST)
+    broker.data_source = Mock()
+    broker.data_source.get_conid_from_asset.return_value = 265598
+    broker.data_source.get_contract_rules.return_value = {"rules": {"increment": 0.01}}
+    return broker
+
+
+def _order(**kwargs):
+    defaults = {
+        "strategy": "ibkr_rest_order_semantics",
+        "asset": Asset("SPY"),
+        "quantity": 1,
+        "side": Order.OrderSide.BUY,
+        "time_in_force": "gtc",
+        "exchange": "SMART",
+    }
+    defaults.update(kwargs)
+    return Order(**defaults)
+
+
+def test_simple_order_payload_is_unchanged(broker):
+    order = _order(
+        identifier="simple-parent",
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+    )
+
+    payload = broker._get_order_data_for_submission(order)
+
+    ticket = payload["orders"][0]
+    assert ticket == {
+        "conid": 265598,
+        "quantity": 1,
+        "orderType": "LMT",
+        "side": "BUY",
+        "tif": "GTC",
+        "price": pytest.approx(99.99),
+        "listingExchange": "SMART",
+    }
+    assert not {"cOID", "parentId", "isSingleGroup"}.intersection(ticket)
+    broker.data_source.get_conid_from_asset.assert_called_once_with(order.asset, exchange="SMART")
+
+
+def test_bracket_payload_with_one_child_links_parent_and_inherits_exchange(broker):
+    parent = _order(
+        identifier="bracket-parent",
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+    )
+    child = parent.child_orders[0]
+
+    payload = broker._get_order_data_for_submission(parent)
+
+    parent_ticket, child_ticket = payload["orders"]
+    assert parent_ticket["cOID"] == "bracket-parent"
+    assert child_ticket["parentId"] == "bracket-parent"
+    assert "cOID" not in child_ticket
+    assert parent_ticket["price"] == pytest.approx(99.99)
+    assert child_ticket["price"] == pytest.approx(109.99)
+    assert child_ticket["listingExchange"] == "SMART"
+    assert child.exchange is None
+    assert broker.data_source.get_conid_from_asset.call_args_list == [
+        call(parent.asset, exchange="SMART"),
+        call(child.asset, exchange="SMART"),
+    ]
+
+
+def test_bracket_payload_with_two_children_only_links_the_parent(broker):
+    parent = _order(
+        identifier="bracket-parent-two",
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+        secondary_stop_price=95.0,
+    )
+
+    payload = broker._get_order_data_for_submission(parent)
+
+    assert len(payload["orders"]) == 3
+    assert payload["orders"][0]["cOID"] == "bracket-parent-two"
+    assert payload["orders"][1]["parentId"] == "bracket-parent-two"
+    assert payload["orders"][2]["parentId"] == "bracket-parent-two"
+    assert "cOID" not in payload["orders"][1]
+    assert "cOID" not in payload["orders"][2]
+    assert payload["orders"][1]["orderType"] == "LMT"
+    assert payload["orders"][1]["price"] == pytest.approx(109.99)
+    assert payload["orders"][2]["orderType"] == "STP"
+    assert payload["orders"][2]["auxPrice"] == pytest.approx(94.99)
+
+
+def test_advanced_parent_coid_is_stable_safe_and_within_ibkr_limit(broker):
+    parent = _order(
+        identifier="not IBKR safe/" + "x" * 100,
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+    )
+
+    first_payload = broker._get_order_data_for_submission(parent)
+    second_payload = broker._get_order_data_for_submission(parent)
+    c_oid = first_payload["orders"][0]["cOID"]
+
+    assert c_oid == second_payload["orders"][0]["cOID"]
+    assert len(c_oid) <= 64
+    assert c_oid.startswith("lumibot-")
+    assert first_payload["orders"][1]["parentId"] == c_oid
+
+
+def test_oto_payload_preserves_explicit_child_settings(broker):
+    child = _order(
+        identifier="explicit-oto-child",
+        quantity=2,
+        side=Order.OrderSide.SELL,
+        limit_price=101.25,
+        order_type=Order.OrderType.LIMIT,
+        time_in_force="day",
+        exchange="ARCA",
+    )
+    parent = _order(
+        identifier="oto-parent",
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.OTO,
+        child_orders=[child],
+    )
+
+    payload = broker._get_order_data_for_submission(parent)
+
+    assert payload["orders"][0]["cOID"] == "oto-parent"
+    assert payload["orders"][1] == {
+        "conid": 265598,
+        "quantity": 2,
+        "orderType": "LMT",
+        "side": "SELL",
+        "tif": "DAY",
+        "price": pytest.approx(101.24),
+        "listingExchange": "ARCA",
+        "parentId": "oto-parent",
+    }
+    assert "cOID" not in payload["orders"][1]
+
+
+def test_oco_payload_excludes_conceptual_parent_and_marks_both_children(broker):
+    parent = _order(
+        identifier="oco-parent",
+        side=Order.OrderSide.SELL,
+        limit_price=110.0,
+        stop_price=95.0,
+        order_class=Order.OrderClass.OCO,
+    )
+
+    payload = broker._get_order_data_for_submission(parent)
+
+    assert len(payload["orders"]) == 2
+    assert [ticket["orderType"] for ticket in payload["orders"]] == ["LMT", "STP"]
+    assert all(ticket["isSingleGroup"] is True for ticket in payload["orders"])
+    assert all("cOID" not in ticket for ticket in payload["orders"])
+    assert all("parentId" not in ticket for ticket in payload["orders"])
+    assert all(ticket["listingExchange"] == "SMART" for ticket in payload["orders"])
+
+
+@pytest.mark.parametrize("order_class", [Order.OrderClass.BRACKET, Order.OrderClass.OTO, Order.OrderClass.OCO])
+def test_invalid_advanced_child_count_prevents_package_serialization(broker, order_class):
+    if order_class is Order.OrderClass.BRACKET:
+        parent = _order(
+            limit_price=100.0,
+            order_type=Order.OrderType.LIMIT,
+            order_class=order_class,
+            secondary_limit_price=110.0,
+        )
+        parent.child_orders = []
+        expected_count = "one or two"
+    elif order_class is Order.OrderClass.OTO:
+        parent = _order(
+            limit_price=100.0,
+            order_type=Order.OrderType.LIMIT,
+            order_class=order_class,
+            secondary_limit_price=110.0,
+        )
+        parent.child_orders.append(parent.child_orders[0])
+        expected_count = "exactly one"
+    else:
+        parent = _order(
+            side=Order.OrderSide.SELL,
+            limit_price=110.0,
+            stop_price=95.0,
+            order_class=order_class,
+        )
+        parent.child_orders.pop()
+        expected_count = "exactly two"
+
+    with pytest.raises(ValueError, match=expected_count):
+        broker._get_order_data_for_submission(parent)
+
+    broker.data_source.get_conid_from_asset.assert_not_called()
+
+
+def test_unserializable_advanced_child_prevents_complete_package(broker):
+    parent = _order(
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+    )
+    broker.data_source.get_conid_from_asset.side_effect = [265598, None]
+
+    with pytest.raises(ValueError, match="Unable to serialize IBKR REST bracket child ticket"):
+        broker._get_order_data_for_submission(parent)
+
+    broker.data_source.execute_order.assert_not_called()

--- a/tests/test_interactive_brokers_rest_order_semantics.py
+++ b/tests/test_interactive_brokers_rest_order_semantics.py
@@ -35,6 +35,10 @@ def broker(monkeypatch):
     broker._tracked_orders_filter_cache = {}
     broker._active_tracked_orders_filter_cache = {}
     broker._on_new_order = Mock()
+    broker._strategy_name = "ibkr_rest_order_semantics"
+    broker._first_iteration = False
+    broker.sync_positions = Mock()
+    broker.data_source.get_contract_details.return_value = {"instrument_type": "STK"}
 
     broker.dispatched_events = []
 
@@ -47,6 +51,12 @@ def broker(monkeypatch):
                 broker._on_new_order(processed_order)
         elif event == broker.PLACEHOLDER_ORDER:
             broker._process_placeholder_order(order)
+        elif event == broker.FILLED_ORDER:
+            order.status = broker.FILLED_ORDER
+            order.set_filled()
+        elif event == broker.CANCELED_ORDER:
+            order.status = broker.CANCELED_ORDER
+            order.set_canceled()
         elif event == broker.ERROR_ORDER:
             order.set_error(kwargs["error_msg"])
 
@@ -65,6 +75,24 @@ def _order(**kwargs):
     }
     defaults.update(kwargs)
     return Order(**defaults)
+
+
+def _poll_order(order_id, status="Open", avg_price=None):
+    response = {
+        "orderId": order_id,
+        "secType": "STK",
+        "totalSize": 1,
+        "conid": 265598,
+        "ticker": "SPY",
+        "cashCcy": "USD",
+        "timeInForce": "GTC",
+        "status": status,
+        "side": "BUY",
+        "price": 100.0,
+    }
+    if avg_price is not None:
+        response["avgPrice"] = avg_price
+    return response
 
 
 def test_simple_order_payload_is_unchanged(broker):
@@ -625,3 +653,140 @@ def test_cancel_continues_after_exception_and_rejection(broker):
     broker.cancel_order(parent)
 
     assert [args.args[0] for args in broker.data_source.delete_order.call_args_list] == native_orders
+
+
+@pytest.mark.parametrize(
+    ("submission_order_id", "poll_order_id"),
+    [("8101", 8101), (8102, "8102")],
+)
+def test_polling_matches_simple_order_despite_order_id_type_changes(
+    broker,
+    submission_order_id,
+    poll_order_id,
+):
+    order = _order(limit_price=100.0, order_type=Order.OrderType.LIMIT)
+    broker.data_source.execute_order.return_value = [{"order_id": submission_order_id}]
+    broker._submit_order(order)
+    raw_order = _poll_order(poll_order_id, status="Open")
+    broker.data_source.get_broker_all_orders.return_value = [raw_order]
+
+    broker.do_polling()
+
+    assert order.identifier == str(submission_order_id)
+    assert order._raw is raw_order
+    assert order.status == Order.OrderStatus.OPEN
+    assert broker.get_all_orders() == [order]
+    broker.sync_positions.assert_called_once_with(None)
+
+
+def test_polling_updates_bracket_native_orders_without_erasing_child_relationships(broker):
+    parent = _order(
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+        secondary_stop_price=95.0,
+    )
+    children = list(parent.child_orders)
+    broker.data_source.execute_order.return_value = [
+        {"order_id": "8201"},
+        {"order_id": "8202"},
+        {"order_id": "8203"},
+    ]
+    broker._submit_order(parent)
+    raw_orders = [_poll_order(8201), _poll_order(8202), _poll_order(8203)]
+    broker.data_source.get_broker_all_orders.return_value = raw_orders
+
+    broker.do_polling()
+
+    assert parent.child_orders == children
+    assert [child.parent_identifier for child in children] == ["8201", "8201"]
+    assert [parent._raw, *(child._raw for child in children)] == raw_orders
+    assert set(broker.get_all_orders()) == {parent, *children}
+
+
+def test_polling_updates_oto_parent_and_child_in_place(broker):
+    parent = _order(
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.OTO,
+        secondary_limit_price=110.0,
+    )
+    child = parent.child_orders[0]
+    broker.data_source.execute_order.return_value = [
+        {"order_id": 8301},
+        {"order_id": 8302},
+    ]
+    broker._submit_order(parent)
+    raw_orders = [_poll_order("8301"), _poll_order("8302")]
+    broker.data_source.get_broker_all_orders.return_value = raw_orders
+
+    broker.do_polling()
+
+    assert parent.child_orders == [child]
+    assert child.parent_identifier == "8301"
+    assert parent._raw is raw_orders[0]
+    assert child._raw is raw_orders[1]
+    assert set(broker.get_all_orders()) == {parent, child}
+
+
+def test_polling_keeps_oco_placeholder_connected_to_known_children(broker):
+    parent = _order(
+        identifier="local-oco-container",
+        side=Order.OrderSide.SELL,
+        limit_price=110.0,
+        stop_price=95.0,
+        order_class=Order.OrderClass.OCO,
+    )
+    children = list(parent.child_orders)
+    broker.data_source.execute_order.return_value = [
+        {"order_id": "8401"},
+        {"order_id": "8402"},
+    ]
+    broker._submit_order(parent)
+    raw_orders = [_poll_order(8401), _poll_order(8402)]
+    broker.data_source.get_broker_all_orders.return_value = raw_orders
+
+    broker.do_polling()
+
+    assert parent.identifier == "local-oco-container"
+    assert parent.child_orders == children
+    assert [child.parent_identifier for child in children] == [parent.identifier, parent.identifier]
+    assert [child._raw for child in children] == raw_orders
+    assert parent in broker._placeholder_orders
+    assert set(broker.get_all_orders()) == {parent, *children}
+
+
+def test_polling_dispatches_filled_and_canceled_child_status_changes(broker):
+    parent = _order(
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+        secondary_stop_price=95.0,
+    )
+    first_child, second_child = parent.child_orders
+    broker.data_source.execute_order.return_value = [
+        {"order_id": "8501"},
+        {"order_id": "8502"},
+        {"order_id": "8503"},
+    ]
+    broker._submit_order(parent)
+    broker.dispatched_events.clear()
+    raw_orders = [
+        _poll_order(8501, status="Open"),
+        _poll_order(8502, status="Filled", avg_price=110.0),
+        _poll_order(8503, status="Canceled"),
+    ]
+    broker.data_source.get_broker_all_orders.return_value = raw_orders
+
+    broker.do_polling()
+
+    assert first_child.status == Order.OrderStatus.FILLED
+    assert second_child.status == Order.OrderStatus.CANCELED
+    assert first_child._raw is raw_orders[1]
+    assert second_child._raw is raw_orders[2]
+    assert [event for event, _, _ in broker.dispatched_events] == [
+        broker.FILLED_ORDER,
+        broker.CANCELED_ORDER,
+    ]

--- a/tests/test_interactive_brokers_rest_order_semantics.py
+++ b/tests/test_interactive_brokers_rest_order_semantics.py
@@ -491,8 +491,9 @@ def test_submit_oco_rejects_ambiguous_acknowledgement_order_and_cleans_up(broker
             ["5001", "5002"],
         ),
         ([{"error": "rejected"}, {"order_id": "5002"}], ["5002"]),
+        ([{"order_id": "-1"}, {"order_id": "5002"}], ["5002"]),
     ],
-    ids=["malformed", "short", "long", "mixed", "mixed-first-error"],
+    ids=["malformed", "short", "long", "mixed", "mixed-first-error", "placeholder"],
 )
 def test_invalid_acknowledgement_package_cleans_every_acknowledged_id(
     broker,

--- a/tests/test_interactive_brokers_rest_order_semantics.py
+++ b/tests/test_interactive_brokers_rest_order_semantics.py
@@ -236,9 +236,27 @@ def test_oco_payload_excludes_conceptual_parent_and_marks_both_children(broker):
     assert len(payload["orders"]) == 2
     assert [ticket["orderType"] for ticket in payload["orders"]] == ["LMT", "STP"]
     assert all(ticket["isSingleGroup"] is True for ticket in payload["orders"])
-    assert all("cOID" not in ticket for ticket in payload["orders"])
+    assert [ticket["cOID"] for ticket in payload["orders"]] == [
+        child.identifier for child in parent.child_orders
+    ]
+    assert len({ticket["cOID"] for ticket in payload["orders"]}) == 2
     assert all("parentId" not in ticket for ticket in payload["orders"])
     assert all(ticket["listingExchange"] == "SMART" for ticket in payload["orders"])
+
+
+def test_oco_duplicate_child_coids_fail_before_contract_lookup(broker):
+    parent = _order(
+        side=Order.OrderSide.SELL,
+        limit_price=110.0,
+        stop_price=95.0,
+        order_class=Order.OrderClass.OCO,
+    )
+    parent.child_orders[1].identifier = parent.child_orders[0].identifier
+
+    with pytest.raises(ValueError, match="distinct identifiers for cOID correlation"):
+        broker._get_order_data_for_submission(parent)
+
+    broker.data_source.get_conid_from_asset.assert_not_called()
 
 
 @pytest.mark.parametrize("order_class", [Order.OrderClass.BRACKET, Order.OrderClass.OTO, Order.OrderClass.OCO])
@@ -405,9 +423,14 @@ def test_submit_oco_keeps_local_parent_placeholder_and_tracks_native_children(br
         order_class=Order.OrderClass.OCO,
     )
     children = list(parent.child_orders)
+    child_coids = [child.identifier for child in children]
     response = [
+        {
+            "order_id": "4002",
+            "order_status": "Submitted",
+            "local_order_id": child_coids[1],
+        },
         {"order_id": 4001, "order_status": "Submitted"},
-        {"order_id": "4002", "order_status": "Submitted"},
     ]
     broker.data_source.execute_order.return_value = response
 
@@ -418,7 +441,7 @@ def test_submit_oco_keeps_local_parent_placeholder_and_tracks_native_children(br
     assert parent in broker._placeholder_orders
     assert parent not in broker._new_orders
     assert [child.identifier for child in children] == ["4001", "4002"]
-    assert [child._raw for child in children] == response
+    assert [child._raw for child in children] == [response[1], response[0]]
     assert all(child.parent_identifier == "local-oco" for child in children)
     assert all(child in broker._new_orders for child in children)
     assert all(child not in broker._unprocessed_orders for child in children)
@@ -429,6 +452,29 @@ def test_submit_oco_keeps_local_parent_placeholder_and_tracks_native_children(br
         broker.NEW_ORDER,
     ]
     assert [args.args[0] for args in broker._on_new_order.call_args_list] == children
+
+
+def test_submit_oco_rejects_ambiguous_acknowledgement_order_and_cleans_up(broker):
+    parent = _order(
+        identifier="ambiguous-oco",
+        side=Order.OrderSide.SELL,
+        limit_price=110.0,
+        stop_price=95.0,
+        order_class=Order.OrderClass.OCO,
+    )
+    broker.data_source.execute_order.return_value = [
+        {"order_id": "4011", "order_status": "Submitted"},
+        {"order_id": "4012", "order_status": "Submitted"},
+    ]
+
+    broker._submit_order(parent)
+
+    cleanup_orders = [args.args[0] for args in broker.data_source.delete_order.call_args_list]
+    assert [cleanup.identifier for cleanup in cleanup_orders] == ["4011", "4012"]
+    assert parent.status == Order.OrderStatus.ERROR
+    assert all(child.status == Order.OrderStatus.ERROR for child in parent.child_orders)
+    assert "does not identify enough OCO acknowledgements" in parent.error_message
+    assert not broker.get_all_orders()
 
 
 @pytest.mark.parametrize(
@@ -740,9 +786,10 @@ def test_polling_keeps_oco_placeholder_connected_to_known_children(broker):
         order_class=Order.OrderClass.OCO,
     )
     children = list(parent.child_orders)
+    child_coids = [child.identifier for child in children]
     broker.data_source.execute_order.return_value = [
-        {"order_id": "8401"},
-        {"order_id": "8402"},
+        {"order_id": "8401", "local_order_id": child_coids[0]},
+        {"order_id": "8402", "local_order_id": child_coids[1]},
     ]
     broker._submit_order(parent)
     raw_orders = [_poll_order(8401), _poll_order(8402)]

--- a/tests/test_interactive_brokers_rest_order_semantics.py
+++ b/tests/test_interactive_brokers_rest_order_semantics.py
@@ -4,7 +4,9 @@ import pytest
 
 import lumibot.brokers.interactive_brokers_rest as ibkr_rest_module
 from lumibot.brokers.interactive_brokers_rest import InteractiveBrokersREST
+from lumibot.data_sources.interactive_brokers_rest_data import InteractiveBrokersRESTData
 from lumibot.entities import Asset, Order
+from lumibot.trading_builtins.safe_list import SafeList
 
 
 @pytest.fixture
@@ -14,6 +16,41 @@ def broker(monkeypatch):
     broker.data_source = Mock()
     broker.data_source.get_conid_from_asset.return_value = 265598
     broker.data_source.get_contract_rules.return_value = {"rules": {"increment": 0.01}}
+    broker.name = InteractiveBrokersREST.NAME
+    broker.logger = Mock()
+    broker.logger.isEnabledFor.return_value = False
+    broker._log_order_status = Mock()
+    broker._hold_trade_events = False
+    broker._held_trades = []
+    broker._subscribers = SafeList(None)
+    broker._unprocessed_orders = SafeList(None)
+    broker._placeholder_orders = SafeList(None)
+    broker._new_orders = SafeList(None)
+    broker._canceled_orders = SafeList(None)
+    broker._partially_filled_orders = SafeList(None)
+    broker._filled_orders = SafeList(None)
+    broker._error_orders = SafeList(None)
+    broker._tracked_orders_cache_key = None
+    broker._tracked_orders_cache_value = []
+    broker._tracked_orders_filter_cache = {}
+    broker._active_tracked_orders_filter_cache = {}
+    broker._on_new_order = Mock()
+
+    broker.dispatched_events = []
+
+    def dispatch_and_process(event, **kwargs):
+        order = kwargs["order"]
+        broker.dispatched_events.append((event, order, order.status))
+        if event == broker.NEW_ORDER:
+            processed_order = broker._process_new_order(order)
+            if processed_order:
+                broker._on_new_order(processed_order)
+        elif event == broker.PLACEHOLDER_ORDER:
+            broker._process_placeholder_order(order)
+        elif event == broker.ERROR_ORDER:
+            order.set_error(kwargs["error_msg"])
+
+    broker._safe_stream_dispatch = Mock(side_effect=dispatch_and_process)
     return broker
 
 
@@ -224,3 +261,213 @@ def test_unserializable_advanced_child_prevents_complete_package(broker):
         broker._get_order_data_for_submission(parent)
 
     broker.data_source.execute_order.assert_not_called()
+
+
+def test_submit_simple_maps_raw_acknowledgement_and_tracks_once(broker):
+    order = _order(
+        identifier="local-simple",
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+    )
+    response = [{"order_id": 1001, "order_status": "Submitted"}]
+    broker.data_source.execute_order.return_value = response
+
+    result = broker._submit_order(order)
+
+    assert result is order
+    assert order.identifier == "1001"
+    assert order._raw is response[0]
+    assert order.was_transmitted()
+    assert order in broker._new_orders
+    assert order not in broker._unprocessed_orders
+    assert order._new_event.is_set()
+    assert broker.dispatched_events == [(broker.NEW_ORDER, order, Order.OrderStatus.SUBMITTED)]
+    broker._on_new_order.assert_called_once_with(order)
+    broker.data_source.execute_order.assert_called_once()
+    assert broker.data_source.execute_order.call_args.kwargs == {"return_raw_response": True}
+
+
+def test_execute_order_can_return_complete_mixed_response_without_network():
+    data_source = InteractiveBrokersRESTData.__new__(InteractiveBrokersRESTData)
+    data_source.base_url = "https://example.invalid"
+    data_source.account_id = "test-account"
+    data_source.ping_iserver = Mock()
+    response = [{"error": "rejected"}, {"order_id": "1002"}]
+    data_source.post_to_endpoint = Mock(return_value=response)
+
+    result = data_source.execute_order({"orders": [{}, {}]}, return_raw_response=True)
+
+    assert result is response
+    data_source.ping_iserver.assert_called_once_with()
+    data_source.post_to_endpoint.assert_called_once_with(
+        "https://example.invalid/iserver/account/test-account/orders",
+        {"orders": [{}, {}]},
+        description="Executing order",
+    )
+
+
+def test_submit_bracket_maps_and_tracks_every_native_leg(broker):
+    parent = _order(
+        identifier="local-bracket",
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+        secondary_stop_price=95.0,
+    )
+    children = list(parent.child_orders)
+    response = [
+        {"order_id": 2001, "order_status": "Submitted"},
+        {"order_id": "2002", "order_status": "Submitted"},
+        {"order_id": 2003, "order_status": "Submitted"},
+    ]
+    broker.data_source.execute_order.return_value = response
+
+    broker._submit_order(parent)
+
+    native_orders = [parent, *children]
+    assert parent.child_orders == children
+    assert [native.identifier for native in native_orders] == ["2001", "2002", "2003"]
+    assert [native._raw for native in native_orders] == response
+    assert all(native.was_transmitted() for native in native_orders)
+    assert all(child.parent_identifier == "2001" for child in children)
+    assert all(native in broker._new_orders for native in native_orders)
+    assert all(native not in broker._unprocessed_orders for native in native_orders)
+    assert all(native._new_event.is_set() for native in native_orders)
+    assert [event for event, _, _ in broker.dispatched_events] == [broker.NEW_ORDER] * 3
+    assert [status for _, _, status in broker.dispatched_events] == [Order.OrderStatus.SUBMITTED] * 3
+    assert [args.args[0] for args in broker._on_new_order.call_args_list] == native_orders
+
+
+def test_submit_oto_maps_parent_and_child_in_request_order(broker):
+    parent = _order(
+        identifier="local-oto",
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.OTO,
+        secondary_limit_price=110.0,
+    )
+    child = parent.child_orders[0]
+    response = [
+        {"order_id": "3001", "order_status": "Submitted"},
+        {"order_id": 3002, "order_status": "Submitted"},
+    ]
+    broker.data_source.execute_order.return_value = response
+
+    broker._submit_order(parent)
+
+    assert parent.identifier == "3001"
+    assert child.identifier == "3002"
+    assert child.parent_identifier == "3001"
+    assert parent._raw is response[0]
+    assert child._raw is response[1]
+    assert parent in broker._new_orders
+    assert child in broker._new_orders
+    assert len(broker._unprocessed_orders) == 0
+    assert broker._on_new_order.call_count == 2
+
+
+def test_submit_oco_keeps_local_parent_placeholder_and_tracks_native_children(broker):
+    parent = _order(
+        identifier="local-oco",
+        side=Order.OrderSide.SELL,
+        limit_price=110.0,
+        stop_price=95.0,
+        order_class=Order.OrderClass.OCO,
+    )
+    children = list(parent.child_orders)
+    response = [
+        {"order_id": 4001, "order_status": "Submitted"},
+        {"order_id": "4002", "order_status": "Submitted"},
+    ]
+    broker.data_source.execute_order.return_value = response
+
+    broker._submit_order(parent)
+
+    assert parent.identifier == "local-oco"
+    assert not parent.was_transmitted()
+    assert parent in broker._placeholder_orders
+    assert parent not in broker._new_orders
+    assert [child.identifier for child in children] == ["4001", "4002"]
+    assert [child._raw for child in children] == response
+    assert all(child.parent_identifier == "local-oco" for child in children)
+    assert all(child in broker._new_orders for child in children)
+    assert all(child not in broker._unprocessed_orders for child in children)
+    assert parent._new_event.is_set()
+    assert [event for event, _, _ in broker.dispatched_events] == [
+        broker.PLACEHOLDER_ORDER,
+        broker.NEW_ORDER,
+        broker.NEW_ORDER,
+    ]
+    assert [args.args[0] for args in broker._on_new_order.call_args_list] == children
+
+
+@pytest.mark.parametrize(
+    ("response", "cleanup_ids"),
+    [
+        ([{"order_id": "5001"}, "malformed-entry"], ["5001"]),
+        ([{"order_id": "5001"}], ["5001"]),
+        (
+            [{"order_id": "5001"}, {"order_id": "5002"}, {"order_id": "5003"}],
+            ["5001", "5002", "5003"],
+        ),
+        (
+            [{"order_id": "5001"}, {"order_id": "5002", "error": "rejected"}],
+            ["5001", "5002"],
+        ),
+        ([{"error": "rejected"}, {"order_id": "5002"}], ["5002"]),
+    ],
+    ids=["malformed", "short", "long", "mixed", "mixed-first-error"],
+)
+def test_invalid_acknowledgement_package_cleans_every_acknowledged_id(
+    broker,
+    response,
+    cleanup_ids,
+):
+    parent = _order(
+        identifier="failed-bracket",
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+    )
+    original_identifiers = [parent.identifier, parent.child_orders[0].identifier]
+    broker.data_source.execute_order.return_value = response
+
+    broker._submit_order(parent)
+
+    cleanup_orders = [args.args[0] for args in broker.data_source.delete_order.call_args_list]
+    assert [cleanup.identifier for cleanup in cleanup_orders] == cleanup_ids
+    assert [parent.identifier, parent.child_orders[0].identifier] == original_identifiers
+    assert parent.status == Order.OrderStatus.ERROR
+    assert parent.child_orders[0].status == Order.OrderStatus.ERROR
+    assert not parent.was_transmitted()
+    assert not parent.child_orders[0].was_transmitted()
+    assert "Invalid IBKR REST order acknowledgement package" in parent.error_message
+    assert len(broker._unprocessed_orders) == 0
+    assert len(broker._new_orders) == 0
+    assert [event for event, _, _ in broker.dispatched_events] == [broker.ERROR_ORDER]
+    broker._on_new_order.assert_not_called()
+
+
+def test_cleanup_continues_after_an_earlier_cancel_fails(broker):
+    parent = _order(
+        identifier="cleanup-bracket",
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+    )
+    broker.data_source.execute_order.return_value = [
+        {"order_id": "6001"},
+        {"order_id": "6002"},
+        {"order_id": "6003"},
+    ]
+    broker.data_source.delete_order.side_effect = [RuntimeError("first cleanup failed"), None, None]
+
+    broker._submit_order(parent)
+
+    cleanup_orders = [args.args[0] for args in broker.data_source.delete_order.call_args_list]
+    assert [cleanup.identifier for cleanup in cleanup_orders] == ["6001", "6002", "6003"]
+    assert parent.status == Order.OrderStatus.ERROR
+    assert broker._on_new_order.call_count == 0

--- a/tests/test_interactive_brokers_rest_order_semantics.py
+++ b/tests/test_interactive_brokers_rest_order_semantics.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest.mock import Mock, call
 
 import pytest
@@ -790,3 +791,110 @@ def test_polling_dispatches_filled_and_canceled_child_status_changes(broker):
         broker.FILLED_ORDER,
         broker.CANCELED_ORDER,
     ]
+
+
+def _gtd_date():
+    return datetime(2026, 9, 1, 15, 30, tzinfo=timezone.utc)
+
+
+def test_rest_simple_gtd_fails_before_conid_or_execute_order(broker):
+    order = _order(
+        time_in_force="gtd",
+        good_till_date=_gtd_date(),
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+    )
+
+    with pytest.raises(NotImplementedError, match="exact-date GTD submission is not supported"):
+        broker._submit_order(order)
+
+    broker.data_source.get_conid_from_asset.assert_not_called()
+    broker.data_source.get_contract_rules.assert_not_called()
+    broker.data_source.execute_order.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "order_class, order_kwargs",
+    [
+        (Order.OrderClass.BRACKET, {"limit_price": 100.0, "secondary_limit_price": 110.0}),
+        (Order.OrderClass.OTO, {"limit_price": 100.0, "secondary_limit_price": 110.0}),
+        (Order.OrderClass.OCO, {"side": Order.OrderSide.SELL, "limit_price": 110.0, "stop_price": 95.0}),
+    ],
+)
+def test_rest_advanced_parent_gtd_fails_before_package_serialization(broker, order_class, order_kwargs):
+    parent = _order(
+        order_class=order_class,
+        time_in_force="gtd",
+        good_till_date=_gtd_date(),
+        **order_kwargs,
+    )
+
+    with pytest.raises(NotImplementedError, match="exact-date GTD submission is not supported"):
+        broker._submit_order(parent)
+
+    broker.data_source.get_conid_from_asset.assert_not_called()
+    broker.data_source.execute_order.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "order_class, order_kwargs",
+    [
+        (Order.OrderClass.BRACKET, {"limit_price": 100.0, "secondary_limit_price": 110.0}),
+        (Order.OrderClass.OTO, {"limit_price": 100.0, "secondary_limit_price": 110.0}),
+        (Order.OrderClass.OCO, {"side": Order.OrderSide.SELL, "limit_price": 110.0, "stop_price": 95.0}),
+    ],
+)
+def test_rest_advanced_child_gtd_fails_before_package_serialization(broker, order_class, order_kwargs):
+    parent = _order(order_class=order_class, **order_kwargs)
+    child = parent.child_orders[0]
+    child.time_in_force = "gtd"
+    child.good_till_date = _gtd_date()
+
+    with pytest.raises(NotImplementedError, match="exact-date GTD submission is not supported"):
+        broker._submit_order(parent)
+
+    broker.data_source.get_conid_from_asset.assert_not_called()
+    broker.data_source.execute_order.assert_not_called()
+
+
+def test_rest_multileg_gtd_fails_before_conid_or_execute_order(broker):
+    leg = _order(time_in_force="gtd", good_till_date=_gtd_date())
+
+    with pytest.raises(NotImplementedError, match="exact-date GTD submission is not supported"):
+        broker._submit_orders([leg], is_multileg=True)
+
+    broker.data_source.get_conid_from_asset.assert_not_called()
+    broker.data_source.execute_order.assert_not_called()
+
+
+@pytest.mark.parametrize("order_class", [Order.OrderClass.SIMPLE, Order.OrderClass.BRACKET])
+def test_rest_good_till_date_without_gtd_is_rejected(order_class, broker):
+    order_kwargs = {
+        "time_in_force": "gtc",
+        "good_till_date": _gtd_date(),
+        "limit_price": 100.0,
+        "order_type": Order.OrderType.LIMIT,
+    }
+    if order_class is Order.OrderClass.BRACKET:
+        order_kwargs.update(order_class=order_class, secondary_limit_price=110.0)
+    order = _order(**order_kwargs)
+
+    with pytest.raises(ValueError, match="good_till_date requires time_in_force='gtd'"):
+        broker._submit_order(order)
+
+    broker.data_source.get_conid_from_asset.assert_not_called()
+    broker.data_source.execute_order.assert_not_called()
+
+
+@pytest.mark.parametrize("time_in_force", ["day", "gtc"])
+def test_rest_supported_time_in_force_payload_remains_unchanged(broker, time_in_force):
+    order = _order(
+        time_in_force=time_in_force,
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+    )
+
+    payload = broker._get_order_data_for_submission(order)
+
+    assert payload["orders"][0]["tif"] == time_in_force.upper()
+    assert "goodTillDate" not in payload["orders"][0]

--- a/tests/test_interactive_brokers_rest_order_semantics.py
+++ b/tests/test_interactive_brokers_rest_order_semantics.py
@@ -17,6 +17,10 @@ def broker(monkeypatch):
     broker.data_source = Mock()
     broker.data_source.get_conid_from_asset.return_value = 265598
     broker.data_source.get_contract_rules.return_value = {"rules": {"increment": 0.01}}
+    broker.data_source.get_broker_all_orders_once.return_value = []
+    # Reconciliation timing is tested deterministically; unit failures must not
+    # wait for the production bounded polling window.
+    monkeypatch.setattr(ibkr_rest_module, "_ADVANCED_ACK_RECONCILIATION_SECONDS", 0.0)
     broker.name = InteractiveBrokersREST.NAME
     broker.logger = Mock()
     broker.logger.isEnabledFor.return_value = False
@@ -134,7 +138,7 @@ def test_bracket_payload_with_one_child_links_parent_and_inherits_exchange(broke
     parent_ticket, child_ticket = payload["orders"]
     assert parent_ticket["cOID"] == "bracket-parent"
     assert child_ticket["parentId"] == "bracket-parent"
-    assert "cOID" not in child_ticket
+    assert child_ticket["cOID"] == child.identifier
     assert parent_ticket["price"] == pytest.approx(99.99)
     assert child_ticket["price"] == pytest.approx(109.99)
     assert child_ticket["listingExchange"] == "SMART"
@@ -161,12 +165,16 @@ def test_bracket_payload_with_two_children_only_links_the_parent(broker):
     assert payload["orders"][0]["cOID"] == "bracket-parent-two"
     assert payload["orders"][1]["parentId"] == "bracket-parent-two"
     assert payload["orders"][2]["parentId"] == "bracket-parent-two"
-    assert "cOID" not in payload["orders"][1]
-    assert "cOID" not in payload["orders"][2]
+    assert [ticket["cOID"] for ticket in payload["orders"][1:]] == [
+        child.identifier for child in parent.child_orders
+    ]
     assert payload["orders"][1]["orderType"] == "LMT"
     assert payload["orders"][1]["price"] == pytest.approx(109.99)
     assert payload["orders"][2]["orderType"] == "STP"
-    assert payload["orders"][2]["auxPrice"] == pytest.approx(94.99)
+    # Client Portal REST requires an STP trigger in ``price``; ``auxPrice``
+    # is only the trigger field for an STP LMT ticket.
+    assert payload["orders"][2]["price"] == pytest.approx(94.99)
+    assert "auxPrice" not in payload["orders"][2]
 
 
 def test_advanced_parent_coid_is_stable_safe_and_within_ibkr_limit(broker):
@@ -186,6 +194,7 @@ def test_advanced_parent_coid_is_stable_safe_and_within_ibkr_limit(broker):
     assert len(c_oid) <= 64
     assert c_oid.startswith("lumibot-")
     assert first_payload["orders"][1]["parentId"] == c_oid
+    assert first_payload["orders"][1]["cOID"] == parent.child_orders[0].identifier
 
 
 def test_oto_payload_preserves_explicit_child_settings(broker):
@@ -217,9 +226,9 @@ def test_oto_payload_preserves_explicit_child_settings(broker):
         "tif": "DAY",
         "price": pytest.approx(101.24),
         "listingExchange": "ARCA",
+        "cOID": "explicit-oto-child",
         "parentId": "oto-parent",
     }
-    assert "cOID" not in payload["orders"][1]
 
 
 def test_oco_payload_excludes_conceptual_parent_and_marks_both_children(broker):
@@ -242,6 +251,30 @@ def test_oco_payload_excludes_conceptual_parent_and_marks_both_children(broker):
     assert len({ticket["cOID"] for ticket in payload["orders"]}) == 2
     assert all("parentId" not in ticket for ticket in payload["orders"])
     assert all(ticket["listingExchange"] == "SMART" for ticket in payload["orders"])
+    assert payload["orders"][1]["price"] == pytest.approx(94.99)
+    assert "auxPrice" not in payload["orders"][1]
+
+
+def test_stop_and_stop_limit_payloads_use_client_portal_price_fields(broker):
+    stop = _order(
+        stop_price=95.0,
+        order_type=Order.OrderType.STOP,
+    )
+    stop_limit = _order(
+        limit_price=96.0,
+        stop_price=95.0,
+        order_type=Order.OrderType.STOP_LIMIT,
+    )
+
+    stop_ticket = broker._get_order_data_for_submission(stop)["orders"][0]
+    stop_limit_ticket = broker._get_order_data_for_submission(stop_limit)["orders"][0]
+
+    assert stop_ticket["orderType"] == "STP"
+    assert stop_ticket["price"] == pytest.approx(94.99)
+    assert "auxPrice" not in stop_ticket
+    assert stop_limit_ticket["orderType"] == "STP LMT"
+    assert stop_limit_ticket["price"] == pytest.approx(95.99)
+    assert stop_limit_ticket["auxPrice"] == pytest.approx(94.99)
 
 
 def test_oco_duplicate_child_coids_fail_before_contract_lookup(broker):
@@ -252,6 +285,22 @@ def test_oco_duplicate_child_coids_fail_before_contract_lookup(broker):
         order_class=Order.OrderClass.OCO,
     )
     parent.child_orders[1].identifier = parent.child_orders[0].identifier
+
+    with pytest.raises(ValueError, match="distinct identifiers for cOID correlation"):
+        broker._get_order_data_for_submission(parent)
+
+    broker.data_source.get_conid_from_asset.assert_not_called()
+
+
+def test_bracket_duplicate_parent_and_child_coids_fail_before_contract_lookup(broker):
+    parent = _order(
+        identifier="duplicate-coid",
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+    )
+    parent.child_orders[0].identifier = parent.identifier
 
     with pytest.raises(ValueError, match="distinct identifiers for cOID correlation"):
         broker._get_order_data_for_submission(parent)
@@ -353,6 +402,43 @@ def test_execute_order_can_return_complete_mixed_response_without_network():
     )
 
 
+def test_get_broker_all_orders_once_is_bounded_and_does_not_ping():
+    data_source = InteractiveBrokersRESTData.__new__(InteractiveBrokersRESTData)
+    data_source.base_url = "https://example.invalid"
+    data_source.account_id = "test-account"
+    data_source.ping_iserver = Mock()
+    orders = [{"orderId": "1901", "order_ref": "local-order"}]
+    data_source.get_from_endpoint = Mock(return_value={"orders": orders})
+
+    assert data_source.get_broker_all_orders_once() is orders
+    data_source.ping_iserver.assert_not_called()
+    data_source.get_from_endpoint.assert_called_once_with(
+        "https://example.invalid/iserver/account/orders?force=true&accountId=test-account",
+        "Reconciling submitted orders",
+        allow_fail=True,
+        silent=True,
+        max_retries=0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        ({"order_id": "1902"}, True),
+        ({"error": "order does not exist"}, False),
+        (None, False),
+    ],
+)
+def test_delete_order_reports_error_payload_as_failure(response, expected):
+    data_source = InteractiveBrokersRESTData.__new__(InteractiveBrokersRESTData)
+    data_source.base_url = "https://example.invalid"
+    data_source.account_id = "test-account"
+    data_source.ping_iserver = Mock()
+    data_source.delete_to_endpoint = Mock(return_value=response)
+
+    assert data_source.delete_order(Mock(identifier="1902")) is expected
+
+
 def test_submit_bracket_maps_and_tracks_every_native_leg(broker):
     parent = _order(
         identifier="local-bracket",
@@ -363,10 +449,11 @@ def test_submit_bracket_maps_and_tracks_every_native_leg(broker):
         secondary_stop_price=95.0,
     )
     children = list(parent.child_orders)
+    coids = [parent.identifier, *(child.identifier for child in children)]
     response = [
-        {"order_id": 2001, "order_status": "Submitted"},
-        {"order_id": "2002", "order_status": "Submitted"},
-        {"order_id": 2003, "order_status": "Submitted"},
+        {"order_id": 2001, "order_status": "Submitted", "local_order_id": coids[0]},
+        {"order_id": "2002", "order_status": "Submitted", "local_order_id": coids[1]},
+        {"order_id": 2003, "order_status": "Submitted", "local_order_id": coids[2]},
     ]
     broker.data_source.execute_order.return_value = response
 
@@ -386,6 +473,88 @@ def test_submit_bracket_maps_and_tracks_every_native_leg(broker):
     assert [args.args[0] for args in broker._on_new_order.call_args_list] == native_orders
 
 
+def test_submit_bracket_reconciles_documented_short_response_by_child_coid(broker):
+    """IBKR documents fewer immediate rows than submitted bracket tickets."""
+    parent = _order(
+        identifier="reconciled-bracket",
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+        secondary_stop_price=95.0,
+    )
+    native_orders = [parent, *parent.child_orders]
+    coids = [native.identifier for native in native_orders]
+    broker.data_source.execute_order.return_value = [
+        {"order_id": "2051", "local_order_id": coids[0]},
+        {"order_id": "2052", "local_order_id": coids[1]},
+    ]
+    polled = [
+        {"orderId": "2051", "order_ref": coids[0]},
+        {"orderId": "2052", "order_ref": coids[1]},
+        {"orderId": "2053", "order_ref": coids[2]},
+    ]
+    broker.data_source.get_broker_all_orders_once.return_value = polled
+
+    broker._submit_order(parent)
+
+    assert [native.identifier for native in native_orders] == ["2051", "2052", "2053"]
+    assert [native._raw for native in native_orders] == polled
+    assert all(native in broker._new_orders for native in native_orders)
+    broker.data_source.delete_order.assert_not_called()
+
+
+def test_failed_reconciliation_cleans_ids_found_during_polling(broker):
+    parent = _order(
+        identifier="partially-reconciled-bracket",
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+        secondary_stop_price=95.0,
+    )
+    coids = [parent.identifier, *(child.identifier for child in parent.child_orders)]
+    broker.data_source.execute_order.return_value = [
+        {"order_id": "2061", "local_order_id": coids[0]},
+    ]
+    broker.data_source.get_broker_all_orders_once.return_value = [
+        {"orderId": "2061", "order_ref": coids[0]},
+        {"orderId": "2062", "order_ref": coids[1]},
+    ]
+
+    broker._submit_order(parent)
+
+    cleanup_orders = [args.args[0] for args in broker.data_source.delete_order.call_args_list]
+    assert [cleanup.identifier for cleanup in cleanup_orders] == ["2061", "2062"]
+    assert "resolved 2 of 3 native tickets" in parent.error_message
+    assert parent.status == Order.OrderStatus.ERROR
+
+
+def test_reconciliation_rejects_and_cleans_an_unmapped_submission_id(broker):
+    parent = _order(
+        identifier="unexpected-id-bracket",
+        limit_price=100.0,
+        order_type=Order.OrderType.LIMIT,
+        order_class=Order.OrderClass.BRACKET,
+        secondary_limit_price=110.0,
+    )
+    coids = [parent.identifier, parent.child_orders[0].identifier]
+    broker.data_source.execute_order.return_value = [
+        {"order_id": "2079"},
+    ]
+    broker.data_source.get_broker_all_orders_once.return_value = [
+        {"orderId": "2071", "order_ref": coids[0]},
+        {"orderId": "2072", "order_ref": coids[1]},
+    ]
+
+    broker._submit_order(parent)
+
+    cleanup_orders = [args.args[0] for args in broker.data_source.delete_order.call_args_list]
+    assert [cleanup.identifier for cleanup in cleanup_orders] == ["2079", "2071", "2072"]
+    assert "broker ID outside the reconciled package" in parent.error_message
+    assert parent.status == Order.OrderStatus.ERROR
+
+
 def test_submit_oto_maps_parent_and_child_in_request_order(broker):
     parent = _order(
         identifier="local-oto",
@@ -396,8 +565,8 @@ def test_submit_oto_maps_parent_and_child_in_request_order(broker):
     )
     child = parent.child_orders[0]
     response = [
-        {"order_id": "3001", "order_status": "Submitted"},
-        {"order_id": 3002, "order_status": "Submitted"},
+        {"order_id": "3001", "order_status": "Submitted", "local_order_id": parent.identifier},
+        {"order_id": 3002, "order_status": "Submitted", "local_order_id": child.identifier},
     ]
     broker.data_source.execute_order.return_value = response
 
@@ -473,7 +642,7 @@ def test_submit_oco_rejects_ambiguous_acknowledgement_order_and_cleans_up(broker
     assert [cleanup.identifier for cleanup in cleanup_orders] == ["4011", "4012"]
     assert parent.status == Order.OrderStatus.ERROR
     assert all(child.status == Order.OrderStatus.ERROR for child in parent.child_orders)
-    assert "does not identify enough OCO acknowledgements" in parent.error_message
+    assert "does not identify enough acknowledgements" in parent.error_message
     assert not broker.get_all_orders()
 
 
@@ -736,10 +905,11 @@ def test_polling_updates_bracket_native_orders_without_erasing_child_relationshi
         secondary_stop_price=95.0,
     )
     children = list(parent.child_orders)
+    coids = [parent.identifier, *(child.identifier for child in children)]
     broker.data_source.execute_order.return_value = [
-        {"order_id": "8201"},
-        {"order_id": "8202"},
-        {"order_id": "8203"},
+        {"order_id": "8201", "local_order_id": coids[0]},
+        {"order_id": "8202", "local_order_id": coids[1]},
+        {"order_id": "8203", "local_order_id": coids[2]},
     ]
     broker._submit_order(parent)
     raw_orders = [_poll_order(8201), _poll_order(8202), _poll_order(8203)]
@@ -762,8 +932,8 @@ def test_polling_updates_oto_parent_and_child_in_place(broker):
     )
     child = parent.child_orders[0]
     broker.data_source.execute_order.return_value = [
-        {"order_id": 8301},
-        {"order_id": 8302},
+        {"order_id": 8301, "local_order_id": parent.identifier},
+        {"order_id": 8302, "local_order_id": child.identifier},
     ]
     broker._submit_order(parent)
     raw_orders = [_poll_order("8301"), _poll_order("8302")]
@@ -816,9 +986,9 @@ def test_polling_dispatches_filled_and_canceled_child_status_changes(broker):
     )
     first_child, second_child = parent.child_orders
     broker.data_source.execute_order.return_value = [
-        {"order_id": "8501"},
-        {"order_id": "8502"},
-        {"order_id": "8503"},
+        {"order_id": "8501", "local_order_id": parent.identifier},
+        {"order_id": "8502", "local_order_id": first_child.identifier},
+        {"order_id": "8503", "local_order_id": second_child.identifier},
     ]
     broker._submit_order(parent)
     broker.dispatched_events.clear()

--- a/tests/test_interactive_brokers_rest_order_semantics.py
+++ b/tests/test_interactive_brokers_rest_order_semantics.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from threading import RLock
 from unittest.mock import Mock, call
 
 import pytest
@@ -14,6 +15,9 @@ from lumibot.trading_builtins.safe_list import SafeList
 def broker(monkeypatch):
     monkeypatch.setattr(ibkr_rest_module, "colored", lambda text, *args, **kwargs: text)
     broker = InteractiveBrokersREST.__new__(InteractiveBrokersREST)
+    # This fixture bypasses Broker.__init__; supply the lock that normal broker
+    # construction creates because dispatched order processing uses it.
+    broker._lock = RLock()
     broker.data_source = Mock()
     broker.data_source.get_conid_from_asset.return_value = 265598
     broker.data_source.get_contract_rules.return_value = {"rules": {"increment": 0.01}}

--- a/tests/test_interactive_brokers_rest_paper_order_apitest.py
+++ b/tests/test_interactive_brokers_rest_paper_order_apitest.py
@@ -1,0 +1,13 @@
+"""Read-only safety scaffold for future IBKR REST paper-order API tests."""
+
+import pytest
+
+from tests.ibkr_rest_paper_order_safety import ibkr_rest_paper_order_data_source
+
+
+pytestmark = [pytest.mark.apitest, pytest.mark.ibkr]
+
+
+def test_authenticated_paper_order_gate(ibkr_rest_paper_order_data_source):
+    """Verify the gate before a future test constructs or submits an order."""
+    assert ibkr_rest_paper_order_data_source.account_id.upper().startswith("DU")

--- a/tests/test_legacy_ib_gateway_order_semantics.py
+++ b/tests/test_legacy_ib_gateway_order_semantics.py
@@ -1,0 +1,88 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from lumibot.brokers.interactive_brokers import IBApp, IBWrapper
+from lumibot.entities import Asset, Order
+
+
+def _legacy_ib_app():
+    app = IBApp.__new__(IBApp)
+    identifiers = iter(range(1000, 1100))
+    app.nextOrderId = lambda: next(identifiers)
+    return app
+
+
+def _legacy_order(order_class):
+    return SimpleNamespace(
+        order_class=order_class,
+        identifier=999,
+        side="buy",
+        quantity=1,
+        order_type="limit",
+        limit_price=100.0,
+        stop_price=95.0,
+        trail_price=None,
+        trail_percent=None,
+        time_in_force="gtd",
+        good_till_date=datetime(2026, 9, 1, 15, 30),
+    )
+
+
+@pytest.mark.parametrize(
+    ("order_class", "expected_order_count"),
+    [("", 1), ("bracket", 3), ("oto", 2), ("oco", 2)],
+)
+def test_legacy_ib_orders_apply_gtd_to_every_native_leg(order_class, expected_order_count):
+    native_orders = _legacy_ib_app().create_order(_legacy_order(order_class))
+
+    assert len(native_orders) == expected_order_count
+    assert [native_order.tif for native_order in native_orders] == ["GTD"] * expected_order_count
+    assert [native_order.goodTillDate for native_order in native_orders] == ["20260901 15:30:00"] * expected_order_count
+
+
+def test_legacy_ib_last_close_populates_price_only_without_last_trade():
+    wrapper = IBWrapper.__new__(IBWrapper)
+    wrapper.should_use_last_close = True
+
+    wrapper.tickPrice(reqId=1, tickType=9, price=123.45, attrib=None)
+
+    assert wrapper.price == 123.45
+    assert wrapper.tick_type_used == 9
+
+    wrapper.tickPrice(reqId=1, tickType=4, price=125.00, attrib=None)
+    wrapper.tickPrice(reqId=1, tickType=9, price=123.45, attrib=None)
+
+    assert wrapper.price == 125.00
+    assert wrapper.tick_type_used == 4
+
+
+@pytest.mark.parametrize(
+    "order_class, prices",
+    [
+        (Order.OrderClass.OCO, {"limit_price": 110.0, "stop_price": 95.0}),
+        (Order.OrderClass.BRACKET, {"secondary_limit_price": 110.0, "secondary_stop_price": 95.0}),
+        (Order.OrderClass.OTO, {"secondary_limit_price": 110.0}),
+    ],
+)
+def test_automatic_advanced_children_inherit_parent_gtd(order_class, prices):
+    good_till_date = datetime(2026, 9, 1, 15, 30, tzinfo=timezone.utc)
+    order_kwargs = {
+        "strategy": "legacy_gateway_test",
+        "asset": Asset("SPY"),
+        "quantity": 1,
+        "side": Order.OrderSide.BUY,
+        "order_type": Order.OrderType.LIMIT,
+        "order_class": order_class,
+        "time_in_force": "gtd",
+        "good_till_date": good_till_date,
+    }
+    if order_class is not Order.OrderClass.OCO:
+        order_kwargs["limit_price"] = 100.0
+    order_kwargs.update(prices)
+    parent = Order(**order_kwargs)
+
+    assert parent.child_orders
+    assert all(child.time_in_force == "gtd" for child in parent.child_orders)
+    assert all(child.good_till_date == good_till_date for child in parent.child_orders)


### PR DESCRIPTION
## Summary

- Align IBKR REST BRACKET, OTO, and OCO order submission, tracking, and cancellation behavior with the established LumiBot order path.
- Correct Client Portal REST STOP and STOP_LIMIT price-field serialization.
- Add opt-in, paper-account-gated advanced-order smoke coverage.
- Add bounded acknowledgement reconciliation and safe cleanup for advanced order packages.
- Add a GTD `/orders/whatif` capability probe. REST GTD remains intentionally disabled because the paper probe was rejected.
- Document the authorized paper-test procedure and safety limits.

## Safety

- Paper tests require `IB_USE_PAPER_ACCOUNT=true` explicitly.
- The authenticated account must satisfy the paper-account identity gate.
- API tests remain excluded from ordinary CI.
- Diagnostics do not expose credentials, complete account IDs, or raw broker responses.

## Validation

- Deterministic IBKR REST tests: passed.
- `git diff --check`: passed.
- Authorized IBKR paper advanced-order test: passed; all submitted paper orders were cancelled with zero fills.
- No production or live-account testing was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Interactive Brokers REST support for BRACKET, OTO, and OCO orders, including tracking, polling, reconciliation, and cancellation.
  * Advanced-order legs now retain distinct broker identifiers and inherited expiration settings.
  * Added correct REST stop and stop-limit trigger-price handling.

* **Bug Fixes**
  * Improved handling and cleanup of partially acknowledged orders.
  * Corrected legacy Gateway expiration handling and fallback pricing.
  * REST GTD submissions now fail explicitly when unsupported.

* **Documentation**
  * Added REST and legacy order-semantics guides, safety requirements, and paper-trading validation runbooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->