### PR TITLE
fix(tools): preserve intraday bar timestamps for Yahoo data

### DIFF
--- a/lumibot/tools/yahoo_helper.py
+++ b/lumibot/tools/yahoo_helper.py
@@ -316,7 +316,12 @@ class YahooHelper:
                         df.index = df.index.tz_localize(tz_name)
                     else:
                         df.index = df.index.tz_convert(tz_name)
-                    df.index = df.index.map(lambda t: t.replace(hour=16, minute=0))
+                    # Daily bars are stamped at the session close (16:00 ET) so the
+                    # latest bar counts as "closed". Intraday bars must keep their
+                    # real timestamps: stamping every bar to 16:00 would collapse
+                    # the whole intraday series onto a single (duplicated) index.
+                    if interval == "1d":
+                        df.index = df.index.map(lambda t: t.replace(hour=16, minute=0))
 
                 # Crypto/CCC market
                 elif market == "ccc_market" and tz_name:
@@ -324,7 +329,8 @@ class YahooHelper:
                         df.index = df.index.tz_localize(tz_name)
                     else:
                         df.index = df.index.tz_convert(tz_name)
-                    df.index = df.index.map(lambda t: t.replace(hour=23, minute=59))
+                    if interval == "1d":
+                        df.index = df.index.map(lambda t: t.replace(hour=23, minute=59))
 
         # Finally, run any custom DataFrame processing
         df = YahooHelper.process_df(df, asset_info=info)

--- a/tests/backtest/test_yahoo_helper_intraday_timestamps.py
+++ b/tests/backtest/test_yahoo_helper_intraday_timestamps.py
@@ -1,0 +1,118 @@
+import pandas as pd
+import pytest
+
+from lumibot.tools import yahoo_helper
+from lumibot.tools.yahoo_helper import YahooHelper
+
+
+class _FakeTicker:
+    def __init__(self, frame):
+        self._frame = frame
+
+    def history(self, **kwargs):
+        return self._frame.copy()
+
+
+class _FakeYFinance:
+    def __init__(self, frame):
+        self._frame = frame
+
+    def Ticker(self, symbol):
+        return _FakeTicker(self._frame)
+
+
+def _intraday_frame(tz="America/New_York"):
+    """Three 1-minute bars as yfinance returns them (tz-aware)."""
+    idx = pd.DatetimeIndex(
+        [
+            pd.Timestamp("2025-01-02 09:30:00", tz=tz),
+            pd.Timestamp("2025-01-02 09:31:00", tz=tz),
+            pd.Timestamp("2025-01-02 09:32:00", tz=tz),
+        ]
+    )
+    return pd.DataFrame(
+        {
+            "Open": [200.0, 200.1, 200.2],
+            "High": [200.5, 200.4, 200.6],
+            "Low": [199.8, 199.9, 200.0],
+            "Close": [200.3, 200.2, 200.5],
+            "Volume": [100, 200, 150],
+            "Dividends": [0.0, 0.0, 0.0],
+            "Stock Splits": [0.0, 0.0, 0.0],
+        },
+        index=idx,
+    )
+
+
+def _daily_frame():
+    idx = pd.DatetimeIndex(["2025-01-02", "2025-01-03"])
+    return pd.DataFrame(
+        {
+            "Open": [200.0, 201.0],
+            "High": [202.0, 203.0],
+            "Low": [199.0, 200.0],
+            "Close": [201.0, 202.0],
+            "Volume": [1000, 1100],
+            "Dividends": [0.0, 0.0],
+            "Stock Splits": [0.0, 0.0],
+        },
+        index=idx,
+    )
+
+
+def _patch_yahoo(monkeypatch, frame, info):
+    monkeypatch.setattr(yahoo_helper, "yf", _FakeYFinance(frame))
+    monkeypatch.setattr(YahooHelper, "sleep_and_get_proxy", staticmethod(lambda: None))
+    monkeypatch.setattr(YahooHelper, "get_symbol_info", staticmethod(lambda symbol: info))
+
+
+US_INFO = {"info": {"market": "us_market", "exchangeTimezoneName": "America/New_York"}}
+CCC_INFO = {"info": {"market": "ccc_market", "exchangeTimezoneName": "UTC"}}
+
+
+@pytest.mark.parametrize("interval", ["1m", "15m"])
+def test_intraday_us_timestamps_are_preserved(monkeypatch, interval):
+    """Intraday bars must keep their real bar timestamps instead of all being
+    stamped to 16:00 (which collapses every bar onto a single index value)."""
+    _patch_yahoo(monkeypatch, _intraday_frame(), US_INFO)
+    df = YahooHelper.download_symbol_data("AAPL", interval=interval)
+
+    assert not df.empty
+    times = df.index
+    # Distinct bar times are preserved: no duplicate timestamps.
+    assert len(times.unique()) == len(times)
+    assert times.hour[0] == 9 and times.minute[0] == 30
+
+
+def test_daily_us_bars_are_still_stamped_at_session_close(monkeypatch):
+    """Daily US bars keep the existing behaviour: stamped at 16:00 ET."""
+    _patch_yahoo(monkeypatch, _daily_frame(), US_INFO)
+    df = YahooHelper.download_symbol_data("AAPL", interval="1d")
+
+    assert not df.empty
+    assert set(df.index.hour) == {16}
+    assert set(df.index.minute) == {0}
+
+
+def test_intraday_crypto_timestamps_are_preserved(monkeypatch):
+    """Crypto intraday bars keep their timestamps instead of all being stamped
+    to 23:59."""
+    frame = _intraday_frame(tz="UTC")
+    _patch_yahoo(monkeypatch, frame, CCC_INFO)
+    df = YahooHelper.download_symbol_data("BTC-USD", interval="1m")
+
+    assert not df.empty
+    times = df.index
+    assert len(times.unique()) == len(times)
+    assert times.minute[0] == 30
+
+
+def test_intraday_timestamps_survive_when_info_is_missing(monkeypatch):
+    """When symbol info is unavailable the intraday timestamps are untouched."""
+    _patch_yahoo(monkeypatch, _intraday_frame(), None)
+    df = YahooHelper.download_symbol_data("AAPL", interval="1m")
+
+    assert not df.empty
+    times = df.index
+    assert len(times.unique()) == len(times)
+    assert times.hour[0] == 9 and times.minute[0] == 30


