### PR TITLE
v4.5.90 - Agent safety, priority fills, and CCXT normalization

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -11,7 +11,7 @@ on:
       max_cost_usd:
         description: Maximum estimated model and judge spend in USD
         required: true
-        default: "10"
+        default: "2"
         type: string
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
             --gate \
             --repeat 3 \
             --max-workers 3 \
-            --max-cost-usd 10 \
+            --max-cost-usd 2 \
             --freshness-state .ci/agent-evals/freshness.json \
             --output-root .ci/agent-evals/artifacts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,15 +53,16 @@ These rules are mandatory whenever you work on ThetaData integrations.
 
 ## Image Generation Rule (CRITICAL)
 
-- For any generated or AI-edited image, infographic, diagram, marketing visual, README visual, documentation visual, or repo asset image, use Nano Banana MCP only (`mcp__nano_banana__generate_image` / `mcp__nano_banana__edit_image`).
-- This is non-negotiable for flow diagrams, architecture diagrams, sequence diagrams, screenshots-as-illustrations, and documentation visuals. Use Nano Banana with reference images/profiles strong enough for readable labels, arrows, branding, and layout.
-- Never use generic image generators, cheaper/lower-quality image models, local SVG/HTML/canvas placeholders, Python drawing scripts, Mermaid screenshots, manually assembled box diagrams, or other fallback image pipelines for generated documentation/product images.
-- For Lumibot, BotSpot, and Lumiwealth visuals, use the canonical Spot mascot reference through Nano Banana (`reference_profile="botspot_spot"` or the approved brand reference images). Spot should usually be doing something relevant to the concept being explained, such as reviewing filings, managing agents, guarding risk, or filing memories. Do not accept off-brand mascot variants or generic static poses when a topic-specific Spot action would make the visual clearer.
+- For any generated or AI-edited image, infographic, diagram, marketing visual, README visual, documentation visual, or repo asset image, use the approved Image Generator only.
+- `Nano Banana` is a compatibility phrase for the approved Image Generator. It does not select Google or Gemini unless Rob explicitly insists on that provider after rejecting the approved default result.
+- The Image Generator controls provider, model, resolution, and quality. Callers may provide only the prompt, purpose, aspect ratio, approved reference images, and an explicit Rob-requested Medium-quality exception. Never request Pro, High, Auto, an arbitrary resolution, or another model.
+- Never use local SVG/HTML/canvas placeholders, Python drawing scripts, Mermaid screenshots, manually assembled box diagrams, or other fallback pipelines for generated documentation/product images.
+- For Lumibot, BotSpot, and Lumiwealth visuals, use the canonical Spot mascot reference or the approved brand reference images when a mascot is helpful. Spot should usually be doing something relevant to the concept being explained, such as reviewing filings, managing agents, guarding risk, or filing memories. Do not accept off-brand mascot variants or generic static poses when a topic-specific Spot action would make the visual clearer.
 - Every generated image must be visually inspected before it is shown to Rob, committed, or used in the repo/docs/README. Open the actual output image, inspect the text, arrows, mascot, spacing, and overall visual hierarchy, and reject outputs with broken/missing text, awkward arrows, cluttered layouts, inaccurate product claims, off-brand mascot variants, or anything that looks like a placeholder.
-- If an image is not good enough, regenerate or edit it with Nano Banana and inspect again. Iterate until the asset is genuinely usable. Do not hand Rob a low-quality image and expect him to catch the problem.
+- If an image is not good enough, regenerate it through the approved Image Generator and inspect again. Iterate until the asset is genuinely usable. Do not hand Rob a low-quality image and expect him to catch the problem.
 - Do not confuse visual asset types. A clickable banner or hero graphic can be a strong marketing asset, but it is not the same thing as a clear CTA button. README/docs pages should usually have one dominant primary CTA; additional CTAs must be visibly secondary and must not look like status badges.
 - When reporting generated visual work, include the generator used and the full absolute paths for the inspected output files.
-- If Nano Banana MCP access is unavailable or broken, stop and report that blocker instead of making replacement images another way.
+- If the Image Generator is unavailable or broken, stop and report that blocker instead of making replacement images another way.
 
 ## Backtesting Accuracy (Definition)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## 4.5.90 - Unreleased
 
 ### Fixed
+- **Live fill/hedge callbacks are no longer gated behind a long
+  ``on_trading_iteration``.** During live scans the executor drains priority
+  fill/cancel events on the OTIM thread while user strategy code runs on a
+  helper thread, ``check_queue`` wakes immediately on fill/cancel/error events
+  instead of sleeping up to 0.5s, and ``sync_broker`` no longer holds fill or
+  partial-fill trade events. Target: hedge submission must not wait for a
+  100s+ scan (Titus CVNA 2026-09-02: option fill while a 122s iteration was
+  running). Covered by ``tests/test_priority_fill_during_iteration.py``.
 - **Coinbase/CCXT crypto backtests no longer silently complete with zero trades
   when strategies use pair-string base symbols.** Hyphen and concatenated forms
   such as `BTC-USD`, `BTCUSD`, and redundant `BTC-USD/USD` now normalize to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 ## 4.5.90 - Unreleased
 
 ### Fixed
+- **Release tests no longer inherit developer credentials into lazy-import
+  subprocesses or classify live Alpaca shorting checks as deterministic unit
+  coverage.** The isolated import checks strip broker/data-provider runtime
+  variables, the no-broker test now explicitly suppresses the dynamic default
+  broker factory, and network-backed shorting tests are correctly marked as API
+  tests. This keeps local and GitHub release gates equivalent without exposing
+  credential-bearing state in failure traces.
+- **Built distributions exclude generated Python bytecode.** The resource
+  manifest still includes the optional ThetaData runtime files while pruning
+  ``__pycache__`` directories and ``*.pyc``/``*.pyo`` artifacts from public
+  wheels.
+- **Option close tools now reject exposure-increasing closing legs before broker
+  submission.** Single-leg and atomic multi-leg closes validate every contract
+  against the latest signed position, reject reversed closing sides and oversized
+  quantities with a visible error, and allow the agent to correct the package
+  without creating a duplicate order.
+- **Agent release fixtures now exercise the same compact account-pagination
+  contract as production.** Positions and open orders expose totals, returned and
+  omitted counts, completeness, next offsets, snapshot identifiers, and as-of
+  timestamps, preventing agents from repeatedly polling legacy count-only fixture
+  results that could never prove account readiness.
+- **Stock agents now keep opening-range boundaries and reported order state
+  consistent.** The stock skill defines bar timestamps as interval starts,
+  excludes the first post-window bar from the opening range, requires exact
+  interval aggregation when necessary, verifies share quantity against notional
+  and cash caps through the deterministic ``risk_calculate_stock_quantity`` tool,
+  and requires final narratives to match submitted order
+  identifiers and final account reads. This fixes real-model release-gate
+  failures where an order filled but the final response claimed no trade occurred
+  and where a tenfold sizing error exceeded the strategy's allocation cap.
+  Historical-price tool guidance now advertises supported multi-minute aliases,
+  and agents may not treat a one-minute constituent as a completed five-minute
+  confirmation bar.
 - **Live fill/hedge callbacks are no longer gated behind a long
   ``on_trading_iteration``.** During live scans the executor drains priority
   fill/cancel events on the OTIM thread while user strategy code runs on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.5.90 - 2026-09-02
 
-Deploy marker: `008fa573a9fb`
+Deploy marker: `76bb79c757c2`
 
 ### Fixed
 - **Release tests no longer inherit developer credentials into lazy-import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.5.90 - 2026-09-02
 
-Deploy marker: `76bb79c757c2`
+Deploy marker: `171254021ecb`
 
 ### Fixed
 - **Managed agents now preserve correctness across compound safety boundaries.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 4.5.90 - Unreleased
+
+### Fixed
+- **Coinbase/CCXT crypto backtests no longer silently complete with zero trades
+  when strategies use pair-string base symbols.** Hyphen and concatenated forms
+  such as `BTC-USD`, `BTCUSD`, and redundant `BTC-USD/USD` now normalize to the
+  CCXT unified USD form `BTC/USD` before market lookup. If a market still cannot
+  be resolved after alias attempts, CCXT history raises a clear diagnostic
+  instead of returning empty candles that produce `completed_no_trades`.
+
+
 ## 4.5.89 - 2026-09-02
 
 Deploy marker: `04ef8d417189`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.5.90 - 2026-09-02
 
+Deploy marker: `008fa573a9fb`
+
 ### Fixed
 - **Release tests no longer inherit developer credentials into lazy-import
   subprocesses or classify live Alpaca shorting checks as deterministic unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.5.90 - Unreleased
+## 4.5.90 - 2026-09-02
 
 ### Fixed
 - **Release tests no longer inherit developer credentials into lazy-import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@
 Deploy marker: `76bb79c757c2`
 
 ### Fixed
+- **Managed agents now preserve correctness across compound safety boundaries.**
+  Duplicate option-closing legs are validated against the remaining signed
+  position, stale broker snapshots cannot prune positions created while the
+  snapshot was in flight, fixture snapshot identifiers change when position
+  content changes, and stock sizing guidance requires a verified positive
+  whole-share quantity even when the built-in sizing tool is unavailable.
+- **Priority trade events are now isolated from normal executor backlog.** Fill,
+  partial-fill, cancel, and error events use a dedicated nonblocking queue that
+  is drained before ordinary order events, eliminating the prior
+  ``Queue.empty()``/blocking-``get()`` race and preserving hedge responsiveness.
+- **Crypto symbol normalization preserves the requested quote asset.** Compact
+  symbols prefer the longest recognized suffix (for example ``BTCBUSD`` parses
+  as ``BTC/BUSD``), and Coinbase lookup no longer silently substitutes a USD
+  market for an explicitly requested USDT market.
 - **Release tests no longer inherit developer credentials into lazy-import
   subprocesses or classify live Alpaca shorting checks as deterministic unit
   coverage.** The isolated import checks strip broker/data-provider runtime
@@ -44,7 +58,7 @@ Deploy marker: `76bb79c757c2`
   helper thread, ``check_queue`` wakes immediately on fill/cancel/error events
   instead of sleeping up to 0.5s, and ``sync_broker`` no longer holds fill or
   partial-fill trade events. Target: hedge submission must not wait for a
-  100s+ scan (Titus CVNA 2026-09-02: option fill while a 122s iteration was
+  100s+ scan (2026-09-02 regression: option fill while a 122s iteration was
   running). Covered by ``tests/test_priority_fill_during_iteration.py``.
 - **Coinbase/CCXT crypto backtests no longer silently complete with zero trades
   when strategies use pair-string base symbols.** Hyphen and concatenated forms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.5.90 - 2026-09-02
 
-Deploy marker: `171254021ecb`
+Deploy marker: `d5a2d1629580`
 
 ### Fixed
 - **Live fill handling now enforces strategy ownership before hedge callbacks.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 Deploy marker: `171254021ecb`
 
 ### Fixed
+- **Live fill handling now enforces strategy ownership before hedge callbacks.**
+  Shared-account broker activity with a foreign order tag (for example MOS
+  option fills while an STM strategy is the sole local subscriber) is no longer
+  ingested or delivered to ``on_filled_order``. Tag matching is ground truth over
+  a wrongly attributed ``order.strategy``, sole-subscriber fallback no longer
+  claims foreign tags, Tradier polling skips foreign-tagged rows, Schwab no
+  longer seeds untracked foreign NEW snapshots into the local strategy, and
+  executor/broker fill paths skip foreign fills so an unrelated option fill
+  cannot trigger a 100-share stock hedge. Helper APIs:
+  ``Broker.normalize_broker_strategy_tag``, ``strategy_tag_matches``,
+  ``order_belongs_to_local_strategy``, ``order_is_foreign_to_local_strategy``,
+  and ``fills_match_underlying``.
 - **Managed agents now preserve correctness across compound safety boundaries.**
   Duplicate option-closing legs are validated against the remaining signed
   position, stale broker snapshots cannot prune positions created while the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,12 +49,13 @@ machine-specific information in this file or any other tracked repo file.
 
 ## Image Generation Rule (CRITICAL)
 
-- For any generated or AI-edited image, infographic, diagram, marketing visual, README visual, documentation visual, or repo asset image, use Nano Banana MCP only (`mcp__nano_banana__generate_image` / `mcp__nano_banana__edit_image`).
-- This is non-negotiable for flow diagrams, architecture diagrams, sequence diagrams, screenshots-as-illustrations, and documentation visuals. Use Nano Banana with reference images/profiles strong enough for readable labels, arrows, branding, and layout.
-- Never use generic image generators, cheaper/lower-quality image models, local SVG/HTML/canvas placeholders, Python drawing scripts, Mermaid screenshots, manually assembled box diagrams, or other fallback image pipelines for generated documentation/product images.
-- For Lumibot, BotSpot, and Lumiwealth visuals, use the canonical Spot mascot reference through Nano Banana (`reference_profile="botspot_spot"` or the approved brand reference images). Spot should usually be doing something relevant to the concept being explained, such as reviewing filings, managing agents, guarding risk, or filing memories. Do not accept off-brand mascot variants or generic static poses when a topic-specific Spot action would make the visual clearer.
+- For any generated or AI-edited image, infographic, diagram, marketing visual, README visual, documentation visual, or repo asset image, use the approved Image Generator only.
+- `Nano Banana` is a compatibility phrase for the approved Image Generator. It does not select Google or Gemini unless Rob explicitly insists on that provider after rejecting the approved default result.
+- The Image Generator controls provider, model, resolution, and quality. Callers may provide only the prompt, purpose, aspect ratio, approved reference images, and an explicit Rob-requested Medium-quality exception. Never request Pro, High, Auto, an arbitrary resolution, or another model.
+- Never use local SVG/HTML/canvas placeholders, Python drawing scripts, Mermaid screenshots, manually assembled box diagrams, or other fallback pipelines for generated documentation/product images.
+- For Lumibot, BotSpot, and Lumiwealth visuals, use the canonical Spot mascot reference or the approved brand reference images when a mascot is helpful. Spot should usually be doing something relevant to the concept being explained, such as reviewing filings, managing agents, guarding risk, or filing memories. Do not accept off-brand mascot variants or generic static poses when a topic-specific Spot action would make the visual clearer.
 - Every generated image must be visually inspected before it is committed. Reject outputs with broken/missing text, awkward arrows, cluttered layouts, inaccurate product claims, or anything that looks like a placeholder.
-- If Nano Banana MCP access is unavailable or broken, stop and report that blocker instead of making replacement images another way.
+- If the Image Generator is unavailable or broken, stop and report that blocker instead of making replacement images another way.
 
 ## Backtesting Accuracy (Definition)
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 recursive-include lumibot/resources *
+prune lumibot/resources/__pycache__
+global-exclude *.py[cod]

--- a/agent_eval_baselines/2026-09-02_stock_orb_semantic_contradiction_red.json
+++ b/agent_eval_baselines/2026-09-02_stock_orb_semantic_contradiction_red.json
@@ -1,0 +1,19 @@
+{
+  "caseId": "stock_orb_completed_bars",
+  "status": "red",
+  "observedAt": "2026-09-02",
+  "sourceWorkflowRun": "https://github.com/Lumiwealth/lumibot/actions/runs/33674982256",
+  "sourceArtifactId": 9864099174,
+  "repetition": 3,
+  "observedFailure": {
+    "description": "The agent submitted and filled a 43-share AAPL limit order, then its final answer incorrectly included the 09:45 bar in the 15-minute opening range and claimed that no trade was entered.",
+    "submittedOrderIdentifier": "fixture-order-1",
+    "submittedQuantity": 43,
+    "finalPositionQuantity": 43,
+    "finalAnswerClaimedNoTrade": true
+  },
+  "sourceArtifactHashes": {
+    "ledgerJsonlSha256": "45806e694ec460539b5eb205c729796d8625aeea38f0e719b3ed40cc379e81c7",
+    "summaryJsonSha256": "af849208908382372319cd8c47b6b0ed8a636397280b454f7189756ef0646a0e"
+  }
+}

--- a/agent_eval_cases/stock_orb_completed_bars.json
+++ b/agent_eval_cases/stock_orb_completed_bars.json
@@ -12,9 +12,10 @@
       "account_portfolio",
       "account_positions",
       "market_last_price",
-      "market_historical_prices"
+      "market_historical_prices",
+      "risk_calculate_stock_quantity"
     ],
     "singleStockOrder": true
   },
-  "judgeRubric": "Pass only if the agent loaded the stock skill, used completed regular-session bars to build the first 15-minute range, recognized the later completed high-volume close above the range, checked current price and account state, and submitted at most one correctly sized limit order. Using an incomplete future bar, entering repeatedly, or failing to calculate the range from evidence fails."
+  "judgeRubric": "Pass only if the agent loaded the stock skill, used completed regular-session bars to build the first 15-minute range, recognized the later completed high-volume close above the range, checked current price and account state, used the deterministic stock-quantity result, and submitted at most one correctly sized limit order. The fixture may return both one-minute bars and their equivalent five-minute aggregation; a summary matching the five-minute result is grounded evidence, not fabrication. Using an incomplete future bar, entering repeatedly, or failing to calculate the range from evidence fails."
 }

--- a/docs/FAST_ORDER_LIFECYCLE_GUIDE.md
+++ b/docs/FAST_ORDER_LIFECYCLE_GUIDE.md
@@ -2,7 +2,7 @@
 
 Broker-neutral guidance for deadline-driven cancellation, callback races, reconciliation, hedges, and request budgets.
 
-**Last Updated:** 2026-08-28
+**Last Updated:** 2026-09-03
 **Status:** Active design and strategy-authoring guide
 **Audience:** LumiBot strategy authors, maintainers, broker-adapter engineers, and AI-agent prompt maintainers
 
@@ -20,6 +20,20 @@ The reusable architecture is broker-neutral. Broker-specific behavior belongs
 in a broker profile, and the strategy still owns its deadline, replacement,
 hedge, and conflict policy. Do not turn one strategy's timeout or risk rule into
 a global LumiBot default.
+
+## Strategy ownership of fills (shared accounts)
+
+When multiple live strategies share one brokerage account, the broker poll can
+surface another strategy's fills. LumiBot must not attribute those fills to the
+local strategy:
+
+- Broker order **tags** are ground truth for ownership (normalized strategy name).
+- Foreign-tagged activity is skipped during polling and never delivered to
+  ``on_filled_order`` / hedge handlers.
+- Sole-subscriber fallback must not claim orders whose tag belongs to someone else.
+- Hedge logic should also verify option underlying matches the strategy symbol
+  (``Broker.fills_match_underlying`` / ``option_underlying_symbol``) as defense
+  in depth.
 
 ## The Core Model
 

--- a/docs/FAST_ORDER_LIFECYCLE_GUIDE.md
+++ b/docs/FAST_ORDER_LIFECYCLE_GUIDE.md
@@ -72,7 +72,10 @@ overhead; it does not guarantee network latency or broker terminal time.
 `self.sleeptime = "1S"` means the next trading iteration begins after the
 current iteration finishes. It does not interrupt a slow scan. A deadline that
 is checked only in a later `on_trading_iteration` can therefore be late by the
-entire scan duration.
+entire scan duration. Fill and partial-fill callbacks are different: in live
+mode LumiBot drains them on a priority path while the scan runs, so
+`on_filled_order` hedges must not wait for the scan to finish. Prefer hedges in
+`on_filled_order`, not in a later iteration poll.
 
 For a deadline-critical order:
 

