### PR TITLE
fix(tools): handle yfinance frames without Adj Open/High/Low in format_df

### DIFF
--- a/lumibot/tools/yahoo_helper.py
+++ b/lumibot/tools/yahoo_helper.py
@@ -137,19 +137,32 @@ class YahooHelper:
             return df
 
         if auto_adjust:
-            del df["Close"]
-            del df["Open"]
-            del df["High"]
-            del df["Low"]
-            df.rename(
-                columns={
-                    "Adj Close": "Close",
-                    "Adj Open": "Open",
-                    "Adj High": "High",
-                    "Adj Low": "Low",
-                },
-                inplace=True,
-            )
+            if "Adj Open" in df.columns:
+                # Older yfinance versions return split/dividend-adjusted
+                # Open/High/Low/Close columns.
+                del df["Close"]
+                del df["Open"]
+                del df["High"]
+                del df["Low"]
+                df.rename(
+                    columns={
+                        "Adj Close": "Close",
+                        "Adj Open": "Open",
+                        "Adj High": "High",
+                        "Adj Low": "Low",
+                    },
+                    inplace=True,
+                )
+            else:
+                # Newer yfinance versions only return "Adj Close". Scale the
+                # raw OHLC columns by the Adj Close / Close ratio (the same
+                # adjustment yfinance applies for auto_adjust=True), then drop
+                # the adjusted column. Without this, Open/High/Low would be
+                # lost and get_last_price() would return None.
+                adj_ratio = df["Adj Close"] / df["Close"]
+                for col in ["Open", "High", "Low", "Close"]:
+                    df[col] = df[col] * adj_ratio
+                del df["Adj Close"]
         else:
             for col in ["Adj Open", "Adj High", "Adj Low"]:
                 if col in df.columns:


### PR DESCRIPTION
## Summary

`YahooHelper.format_df(..., auto_adjust=True)` drops every price column on current yfinance releases, which makes `get_last_price()` return `None` and breaks anything downstream that reads OHLC.

Fixes #992.

## Root cause

The `auto_adjust=True` branch unconditionally deletes the raw `Close/Open/High/Low` columns and renames the `Adj *` columns. Older yfinance versions return `Adj Open/High/Low/Close`; newer versions only return `Adj Close`. In that case the rename mapping never matches, so all price columns end up deleted.

## Change

- If `"Adj Open"` is present in the frame → keep the existing legacy rename path (unchanged behaviour for old yfinance).
- Otherwise → scale the raw `Open/High/Low/Close` columns by the `Adj Close / Close` ratio (the same adjustment yfinance applies when `auto_adjust=True`), then drop only `Adj Close`.

## Verification

Loaded the real module (stubbing the `fp`/`yfinance`/`lumibot.constants` import chain) and asserted:

1. modern shape (`Adj Close` only) → output keeps exactly `[Open, High, Low, Close, Volume]`, values scaled by the ratio (Close₀ = Adj Close₀)
2. legacy shape (full `Adj *`) → output keeps exactly `[Open, High, Low, Close, Volume]`
3. `auto_adjust=False` → `Adj *` columns removed, `Close` and `Adj Close` preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with multiple yfinance adjusted-price formats.
  * Adjusted historical Open, High, Low, and Close values are now preserved when only adjusted closing prices are provided.
  * Prevented cases where the latest price could be unavailable due to differing market data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->