### PR DESCRIPTION
## Summary

`YahooHelper.download_symbol_data` stamps **every** US-market row at 16:00 (and every crypto/CCC row at 23:59). That is correct for daily bars — lumibot stamps daily bars at the session close so the latest bar counts as "closed" — but it collapses all intraday `1m`/`15m` bars onto a single, duplicated index value.

This makes intraday data unusable for US/crypto symbols: every bar ends up with the identical timestamp, so downstream lookups (e.g. `YahooData._get_filtered_end_index`) behave incorrectly.

## Root cause

The session-close stamping in `download_symbol_data` is applied unconditionally, regardless of `interval`:

```python
df.index = df.index.map(lambda t: t.replace(hour=16, minute=0))  # US market
df.index = df.index.map(lambda t: t.replace(hour=23, minute=59))  # crypto
```

For `1m`/`15m` frames this turns e.g. `09:30 / 09:31 / 09:32` into `16:00 / 16:00 / 16:00` (3 duplicated index entries). The single-symbol path (`download_symbol_data`) stamps, while the batch path (`download_symbols_data`) does not — the inconsistency confirms this is a daily-only concern that leaked into all intervals.

## Change

Only apply the session-close stamp for the `"1d"` interval, so intraday bars keep their real timestamps:

- `if interval == "1d":` guard around the 16:00 (US) and 23:59 (crypto) stamping.
- Daily behaviour is unchanged.

## Verification

New regression tests in `tests/backtest/test_yahoo_helper_intraday_timestamps.py`:

1. US intraday `1m` and `15m` → real bar timestamps preserved (no duplicate index).
2. US daily `1d` → still stamped at 16:00 ET (existing behaviour preserved).
3. Crypto intraday `1m` → timestamps preserved (no 23:59 collapse).
4. Missing symbol info → intraday timestamps untouched.

`pytest tests/backtest/test_yahoo_helper_intraday_timestamps.py tests/backtest/test_yahoo_helper_actions.py` → 7 passed.

Note: this fix is independent from the `auto_adjust` handling (see #1149) and from PR #1162, which I'm closing in favour of this narrower, layer-correct change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Yahoo market data timestamps for daily U.S. market bars, which now consistently use 16:00 ET.
  * Preserved actual timestamps for intraday U.S. bars.
  * Continued assigning 23:59 timestamps to daily cryptocurrency bars.
  * Improved timestamp handling when symbol information is unavailable.

* **Tests**
  * Added coverage for daily and intraday timestamp behavior across U.S., cryptocurrency, and symbols without metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->