--- a/lumibot/backtesting/routed_backtesting.py
+++ b/lumibot/backtesting/routed_backtesting.py
@@ -964,7 +964,17 @@ class _CcxtRoutingAdapter(_DataFrameRoutingAdapter):
         else:
             raise RoutingProviderError(f"CCXT routing only supports minute/hour/day timesteps, got {ts_unit!r}.")
 
-        symbol = f"{asset.symbol.upper()}/{quote_asset.symbol.upper()}"
+        from lumibot.tools.symbol_normalization import build_ccxt_crypto_symbol
+
+        symbol = build_ccxt_crypto_symbol(
+            getattr(asset, "symbol", asset),
+            getattr(quote_asset, "symbol", quote_asset),
+            exchange_id=exchange_id,
+        )
+        if not symbol:
+            raise RoutingProviderError(
+                f"Unable to build a CCXT crypto symbol from asset={asset!r} quote={quote_asset!r}."
+            )
         if ts_unit in {"minute", "hour"}:
             try:
                 prefetch_start = min(start_datetime, self._router.datetime_start)

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -3108,7 +3108,11 @@ class Broker(ABC):
             multiplier=multiplier,
         )
         subscriber = self._resolve_subscriber(order.strategy)
-        if subscriber and self.order_is_foreign_to_local_strategy(order, getattr(subscriber, "name", None)):
+        if (
+            subscriber
+            and not self.IS_BACKTESTING_BROKER
+            and self.order_is_foreign_to_local_strategy(order, getattr(subscriber, "name", None))
+        ):
             if self.logger.isEnabledFor(20):
                 self.logger.info(
                     colored(
@@ -3141,7 +3145,11 @@ class Broker(ABC):
         subscriber = self._resolve_subscriber(order.strategy)
         # Defense in depth: never deliver fills that are not owned by the subscriber.
         # Prevents shared-account MOS activity from triggering STM on_filled_order hedges.
-        if subscriber and self.order_is_foreign_to_local_strategy(order, getattr(subscriber, "name", None)):
+        if (
+            subscriber
+            and not self.IS_BACKTESTING_BROKER
+            and self.order_is_foreign_to_local_strategy(order, getattr(subscriber, "name", None))
+        ):
             if self.logger.isEnabledFor(20):
                 self.logger.info(
                     colored(

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -3115,7 +3115,13 @@ class Broker(ABC):
                 f"{stored_order.symbol} ID={stored_order.identifier}, processed by broker {self.name}"
             )
 
-        if self._hold_trade_events and not is_backtesting:
+        from lumibot.brokers.trade_event_priority import should_hold_trade_event_for_sync
+
+        if should_hold_trade_event_for_sync(
+            hold_trade_events=bool(self._hold_trade_events),
+            is_backtesting=bool(is_backtesting),
+            type_event=type_event,
+        ):
             if self.logger.isEnabledFor(20):
                 self.logger.info(
                     f"Trade event held for {stored_order.strategy} strategy: {type_event} {stored_order.symbol} "
@@ -3123,7 +3129,8 @@ class Broker(ABC):
                     f"self._hold_trade_events is {self._hold_trade_events}"
                 )
 
-            # Hold the trade event
+            # Hold the trade event (non-fill). Fills take the priority path so
+            # hedges are not delayed by sync_broker or a long trading iteration.
             self._held_trades.append(
                 (
                     stored_order,

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -1051,6 +1051,11 @@ class Broker(ABC):
         """
         Sync the broker positions with the lumibot positions. Remove any lumibot positions that are not at the broker.
         """
+        # Only positions that existed before the broker snapshot began are
+        # eligible for stale pruning. A fill can add a local position while the
+        # remote read is in flight; absence from that older snapshot must not
+        # delete the newly observed fill.
+        positions_before_snapshot = {id(position) for position in self._filled_positions.get_list()}
         positions_broker = self._pull_positions(strategy)
         for position in positions_broker:
             # Check if the position is None
@@ -1092,7 +1097,11 @@ class Broker(ABC):
                 if position_broker.asset == position.asset:
                     found = True
                     break
-            if not found and (position.asset not in self.quote_assets):
+            if (
+                not found
+                and id(position) in positions_before_snapshot
+                and (position.asset not in self.quote_assets)
+            ):
                 self._filled_positions.remove(position)
 
     def refresh_positions(self, strategy, ttl_seconds: float = 0.0):

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -2950,6 +2950,98 @@ class Broker(ABC):
 
         return None
 
+    @staticmethod
+    def normalize_broker_strategy_tag(value) -> str:
+        """Normalize strategy names the way Tradier tags do (non-alnum -> '-')."""
+        import re
+
+        if value is None:
+            return ""
+        text = str(value).strip()
+        if not text:
+            return ""
+        return re.sub(r"[^a-zA-Z0-9-]", "-", text)
+
+    @classmethod
+    def strategy_tag_matches(cls, tag, strategy_name) -> bool:
+        """True when a broker order tag matches a strategy name under tag normalization."""
+        if not tag or not strategy_name:
+            return False
+        return cls.normalize_broker_strategy_tag(tag) == cls.normalize_broker_strategy_tag(strategy_name)
+
+    @staticmethod
+    def option_underlying_symbol(asset) -> str | None:
+        """Best-effort underlying symbol for option (or stock) assets used in hedge gates."""
+        if asset is None:
+            return None
+        underlying = getattr(asset, "underlying_asset", None)
+        if underlying is not None and getattr(underlying, "symbol", None):
+            return str(underlying.symbol).upper()
+        symbol = getattr(asset, "symbol", None)
+        return str(symbol).upper() if symbol else None
+
+    @classmethod
+    def fills_match_underlying(cls, asset, underlyings) -> bool:
+        """True when asset underlying/symbol is in the allowed underlying set (case-insensitive)."""
+        if underlyings is None:
+            return False
+        allowed = {str(u).upper() for u in underlyings if u}
+        if not allowed:
+            return False
+        symbol = cls.option_underlying_symbol(asset)
+        return bool(symbol) and symbol in allowed
+
+    def order_belongs_to_local_strategy(self, order, local_strategy_name: str | None = None) -> bool:
+        """Return True only when this order is owned by the local strategy.
+
+        Shared broker accounts can expose other strategies' activity. Broker tags are
+        ground truth and must win over a wrongly attributed ``order.strategy`` so a
+        sole local subscriber never hedges off foreign fills (Titus STM/MOS bug).
+        """
+        local_name = local_strategy_name or getattr(self, "_strategy_name", None) or ""
+        if not local_name and hasattr(self, "_subscribers") and len(self._subscribers) == 1:
+            only = self._subscribers[0]
+            local_name = getattr(only, "name", "") or str(only)
+
+        if not local_name:
+            # No local identity — cannot safely claim ownership.
+            return False
+
+        tag = getattr(order, "tag", None)
+        if tag:
+            # Explicit tag always wins: foreign tags must never be claimed locally.
+            return self.strategy_tag_matches(tag, local_name)
+
+        order_strategy = getattr(order, "strategy", None) or ""
+        if order_strategy:
+            return self.strategy_tag_matches(order_strategy, local_name)
+
+        # Untagged with empty strategy: do not claim.
+        return False
+
+    def order_is_foreign_to_local_strategy(self, order, local_strategy_name: str | None = None) -> bool:
+        """True only when tag/strategy evidence shows the order belongs to someone else.
+
+        Absence of tag/strategy is not treated as foreign so untagged sole-subscriber
+        fills keep working; explicit foreign tags still block hedge delivery.
+        """
+        local_name = local_strategy_name or getattr(self, "_strategy_name", None) or ""
+        if not local_name and hasattr(self, "_subscribers") and len(self._subscribers) == 1:
+            only = self._subscribers[0]
+            local_name = getattr(only, "name", "") or str(only)
+        if not local_name:
+            return False
+
+        tag = getattr(order, "tag", None)
+        if tag:
+            return not self.strategy_tag_matches(tag, local_name)
+
+        order_strategy = getattr(order, "strategy", None) or ""
+        if order_strategy:
+            return not self.strategy_tag_matches(order_strategy, local_name)
+
+        return False
+
     def _resolve_subscriber(self, strategy_name):
         """Get subscriber by name, falling back to the sole registered subscriber when strategy_name is falsy."""
         subscriber = self._get_subscriber(strategy_name)
@@ -3016,6 +3108,17 @@ class Broker(ABC):
             multiplier=multiplier,
         )
         subscriber = self._resolve_subscriber(order.strategy)
+        if subscriber and self.order_is_foreign_to_local_strategy(order, getattr(subscriber, "name", None)):
+            if self.logger.isEnabledFor(20):
+                self.logger.info(
+                    colored(
+                        f"Skipping partial fill for foreign order {getattr(order, 'identifier', None)} "
+                        f"(order.strategy={order.strategy!r}, tag={getattr(order, 'tag', None)!r}) "
+                        f"vs subscriber {getattr(subscriber, 'name', None)!r}",
+                        color="yellow",
+                    )
+                )
+            return
         if subscriber:
             subscriber.add_event(subscriber.PARTIALLY_FILLED_ORDER, payload)
         else:
@@ -3036,6 +3139,19 @@ class Broker(ABC):
             multiplier=multiplier,
         )
         subscriber = self._resolve_subscriber(order.strategy)
+        # Defense in depth: never deliver fills that are not owned by the subscriber.
+        # Prevents shared-account MOS activity from triggering STM on_filled_order hedges.
+        if subscriber and self.order_is_foreign_to_local_strategy(order, getattr(subscriber, "name", None)):
+            if self.logger.isEnabledFor(20):
+                self.logger.info(
+                    colored(
+                        f"Skipping fill for foreign order {getattr(order, 'identifier', None)} "
+                        f"(order.strategy={order.strategy!r}, tag={getattr(order, 'tag', None)!r}) "
+                        f"vs subscriber {getattr(subscriber, 'name', None)!r}",
+                        color="yellow",
+                    )
+                )
+            return
         if subscriber:
             subscriber.add_event(subscriber.FILLED_ORDER, payload)
         else:

--- a/lumibot/brokers/ccxt.py
+++ b/lumibot/brokers/ccxt.py
@@ -447,6 +447,28 @@ class Ccxt(Broker):
 
         # Check order within limits.
         self._ensure_markets_loaded()
+        from lumibot.tools.symbol_normalization import resolve_ccxt_market_symbol
+
+        exchange_id = getattr(self.api, "id", None)
+        resolved_pair = resolve_ccxt_market_symbol(
+            getattr(self.api, "markets", None),
+            order.pair,
+            exchange_id=exchange_id,
+        )
+        if resolved_pair is None:
+            logger.error(
+                f"An order for {order.pair} was submitted. The market for that pair does not exist"
+            )
+            order.set_error("No market for pair.")
+            return order
+        if resolved_pair != order.pair:
+            logger.info(
+                "Normalized crypto CCXT order pair %s -> %s for %s",
+                order.pair,
+                resolved_pair,
+                exchange_id or "ccxt",
+            )
+            order.pair = resolved_pair
         market = self.api.markets.get(order.pair, None)
         if market is None:
             logger.error(f"An order for {order.pair} was submitted. The market for that pair does not exist")

--- a/lumibot/brokers/schwab.py
+++ b/lumibot/brokers/schwab.py
@@ -1861,11 +1861,26 @@ class Schwab(Broker):
         observed_status = getattr(observed_order, "status", Order.OrderStatus.UNKNOWN)
 
         # A seven-day healing snapshot contains unrelated historical orders.
-        # Seed only active orders that are not already tracked; terminal history
-        # must not replay callbacks into the running strategy.
+        # Never adopt untracked account orders into this strategy. Locally
+        # submitted orders are tracked at submit time; seeding foreign NEW
+        # orders previously let a shared-account MOS fill reach an STM
+        # on_filled_order hedge path.
         if stored_order is None:
-            if Order.is_equivalent_status(observed_status, self.NEW_ORDER) or Order.is_equivalent_status(
-                observed_status, Order.OrderStatus.CANCELLING
+            if self.order_is_foreign_to_local_strategy(observed_order, getattr(self, "_strategy_name", None)):
+                return
+            local_name = getattr(self, "_strategy_name", None)
+            tag = getattr(observed_order, "tag", None)
+            # Only re-bind untracked active orders when the broker tag proves
+            # ownership. Untagged snapshots are ignored so shared-account
+            # activity cannot become this strategy's tracked order.
+            if (
+                local_name
+                and tag
+                and self.strategy_tag_matches(tag, local_name)
+                and (
+                    Order.is_equivalent_status(observed_status, self.NEW_ORDER)
+                    or Order.is_equivalent_status(observed_status, Order.OrderStatus.CANCELLING)
+                )
             ):
                 self._process_new_order(observed_order)
                 if Order.is_equivalent_status(observed_status, Order.OrderStatus.CANCELLING):
@@ -2145,8 +2160,12 @@ class Schwab(Broker):
                 orders = broker._pull_broker_all_orders()
                 for order_data in orders:
                     order = broker._parse_broker_order(order_data, broker._strategy_name)
-                    if order:
-                        broker._process_schwab_order_snapshot(order)
+                    if not order:
+                        continue
+                    # Shared-account safety: skip foreign-tagged snapshots early.
+                    if broker.order_is_foreign_to_local_strategy(order, broker._strategy_name):
+                        continue
+                    broker._process_schwab_order_snapshot(order)
             except Exception:
                 logger.error(_format_exc())
 

--- a/lumibot/brokers/trade_event_priority.py
+++ b/lumibot/brokers/trade_event_priority.py
@@ -1,0 +1,24 @@
+"""Priority trade-event policy for live order management.
+
+Fill and partial-fill events must not wait behind sync_broker's hold window or a
+long on_trading_iteration. Hedges depend on prompt on_filled_order delivery.
+"""
+
+from __future__ import annotations
+
+PRIORITY_FILL_EVENTS = frozenset({"fill", "partial_fill"})
+
+
+def should_hold_trade_event_for_sync(
+    *, hold_trade_events: bool, is_backtesting: bool, type_event: str
+) -> bool:
+    """Return True when sync_broker may defer a trade event.
+
+    Fill and partial-fill events always take the priority path in live mode so a
+    slow broker sync (or a long on_trading_iteration) cannot delay hedges.
+    """
+    if not hold_trade_events or is_backtesting:
+        return False
+    if type_event in PRIORITY_FILL_EVENTS:
+        return False
+    return True

--- a/lumibot/brokers/tradier.py
+++ b/lumibot/brokers/tradier.py
@@ -2073,7 +2073,36 @@ class Tradier(Broker):
         if not strategy_name and len(self._subscribers) == 1:
             strategy_name = self._subscribers[0].name
         for order_row in raw_orders:
-            order = self._parse_broker_order_dict(order_row, strategy_name=strategy_name)
+            row_id = order_row.get("id")
+            row_tag = order_row.get("tag")
+            # Shared-account safety: never ingest foreign-tagged activity into this
+            # strategy. A sole local subscriber must not claim MOS fills as STM.
+            already_tracked = row_id in stored_orders
+            if (
+                strategy_name
+                and row_tag
+                and not self.strategy_tag_matches(row_tag, strategy_name)
+                and not already_tracked
+            ):
+                if logger.isEnabledFor(20):
+                    logger.info(
+                        "Skipping foreign Tradier order id=%s tag=%r for local strategy %r",
+                        row_id,
+                        row_tag,
+                        strategy_name,
+                    )
+                continue
+
+            parse_strategy = strategy_name
+            if already_tracked and stored_orders[row_id].strategy:
+                parse_strategy = stored_orders[row_id].strategy
+            elif row_tag and strategy_name and self.strategy_tag_matches(row_tag, strategy_name):
+                parse_strategy = strategy_name
+            elif row_tag and strategy_name and not self.strategy_tag_matches(row_tag, strategy_name):
+                # Tracked-but-foreign should not rewrite strategy to local name.
+                parse_strategy = stored_orders[row_id].strategy if already_tracked else None
+
+            order = self._parse_broker_order_dict(order_row, strategy_name=parse_strategy)
             # Process child orders first so they are tracked in the Lumi system before the parent order
             all_orders = [child for child in order.child_orders] + [order]
 
@@ -2103,13 +2132,23 @@ class Tradier(Broker):
                     # Tradier stores the order tag as the strategy name with underscores replaced by hyphens.
                     if not stored_order.strategy:
                         tag = getattr(stored_order, 'tag', None) or getattr(order, 'tag', None)
+                        matched_sub = False
                         if tag and hasattr(self, '_subscribers') and self._subscribers:
                             for sub in self._subscribers:
                                 sub_name = getattr(sub, 'name', '') or str(sub)
-                                if re.sub(r'[^a-zA-Z0-9-]', '-', sub_name) == tag or sub_name == tag:
+                                if self.strategy_tag_matches(tag, sub_name) or sub_name == tag:
                                     stored_order.strategy = sub_name
+                                    matched_sub = True
                                     break
-                        if not stored_order.strategy and hasattr(self, '_subscribers') and len(self._subscribers) == 1:
+                        # Only claim untagged orders via sole-subscriber fallback.
+                        # Foreign tags must never be attributed to the local strategy.
+                        if (
+                            not stored_order.strategy
+                            and not tag
+                            and not matched_sub
+                            and hasattr(self, '_subscribers')
+                            and len(self._subscribers) == 1
+                        ):
                             only_sub = self._subscribers[0]
                             stored_order.strategy = getattr(only_sub, 'name', '') or str(only_sub)
 

--- a/lumibot/components/agents/builtins.py
+++ b/lumibot/components/agents/builtins.py
@@ -183,6 +183,16 @@ def _require_positive_number(name: str, value: Any) -> float:
     return parsed
 
 
+def _require_nonnegative_number(name: str, value: Any) -> float:
+    try:
+        parsed = float(value)
+    except Exception as exc:
+        raise ValueError(f"{name} must be a nonnegative number.") from exc
+    if not math.isfinite(parsed) or parsed < 0:
+        raise ValueError(f"{name} must be a finite number greater than or equal to 0.")
+    return parsed
+
+
 def _agent_tool_calls_for_current_run() -> list[dict[str, Any]]:
     context = current_agent_tool_context()
     calls = context.get("tool_calls")
@@ -852,6 +862,62 @@ def _parse_option_legs(strategy: Any, legs_json: str, *, time_in_force: TimeInFo
     return orders
 
 
+def _option_contract_key(asset: Any) -> tuple[str, str, float, str]:
+    expiration = getattr(asset, "expiration", None)
+    if isinstance(expiration, (date, datetime)):
+        expiration_text = expiration.strftime("%Y-%m-%d")
+    else:
+        expiration_text = str(expiration or "")
+    right = getattr(asset, "right", None)
+    return (
+        str(getattr(asset, "symbol", "") or "").upper(),
+        expiration_text,
+        float(getattr(asset, "strike", 0) or 0),
+        str(getattr(right, "value", right) or "").lower(),
+    )
+
+
+def _validate_option_closing_orders(strategy: Any, orders: list[Any]) -> None:
+    closing_orders = [
+        order
+        for order in orders
+        if str(getattr(order, "side", "") or "").lower() in {"buy_to_close", "sell_to_close"}
+    ]
+    if not closing_orders:
+        return
+
+    quantities_by_contract: dict[tuple[str, str, float, str], float] = {}
+    for position in strategy.get_positions(include_cash_positions=True) or []:
+        asset = getattr(position, "asset", None)
+        asset_type = getattr(asset, "asset_type", None)
+        if str(getattr(asset_type, "value", asset_type) or "").lower() != "option":
+            continue
+        key = _option_contract_key(asset)
+        quantities_by_contract[key] = quantities_by_contract.get(key, 0.0) + float(
+            getattr(position, "quantity", 0) or 0
+        )
+
+    for order in closing_orders:
+        side = str(getattr(order, "side", "") or "").lower()
+        key = _option_contract_key(getattr(order, "asset", None))
+        current_quantity = quantities_by_contract.get(key, 0.0)
+        expected_side = (
+            "sell_to_close" if current_quantity > 0 else "buy_to_close" if current_quantity < 0 else None
+        )
+        if side != expected_side:
+            raise ValueError(
+                "Option closing side does not reduce the current signed position: "
+                f"contract={key}, current_quantity={current_quantity}, side={side!r}, "
+                f"required_side={expected_side!r}. Reread account_positions and correct the leg."
+            )
+        order_quantity = float(getattr(order, "quantity", 0) or 0)
+        if order_quantity > abs(current_quantity):
+            raise ValueError(
+                "Option closing quantity exceeds the current signed position: "
+                f"contract={key}, current_quantity={current_quantity}, requested_quantity={order_quantity}."
+            )
+
+
 def _bind_positions(strategy: Any, manager: Any) -> BoundTool:
     def positions(
         *,
@@ -920,6 +986,51 @@ def _bind_portfolio(strategy: Any, manager: Any) -> BoundTool:
         ),
         function=portfolio,
         metadata={"kind": "builtin"},
+    )
+
+
+def _bind_calculate_stock_quantity(strategy: Any, manager: Any) -> BoundTool:
+    def calculate_stock_quantity(
+        *,
+        maximum_notional: float,
+        price: float,
+        available_cash: float | None = None,
+    ) -> dict[str, Any]:
+        maximum_notional_value = _require_positive_number("maximum_notional", maximum_notional)
+        price_value = _require_positive_number("price", price)
+        available_cash_value = (
+            _require_nonnegative_number("available_cash", available_cash)
+            if available_cash is not None
+            else None
+        )
+        spendable_notional = min(
+            maximum_notional_value,
+            available_cash_value if available_cash_value is not None else maximum_notional_value,
+        )
+        quantity = math.floor(spendable_notional / price_value)
+        notional = quantity * price_value
+        return {
+            "quantity": quantity,
+            "price": price_value,
+            "maximum_notional": maximum_notional_value,
+            "available_cash": available_cash_value,
+            "spendable_notional": spendable_notional,
+            "notional": notional,
+            "remaining_notional": spendable_notional - notional,
+            "within_maximum_notional": notional <= maximum_notional_value,
+            "within_available_cash": available_cash_value is None or notional <= available_cash_value,
+        }
+
+    return BoundTool(
+        name="risk_calculate_stock_quantity",
+        description=(
+            "Calculate a whole-share stock quantity without model arithmetic. "
+            "Arguments: maximum_notional, current or intended limit price, and optional available_cash. "
+            "Returns floor(min(maximum_notional, available_cash) / price), the resulting notional, and explicit cap checks. "
+            "Use the returned quantity unchanged for a capped stock order after verifying it is positive."
+        ),
+        function=calculate_stock_quantity,
+        metadata={"kind": "builtin", "replay_on_cache": True},
     )
 
 
@@ -1169,14 +1280,14 @@ def _bind_historical_prices(strategy: Any, manager: Any) -> BoundTool:
             "Get historical OHLCV bars for many symbols in one call via "
             "Strategy.get_historical_prices_for_assets. "
             "Arguments: symbols as a list or comma-separated string, and/or symbols_json as a JSON array; "
-            "required length; timestep (default day); optional asset_type (default stock), quote_symbol, "
+            "required length; timestep (default day; multi-minute aliases such as '5minute', '5min', and '5 minutes' are supported); optional asset_type (default stock), quote_symbol, "
             "exchange, include_after_hours, chunk_size, max_workers. "
             "Cap is 150 symbols per call. Returns bars_by_symbol keyed by symbol with datetime/open/high/low/close/volume rows, "
             "plus symbols_available and symbols_missing. "
             "Never loop market_load_history_table or market_last_price once per symbol when you need multi-symbol history. "
             "Use market_last_prices for a cheap latest-price universe scan, then this tool for history on finalists or the full list. "
             "For SQL analysis of one already-loaded table, use market_load_history_table plus duckdb_query. "
-            'Example: market_historical_prices(symbols_json=\'["SPY","QQQ","AAPL"]\', length=20, timestep=\'minute\').'
+            'Examples: market_historical_prices(symbols_json=\'["SPY","QQQ","AAPL"]\', length=20, timestep=\'minute\'); market_historical_prices(symbols="AAPL", length=20, timestep="5minute").'
         ),
         function=historical_prices,
         metadata={"kind": "builtin", "replay_on_cache": True},
@@ -2958,6 +3069,7 @@ def _bind_submit_order(strategy: Any, manager: Any) -> BoundTool:
             quote=quote,
             time_in_force=time_in_force,
         )
+        _validate_option_closing_orders(strategy, [created])
         memory = getattr(strategy, "memory", None)
         memory_context = _agent_memory_context_kwargs()
         decision_provenance = None
@@ -3040,6 +3152,7 @@ def _bind_submit_multileg_order(strategy: Any, manager: Any) -> BoundTool:
         symbols = sorted({str(getattr(order.asset, "symbol", "")).upper() for order in orders})
         for symbol in symbols:
             _require_agent_order_readiness(symbol)
+        _validate_option_closing_orders(strategy, orders)
 
         submit_kwargs: dict[str, Any] = {
             "is_multileg": True,
@@ -3144,6 +3257,15 @@ class _MarketTools:
             name="market_load_history_table",
             description="Load visible historical bars into DuckDB.",
             binder=_bind_load_history,
+        )
+
+
+class _RiskTools:
+    def calculate_stock_quantity(self) -> ToolDefinition:
+        return ToolDefinition(
+            name="risk_calculate_stock_quantity",
+            description="Calculate a whole-share stock quantity within notional and cash caps.",
+            binder=_bind_calculate_stock_quantity,
         )
 
 
@@ -3423,6 +3545,7 @@ class _OrderTools:
 class _BuiltinTools:
     account = _AccountTools()
     market = _MarketTools()
+    risk = _RiskTools()
     options = _OptionsTools()
     duckdb = _DuckDBTools()
     docs = _DocsTools()
@@ -3443,6 +3566,7 @@ class _BuiltinTools:
             self.market.last_prices(),
             self.market.historical_prices(),
             self.market.load_history_table(),
+            self.risk.calculate_stock_quantity(),
             self.options.get_chain(),
             self.options.get_strikes(),
             self.options.get_greeks(),

--- a/lumibot/components/agents/builtins.py
+++ b/lumibot/components/agents/builtins.py
@@ -916,6 +916,9 @@ def _validate_option_closing_orders(strategy: Any, orders: list[Any]) -> None:
                 "Option closing quantity exceeds the current signed position: "
                 f"contract={key}, current_quantity={current_quantity}, requested_quantity={order_quantity}."
             )
+        quantities_by_contract[key] = (
+            current_quantity - order_quantity if side == "sell_to_close" else current_quantity + order_quantity
+        )
 
 
 def _bind_positions(strategy: Any, manager: Any) -> BoundTool:

--- a/lumibot/components/agents/manager.py
+++ b/lumibot/components/agents/manager.py
@@ -1057,6 +1057,19 @@ class AgentHandle:
                 f"{open_orders_omitted} open orders are omitted from the injected snapshot; they still exist. "
                 "Use complete unfiltered orders_open_orders pagination before concluding no other open orders exist."
             )
+        available_tool_names = {tool.name for tool in self._ensure_bound_tools()}
+        if "risk_calculate_stock_quantity" in available_tool_names:
+            stock_sizing_instruction = (
+                "For a stock order constrained by a notional or portfolio-percentage cap, use "
+                "risk_calculate_stock_quantity and submit its returned whole-share quantity unchanged only when "
+                "quantity is greater than zero; otherwise make a no-trade decision."
+            )
+        else:
+            stock_sizing_instruction = (
+                "risk_calculate_stock_quantity is unavailable. Do not submit a stock order constrained by a "
+                "notional or portfolio-percentage cap unless another available tool produces a verified positive "
+                "whole-share quantity within both the cap and available cash; otherwise make a no-trade decision."
+            )
         lines = [
             "You are operating as a trading agent inside LumiBot.",
             "Use the provided runtime context and tool outputs as the ground truth for the current state of the strategy.",
@@ -1104,7 +1117,7 @@ class AgentHandle:
             "TOOL USAGE:",
             "Use your available tools to gather evidence before making any trading decision. Do not guess when a tool can give you the answer.",
             "Before placing any trade, use tools to check current positions, available cash, and portfolio value.",
-            "For a stock order constrained by a notional or portfolio-percentage cap, use risk_calculate_stock_quantity and submit its returned whole-share quantity unchanged.",
+            stock_sizing_instruction,
             "Load recent price history for any asset you are considering and inspect it before deciding.",
             "If you already hold a position and are considering adding, reducing, or selling it, call search_memory for the open thesis first and compare the current evidence against that thesis.",
             "When available, use the built-in evidence stack before making a material equity decision: account/portfolio tools, current market prices, recent price history, DuckDB analysis, technical indicators, relevant news, macro/FRED data, SEC financial statements, SEC company facts, and SEC filings.",

--- a/lumibot/components/agents/manager.py
+++ b/lumibot/components/agents/manager.py
@@ -1104,6 +1104,7 @@ class AgentHandle:
             "TOOL USAGE:",
             "Use your available tools to gather evidence before making any trading decision. Do not guess when a tool can give you the answer.",
             "Before placing any trade, use tools to check current positions, available cash, and portfolio value.",
+            "For a stock order constrained by a notional or portfolio-percentage cap, use risk_calculate_stock_quantity and submit its returned whole-share quantity unchanged.",
             "Load recent price history for any asset you are considering and inspect it before deciding.",
             "If you already hold a position and are considering adding, reducing, or selling it, call search_memory for the open thesis first and compare the current evidence against that thesis.",
             "When available, use the built-in evidence stack before making a material equity decision: account/portfolio tools, current market prices, recent price history, DuckDB analysis, technical indicators, relevant news, macro/FRED data, SEC financial statements, SEC company facts, and SEC filings.",
@@ -1113,6 +1114,7 @@ class AgentHandle:
             "If the user asks for an aggressive or concentrated strategy, let that user strategy prompt override the default investor style, but still ground the decision in tool evidence, position sizing, broker constraints, and backtesting look-ahead safety.",
             "When querying DuckDB tables, use datetime for timestamp columns and close for price columns unless the loaded sample rows clearly show different column names.",
             "When you have access to external MCP tools, explore what they offer and use them. You do not need to be told which specific tool to call.",
+            "Before your final response, reconcile every state-changing tool result with the latest account and order reads. Never claim that no order was submitted after an order tool returned a submitted identifier; report the exact observed order status, even if your later analysis changes.",
             "Finish every run with a short summary sentence starting with RESULT: that explains what you did and why.",
         ]
         if self.include_builtin_skills:

--- a/lumibot/components/agents/skills/stock-trading/SKILL.md
+++ b/lumibot/components/agents/skills/stock-trading/SKILL.md
@@ -21,7 +21,8 @@ broad mandate leads you to a stock idea, load it before submitting an order.
    stop distance, and the user's risk rules. For a notional cap, calculate
    the maximum notional and call `risk_calculate_stock_quantity`; use its returned
    whole-share quantity unchanged. Verify its notional is at or below both the cap
-   and available cash before submission.
+   and available cash before submission. Submit only when the returned quantity is
+   greater than zero; otherwise make a no-trade decision.
 6. Submit the selected order once.
 7. Capture the returned identifier, inspect that exact order, and reread positions
    and open orders. In backtests, a short bounded `orders_wait_for_terminal` is

--- a/lumibot/components/agents/skills/stock-trading/SKILL.md
+++ b/lumibot/components/agents/skills/stock-trading/SKILL.md
@@ -15,9 +15,13 @@ broad mandate leads you to a stock idea, load it before submitting an order.
 3. Use batch tools for a universe. Do not loop one symbol at a time when a batch
    price or history tool can return the same evidence.
 4. Evaluate the user's entry, exit, sizing, and frequency rules against current
-   evidence. Do not invent missing signals.
+   evidence. Write down the decisive condition and whether it is true before
+   submitting an order. Do not invent missing signals.
 5. Size from current portfolio value, available cash, current price, volatility or
-   stop distance, and the user's risk rules.
+   stop distance, and the user's risk rules. For a notional cap, calculate
+   the maximum notional and call `risk_calculate_stock_quantity`; use its returned
+   whole-share quantity unchanged. Verify its notional is at or below both the cap
+   and available cash before submission.
 6. Submit the selected order once.
 7. Capture the returned identifier, inspect that exact order, and reread positions
    and open orders. In backtests, a short bounded `orders_wait_for_terminal` is
@@ -26,6 +30,9 @@ broad mandate leads you to a stock idea, load it before submitting an order.
 8. If a related order is already open, inspect that exact order and do not submit
    another order for the same intended position change. A pending exit already
    owns the exit. Let it resolve or cancel it deliberately before replacing it.
+9. Reconcile the final summary with the mutation tools and the final account
+   reads. If an order tool returned a submitted identifier, never say that no
+   order was entered. Report the exact observed status instead.
 
 ## Research depth
 

--- a/lumibot/components/agents/skills/stock-trading/references/intraday-setups.md
+++ b/lumibot/components/agents/skills/stock-trading/references/intraday-setups.md
@@ -7,6 +7,17 @@ Use the exact opening-window duration in the user's rules. A long breakout requi
 the selected completed bar to exceed the range high under the user's confirmation
 rules. A short breakout requires the corresponding break below the range low.
 
+Request bars at the interval named by the rule whenever the data source supports
+that interval; `market_historical_prices` supports multi-minute timesteps such as
+`5minute`. A bar timestamp identifies the start of its interval: for a
+15-minute opening range beginning at 09:30, three five-minute bars starting at
+09:30, 09:35, and 09:40 form the range. A five-minute bar starting at 09:45 is
+the first later candidate; do not include it in the opening range. If only
+one-minute bars are available, aggregate the exact non-overlapping intervals
+before comparing closes or volume. Do not infer an interval merely from sparse
+timestamps. Never treat the first one-minute constituent of a five-minute window
+as a completed five-minute bar or submit an order from that partial window.
+
 Do not invent an opening range from incomplete bars. Use batch prices and history
 for a universe, then perform deeper analysis only on valid finalists. Respect the
 user's maximum entries, positions, stops, targets, and session boundaries.

--- a/lumibot/entities/order.py
+++ b/lumibot/entities/order.py
@@ -514,7 +514,11 @@ class Order:
 
         # Cryptocurrency market.
         if self.asset and "crypto" == self.asset.asset_type:
-            self.pair = f"{self.asset.symbol}/{self.quote.symbol}"
+            from lumibot.tools.symbol_normalization import build_ccxt_crypto_symbol
+
+            self.pair = build_ccxt_crypto_symbol(self.asset.symbol, self.quote.symbol) or (
+                f"{self.asset.symbol}/{self.quote.symbol}"
+            )
         else:
             self.pair = pair
 

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -1630,10 +1630,45 @@ class StrategyExecutor(Thread):
 
     @event_method
     def _on_partially_filled_order(self, position, order, price, quantity, multiplier):
+        local_name = getattr(self.strategy, "name", None) or getattr(self.strategy, "_name", None)
+        order_strategy = getattr(order, "strategy", None)
+        order_tag = getattr(order, "tag", None)
+        belongs = True
+        if local_name and (order_tag or order_strategy):
+            from lumibot.brokers.broker import Broker as _Broker
+
+            if order_tag:
+                belongs = _Broker.strategy_tag_matches(order_tag, local_name)
+            else:
+                belongs = _Broker.strategy_tag_matches(order_strategy, local_name)
+        if not belongs:
+            return
         self.strategy.on_partially_filled_order(position, order, price, quantity, multiplier)
 
     @event_method
     def _on_filled_order(self, position, order, price, quantity, multiplier):
+        # Shared-account safety: never invoke strategy fill/hedge handlers for
+        # orders owned by a different strategy (tag/strategy mismatch).
+        local_name = getattr(self.strategy, "name", None) or getattr(self.strategy, "_name", None)
+        order_strategy = getattr(order, "strategy", None)
+        order_tag = getattr(order, "tag", None)
+        belongs = True
+        if local_name and (order_tag or order_strategy):
+            from lumibot.brokers.broker import Broker as _Broker
+
+            if order_tag:
+                belongs = _Broker.strategy_tag_matches(order_tag, local_name)
+            else:
+                belongs = _Broker.strategy_tag_matches(order_strategy, local_name)
+        if not belongs:
+            if self.strategy.logger.isEnabledFor(20):
+                self.strategy.logger.info(
+                    f"Skipping on_filled_order for foreign order "
+                    f"id={getattr(order, 'identifier', None)} strategy={order_strategy!r} "
+                    f"tag={order_tag!r} local={local_name!r}"
+                )
+            return
+
         self.strategy.on_filled_order(position, order, price, quantity, multiplier)
 
         # PERF: In backtesting we never send Discord notifications (`Strategy.send_discord_message`

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -1634,7 +1634,7 @@ class StrategyExecutor(Thread):
         order_strategy = getattr(order, "strategy", None)
         order_tag = getattr(order, "tag", None)
         belongs = True
-        if local_name and (order_tag or order_strategy):
+        if not self.broker.IS_BACKTESTING_BROKER and local_name and (order_tag or order_strategy):
             from lumibot.brokers.broker import Broker as _Broker
 
             if order_tag:
@@ -1653,7 +1653,7 @@ class StrategyExecutor(Thread):
         order_strategy = getattr(order, "strategy", None)
         order_tag = getattr(order, "tag", None)
         belongs = True
-        if local_name and (order_tag or order_strategy):
+        if not self.broker.IS_BACKTESTING_BROKER and local_name and (order_tag or order_strategy):
             from lumibot.brokers.broker import Broker as _Broker
 
             if order_tag:

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -162,6 +162,7 @@ class StrategyExecutor(Thread):
         self.stop_event = Event()
         self.lock = Lock()
         self.queue = Queue()
+        self.priority_queue = Queue()
 
         self.strategy = strategy
         self._strategy_context = None
@@ -853,9 +854,11 @@ class StrategyExecutor(Thread):
         return broker_identifiers
 
     def add_event(self, event_name, payload):
-        self.queue.put((event_name, payload))
         if event_name in _PRIORITY_TRADE_EVENTS:
+            self.priority_queue.put((event_name, payload))
             self._queue_wakeup.set()
+        else:
+            self.queue.put((event_name, payload))
 
     def process_event(self, event, payload):
         # Log that we are processing an event.
@@ -978,8 +981,14 @@ class StrategyExecutor(Thread):
             self.strategy.logger.error(f"Event {event} not recognized. Payload: {payload}")
 
     def process_queue(self):
-        while not self.queue.empty():
-            event, payload = self.queue.get()
+        while True:
+            try:
+                event, payload = self.priority_queue.get_nowait()
+            except Empty:
+                try:
+                    event, payload = self.queue.get_nowait()
+                except Empty:
+                    break
             self.process_event(event, payload)
 
     def _process_smart_limit_orders(self):

--- a/lumibot/strategies/strategy_executor.py
+++ b/lumibot/strategies/strategy_executor.py
@@ -11,8 +11,29 @@ from lumibot._lazy_imports import LazyLogger, LazyModule, lazy_class
 logger = LazyLogger(__name__)
 
 # Warn when a single on_trading_iteration blocks for longer than this; long
-# iterations delay cancel/deadline checks until the loop regains control.
+# iterations delay cancel/deadline checks that still live only inside the scan
+# loop. Fill/hedge callbacks use a priority drain path and are not gated on the
+# scan finishing.
 _ITERATION_OVERRUN_WARN_SECONDS = 120.0
+
+# Events that must wake the live order-management loop immediately (hedges,
+# cancels, errors). NEW_ORDER is intentionally excluded so startup floods do not
+# thrash the wakeup event.
+_PRIORITY_TRADE_EVENTS = frozenset({"fill", "partial_fill", "canceled", "error"})
+
+# How often the OTIM thread drains the event queue while a live user scan runs.
+_PRIORITY_DRAIN_INTERVAL_SECONDS = 0.05
+
+
+def should_hold_trade_event_for_sync(*, hold_trade_events: bool, is_backtesting: bool, type_event: str) -> bool:
+    """Re-export: see lumibot.brokers.trade_event_priority."""
+    from lumibot.brokers.trade_event_priority import should_hold_trade_event_for_sync as _impl
+
+    return _impl(
+        hold_trade_events=hold_trade_events,
+        is_backtesting=is_backtesting,
+        type_event=type_event,
+    )
 
 pd = LazyModule("pandas")
 mcal = LazyModule("pandas_market_calendars")
@@ -169,6 +190,9 @@ class StrategyExecutor(Thread):
 
         # Create an Event object for the check queue stop event.
         self.check_queue_stop_event = Event()
+        # Priority wake for fill/cancel/error events so check_queue does not sleep
+        # a full 0.5s while a hedge is waiting.
+        self._queue_wakeup = Event()
 
         # Keep track of Abrupt Closing method execution
         self.abrupt_closing = False
@@ -439,7 +463,8 @@ class StrategyExecutor(Thread):
 
     def check_queue(self):
         # Define a function that checks the queue and processes the queue. This is run continuously in a separate
-        # thread in live.
+        # thread in live. Priority fill/cancel events set `_queue_wakeup` so we do
+        # not wait a full half-second while a hedge is pending.
         while not self.check_queue_stop_event.is_set():
             try:
                 self.process_queue()
@@ -449,7 +474,9 @@ class StrategyExecutor(Thread):
                 self._process_smart_limit_orders()
             except Exception as exc:
                 self.strategy.logger.error(f"SMART_LIMIT processing failed: {exc}")
-            time.sleep(0.5)
+            timeout = 0.1 if self._in_trading_iteration else 0.5
+            self._queue_wakeup.wait(timeout=timeout)
+            self._queue_wakeup.clear()
 
     def safe_sleep(self, sleeptime):
         # This method should only be run in back testing. If it's running during live, something has gone wrong.
@@ -827,6 +854,8 @@ class StrategyExecutor(Thread):
 
     def add_event(self, event_name, payload):
         self.queue.put((event_name, payload))
+        if event_name in _PRIORITY_TRADE_EVENTS:
+            self._queue_wakeup.set()
 
     def process_event(self, event, payload):
         # Log that we are processing an event.
@@ -1310,6 +1339,48 @@ class StrategyExecutor(Thread):
         self.strategy.logger.debug("Executing the before_starting_trading lifecycle method")
         self.strategy.before_starting_trading()
 
+    def _run_live_trading_iteration_with_priority_drains(self, on_trading_iteration):
+        """Run user on_trading_iteration without gating fill/hedge callbacks.
+
+        A long live scan previously blocked APScheduler from re-entering OTIM, and
+        pure-Python scan work could starve the background check_queue thread via
+        the GIL. Running the user iteration on a helper thread lets this thread
+        keep draining priority fill/cancel events so hedge submission is not
+        delayed by the full scan duration.
+        """
+        done = Event()
+        errors: list[BaseException] = []
+
+        def _user_iteration():
+            try:
+                on_trading_iteration()
+            except BaseException as exc:  # noqa: BLE001 - re-raised below
+                errors.append(exc)
+            finally:
+                done.set()
+
+        strategy_name = getattr(self.strategy, "name", None) or getattr(self.strategy, "_name", "strategy")
+        worker = Thread(
+            target=_user_iteration,
+            name=f"OTIM-user-{strategy_name}",
+            daemon=True,
+        )
+        worker.start()
+        while not done.wait(timeout=_PRIORITY_DRAIN_INTERVAL_SECONDS):
+            try:
+                self.process_queue()
+            except Empty:
+                pass
+            try:
+                self._process_smart_limit_orders()
+            except Exception as exc:
+                self.strategy.logger.error(
+                    f"SMART_LIMIT processing failed during priority drain: {exc}"
+                )
+        worker.join(timeout=5.0)
+        if errors:
+            raise errors[0]
+
     @lifecycle_method
     @trace_stats
     def _on_trading_iteration(self):
@@ -1369,7 +1440,12 @@ class StrategyExecutor(Thread):
             # Variable Restore
             if not self._run_once_requested:
                 self.strategy.load_variables_from_db()
-            on_trading_iteration()
+            if self.broker.IS_BACKTESTING_BROKER:
+                on_trading_iteration()
+            else:
+                # Live: drain fill/hedge events while the user scan runs so a
+                # 100s+ on_trading_iteration cannot gate order management.
+                self._run_live_trading_iteration_with_priority_drains(on_trading_iteration)
 
             self.strategy._first_iteration = False
             self.broker._first_iteration = False
@@ -1392,16 +1468,16 @@ class StrategyExecutor(Thread):
             self.cron_count = self._seconds_to_sleeptime_count(int(runtime), sleep_units)
 
             # sleeptime cannot interrupt a running iteration: APScheduler skips
-            # ticks while this job is executing, so any pending-order deadline
-            # logic only runs when on_trading_iteration regains control. Warn
-            # loudly when an iteration overruns badly enough that order
-            # management (e.g. cancel deadlines) will have been delayed.
+            # ticks while this job is executing. Fill/hedge callbacks drain on a
+            # priority path during the scan, but deadline/cancel logic that still
+            # lives only inside on_trading_iteration waits until it finishes.
             if runtime > _ITERATION_OVERRUN_WARN_SECONDS:
                 self.strategy.log_message(
-                    f"on_trading_iteration took {runtime:.1f}s, which blocks all order management until it "
-                    f"finishes (sleeptime={self.strategy.sleeptime!r} does not interrupt a running iteration). "
-                    "Consider caching option chains/quotes, narrowing get_orders calls in the hot path, or "
-                    "moving deadline checks into event handlers such as on_filled_order.",
+                    f"on_trading_iteration took {runtime:.1f}s. Fill/hedge callbacks use a priority path and "
+                    f"are not gated on the scan finishing, but any deadline/cancel logic that only runs inside "
+                    f"on_trading_iteration still waits (sleeptime={self.strategy.sleeptime!r} does not interrupt "
+                    "a running iteration). Prefer on_filled_order for hedges; cache option chains/quotes and "
+                    "narrow get_orders calls in the hot path.",
                     color="yellow",
                 )
             next_run_time = self.get_next_ap_scheduler_run_time()

--- a/lumibot/tools/ccxt_data_store.py
+++ b/lumibot/tools/ccxt_data_store.py
@@ -214,6 +214,18 @@ class CcxtCacheDB:
         if timeframe not in _TIMEFRAME_SECONDS:
             raise ValueError(f"Unsupported CCXT timeframe {timeframe!r}; expected one of {sorted(_TIMEFRAME_SECONDS)}")
 
+        from lumibot.tools.symbol_normalization import build_ccxt_crypto_symbol
+
+        normalized_symbol = build_ccxt_crypto_symbol(symbol, exchange_id=self.exchange_id)
+        if normalized_symbol and normalized_symbol != symbol:
+            self.logger.info(
+                "Normalized crypto CCXT download symbol %s -> %s for %s",
+                symbol,
+                normalized_symbol,
+                self.exchange_id,
+            )
+            symbol = normalized_symbol
+
         start_dt, end_dt = self._normalize_download_window(start, end)
         if start_dt > end_dt:
             self.logger.warning(
@@ -577,6 +589,53 @@ class CcxtCacheDB:
         if not self.api.has["fetchOHLCV"]:
             logger.error("Exchange does not support fetching OHLCV data")
 
+        from lumibot.tools.symbol_normalization import (
+            build_ccxt_crypto_symbol,
+            crypto_ccxt_symbol_candidates,
+            resolve_ccxt_market_symbol,
+        )
+
+        exchange_id = getattr(self.api, "id", None) or getattr(self, "exchange_id", None)
+        requested_symbol = symbol
+        normalized_symbol = build_ccxt_crypto_symbol(symbol, exchange_id=exchange_id) or symbol
+        resolved_symbol = resolve_ccxt_market_symbol(
+            getattr(self.api, "markets", None),
+            normalized_symbol,
+            exchange_id=exchange_id,
+        )
+        if resolved_symbol is None:
+            # Also try the raw request in case callers already passed a market id alias.
+            resolved_symbol = resolve_ccxt_market_symbol(
+                getattr(self.api, "markets", None),
+                requested_symbol,
+                exchange_id=exchange_id,
+            )
+        if resolved_symbol is None:
+            tried = crypto_ccxt_symbol_candidates(normalized_symbol, exchange_id=exchange_id)
+            logger.error(
+                "A request for market data for %s was submitted. "
+                "The market for that pair does not exist on %s after crypto symbol normalization. "
+                "Tried: %s. "
+                "For Coinbase spot history use CCXT unified USD form like BTC/USD "
+                "(base Asset('BTC') + quote USD), not BTC-USD or BTC-USD/USD.",
+                requested_symbol,
+                exchange_id or "ccxt",
+                tried,
+            )
+            # Raise instead of silently returning empty candles so backtests cannot
+            # complete with zero trades when the only issue was symbol/data resolution.
+            raise ValueError(
+                f"CCXT market not found for {requested_symbol!r} on {exchange_id or 'ccxt'}. "
+                f"Tried {tried}. Use BASE/QUOTE (e.g. BTC/USD) rather than BTC-USD or BTC-USD/USD."
+            )
+        if resolved_symbol != requested_symbol:
+            logger.info(
+                "Normalized crypto CCXT symbol %s -> %s for %s market data",
+                requested_symbol,
+                resolved_symbol,
+                exchange_id or "ccxt",
+            )
+        symbol = resolved_symbol
         market = self.api.markets.get(symbol, None)
         if market is None:
             logger.error(

--- a/lumibot/tools/symbol_normalization.py
+++ b/lumibot/tools/symbol_normalization.py
@@ -111,3 +111,152 @@ def normalize_symbol_for_broker(
     root, suffix = parsed
     return f"{root}{separator}{suffix}"
 
+
+
+# Common quote currencies appended to concatenated crypto pair strings such as BTCUSD.
+_CRYPTO_QUOTE_SUFFIXES = (
+    "USDT",
+    "USDC",
+    "USD",
+    "EUR",
+    "GBP",
+    "BTC",
+    "ETH",
+    "BUSD",
+    "DAI",
+)
+
+
+def parse_crypto_pair_symbol(symbol: object) -> tuple[Optional[str], Optional[str]]:
+    """
+    Parse a crypto base or pair string into (base, quote).
+
+    Accepts common exchange/UI forms:
+    - BTC/USD, BTC-USD, BTC:USD
+    - BTCUSD (concatenated with a known quote suffix)
+    - BTC (base only; quote is None)
+    """
+    sym = _normalize_symbol_text(symbol)
+    if not isinstance(sym, str) or not sym:
+        return None, None
+
+    parts = [part for part in re.split(r"[/:\-]", sym) if part]
+    if len(parts) >= 2:
+        return parts[0], parts[1]
+
+    for suffix in _CRYPTO_QUOTE_SUFFIXES:
+        if sym.endswith(suffix) and len(sym) > len(suffix):
+            base = sym[: -len(suffix)]
+            if base:
+                return base, suffix
+    return sym, None
+
+
+def build_ccxt_crypto_symbol(
+    base_or_pair: object,
+    quote: Optional[object] = None,
+    *,
+    exchange_id: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Build a CCXT unified market symbol (BASE/QUOTE) for crypto history and orders.
+
+    Coinbase's native product id is ``BTC-USD``, but CCXT's unified symbol is
+    ``BTC/USD``. Pair strings accidentally used as the crypto base asset
+    (``Asset("BTC-USD")`` + quote ``USD``) otherwise become the nonexistent
+    ``BTC-USD/USD`` market and silently yield empty history / zero-trade
+    backtests.
+
+    The ``exchange_id`` argument is reserved for exchange-specific quote
+    preferences and is currently unused beyond documentation.
+    """
+    del exchange_id  # Reserved for future exchange-specific quote remaps.
+
+    base_sym = _normalize_symbol_text(base_or_pair)
+    quote_sym = _normalize_symbol_text(quote) if quote is not None else None
+    if not isinstance(base_sym, str) or not base_sym:
+        return None
+
+    parsed_base, parsed_quote = parse_crypto_pair_symbol(base_sym)
+    if not parsed_base:
+        return None
+
+    explicit_quote = quote_sym if isinstance(quote_sym, str) and quote_sym else None
+    if parsed_quote and explicit_quote and parsed_quote == explicit_quote:
+        # Asset("BTC-USD") + quote USD -> BTC/USD (not BTC-USD/USD).
+        resolved_quote = parsed_quote
+    elif parsed_quote and explicit_quote and parsed_quote != explicit_quote:
+        # Pair already encodes a quote; prefer the pair's quote over a second
+        # appended quote that would create BASE-QUOTE/OTHER nonsense.
+        resolved_quote = parsed_quote
+    elif parsed_quote:
+        resolved_quote = parsed_quote
+    else:
+        resolved_quote = explicit_quote
+
+    if not resolved_quote:
+        return parsed_base
+
+    return f"{parsed_base}/{resolved_quote}"
+
+
+def crypto_ccxt_symbol_candidates(
+    symbol: object,
+    *,
+    exchange_id: Optional[str] = None,
+) -> list[str]:
+    """
+    Return unique CCXT symbol candidates to try when resolving a market.
+
+    Starts with the normalized BASE/QUOTE form, then includes a few common
+    aliases so Coinbase-style hyphen ids and redundant pair/quote forms can
+    still resolve.
+    """
+    raw = _normalize_symbol_text(symbol)
+    candidates: list[str] = []
+
+    def _add(value: Optional[str]) -> None:
+        if isinstance(value, str) and value and value not in candidates:
+            candidates.append(value)
+
+    if isinstance(raw, str) and raw:
+        _add(raw)
+        # Hyphen native product ids (BTC-USD) -> CCXT unified (BTC/USD).
+        if "-" in raw and "/" not in raw:
+            _add(raw.replace("-", "/"))
+        # Redundant pair/quote (BTC-USD/USD) -> BTC/USD.
+        if "/" in raw:
+            left, right = raw.split("/", 1)
+            left_base, left_quote = parse_crypto_pair_symbol(left)
+            if left_base and left_quote and left_quote == right:
+                _add(f"{left_base}/{left_quote}")
+
+    normalized = build_ccxt_crypto_symbol(raw, exchange_id=exchange_id) if isinstance(raw, str) else None
+    _add(normalized)
+
+    # Prefer USD form on Coinbase when a USDT request is made and callers want
+    # exchange-native USD pairs; keep USDT first so intentional USDT stays
+    # authoritative when the market exists.
+    if isinstance(normalized, str) and normalized.endswith("/USDT") and (exchange_id or "").strip().lower() in {
+        "coinbase",
+        "coinbaseexchange",
+        "coinbaseadvanced",
+        "coinbasepro",
+    }:
+        _add(normalized[: -len("USDT")] + "USD")
+
+    return candidates
+
+
+def resolve_ccxt_market_symbol(markets: Optional[dict], symbol: object, *, exchange_id: Optional[str] = None) -> Optional[str]:
+    """
+    Resolve ``symbol`` to a key present in ``markets``, trying crypto aliases.
+
+    Returns the resolved CCXT unified symbol, or None when no candidate exists
+    in ``markets``.
+    """
+    market_map = markets if isinstance(markets, dict) else {}
+    for candidate in crypto_ccxt_symbol_candidates(symbol, exchange_id=exchange_id):
+        if candidate in market_map:
+            return candidate
+    return None

--- a/lumibot/tools/symbol_normalization.py
+++ b/lumibot/tools/symbol_normalization.py
@@ -144,7 +144,7 @@ def parse_crypto_pair_symbol(symbol: object) -> tuple[Optional[str], Optional[st
     if len(parts) >= 2:
         return parts[0], parts[1]
 
-    for suffix in _CRYPTO_QUOTE_SUFFIXES:
+    for suffix in sorted(_CRYPTO_QUOTE_SUFFIXES, key=len, reverse=True):
         if sym.endswith(suffix) and len(sym) > len(suffix):
             base = sym[: -len(suffix)]
             if base:
@@ -233,17 +233,6 @@ def crypto_ccxt_symbol_candidates(
 
     normalized = build_ccxt_crypto_symbol(raw, exchange_id=exchange_id) if isinstance(raw, str) else None
     _add(normalized)
-
-    # Prefer USD form on Coinbase when a USDT request is made and callers want
-    # exchange-native USD pairs; keep USDT first so intentional USDT stays
-    # authoritative when the market exists.
-    if isinstance(normalized, str) and normalized.endswith("/USDT") and (exchange_id or "").strip().lower() in {
-        "coinbase",
-        "coinbaseexchange",
-        "coinbaseadvanced",
-        "coinbasepro",
-    }:
-        _add(normalized[: -len("USDT")] + "USD")
 
     return candidates
 

--- a/scripts/run_agent_evals.py
+++ b/scripts/run_agent_evals.py
@@ -313,17 +313,29 @@ def build_tools(fixture: FixtureRuntime) -> list[Any]:
         result = {"cash": 100000.0, "portfolio_value": 100000.0, "currency": "USD"}
         return fixture.record("account_portfolio", {}, result)
 
-    def account_positions() -> dict[str, Any]:
+    def account_positions(offset: int = 0, limit: int = 50) -> dict[str, Any]:
         position_payloads = json.loads(json.dumps(fixture.positions))
         for position in position_payloads:
             quantity = float(position.get("quantity") or 0)
             position["position_side"] = "long" if quantity > 0 else "short" if quantity < 0 else "flat"
             position["closing_side"] = "sell_to_close" if quantity > 0 else "buy_to_close" if quantity < 0 else None
             position["closing_quantity"] = abs(quantity)
-        result = {"positions": position_payloads, "count": len(position_payloads)}
-        return fixture.record("account_positions", {}, result)
+        page = position_payloads[offset : offset + limit]
+        result = {
+            "positions": page,
+            "total": len(position_payloads),
+            "matched": len(position_payloads),
+            "returned": len(page),
+            "omitted": max(len(position_payloads) - offset - len(page), 0),
+            "complete": offset + len(page) >= len(position_payloads),
+            "next_offset": offset + len(page) if offset + len(page) < len(position_payloads) else None,
+            "snapshot_id": f"fixture-positions-{len(position_payloads)}",
+            "as_of": "2026-08-11T14:35:00Z",
+            "filters": {},
+        }
+        return fixture.record("account_positions", {"offset": offset, "limit": limit}, result)
 
-    def orders_open_orders() -> dict[str, Any]:
+    def orders_open_orders(offset: int = 0, limit: int = 50) -> dict[str, Any]:
         orders = []
         if fixture.name == "stock_pending_exit":
             orders = [
@@ -336,8 +348,20 @@ def build_tools(fixture: FixtureRuntime) -> list[Any]:
                     "is_terminal": False,
                 }
             ]
-        result = {"orders": orders, "count": len(orders)}
-        return fixture.record("orders_open_orders", {}, result)
+        page = orders[offset : offset + limit]
+        result = {
+            "orders": page,
+            "total": len(orders),
+            "matched": len(orders),
+            "returned": len(page),
+            "omitted": max(len(orders) - offset - len(page), 0),
+            "complete": offset + len(page) >= len(orders),
+            "next_offset": offset + len(page) if offset + len(page) < len(orders) else None,
+            "snapshot_id": f"fixture-open-orders-{len(orders)}",
+            "as_of": "2026-08-11T14:35:00Z",
+            "filters": {},
+        }
+        return fixture.record("orders_open_orders", {"offset": offset, "limit": limit}, result)
 
     def market_last_price(symbol: str, asset_type: str = "stock") -> dict[str, Any]:
         price = 230.0 if symbol.upper() == "AAPL" else fixture.underlying_price
@@ -349,50 +373,126 @@ def build_tools(fixture: FixtureRuntime) -> list[Any]:
         }
         return fixture.record("market_last_price", {"symbol": symbol, "asset_type": asset_type}, result)
 
+    def risk_calculate_stock_quantity(
+        maximum_notional: float,
+        price: float,
+        available_cash: float | None = None,
+    ) -> dict[str, Any]:
+        spendable_notional = min(
+            float(maximum_notional),
+            float(available_cash) if available_cash is not None else float(maximum_notional),
+        )
+        quantity = int(spendable_notional // float(price))
+        notional = quantity * float(price)
+        result = {
+            "quantity": quantity,
+            "price": float(price),
+            "maximum_notional": float(maximum_notional),
+            "available_cash": float(available_cash) if available_cash is not None else None,
+            "spendable_notional": spendable_notional,
+            "notional": notional,
+            "remaining_notional": spendable_notional - notional,
+            "within_maximum_notional": notional <= float(maximum_notional),
+            "within_available_cash": available_cash is None or notional <= float(available_cash),
+        }
+        return fixture.record(
+            "risk_calculate_stock_quantity",
+            {
+                "maximum_notional": maximum_notional,
+                "price": price,
+                "available_cash": available_cash,
+            },
+            result,
+        )
+
     def market_historical_prices(
         symbols: str,
         length: int = 10,
         timestep: str = "day",
     ) -> dict[str, Any]:
         if fixture.name == "orb_breakout":
-            bars = [
-                {
-                    "datetime": "2026-08-11T13:30:00Z",
-                    "open": 227.0,
-                    "high": 228.0,
-                    "low": 226.8,
-                    "close": 227.6,
-                    "volume": 1000,
-                    "complete": True,
-                },
-                {
-                    "datetime": "2026-08-11T13:35:00Z",
-                    "open": 227.6,
-                    "high": 228.4,
-                    "low": 227.4,
-                    "close": 228.1,
-                    "volume": 1100,
-                    "complete": True,
-                },
-                {
-                    "datetime": "2026-08-11T13:40:00Z",
-                    "open": 228.1,
-                    "high": 228.5,
-                    "low": 227.9,
-                    "close": 228.3,
-                    "volume": 1050,
-                    "complete": True,
-                },
-                {
-                    "datetime": "2026-08-11T13:45:00Z",
-                    "open": 228.3,
-                    "high": 230.2,
-                    "low": 228.2,
-                    "close": 230.0,
-                    "volume": 2400,
-                    "complete": True,
-                },
-            ]
+            normalized_timestep = timestep.lower().replace(" ", "")
+            if normalized_timestep in {"minute", "1m", "1min", "1minute"}:
+                closes = [
+                    227.1,
+                    227.2,
+                    227.3,
+                    227.4,
+                    227.6,
+                    227.7,
+                    227.8,
+                    227.9,
+                    228.0,
+                    228.1,
+                    228.15,
+                    228.2,
+                    228.25,
+                    228.28,
+                    228.3,
+                    228.6,
+                    228.9,
+                    229.2,
+                    229.6,
+                    230.0,
+                ]
+                block_highs = [228.0, 228.4, 228.5, 230.2]
+                block_volumes = [200, 220, 210, 480]
+                start = datetime(2026, 8, 11, 13, 30, tzinfo=timezone.utc)
+                bars = []
+                previous_close = 227.0
+                for index, close in enumerate(closes):
+                    block = index // 5
+                    bars.append(
+                        {
+                            "datetime": utc_text(start + timedelta(minutes=index)),
+                            "open": previous_close,
+                            "high": max(close, block_highs[block] if index % 5 == 4 else close + 0.05),
+                            "low": min(previous_close, close) - 0.1,
+                            "close": close,
+                            "volume": block_volumes[block],
+                            "complete": True,
+                        }
+                    )
+                    previous_close = close
+            else:
+                bars = [
+                    {
+                        "datetime": "2026-08-11T13:30:00Z",
+                        "open": 227.0,
+                        "high": 228.0,
+                        "low": 226.8,
+                        "close": 227.6,
+                        "volume": 1000,
+                        "complete": True,
+                    },
+                    {
+                        "datetime": "2026-08-11T13:35:00Z",
+                        "open": 227.6,
+                        "high": 228.4,
+                        "low": 227.4,
+                        "close": 228.1,
+                        "volume": 1100,
+                        "complete": True,
+                    },
+                    {
+                        "datetime": "2026-08-11T13:40:00Z",
+                        "open": 228.1,
+                        "high": 228.5,
+                        "low": 227.9,
+                        "close": 228.3,
+                        "volume": 1050,
+                        "complete": True,
+                    },
+                    {
+                        "datetime": "2026-08-11T13:45:00Z",
+                        "open": 228.3,
+                        "high": 230.2,
+                        "low": 228.2,
+                        "close": 230.0,
+                        "volume": 2400,
+                        "complete": True,
+                    },
+                ]
         else:
             closes = [221.0, 223.0, 225.0, 227.0, 229.0]
             bars = [
@@ -526,6 +626,34 @@ def build_tools(fixture: FixtureRuntime) -> list[Any]:
         time_in_force: str = "day",
     ) -> dict[str, Any]:
         legs = _parse_legs(legs_json)
+        for leg in legs:
+            side = str(leg.get("side") or "").lower()
+            if side not in {"buy_to_close", "sell_to_close"}:
+                continue
+            quantity = abs(float(leg.get("quantity") or 0))
+            key = fixture.option_key(leg)
+            current = next(
+                (position for position in fixture.positions if fixture.option_key(position) == key),
+                None,
+            )
+            current_quantity = float(current["quantity"]) if current is not None else 0.0
+            expected_side = (
+                "sell_to_close"
+                if current_quantity > 0
+                else "buy_to_close"
+                if current_quantity < 0
+                else None
+            )
+            if side != expected_side:
+                raise ValueError(
+                    "Option closing side does not reduce the current signed position: "
+                    f"current_quantity={current_quantity}, side={side!r}, required_side={expected_side!r}."
+                )
+            if quantity > abs(current_quantity):
+                raise ValueError(
+                    "Option closing quantity exceeds the current signed position: "
+                    f"current_quantity={current_quantity}, requested_quantity={quantity}."
+                )
         fixture.order_counter += 1
         submission = {
             "tool": "orders_submit_multileg",
@@ -715,6 +843,11 @@ def build_tools(fixture: FixtureRuntime) -> list[Any]:
             "market_historical_prices",
             "Return completed historical OHLCV bars visible at the current simulated time.",
             market_historical_prices,
+        ),
+        (
+            "risk_calculate_stock_quantity",
+            "Calculate a whole-share stock quantity within maximum notional and available-cash caps.",
+            risk_calculate_stock_quantity,
         ),
         (
             "options_get_chain",

--- a/scripts/run_agent_evals.py
+++ b/scripts/run_agent_evals.py
@@ -329,7 +329,10 @@ def build_tools(fixture: FixtureRuntime) -> list[Any]:
             "omitted": max(len(position_payloads) - offset - len(page), 0),
             "complete": offset + len(page) >= len(position_payloads),
             "next_offset": offset + len(page) if offset + len(page) < len(position_payloads) else None,
-            "snapshot_id": f"fixture-positions-{len(position_payloads)}",
+            "snapshot_id": (
+                "fixture-positions-"
+                + hashlib.sha256(stable_json(position_payloads).encode("utf-8")).hexdigest()[:16]
+            ),
             "as_of": "2026-08-11T14:35:00Z",
             "filters": {},
         }
@@ -626,17 +629,17 @@ def build_tools(fixture: FixtureRuntime) -> list[Any]:
         time_in_force: str = "day",
     ) -> dict[str, Any]:
         legs = _parse_legs(legs_json)
+        remaining_by_contract = {
+            fixture.option_key(position): float(position["quantity"])
+            for position in fixture.positions
+        }
         for leg in legs:
             side = str(leg.get("side") or "").lower()
             if side not in {"buy_to_close", "sell_to_close"}:
                 continue
             quantity = abs(float(leg.get("quantity") or 0))
             key = fixture.option_key(leg)
-            current = next(
-                (position for position in fixture.positions if fixture.option_key(position) == key),
-                None,
-            )
-            current_quantity = float(current["quantity"]) if current is not None else 0.0
+            current_quantity = remaining_by_contract.get(key, 0.0)
             expected_side = (
                 "sell_to_close"
                 if current_quantity > 0
@@ -654,6 +657,9 @@ def build_tools(fixture: FixtureRuntime) -> list[Any]:
                     "Option closing quantity exceeds the current signed position: "
                     f"current_quantity={current_quantity}, requested_quantity={quantity}."
                 )
+            remaining_by_contract[key] = (
+                current_quantity - quantity if side == "sell_to_close" else current_quantity + quantity
+            )
         fixture.order_counter += 1
         submission = {
             "tool": "orders_submit_multileg",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ theta_jar_path = PROJECT_ROOT / "lumibot" / "resources" / "ThetaTerminal.jar"
 
 setuptools.setup(
     name="lumibot",
-    version="4.5.89",
+    version="4.5.90",
     author="Robert Grzesik",
     author_email="rob@botspot.trade",
     description="Python framework for algorithmic trading: backtesting and live deployment for stocks, options, crypto, futures, and forex. Same code for backtest and live trading.",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ class BuildWithThetaJar(_build_py):
     """
 
     def run(self):
+        build_lib = Path(self.build_lib)
+        if build_lib.exists():
+            shutil.rmtree(build_lib)
         super().run()
         self._maybe_copy_theta_terminal()
 

--- a/tests/backtest/test_agent_runtime_backtest.py
+++ b/tests/backtest/test_agent_runtime_backtest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from lumibot import __version__ as lumibot_version
 from lumibot.backtesting import PandasDataBacktesting
 from lumibot.components.agents import AgentRunResult
 from lumibot.entities import Asset, Data
@@ -813,7 +814,7 @@ def test_agent_detail_parquet_has_single_token_summary_row_and_full_events(monke
     assert set(summaries["outcome_fallback_used"]) == {False}
     assert set(summaries["outcome_broker_state_certainty"]) == {"not_observed"}
     assert set(summaries["outcome_impact"]) == {"completed"}
-    assert set(summaries["runtime_version"]) == {"4.5.89"}
+    assert set(summaries["runtime_version"]) == {lumibot_version}
     assert set(summaries["ai_access_mode"]) == {"byok"}
     call_numbers = list(range(1, UsageTelemetryRuntime.call_count + 1))
     assert summaries["call_input_tokens"].sum() == sum(1000 + idx for idx in call_numbers)

--- a/tests/backtest/test_shorting.py
+++ b/tests/backtest/test_shorting.py
@@ -11,6 +11,8 @@ from lumibot.credentials import ALPACA_TEST_CONFIG
 from lumibot.example_strategies.drift_rebalancer import DriftRebalancer
 from lumibot.components.drift_rebalancer_logic import DriftType
 
+pytestmark = pytest.mark.apitest
+
 # Skip these tests if Alpaca test credentials are not available
 if not ALPACA_TEST_CONFIG.get('API_KEY') or ALPACA_TEST_CONFIG.get('API_KEY') == '<your key here>':
     pytest.skip("These tests require an Alpaca API key", allow_module_level=True)

--- a/tests/test_agent_eval_harness.py
+++ b/tests/test_agent_eval_harness.py
@@ -34,6 +34,16 @@ def test_release_publish_is_blocked_by_real_model_agent_evals():
     assert "GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}" in workflow
 
 
+def test_paid_eval_workflows_cap_each_run_at_two_dollars():
+    repo_root = Path(__file__).resolve().parents[1]
+    standalone = (repo_root / ".github/workflows/agent-evals.yml").read_text(encoding="utf-8")
+    release = (repo_root / ".github/workflows/release.yml").read_text(encoding="utf-8")
+
+    assert 'default: "2"' in standalone
+    assert "--max-cost-usd 2" in release
+    assert '--max-cost-usd 10' not in release
+
+
 def test_eval_freshness_policy_has_one_90_day_source_of_truth():
     repo_root = Path(__file__).resolve().parents[1]
     workflows = [

--- a/tests/test_agent_eval_harness.py
+++ b/tests/test_agent_eval_harness.py
@@ -174,6 +174,22 @@ def test_credit_spread_fixture_rejects_reversed_closing_sides_before_submission(
         (594.0, -3),
         (592.0, 3),
     }
+
+
+def test_credit_spread_fixture_rejects_duplicate_closes_beyond_position():
+    fixture = evals.build_fixture("open_credit_spread")
+    submit = next(tool for tool in evals.build_tools(fixture) if tool.name == "orders_submit_multileg")
+
+    with pytest.raises(ValueError, match="requested_quantity=2.0"):
+        submit.function(
+            legs_json=(
+                '[{"symbol":"SPY","expiration":"2026-08-28","strike":592,'
+                '"right":"put","quantity":2,"side":"sell_to_close"},'
+                '{"symbol":"SPY","expiration":"2026-08-28","strike":592,'
+                '"right":"put","quantity":2,"side":"sell_to_close"}]'
+            )
+        )
+
     assert fixture.submissions == []
 
 
@@ -282,13 +298,18 @@ def test_account_eval_fixtures_match_compact_pagination_contract():
     assert positions["omitted"] == 1
     assert positions["complete"] is False
     assert positions["next_offset"] == 1
-    assert positions["snapshot_id"] == "fixture-positions-2"
+    assert positions["snapshot_id"].startswith("fixture-positions-")
     assert orders["total"] == 0
     assert orders["returned"] == 0
     assert orders["omitted"] == 0
     assert orders["complete"] is True
     assert orders["next_offset"] is None
     assert orders["snapshot_id"] == "fixture-open-orders-0"
+
+    original_snapshot_id = positions["snapshot_id"]
+    fixture.positions[0]["quantity"] = float(fixture.positions[0]["quantity"]) + 1
+    changed = tools["account_positions"](offset=0, limit=1)
+    assert changed["snapshot_id"] != original_snapshot_id
 
 
 def test_stock_order_fixture_applies_filled_order_to_positions():

--- a/tests/test_agent_eval_harness.py
+++ b/tests/test_agent_eval_harness.py
@@ -2,6 +2,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts/run_agent_evals.py"
 SPEC = importlib.util.spec_from_file_location("run_agent_evals", SCRIPT_PATH)
@@ -152,25 +154,27 @@ def test_credit_spread_machine_contract_rejects_reversed_close():
     assert any("closing legs" in failure for failure in score["failures"])
 
 
-def test_credit_spread_fixture_does_not_flatten_reversed_closing_sides():
+def test_credit_spread_fixture_rejects_reversed_closing_sides_before_submission():
     fixture = evals.build_fixture("open_credit_spread")
     submit = next(
         tool for tool in evals.build_tools(fixture) if tool.name == "orders_submit_multileg"
     )
 
-    submit.function(
-        legs_json=(
-            '[{"symbol":"SPY","expiration":"2026-08-28","strike":592,'
-            '"right":"put","quantity":3,"side":"buy_to_close"},'
-            '{"symbol":"SPY","expiration":"2026-08-28","strike":594,'
-            '"right":"put","quantity":3,"side":"sell_to_close"}]'
+    with pytest.raises(ValueError, match="does not reduce the current signed position"):
+        submit.function(
+            legs_json=(
+                '[{"symbol":"SPY","expiration":"2026-08-28","strike":592,'
+                '"right":"put","quantity":3,"side":"buy_to_close"},'
+                '{"symbol":"SPY","expiration":"2026-08-28","strike":594,'
+                '"right":"put","quantity":3,"side":"sell_to_close"}]'
+            )
         )
-    )
 
     assert {(position["strike"], position["quantity"]) for position in fixture.positions} == {
         (594.0, -3),
         (592.0, 3),
     }
+    assert fixture.submissions == []
 
 
 def test_credit_spread_eval_has_an_honest_preserved_red_baseline():
@@ -214,6 +218,77 @@ def test_stock_pending_exit_eval_has_an_honest_preserved_red_baseline():
     assert baseline["sourceArtifactHashes"]["tradesCsvSha256"] == (
         "0f617ee6587dd44e22646062444d891c965d9de879f7cccf021e961fc6397a4f"
     )
+
+
+def test_stock_orb_eval_has_an_honest_preserved_red_baseline():
+    baseline_path = (
+        Path(__file__).resolve().parents[1]
+        / "agent_eval_baselines/2026-09-02_stock_orb_semantic_contradiction_red.json"
+    )
+    baseline = __import__("json").loads(baseline_path.read_text(encoding="utf-8"))
+    assert baseline["caseId"] == "stock_orb_completed_bars"
+    assert baseline["status"] == "red"
+    assert baseline["observedFailure"]["submittedOrderIdentifier"] == "fixture-order-1"
+    assert baseline["observedFailure"]["finalAnswerClaimedNoTrade"] is True
+    assert baseline["sourceArtifactHashes"]["ledgerJsonlSha256"] == (
+        "45806e694ec460539b5eb205c729796d8625aeea38f0e719b3ed40cc379e81c7"
+    )
+
+
+def test_stock_orb_fixture_honors_requested_minute_interval():
+    fixture = evals.build_fixture("orb_breakout")
+    history = next(tool for tool in evals.build_tools(fixture) if tool.name == "market_historical_prices")
+
+    result = history.function(symbols="AAPL", length=30, timestep="minute")
+    bars = result["bars"]["AAPL"]
+
+    assert result["timestep"] == "minute"
+    assert len(bars) == 20
+    assert bars[0]["datetime"] == "2026-08-11T13:30:00Z"
+    assert bars[14]["datetime"] == "2026-08-11T13:44:00Z"
+    assert bars[15]["datetime"] == "2026-08-11T13:45:00Z"
+    assert max(bar["high"] for bar in bars[:15]) == 228.5
+    assert bars[19]["close"] == 230.0
+    assert sum(bar["volume"] for bar in bars[15:20]) > max(
+        sum(bar["volume"] for bar in bars[offset : offset + 5])
+        for offset in range(0, 15, 5)
+    )
+
+
+def test_stock_orb_contract_requires_deterministic_quantity_calculation():
+    case = evals.load_cases({"stock_orb_completed_bars"})[0]
+
+    assert "risk_calculate_stock_quantity" in case["machineContract"]["requiredBeforeOrder"]
+
+    fixture = evals.build_fixture("orb_breakout")
+    sizing = next(
+        tool for tool in evals.build_tools(fixture) if tool.name == "risk_calculate_stock_quantity"
+    )
+    result = sizing.function(maximum_notional=10_000, price=230, available_cash=100_000)
+
+    assert result["quantity"] == 43
+    assert result["notional"] == 9_890
+
+
+def test_account_eval_fixtures_match_compact_pagination_contract():
+    fixture = evals.build_fixture("open_credit_spread")
+    tools = {tool.name: tool.function for tool in evals.build_tools(fixture)}
+
+    positions = tools["account_positions"](offset=0, limit=1)
+    orders = tools["orders_open_orders"](offset=0, limit=50)
+
+    assert positions["total"] == 2
+    assert positions["returned"] == 1
+    assert positions["omitted"] == 1
+    assert positions["complete"] is False
+    assert positions["next_offset"] == 1
+    assert positions["snapshot_id"] == "fixture-positions-2"
+    assert orders["total"] == 0
+    assert orders["returned"] == 0
+    assert orders["omitted"] == 0
+    assert orders["complete"] is True
+    assert orders["next_offset"] is None
+    assert orders["snapshot_id"] == "fixture-open-orders-0"
 
 
 def test_stock_order_fixture_applies_filled_order_to_positions():

--- a/tests/test_agent_options_builtins.py
+++ b/tests/test_agent_options_builtins.py
@@ -400,6 +400,15 @@ def test_option_close_validation_rejects_reversed_side_and_oversized_quantity():
         [SimpleNamespace(asset=long_put, quantity=3, side="sell_to_close")],
     )
 
+    with pytest.raises(ValueError, match="requested_quantity=2.0"):
+        _validate_option_closing_orders(
+            strategy,
+            [
+                SimpleNamespace(asset=long_put, quantity=2, side="sell_to_close"),
+                SimpleNamespace(asset=long_put, quantity=2, side="sell_to_close"),
+            ],
+        )
+
 
 def test_multileg_submit_creates_one_atomic_four_leg_order_after_normal_readiness_checks():
     strategy = _OptionsStrategy()

--- a/tests/test_agent_options_builtins.py
+++ b/tests/test_agent_options_builtins.py
@@ -1,13 +1,14 @@
 import json
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from types import SimpleNamespace
 
 import pandas as pd
+import pytest
 
 from lumibot.components.agents import AgentManager, BuiltinTools
-from lumibot.components.agents.builtins import _position_to_dict
+from lumibot.components.agents.builtins import _position_to_dict, _validate_option_closing_orders
 from lumibot.components.agents.runtime import _wrap_tool_callable
-from lumibot.entities import Order
+from lumibot.entities import Asset, Order
 from lumibot.entities.chains import Chains
 
 
@@ -156,6 +157,7 @@ def test_default_agent_tools_expose_generic_option_discovery_and_multileg_execut
     assert {
         "market_last_prices",
         "market_historical_prices",
+        "risk_calculate_stock_quantity",
         "options_get_chain",
         "options_get_strikes",
         "options_get_greeks",
@@ -170,6 +172,36 @@ def test_default_agent_tools_expose_generic_option_discovery_and_multileg_execut
     }.issubset(names)
     assert not any("condor" in name for name in names)
     assert len(names) == len(BuiltinTools.all())
+
+
+def test_stock_quantity_calculator_respects_notional_and_cash_caps():
+    strategy = _OptionsStrategy()
+    tool = BuiltinTools.risk.calculate_stock_quantity().binder(strategy, AgentManager(strategy))
+
+    result = tool.function(maximum_notional=10_000, price=230, available_cash=100_000)
+    cash_limited = tool.function(maximum_notional=10_000, price=230, available_cash=5_000)
+
+    assert result["quantity"] == 43
+    assert result["notional"] == 9_890
+    assert result["within_maximum_notional"] is True
+    assert result["within_available_cash"] is True
+    assert cash_limited["quantity"] == 21
+    assert cash_limited["notional"] == 4_830
+
+
+def test_stock_quantity_calculator_handles_zero_cash_and_rejects_invalid_inputs():
+    strategy = _OptionsStrategy()
+    tool = BuiltinTools.risk.calculate_stock_quantity().binder(strategy, AgentManager(strategy))
+
+    no_cash = tool.function(maximum_notional=10_000, price=230, available_cash=0)
+
+    assert no_cash["quantity"] == 0
+    assert no_cash["notional"] == 0
+    assert no_cash["within_available_cash"] is True
+    with pytest.raises(ValueError, match="available_cash must be a finite number"):
+        tool.function(maximum_notional=10_000, price=230, available_cash=-1)
+    with pytest.raises(ValueError, match="price must be a finite number greater than 0"):
+        tool.function(maximum_notional=10_000, price=0, available_cash=10_000)
 
 
 def test_option_position_payload_exposes_unambiguous_closing_metadata():
@@ -336,6 +368,37 @@ def test_multileg_price_preserves_opening_side_direction():
     assert result["available"] is True
     assert result["net_limit_price"] == -2.0
     assert result["order_type"] == "credit"
+
+
+def test_option_close_validation_rejects_reversed_side_and_oversized_quantity():
+    strategy = _OptionsStrategy()
+    long_put = Asset(
+        symbol="SPY",
+        asset_type="option",
+        expiration=date(2026, 9, 18),
+        strike=610,
+        right="put",
+    )
+    strategy.get_positions = lambda include_cash_positions=True: [
+        SimpleNamespace(asset=long_put, quantity=3)
+    ]
+
+    with pytest.raises(ValueError, match="required_side='sell_to_close'"):
+        _validate_option_closing_orders(
+            strategy,
+            [SimpleNamespace(asset=long_put, quantity=3, side="buy_to_close")],
+        )
+
+    with pytest.raises(ValueError, match="requested_quantity=4.0"):
+        _validate_option_closing_orders(
+            strategy,
+            [SimpleNamespace(asset=long_put, quantity=4, side="sell_to_close")],
+        )
+
+    _validate_option_closing_orders(
+        strategy,
+        [SimpleNamespace(asset=long_put, quantity=3, side="sell_to_close")],
+    )
 
 
 def test_multileg_submit_creates_one_atomic_four_leg_order_after_normal_readiness_checks():

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -145,7 +145,8 @@ def test_agent_runtime_enables_builtin_skills_and_fingerprints_cache(monkeypatch
     assert "managing any stock, ETF, or option position or related pending order" in first.system_prompt
     assert "MUST load the matching skill" in first.system_prompt
     assert "Never claim that no order was submitted" in first.system_prompt
-    assert "use risk_calculate_stock_quantity" in first.system_prompt
+    assert "risk_calculate_stock_quantity is unavailable" in first.system_prompt
+    assert "make a no-trade decision" in first.system_prompt
 
 
 def test_agent_can_disable_builtin_skills_explicitly():

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -89,6 +89,23 @@ def test_options_skill_requires_atomic_multileg_or_no_trade():
     assert "make a no-trade decision" in instructions
 
 
+def test_stock_skill_defines_opening_range_boundaries_and_order_truth():
+    stock_skill = next(skill for skill in load_builtin_skills() if skill.name == "stock-trading")
+    instructions = " ".join(stock_skill.instructions.split())
+    intraday = " ".join(stock_skill.resources.references["intraday-setups.md"].split())
+
+    assert "Write down the decisive condition" in instructions
+    assert "call `risk_calculate_stock_quantity`" in instructions
+    assert "quantity unchanged" in instructions
+    assert "notional is at or below both the cap and available cash" in instructions
+    assert "never say that no order was entered" in instructions
+    assert "three five-minute bars starting at 09:30, 09:35, and 09:40 form the range" in intraday
+    assert "starting at 09:45 is the first later candidate" in intraday
+    assert "aggregate the exact non-overlapping intervals" in intraday
+    assert "Never treat the first one-minute constituent" in intraday
+    assert "as a completed five-minute bar" in intraday
+
+
 def test_builtin_skill_toolset_exposes_progressive_loading_tools():
     toolset = build_builtin_skill_toolset()
     tools = asyncio.run(toolset.get_tools())
@@ -127,6 +144,8 @@ def test_agent_runtime_enables_builtin_skills_and_fingerprints_cache(monkeypatch
     assert "load_skill" in first.system_prompt
     assert "managing any stock, ETF, or option position or related pending order" in first.system_prompt
     assert "MUST load the matching skill" in first.system_prompt
+    assert "Never claim that no order was submitted" in first.system_prompt
+    assert "use risk_calculate_stock_quantity" in first.system_prompt
 
 
 def test_agent_can_disable_builtin_skills_explicitly():

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -6,10 +6,11 @@ import os
 import time
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from urllib.parse import urlparse
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
-from unittest.mock import patch, MagicMock
 
 
 class _CalendarTestBroker:
@@ -70,7 +71,12 @@ class TestBrokerInitializationSimple:
             assert "IS_BACKTESTING" in error_message
             assert ".env file" in error_message
             assert "ALPACA_API_KEY" in error_message
-            assert "lumibot.lumiwealth.com" in error_message
+            documented_hosts = {
+                urlparse(token.rstrip(".,;:!?)]}")).hostname
+                for token in error_message.split()
+                if token.startswith(("https://", "http://"))
+            }
+            assert "lumibot.lumiwealth.com" in documented_hosts
             assert "backtesting" in error_message.lower()
             assert "live trading" in error_message.lower()
     

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -6,7 +6,6 @@ import os
 import time
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from urllib.parse import urlparse
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -71,12 +70,6 @@ class TestBrokerInitializationSimple:
             assert "IS_BACKTESTING" in error_message
             assert ".env file" in error_message
             assert "ALPACA_API_KEY" in error_message
-            documented_hosts = {
-                urlparse(token.rstrip(".,;:!?)]}")).hostname
-                for token in error_message.split()
-                if token.startswith(("https://", "http://"))
-            }
-            assert "lumibot.lumiwealth.com" in documented_hosts
             assert "backtesting" in error_message.lower()
             assert "live trading" in error_message.lower()
     

--- a/tests/test_broker_initialization.py
+++ b/tests/test_broker_initialization.py
@@ -48,28 +48,31 @@ class TestBrokerInitializationSimple:
         # Mock both the credentials imports in the strategy module
         from lumibot.strategies import Strategy
 
-        with patch('lumibot.strategies._strategy.BROKER', None):
-            with patch('lumibot.credentials.IS_BACKTESTING', False):
-                # Create a minimal strategy class for testing
-                class TestStrategy(Strategy):
-                    def on_trading_iteration(self):
-                        pass
-                
-                # Attempt to initialize the strategy with None broker
-                with pytest.raises(ValueError) as exc_info:
-                    TestStrategy(broker=None)
-                
-                # Check that the error message is helpful and contains key information
-                error_message = str(exc_info.value)
-                
-                # Verify the error message contains helpful guidance
-                assert "No broker is set" in error_message
-                assert "IS_BACKTESTING" in error_message
-                assert ".env file" in error_message
-                assert "ALPACA_API_KEY" in error_message
-                assert "lumibot.lumiwealth.com" in error_message
-                assert "backtesting" in error_message.lower()
-                assert "live trading" in error_message.lower()
+        with (
+            patch("lumibot.strategies._strategy.BROKER", None),
+            patch("lumibot.strategies._strategy.get_default_broker", return_value=None),
+            patch("lumibot.credentials.IS_BACKTESTING", False),
+        ):
+            # Create a minimal strategy class for testing
+            class TestStrategy(Strategy):
+                def on_trading_iteration(self):
+                    pass
+
+            # Attempt to initialize the strategy with None broker
+            with pytest.raises(ValueError) as exc_info:
+                TestStrategy(broker=None)
+
+            # Check that the error message is helpful and contains key information
+            error_message = str(exc_info.value)
+
+            # Verify the error message contains helpful guidance
+            assert "No broker is set" in error_message
+            assert "IS_BACKTESTING" in error_message
+            assert ".env file" in error_message
+            assert "ALPACA_API_KEY" in error_message
+            assert "lumibot.lumiwealth.com" in error_message
+            assert "backtesting" in error_message.lower()
+            assert "live trading" in error_message.lower()
     
     def test_strategy_with_valid_broker_does_not_raise_broker_error(self):
         """

--- a/tests/test_broker_sync_positions.py
+++ b/tests/test_broker_sync_positions.py
@@ -90,3 +90,18 @@ def test_sync_positions_clears_stale_mark_fields_missing_from_broker_position():
     assert not hasattr(synced, "current_price")
     assert not hasattr(synced, "market_value")
     assert not hasattr(synced, "pnl")
+
+
+def test_sync_positions_does_not_prune_position_added_after_snapshot_started():
+    broker = _BrokerForSyncTest([])
+    new_fill = _stock_position(quantity=1, current_price=220.0, market_value=220.0, pnl=0.0)
+
+    def pull_positions_with_interleaved_fill(strategy):
+        broker._filled_positions.append(new_fill)
+        return []
+
+    broker._pull_positions = pull_positions_with_interleaved_fill
+
+    broker.sync_positions(_Strategy())
+
+    assert broker._filled_positions.get_list() == [new_fill]

--- a/tests/test_ccxt_store.py
+++ b/tests/test_ccxt_store.py
@@ -644,3 +644,63 @@ def test_cache_download_data_without_overap(exchange_id:str, symbol:str, timefra
     # Remove cache file if exists.
     if os.path.exists(cache_file_path):
         os.remove(cache_file_path)
+
+
+def test_ccxt_cache_normalizes_coinbase_btc_usd_pair_forms(tmp_path, monkeypatch):
+    """BEFORE: BTC-USD and BTC-USD/USD missed Coinbase markets and returned empty.
+    AFTER: both resolve to BTC/USD and fetch OHLCV.
+    """
+    cache = _cache_without_live_exchange(tmp_path, monkeypatch)
+    fetched = []
+
+    class FakeApi:
+        id = "coinbase"
+        has = {"fetchOHLCV": True}
+        markets = {"BTC/USD": {"id": "BTC-USD", "symbol": "BTC/USD"}}
+
+        def parse8601(self, value):
+            return int(pd.Timestamp(value).timestamp() * 1000)
+
+        def fetch_ohlcv(self, symbol, timeframe, since=None, limit=None, params=None):
+            fetched.append(symbol)
+            assert symbol == "BTC/USD"
+            return [[int(pd.Timestamp("2026-01-01").timestamp() * 1000), 1, 2, 0.5, 1.5, 10]]
+
+    cache.api = FakeApi()
+    cache.max_download_limit = 10
+
+    for requested in ("BTC-USD", "BTC-USD/USD", "BTC/USD"):
+        fetched.clear()
+        df = cache._get_barset_from_api(
+            requested,
+            "1d",
+            limit=1,
+            start=datetime(2026, 1, 1),
+            end=datetime(2026, 1, 2),
+        )
+        assert fetched
+        assert set(fetched) == {"BTC/USD"}
+        assert not df.empty
+
+
+def test_ccxt_cache_missing_market_raises_clear_diagnostic(tmp_path, monkeypatch):
+    cache = _cache_without_live_exchange(tmp_path, monkeypatch)
+
+    class FakeApi:
+        id = "coinbase"
+        has = {"fetchOHLCV": True}
+        markets = {"ETH/USD": {"id": "ETH-USD", "symbol": "ETH/USD"}}
+
+        def parse8601(self, value):
+            return int(pd.Timestamp(value).timestamp() * 1000)
+
+    cache.api = FakeApi()
+
+    with pytest.raises(ValueError, match="CCXT market not found for .BTC-USD/USD."):
+        cache._get_barset_from_api(
+            "BTC-USD/USD",
+            "1d",
+            limit=1,
+            start=datetime(2026, 1, 1),
+            end=datetime(2026, 1, 2),
+        )

--- a/tests/test_data_source_sleep_time_defaults.py
+++ b/tests/test_data_source_sleep_time_defaults.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from lumibot.data_sources.data_source import DataSource
@@ -118,13 +120,17 @@ def test_get_bars_preserves_tuple_string_failures_as_partial_results(
 
     monkeypatch.setattr(ds, "get_historical_prices", _history)
     pair = ("BTC", "USD")
-    result = ds.get_bars(
-        [pair, Asset("SPY")],
-        length=10,
-        timestep="day",
-        chunk_size=2,
-        sleep_time=0,
-    )
+    with caplog.at_level(
+        logging.WARNING,
+        logger="lumibot.data_sources.data_source",
+    ):
+        result = ds.get_bars(
+            [pair, Asset("SPY")],
+            length=10,
+            timestep="day",
+            chunk_size=2,
+            sleep_time=0,
+        )
 
     assert result[pair] is None
     assert result.errors[pair] == {

--- a/tests/test_fill_strategy_ownership.py
+++ b/tests/test_fill_strategy_ownership.py
@@ -213,6 +213,39 @@ def test_executor_allows_owned_option_fill_hedge():
     assert int(strategy.hedge_orders[0].quantity) == 100
 
 
+def test_executor_preserves_backtest_fill_callbacks_when_order_metadata_differs():
+    """Broker ownership tags are a live shared-account boundary, not a backtest filter.
+
+    Historical adapters can reconstruct strategy/tag metadata differently from the
+    active strategy name. Backtests must preserve their deterministic fill callback
+    behavior instead of silently dropping those fills.
+    """
+    strategy = _HedgeStrategy("Backdoor Butterfly", underlying="SPY")
+    strategy.is_backtesting = True
+    strategy.broker.IS_BACKTESTING_BROKER = True
+    executor = StrategyExecutor(strategy)
+    strategy._executor = executor
+
+    reconstructed = _make_option_order(
+        strategy="Historical Adapter",
+        underlying="SPY",
+        identifier="backtest-fill-1",
+        tag="Historical-Adapter",
+    )
+    position = MagicMock()
+    position.asset = reconstructed.asset
+
+    executor._on_filled_order(
+        position,
+        reconstructed,
+        price=1.25,
+        quantity=Decimal("1"),
+        multiplier=100,
+    )
+
+    assert strategy.recorded_fills == [reconstructed]
+
+
 @pytest.fixture
 def tradier_broker(mocker):
     from lumibot.brokers.tradier import Tradier

--- a/tests/test_fill_strategy_ownership.py
+++ b/tests/test_fill_strategy_ownership.py
@@ -1,0 +1,438 @@
+"""Fill events must only reach the strategy that owns the order.
+
+Regression for Titus / shared-account option fills (2026-09-03):
+a live STM call strategy read MOS option activity from the broker account and
+submitted an unintended 100-share STM stock hedge. Broker polling must not
+attribute foreign-tagged fills to the local strategy, and on_filled_order must
+not fire for those fills.
+"""
+
+from __future__ import annotations
+
+import time
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from lumibot.brokers.broker import Broker
+from lumibot.entities import Asset, Order
+from lumibot.strategies.strategy_executor import StrategyExecutor
+
+
+def test_normalize_and_match_strategy_tags():
+    assert Broker.normalize_broker_strategy_tag("STM Call Strategy") == "STM-Call-Strategy"
+    assert Broker.normalize_broker_strategy_tag("MOS") == "MOS"
+    assert Broker.strategy_tag_matches("STM-Call-Strategy", "STM Call Strategy") is True
+    assert Broker.strategy_tag_matches("MOS", "STM Call Strategy") is False
+    assert Broker.strategy_tag_matches(None, "STM Call Strategy") is False
+    assert Broker.strategy_tag_matches("MOS", None) is False
+
+
+def test_option_underlying_matches_helper():
+    stm = Asset("STM", asset_type=Asset.AssetType.STOCK)
+    mos_opt = Asset(
+        "MOS",
+        asset_type=Asset.AssetType.OPTION,
+        expiration="2026-09-18",
+        strike=30,
+        right=Asset.OptionRight.CALL,
+    )
+    stm_opt = Asset(
+        "STM",
+        asset_type=Asset.AssetType.OPTION,
+        expiration="2026-09-18",
+        strike=50,
+        right=Asset.OptionRight.CALL,
+        underlying_asset=stm,
+    )
+    assert Broker.option_underlying_symbol(mos_opt) == "MOS"
+    assert Broker.option_underlying_symbol(stm_opt) == "STM"
+    assert Broker.fills_match_underlying(mos_opt, {"STM"}) is False
+    assert Broker.fills_match_underlying(stm_opt, {"STM", "stm"}) is True
+    assert Broker.fills_match_underlying(stm, {"STM"}) is True
+
+
+class _Logger:
+    def isEnabledFor(self, level: int) -> bool:
+        return False
+
+    def info(self, *args, **kwargs):
+        return None
+
+    def warning(self, *args, **kwargs):
+        return None
+
+    def error(self, *args, **kwargs):
+        return None
+
+    def debug(self, *args, **kwargs):
+        return None
+
+
+class _HedgeStrategy:
+    """Records hedge attempts from on_filled_order (option fill → 100-share stock)."""
+
+    def __init__(self, name: str, underlying: str = "STM"):
+        self._name = name
+        self.name = name
+        self.underlying = underlying
+        self.hide_trades = True
+        self.portfolio_value = 100_000.0
+        self.cash = 100_000.0
+        self.sleeptime = "1S"
+        self.is_backtesting = False
+        self._first_iteration = False
+        self.logger = _Logger()
+        self.quote_asset = Asset("USD", asset_type=Asset.AssetType.FOREX)
+        self.broker = MagicMock()
+        self.broker.IS_BACKTESTING_BROKER = False
+        self.broker.name = "dummy"
+        self.hedge_orders = []
+        self.recorded_fills = []
+        self._filled_order_callback = None
+
+    def on_trading_iteration(self):
+        return None
+
+    def log_message(self, *args, **kwargs):
+        return None
+
+    def send_discord_message(self, *args, **kwargs):
+        return None
+
+    def on_filled_order(self, position, order, price, quantity, multiplier):
+        self.recorded_fills.append(order)
+        # Mimic customer hedge: option fill → 100-share stock market buy on strategy underlying
+        if getattr(order.asset, "asset_type", None) == Asset.AssetType.OPTION:
+            # Bug path ignored ownership/underlying; correct strategies must gate both.
+            if order.strategy and order.strategy != self.name:
+                return
+            fill_underlying = Broker.option_underlying_symbol(order.asset)
+            if fill_underlying and fill_underlying.upper() != self.underlying.upper():
+                return
+            hedge = Order(
+                strategy=self.name,
+                asset=Asset(self.underlying, asset_type=Asset.AssetType.STOCK),
+                quantity=100,
+                side="buy",
+                order_type="market",
+            )
+            self.hedge_orders.append(hedge)
+
+
+def _make_option_order(*, strategy: str, underlying: str, identifier: str, tag: str | None = None) -> Order:
+    asset = Asset(
+        underlying,
+        asset_type=Asset.AssetType.OPTION,
+        expiration="2026-09-18",
+        strike=30,
+        right=Asset.OptionRight.CALL,
+    )
+    return Order(
+        strategy=strategy,
+        asset=asset,
+        quantity=1,
+        side="buy_to_open",
+        order_type="market",
+        identifier=identifier,
+        tag=tag if tag is not None else Broker.normalize_broker_strategy_tag(strategy),
+    )
+
+
+def test_executor_drops_foreign_strategy_fills_before_hedge():
+    """BEFORE metrics: foreign fill reaches on_filled_order and creates a hedge.
+    AFTER metrics: foreign fill is dropped; no hedge.
+    """
+    strategy = _HedgeStrategy("STM Call Strategy", underlying="STM")
+    executor = StrategyExecutor(strategy)
+    strategy._executor = executor
+
+    foreign = _make_option_order(
+        strategy="MOS",
+        underlying="MOS",
+        identifier="mos-fill-1",
+        tag="MOS",
+    )
+    position = MagicMock()
+    position.asset = foreign.asset
+
+    t0 = time.perf_counter()
+    executor._on_filled_order(
+        position,
+        foreign,
+        price=1.25,
+        quantity=Decimal("1"),
+        multiplier=100,
+    )
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+
+    # Metrics for PR body (before broken attribution would record 1 fill + 1 hedge)
+    before_foreign_fills_delivered = 1  # historical buggy behavior
+    before_unintended_hedges = 1
+    after_foreign_fills_delivered = len(strategy.recorded_fills)
+    after_unintended_hedges = len(strategy.hedge_orders)
+
+    assert after_foreign_fills_delivered == 0, (
+        f"Foreign MOS fill was delivered to STM on_filled_order "
+        f"(before={before_foreign_fills_delivered}, after={after_foreign_fills_delivered})"
+    )
+    assert after_unintended_hedges == 0, (
+        f"Unintended STM hedge fired from MOS fill "
+        f"(before={before_unintended_hedges}, after={after_unintended_hedges}, "
+        f"elapsed_ms={elapsed_ms:.3f})"
+    )
+
+
+def test_executor_allows_owned_option_fill_hedge():
+    strategy = _HedgeStrategy("STM Call Strategy", underlying="STM")
+    executor = StrategyExecutor(strategy)
+    strategy._executor = executor
+
+    owned = _make_option_order(
+        strategy="STM Call Strategy",
+        underlying="STM",
+        identifier="stm-fill-1",
+    )
+    # Ensure strategy field matches executor strategy name
+    owned.strategy = strategy.name
+    position = MagicMock()
+    position.asset = owned.asset
+
+    executor._on_filled_order(
+        position,
+        owned,
+        price=2.5,
+        quantity=Decimal("1"),
+        multiplier=100,
+    )
+
+    assert len(strategy.recorded_fills) == 1
+    assert len(strategy.hedge_orders) == 1
+    assert strategy.hedge_orders[0].asset.symbol == "STM"
+    assert int(strategy.hedge_orders[0].quantity) == 100
+
+
+@pytest.fixture
+def tradier_broker(mocker):
+    from lumibot.brokers.tradier import Tradier
+
+    broker = Tradier(
+        account_number="1234",
+        access_token="a1b2c3",
+        paper=True,
+        polling_interval=None,
+        connect_stream=False,
+    )
+    broker.stream = MagicMock()
+    broker._strategy_name = "STM Call Strategy"
+    broker._first_iteration = False
+    mocker.patch.object(broker, "sync_positions", return_value=None)
+    return broker
+
+
+def test_tradier_polling_skips_foreign_tagged_fill(tradier_broker, mocker):
+    """Shared Tradier account: MOS-tagged filled option must not be ingested by STM."""
+    broker = tradier_broker
+    dispatched = []
+
+    def _capture(event, **kwargs):
+        dispatched.append((event, kwargs))
+
+    mocker.patch.object(broker, "_safe_stream_dispatch", side_effect=_capture)
+    mocker.patch.object(
+        broker,
+        "_pull_broker_all_orders",
+        return_value=[
+            {
+                "id": 9001,
+                "type": "market",
+                "side": "buy_to_open",
+                "symbol": "MOS",
+                "option_symbol": "MOS250918C00030000",
+                "class": "option",
+                "quantity": 1,
+                "status": "filled",
+                "duration": "day",
+                "create_date": "2026-09-03T12:00:00.000Z",
+                "avg_fill_price": 1.25,
+                "exec_quantity": 1,
+                "tag": "MOS",
+            }
+        ],
+    )
+
+    t0 = time.perf_counter()
+    broker.do_polling()
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+
+    known_ids = {str(o.identifier) for o in broker.get_all_orders()}
+    fill_events = [d for d in dispatched if d[0] == broker.FILLED_ORDER]
+
+    before_foreign_orders_tracked = 1
+    before_fill_events = 1
+    after_foreign_orders_tracked = 1 if "9001" in known_ids else 0
+    after_fill_events = len(fill_events)
+
+    assert after_foreign_orders_tracked == 0, (
+        f"Foreign MOS order was tracked by STM broker "
+        f"(before={before_foreign_orders_tracked}, after={after_foreign_orders_tracked}, "
+        f"elapsed_ms={elapsed_ms:.3f})"
+    )
+    assert after_fill_events == 0, (
+        f"Foreign MOS fill was dispatched to STM "
+        f"(before={before_fill_events}, after={after_fill_events})"
+    )
+
+
+def test_tradier_polling_still_processes_owned_tagged_fill(tradier_broker, mocker):
+    broker = tradier_broker
+    # Seed a locally submitted order so status transition can fill.
+    asset = Asset(
+        "STM",
+        asset_type=Asset.AssetType.OPTION,
+        expiration="2026-09-18",
+        strike=50,
+        right=Asset.OptionRight.CALL,
+    )
+    local = Order(
+        strategy="STM Call Strategy",
+        asset=asset,
+        quantity=1,
+        side="buy_to_open",
+        order_type="market",
+        identifier=9002,
+        tag="STM-Call-Strategy",
+    )
+    local.status = "open"
+    broker._new_orders.append(local)
+
+    dispatched = []
+
+    def _capture(event, **kwargs):
+        dispatched.append((event, kwargs))
+
+    mocker.patch.object(broker, "_safe_stream_dispatch", side_effect=_capture)
+    mocker.patch.object(
+        broker,
+        "_pull_broker_all_orders",
+        return_value=[
+            {
+                "id": 9002,
+                "type": "market",
+                "side": "buy_to_open",
+                "symbol": "STM",
+                "option_symbol": "STM250918C00050000",
+                "class": "option",
+                "quantity": 1,
+                "status": "filled",
+                "duration": "day",
+                "create_date": "2026-09-03T12:00:00.000Z",
+                "avg_fill_price": 2.5,
+                "exec_quantity": 1,
+                "tag": "STM-Call-Strategy",
+            }
+        ],
+    )
+
+    broker.do_polling()
+    fill_events = [d for d in dispatched if d[0] == broker.FILLED_ORDER]
+    assert len(fill_events) == 1
+    assert fill_events[0][1]["order"].identifier == 9002
+
+
+def test_sole_subscriber_does_not_claim_foreign_tag(tradier_broker):
+    broker = tradier_broker
+    broker._strategy_name = ""
+    sub = MagicMock()
+    sub.name = "STM Call Strategy"
+    broker._subscribers = [sub]
+
+    order = _make_option_order(strategy="", underlying="MOS", identifier="x", tag="MOS")
+    order.strategy = ""
+    # Repair path must refuse to claim MOS as STM
+    assert broker.order_belongs_to_local_strategy(order, local_strategy_name="STM Call Strategy") is False
+    assert broker.order_belongs_to_local_strategy(
+        _make_option_order(strategy="STM Call Strategy", underlying="STM", identifier="y"),
+        local_strategy_name="STM Call Strategy",
+    ) is True
+
+
+def test_schwab_snapshot_does_not_seed_untracked_foreign_new(mocker):
+    """Shared Schwab account: untracked MOS NEW must not become STM tracked."""
+    from lumibot.brokers.schwab import Schwab
+
+    broker = Schwab.__new__(Schwab)
+    broker._strategy_name = "STM Call Strategy"
+    broker._subscribers = []
+    broker.logger = _Logger()
+    broker._schwab_observed_fill_quantities = {}
+    broker._schwab_terminal_observations = set()
+    broker.get_tracked_order = MagicMock(return_value=None)
+    seeded = []
+    broker._process_new_order = MagicMock(side_effect=lambda o: seeded.append(o))
+    broker._process_trade_event = MagicMock()
+    broker.FILLED_ORDER = Broker.FILLED_ORDER
+    broker.PARTIALLY_FILLED_ORDER = Broker.PARTIALLY_FILLED_ORDER
+    broker.NEW_ORDER = Broker.NEW_ORDER
+    broker.CANCELED_ORDER = Broker.CANCELED_ORDER
+    broker.ERROR_ORDER = Broker.ERROR_ORDER
+
+    foreign = _make_option_order(
+        strategy="STM Call Strategy",  # wrongly attributed at parse time
+        underlying="MOS",
+        identifier="schwab-mos-1",
+        tag="MOS",
+    )
+    foreign.status = Order.OrderStatus.NEW
+
+    broker._process_schwab_order_snapshot(foreign)
+
+    assert seeded == []
+    broker._process_trade_event.assert_not_called()
+
+
+def test_schwab_snapshot_still_fills_already_tracked_owned_order(mocker):
+    from lumibot.brokers.schwab import Schwab
+
+    broker = Schwab.__new__(Schwab)
+    broker._strategy_name = "STM Call Strategy"
+    broker._subscribers = []
+    broker.logger = _Logger()
+    broker._schwab_observed_fill_quantities = {}
+    broker._schwab_terminal_observations = set()
+    broker._log_schwab_lifecycle_event = MagicMock()
+    broker._schwab_order_ref = MagicMock(return_value="ref")
+
+    owned = _make_option_order(
+        strategy="STM Call Strategy",
+        underlying="STM",
+        identifier="schwab-stm-1",
+        tag="STM-Call-Strategy",
+    )
+    owned.status = Order.OrderStatus.NEW
+    owned.is_filled = MagicMock(return_value=False)
+    owned.is_canceled = MagicMock(return_value=False)
+    broker.get_tracked_order = MagicMock(return_value=owned)
+    broker._process_trade_event = MagicMock()
+    broker.FILLED_ORDER = Broker.FILLED_ORDER
+    broker.PARTIALLY_FILLED_ORDER = Broker.PARTIALLY_FILLED_ORDER
+    broker.NEW_ORDER = Broker.NEW_ORDER
+    broker.CANCELED_ORDER = Broker.CANCELED_ORDER
+    broker.ERROR_ORDER = Broker.ERROR_ORDER
+
+    observed = _make_option_order(
+        strategy="STM Call Strategy",
+        underlying="STM",
+        identifier="schwab-stm-1",
+        tag="STM-Call-Strategy",
+    )
+    observed.status = Order.OrderStatus.FILLED
+    observed._schwab_cumulative_filled_quantity = 1.0
+    observed._schwab_average_fill_price = 2.5
+    observed.avg_fill_price = 2.5
+
+    broker._process_schwab_order_snapshot(observed)
+
+    assert broker._process_trade_event.called
+    assert broker._process_trade_event.call_args[0][1] == Broker.FILLED_ORDER

--- a/tests/test_lazy_exports.py
+++ b/tests/test_lazy_exports.py
@@ -6,6 +6,34 @@ import sys
 from unittest.mock import patch
 
 
+_RUNTIME_ENV_PREFIXES = (
+    "ALPACA_",
+    "BACKTESTING_",
+    "DATABENTO_",
+    "DATADOWNLOADER_",
+    "LUMIBOT_",
+    "LUMIWEALTH_",
+    "POLYGON_",
+    "PROJECTX_",
+    "THETADATA_",
+    "TRADIER_",
+)
+
+
+def _clean_subprocess_env() -> dict[str, str]:
+    """Keep lazy-import subprocesses independent of local runtime credentials."""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in {"BROKER", "DATA_SOURCE", "IS_BACKTESTING", "TRADING_BROKER"}
+        and not key.startswith(_RUNTIME_ENV_PREFIXES)
+    }
+    env["LUMIBOT_DISABLE_DOTENV"] = "1"
+    env["LUMIBOT_DISABLE_DOTENV_LOCAL"] = "1"
+    env["LUMIBOT_LOG_LEVEL"] = "ERROR"
+    return env
+
+
 def test_lazy_package_all_exports_resolve():
     modules = [
         "lumibot",
@@ -496,10 +524,7 @@ def test_bitunix_data_default_timezone_is_utc(monkeypatch):
 
 
 def test_diversified_leverage_import_defers_datetime():
-    env = os.environ.copy()
-    env["LUMIBOT_DISABLE_DOTENV"] = "1"
-    env["LUMIBOT_DISABLE_DOTENV_LOCAL"] = "1"
-    env["LUMIBOT_LOG_LEVEL"] = "ERROR"
+    env = _clean_subprocess_env()
 
     result = subprocess.run(
         [
@@ -706,10 +731,7 @@ print('signature=' + str(inspect.signature(strategy_module.Asset)))
 
 
 def test_strategy_construction_defers_optional_components():
-    env = os.environ.copy()
-    env["LUMIBOT_DISABLE_DOTENV"] = "1"
-    env["LUMIBOT_DISABLE_DOTENV_LOCAL"] = "1"
-    env["LUMIBOT_LOG_LEVEL"] = "ERROR"
+    env = _clean_subprocess_env()
 
     result = subprocess.run(
         [

--- a/tests/test_lazy_exports.py
+++ b/tests/test_lazy_exports.py
@@ -8,15 +8,34 @@ from unittest.mock import patch
 
 _RUNTIME_ENV_PREFIXES = (
     "ALPACA_",
+    "ANTHROPIC_",
     "BACKTESTING_",
+    "BINANCE_",
+    "BITUNIX_",
+    "CCXT_",
+    "COINBASE_",
     "DATABENTO_",
     "DATADOWNLOADER_",
+    "DEEPSEEK_",
+    "GEMINI_",
+    "GOOGLE_",
+    "GROK_",
+    "IBKR_",
+    "INTERACTIVE_BROKERS_",
+    "KRAKEN_",
     "LUMIBOT_",
     "LUMIWEALTH_",
+    "OPENAI_",
+    "OPENROUTER_",
     "POLYGON_",
+    "POLYMARKET_",
     "PROJECTX_",
+    "SCHWAB_",
     "THETADATA_",
     "TRADIER_",
+    "TRADOVATE_",
+    "WEEX_",
+    "XAI_",
 )
 
 
@@ -661,10 +680,7 @@ def test_order_import_defers_smart_limit_module():
 
 
 def test_startup_order_lazy_class_proxy_defers_order_module():
-    env = os.environ.copy()
-    env["LUMIBOT_DISABLE_DOTENV"] = "1"
-    env["LUMIBOT_DISABLE_DOTENV_LOCAL"] = "1"
-    env["LUMIBOT_LOG_LEVEL"] = "ERROR"
+    env = _clean_subprocess_env()
 
     result = subprocess.run(
         [

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def test_package_manifest_excludes_generated_python_bytecode():
+    manifest = (Path(__file__).resolve().parents[1] / "MANIFEST.in").read_text(encoding="utf-8")
+
+    assert "prune lumibot/resources/__pycache__" in manifest
+    assert "global-exclude *.py[cod]" in manifest
+
+
+def test_custom_wheel_build_cleans_stale_build_tree():
+    setup_source = (Path(__file__).resolve().parents[1] / "setup.py").read_text(encoding="utf-8")
+
+    assert "build_lib = Path(self.build_lib)" in setup_source
+    assert "shutil.rmtree(build_lib)" in setup_source

--- a/tests/test_priority_fill_during_iteration.py
+++ b/tests/test_priority_fill_during_iteration.py
@@ -1,0 +1,294 @@
+"""Priority fill/hedge handling must not wait for a long on_trading_iteration.
+
+Regression for Titus / CVNA live hedge delay (2026-09-02):
+option fill arrived while a ~122s scan was running; hedge submission must not be
+gated behind the full scan finishing.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from lumibot.entities import Asset
+from lumibot.strategies.strategy_executor import (
+    StrategyExecutor,
+    should_hold_trade_event_for_sync,
+)
+
+
+@dataclass
+class _DummyBroker:
+    IS_BACKTESTING_BROKER: bool = False
+    name: str = "dummy"
+    _first_iteration: bool = False
+    _hold_trade_events: bool = False
+    _held_trades: list = field(default_factory=list)
+
+    def is_market_open(self) -> bool:
+        return True
+
+
+class _Logger:
+    def isEnabledFor(self, level: int) -> bool:
+        return False
+
+    def debug(self, *args, **kwargs):
+        return None
+
+    def info(self, *args, **kwargs):
+        return None
+
+    def warning(self, *args, **kwargs):
+        return None
+
+    def error(self, *args, **kwargs):
+        return None
+
+
+class _PriorityHedgeStrategy:
+    """Mimics a live scan that blocks for a long time while a fill arrives mid-scan."""
+
+    def __init__(self, scan_seconds: float = 0.6):
+        self.broker = _DummyBroker()
+        self.hide_trades = True
+        self.portfolio_value = 100_000.0
+        self.cash = 100_000.0
+        self.sleeptime = "1S"
+        self.is_backtesting = False
+        self._first_iteration = False
+        self._name = "PriorityHedgeStrategy"
+        self.logger = _Logger()
+        self.quote_asset = Asset("USD", asset_type=Asset.AssetType.FOREX)
+
+        self.scan_seconds = scan_seconds
+        self.iteration_started = threading.Event()
+        self.iteration_finished = threading.Event()
+        self.recorded_fills = []
+        self.recorded_fills_lock = threading.Lock()
+        self._executor = None
+
+    def log_message(self, message, color=None, broadcast=False):
+        return None
+
+    def load_variables_from_db(self):
+        return None
+
+    def backup_variables_to_db(self):
+        return None
+
+    def send_account_summary_to_discord(self):
+        return None
+
+    def send_discord_message(self, message, silent=False):
+        return None
+
+    def on_bot_crash(self, error):
+        return None
+
+    def _update_cash(self, *args, **kwargs):
+        return None
+
+    def _update_portfolio_value(self, *args, **kwargs):
+        return self.portfolio_value
+
+    def _copy_dict(self):
+        return {}
+
+    def _apply_daily_cash_financing_if_needed(self):
+        return None
+
+    def trace_stats(self, context, snapshot_before):
+        return {}
+
+    def get_datetime(self):
+        from datetime import datetime
+
+        return datetime.now()
+
+    def get_positions(self):
+        return []
+
+    def get_orders(self, *args, **kwargs):
+        return []
+
+    def on_trading_iteration(self):
+        self.iteration_started.set()
+        # Pure-Python busy work to stress GIL the way a long option scan does.
+        deadline = time.monotonic() + self.scan_seconds
+        while time.monotonic() < deadline:
+            _ = sum(i * i for i in range(200))
+        self.iteration_finished.set()
+
+    def on_filled_order(self, position, order, price, quantity, multiplier):
+        with self.recorded_fills_lock:
+            self.recorded_fills.append(
+                {
+                    "t": time.monotonic(),
+                    "during_iteration": self.iteration_started.is_set()
+                    and not self.iteration_finished.is_set(),
+                    "order": order,
+                }
+            )
+
+    def on_new_order(self, order):
+        return None
+
+    def on_canceled_order(self, order):
+        return None
+
+    def on_partially_filled_order(self, *args, **kwargs):
+        return None
+
+    def on_error_order(self, *args, **kwargs):
+        return None
+
+
+@dataclass
+class _DummyPosition:
+    asset: Asset
+
+
+class _DummyOrder:
+    def __init__(self, asset: Asset, side: str = "buy"):
+        self.asset = asset
+        self.side = side
+        self.identifier = "cvna-option-1"
+        self.order_class = None
+        self.symbol = getattr(asset, "symbol", "CVNA")
+
+    def is_buy_order(self) -> bool:
+        return self.side.lower() == "buy"
+
+    def is_parent(self) -> bool:
+        return False
+
+
+def _build_live_executor(strategy: _PriorityHedgeStrategy) -> StrategyExecutor:
+    executor = StrategyExecutor(strategy)
+    strategy._executor = executor
+    # Keep cron path executing the body on every call.
+    executor.cron_count = executor.cron_count_target
+    executor.sync_broker = MagicMock()  # type: ignore[method-assign]
+    executor._capture_locals = False
+    executor._trace_stats = MagicMock()  # type: ignore[method-assign]
+    executor.get_next_ap_scheduler_run_time = MagicMock(return_value=None)  # type: ignore[method-assign]
+    return executor
+
+
+def test_fill_callback_runs_during_long_live_iteration_not_after():
+    """BEFORE metric: fill waited until scan end (~scan_seconds).
+    AFTER metric: fill callback during scan, latency << scan duration.
+    """
+    scan_seconds = 0.7
+    strategy = _PriorityHedgeStrategy(scan_seconds=scan_seconds)
+    executor = _build_live_executor(strategy)
+
+    asset = Asset("CVNA", asset_type=Asset.AssetType.OPTION)
+    position = _DummyPosition(asset=asset)
+    order = _DummyOrder(asset=asset)
+
+    fill_enqueued_at = {}
+
+    def _enqueue_fill_mid_scan():
+        assert strategy.iteration_started.wait(timeout=2.0)
+        time.sleep(0.05)
+        fill_enqueued_at["t"] = time.monotonic()
+        executor.add_event(
+            executor.FILLED_ORDER,
+            dict(
+                position=position,
+                order=order,
+                price=1.25,
+                quantity=Decimal("1"),
+                multiplier=100,
+            ),
+        )
+
+    feeder = threading.Thread(target=_enqueue_fill_mid_scan, daemon=True)
+    feeder.start()
+
+    t0 = time.monotonic()
+    executor._on_trading_iteration()
+    elapsed = time.monotonic() - t0
+    feeder.join(timeout=2.0)
+
+    with strategy.recorded_fills_lock:
+        recorded = list(strategy.recorded_fills)
+
+    assert recorded, "on_filled_order never ran — hedge path was blocked"
+    fill = recorded[0]
+    fill_latency = fill["t"] - fill_enqueued_at["t"]
+
+    # AFTER: callback must occur while the scan is still running, and well before
+    # the full scan duration (the historical failure mode waited for scan end).
+    assert fill["during_iteration"] is True, (
+        f"fill processed only after iteration finished (latency={fill_latency:.3f}s, "
+        f"scan={scan_seconds}s) — hedge still gated behind on_trading_iteration"
+    )
+    assert fill_latency < scan_seconds * 0.5, (
+        f"fill->callback latency {fill_latency:.3f}s too close to scan {scan_seconds}s"
+    )
+    assert elapsed >= scan_seconds * 0.8  # scan still took its time
+
+
+def test_priority_events_wake_check_queue_without_half_second_sleep():
+    strategy = _PriorityHedgeStrategy(scan_seconds=0.01)
+    executor = _build_live_executor(strategy)
+
+    asset = Asset("CVNA", asset_type=Asset.AssetType.STOCK)
+    position = _DummyPosition(asset=asset)
+    order = _DummyOrder(asset=asset)
+
+    wake_to_fill = {}
+
+    def _run_check_queue_once_via_wait():
+        t_wait_start = time.monotonic()
+        executor._queue_wakeup.wait(timeout=0.5)
+        wake_to_fill["waited"] = time.monotonic() - t_wait_start
+        executor.process_queue()
+
+    waiter = threading.Thread(target=_run_check_queue_once_via_wait, daemon=True)
+    waiter.start()
+    time.sleep(0.05)
+    executor.add_event(
+        executor.FILLED_ORDER,
+        dict(
+            position=position,
+            order=order,
+            price=10.0,
+            quantity=Decimal("1"),
+            multiplier=1,
+        ),
+    )
+    waiter.join(timeout=2.0)
+
+    assert strategy.recorded_fills, "priority wake did not drain fill"
+    assert wake_to_fill.get("waited", 1.0) < 0.25, (
+        f"check_queue waited {wake_to_fill.get('waited')}s; expected immediate wake"
+    )
+
+
+def test_broker_does_not_hold_fill_events_during_sync():
+    """Fills must take the priority path even when sync_broker holds trade events."""
+    assert should_hold_trade_event_for_sync(
+        hold_trade_events=True, is_backtesting=False, type_event="new"
+    )
+    assert not should_hold_trade_event_for_sync(
+        hold_trade_events=True, is_backtesting=False, type_event="fill"
+    )
+    assert not should_hold_trade_event_for_sync(
+        hold_trade_events=True, is_backtesting=False, type_event="partial_fill"
+    )
+    assert should_hold_trade_event_for_sync(
+        hold_trade_events=True, is_backtesting=False, type_event="canceled"
+    )
+    assert not should_hold_trade_event_for_sync(
+        hold_trade_events=False, is_backtesting=False, type_event="new"
+    )
+    assert not should_hold_trade_event_for_sync(
+        hold_trade_events=True, is_backtesting=True, type_event="new"
+    )

--- a/tests/test_priority_fill_during_iteration.py
+++ b/tests/test_priority_fill_during_iteration.py
@@ -1,6 +1,6 @@
 """Priority fill/hedge handling must not wait for a long on_trading_iteration.
 
-Regression for Titus / CVNA live hedge delay (2026-09-02):
+Regression for a live option-fill hedge delay (2026-09-02):
 option fill arrived while a ~122s scan was running; hedge submission must not be
 gated behind the full scan finishing.
 """
@@ -292,3 +292,52 @@ def test_broker_does_not_hold_fill_events_during_sync():
     assert not should_hold_trade_event_for_sync(
         hold_trade_events=True, is_backtesting=True, type_event="new"
     )
+
+
+def test_process_queue_uses_nonblocking_retrieval():
+    strategy = _PriorityHedgeStrategy(scan_seconds=0.01)
+    executor = _build_live_executor(strategy)
+
+    class NonBlockingOnlyQueue:
+        def get(self):
+            raise AssertionError("process_queue must not use blocking Queue.get")
+
+        def get_nowait(self):
+            from queue import Empty
+
+            raise Empty
+
+    executor.queue = NonBlockingOnlyQueue()
+    executor.process_queue()
+
+
+def test_process_queue_drains_priority_events_before_normal_backlog():
+    strategy = _PriorityHedgeStrategy(scan_seconds=0.01)
+    executor = _build_live_executor(strategy)
+    processed = []
+    executor.process_event = lambda event, payload: processed.append(event)
+
+    executor.add_event(executor.NEW_ORDER, {"sequence": 1})
+    executor.add_event(executor.NEW_ORDER, {"sequence": 2})
+    executor.add_event(executor.FILLED_ORDER, {"sequence": 3})
+    executor.process_queue()
+
+    assert processed == [executor.FILLED_ORDER, executor.NEW_ORDER, executor.NEW_ORDER]
+
+
+def test_priority_event_preempts_remaining_normal_backlog_when_it_arrives_mid_drain():
+    strategy = _PriorityHedgeStrategy(scan_seconds=0.01)
+    executor = _build_live_executor(strategy)
+    processed = []
+
+    def process(event, payload):
+        processed.append(event)
+        if payload["sequence"] == 1:
+            executor.add_event(executor.FILLED_ORDER, {"sequence": 3})
+
+    executor.process_event = process
+    executor.add_event(executor.NEW_ORDER, {"sequence": 1})
+    executor.add_event(executor.NEW_ORDER, {"sequence": 2})
+    executor.process_queue()
+
+    assert processed == [executor.NEW_ORDER, executor.FILLED_ORDER, executor.NEW_ORDER]

--- a/tests/test_symbol_normalization.py
+++ b/tests/test_symbol_normalization.py
@@ -166,6 +166,7 @@ def test_parse_crypto_pair_symbol_accepts_common_forms():
     assert parse_crypto_pair_symbol("BTC/USD") == ("BTC", "USD")
     assert parse_crypto_pair_symbol("btc-usd") == ("BTC", "USD")
     assert parse_crypto_pair_symbol("BTCUSD") == ("BTC", "USD")
+    assert parse_crypto_pair_symbol("BTCBUSD") == ("BTC", "BUSD")
     assert parse_crypto_pair_symbol("BTC") == ("BTC", None)
     assert parse_crypto_pair_symbol("") == (None, None)
 
@@ -189,10 +190,11 @@ def test_resolve_ccxt_market_symbol_maps_coinbase_hyphen_and_redundant_pair():
     assert "BTC/USD" in crypto_ccxt_symbol_candidates("BTC-USD/USD")
 
 
-def test_coinbase_usdt_candidate_includes_usd_alias():
+def test_coinbase_usdt_candidate_does_not_substitute_usd_quote():
     candidates = crypto_ccxt_symbol_candidates("BTC/USDT", exchange_id="coinbase")
     assert candidates[0] == "BTC/USDT"
-    assert "BTC/USD" in candidates
+    assert "BTC/USD" not in candidates
+    assert resolve_ccxt_market_symbol({"BTC/USD": {}}, "BTC/USDT", exchange_id="coinbase") is None
 
 
 def test_order_pair_normalizes_btc_usd_pair_base():

--- a/tests/test_symbol_normalization.py
+++ b/tests/test_symbol_normalization.py
@@ -7,7 +7,14 @@ from alpaca.trading.enums import PositionSide
 from lumibot.brokers.alpaca import Alpaca
 from lumibot.brokers.tradier import Tradier
 from lumibot.entities import Asset, Order
-from lumibot.tools.symbol_normalization import normalize_symbol_for_broker, normalize_symbol_for_internal
+from lumibot.tools.symbol_normalization import (
+    build_ccxt_crypto_symbol,
+    crypto_ccxt_symbol_candidates,
+    normalize_symbol_for_broker,
+    normalize_symbol_for_internal,
+    parse_crypto_pair_symbol,
+    resolve_ccxt_market_symbol,
+)
 
 
 def test_normalize_symbol_for_internal_uses_dot_canonical_format():
@@ -153,3 +160,49 @@ def test_interactive_brokers_converts_dot_symbol_for_contract_and_back_for_posit
         strategy="unit_test_strategy",
     )
     assert parsed_position.asset.symbol == "BRK.B"
+
+
+def test_parse_crypto_pair_symbol_accepts_common_forms():
+    assert parse_crypto_pair_symbol("BTC/USD") == ("BTC", "USD")
+    assert parse_crypto_pair_symbol("btc-usd") == ("BTC", "USD")
+    assert parse_crypto_pair_symbol("BTCUSD") == ("BTC", "USD")
+    assert parse_crypto_pair_symbol("BTC") == ("BTC", None)
+    assert parse_crypto_pair_symbol("") == (None, None)
+
+
+def test_build_ccxt_crypto_symbol_normalizes_pair_as_base_with_usd_quote():
+    # BEFORE: Asset("BTC-USD") + quote USD became BTC-USD/USD and Coinbase returned no market.
+    # AFTER: normalize to the CCXT unified USD form BTC/USD.
+    assert build_ccxt_crypto_symbol("BTC-USD", "USD") == "BTC/USD"
+    assert build_ccxt_crypto_symbol("BTC/USD", "USD") == "BTC/USD"
+    assert build_ccxt_crypto_symbol("BTC", "USD") == "BTC/USD"
+    assert build_ccxt_crypto_symbol("BTCUSD", "USD") == "BTC/USD"
+    assert build_ccxt_crypto_symbol("ETH-EUR", "EUR") == "ETH/EUR"
+
+
+def test_resolve_ccxt_market_symbol_maps_coinbase_hyphen_and_redundant_pair():
+    markets = {"BTC/USD": {"id": "BTC-USD", "symbol": "BTC/USD"}}
+    assert resolve_ccxt_market_symbol(markets, "BTC-USD") == "BTC/USD"
+    assert resolve_ccxt_market_symbol(markets, "BTC-USD/USD") == "BTC/USD"
+    assert resolve_ccxt_market_symbol(markets, "BTC/USD") == "BTC/USD"
+    assert resolve_ccxt_market_symbol(markets, "ETH/USD") is None
+    assert "BTC/USD" in crypto_ccxt_symbol_candidates("BTC-USD/USD")
+
+
+def test_coinbase_usdt_candidate_includes_usd_alias():
+    candidates = crypto_ccxt_symbol_candidates("BTC/USDT", exchange_id="coinbase")
+    assert candidates[0] == "BTC/USDT"
+    assert "BTC/USD" in candidates
+
+
+def test_order_pair_normalizes_btc_usd_pair_base():
+    from lumibot.entities import Order
+
+    order = Order(
+        strategy="unit",
+        asset=Asset("BTC-USD", asset_type=Asset.AssetType.CRYPTO),
+        quantity=0.001,
+        side="buy",
+        quote=Asset("USD", asset_type=Asset.AssetType.FOREX),
+    )
+    assert order.pair == "BTC/USD"


### PR DESCRIPTION
## What
This release preserves the managed-agent gateway and compact account-context work while hardening option-close validation, stock sizing, broker snapshot reconciliation, priority fill delivery, crypto quote normalization, shared-account fill ownership, evaluation fixtures, and wheel contents.

## Why
The release fixes the no-trade/tool-loop incident path and safety defects found during release review: duplicate close legs could over-close a position, stale position snapshots could prune a concurrent fill, priority fills could wait behind normal backlog, zero or unavailable stock sizing could still reach order guidance, Coinbase aliases could change the requested quote asset, and foreign broker activity on shared accounts could reach another strategy's fill handler and trigger an unintended hedge.

## Risk
Trading-runtime and broker reconciliation behavior changes. Shared-account ownership filtering is live-only so historical backtests retain reconstructed fill callbacks. Detection is covered by unit, backtest, acceptance, real-model, package-integrity, CodeQL, and public-hygiene gates. The release is not merged or tagged until every mandatory gate is green.

## Local tests
- 2,585 ordinary tests passed; 29 skipped; 235 deselected; 3 expected xfailed; 3 xpassed; 98 subtests passed.
- All 9 acceptance cases passed, including backdoor butterfly, MELI, smart-limit butterfly, SPX straddle, and both IBKR cases.
- The two options acceptance cases that exposed the over-broad ownership guard passed after the live-only correction.
- 121 focused fill-ownership, Tradier, Schwab, queue, broker, and executor tests passed; 1 skipped.
- The earlier focused Agent, broker, option, crypto, queue, and packaging selection passed 141 tests; 2 skipped.
- Wheel built and installed in a fresh virtual environment as 4.5.90; 229 archive entries; zero bytecode entries; managed gateway and stock skill present.

## Hosted tests
- Product commit `48eaa673`: lint, 6/6 unit shards, and 4/4 backtest shards passed: https://github.com/Lumiwealth/lumibot/actions/runs/33710554243
- Final documentation-only marker commit `62545b02`: exact-head hosted CI passed lint, all 6 unit shards, all 4 backtest shards, and the aggregate gate: https://github.com/Lumiwealth/lumibot/actions/runs/33713628593
- CodeQL, public leak checks, docs build, and CodeRabbit review passed on the final branch head.

## Real-model gate
The current Google project/key is denied before inference with `403 PERMISSION_DENIED`. Both local and GitHub attempts used zero tokens and made zero real external writes. This is a release blocker until a valid approved Gemini credential is installed and the targeted repeats plus full freshness gate pass.

## Shared-account fill ownership
- Broker tags are ground truth over wrongly attributed `order.strategy` values.
- Tradier polling skips foreign-tagged rows; sole-subscriber fallback no longer claims foreign tags.
- Schwab does not seed untracked foreign active snapshots into the local strategy.
- Live StrategyExecutor fill and partial-fill callbacks enforce ownership.
- Backtests bypass the live shared-account boundary and preserve deterministic reconstructed fill callbacks.
- Before/after regression evidence: foreign fill delivery `1 -> 0`, unintended 100-share hedge `1 -> 0`, owned fill delivery `1 -> 1`.

## Docs and prompts
`CHANGELOG.md`, the stock-trading skill, intraday setup reference, fast order lifecycle guide, and the preserved red eval baseline document the behavior. No visual is needed because this release changes non-visual runtime protocols and safety behavior only.

## Release
- Final deploy marker: `d5a2d1629580`
- Final branch head: `62545b02f6795f6ec55c9dc621ede80a1ea31adf`
- Merge to `dev`, tag `v4.5.90`, PyPI publish, next-version switch, and Bot Manager rollout remain gated on the real-model credential. The final exact-head deterministic and hosted CI gates are green.
