### PR TITLE
feat: add Kalshi live broker and data source

### DIFF
--- a/.github/workflows/kalshi.yml
+++ b/.github/workflows/kalshi.yml
@@ -1,0 +1,89 @@
+name: Kalshi broker qualification
+
+on:
+  pull_request:
+    branches: [dev, main]
+    paths:
+      - 'lumibot/brokers/kalshi.py'
+      - 'lumibot/data_sources/kalshi_data.py'
+      - 'lumibot/tools/kalshi_client.py'
+      - 'lumibot/credentials.py'
+      - 'tests/test_kalshi*'
+      - 'setup.py'
+      - '.github/workflows/kalshi.yml'
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: 'Demo tests may submit orders only in the selected mutation/fill tier'
+        type: choice
+        options: [offline, read-only, orders, fill]
+        default: offline
+
+permissions:
+  contents: read
+
+jobs:
+  offline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.10', '3.11', '3.12']
+    env:
+      LUMIBOT_DISABLE_DOTENV: '1'
+      LUMIBOT_DISABLE_DOTENV_LOCAL: '1'
+      BACKTESTING_DATA_SOURCE: none
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+      - run: python -m pip install -e . pytest pytest-cov pytest-mock ruff
+      - name: Lint Kalshi implementation
+        run: ruff check --select F,I lumibot/brokers/kalshi.py lumibot/data_sources/kalshi_data.py lumibot/tools/kalshi_client.py tests/test_kalshi*.py
+      - name: Offline contracts and coverage
+        run: >-
+          python -m pytest tests/test_kalshi_client.py tests/test_kalshi_data.py
+          tests/test_kalshi_broker.py tests/test_kalshi_stream.py tests/test_kalshi_credentials.py
+          tests/test_kalshi_demo_safety.py
+          -q -m 'not apitest'
+          --cov=lumibot.brokers.kalshi --cov=lumibot.data_sources.kalshi_data
+          --cov=lumibot.tools.kalshi_client --cov-report=term-missing --cov-fail-under=90
+
+  demo:
+    if: github.event_name == 'workflow_dispatch' && inputs.tier != 'offline'
+    needs: offline
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: unit-tests
+    env:
+      LUMIBOT_DISABLE_DOTENV: '1'
+      LUMIBOT_DISABLE_DOTENV_LOCAL: '1'
+      KALSHI_TEST_IS_DEMO: 'true'
+      KALSHI_TEST_API_KEY_ID: ${{ secrets.KALSHI_TEST_API_KEY_ID }}
+      KALSHI_TEST_PRIVATE_KEY: ${{ secrets.KALSHI_TEST_PRIVATE_KEY }}
+      KALSHI_TEST_ENABLE_ORDER_MUTATIONS: ${{ (inputs.tier == 'orders' || inputs.tier == 'fill') && 'true' || 'false' }}
+      KALSHI_TEST_ENABLE_FILL: ${{ inputs.tier == 'fill' && 'true' || 'false' }}
+      KALSHI_TEST_TIER: ${{ inputs.tier }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: Require Demo secrets
+        run: |
+          test -n "$KALSHI_TEST_API_KEY_ID" || { echo 'Configure KALSHI_TEST_API_KEY_ID in the unit-tests environment'; exit 1; }
+          test -n "$KALSHI_TEST_PRIVATE_KEY" || { echo 'Configure KALSHI_TEST_PRIVATE_KEY in the unit-tests environment'; exit 1; }
+      - run: python -m pip install -e . pytest pytest-mock
+      - name: Run the selected Demo tier
+        run: |
+          case "$KALSHI_TEST_TIER" in
+            read-only) marker='kalshi and not kalshi_demo_mutation and not kalshi_demo_fill' ;;
+            orders) marker='kalshi_demo_mutation' ;;
+            fill) marker='kalshi_demo_fill' ;;
+            *) exit 1 ;;
+          esac
+          python -m pytest tests/test_kalshi_apitest.py -m "$marker" -v --tb=short

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Kalshi live broker and data source using the existing prediction-contract asset,
+  credentials loader, order/position types, singular/plural strategy methods, and
+  CustomStream lifecycle. Supports RSA API keys (inline PEM or file), Demo/production,
+  USD balances, positions, orders, simple limit GTC/IOC/FOK/GTD, price modification,
+  cancellation, quotes, last prices and historical candles. Unsupported market and
+  advanced order types fail explicitly. Includes offline and opt-in Demo API tests.
+  Kalshi backtesting and hosted OAuth onboarding are not included.
+
 ## 4.5.91 - 2026-09-06
 
 Deploy marker: `d007efed231d`

--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Lumibot supports stocks, options, crypto, futures, forex, indexes, and predictio
 - TopstepX futures (via ProjectX)
 - Bitunix
 - Polymarket prediction-contract trading and backtesting
+- [Kalshi](https://lumibot.lumiwealth.com/brokers.kalshi.html) live binary prediction contracts: account state, limit GTC/IOC/FOK/GTD orders, price modification, cancellation, streaming, quotes and historical prices. No Kalshi backtesting or unpriced market orders.
 - Selected CCXT crypto paths. Coinbase, Kraken, and WEEX have auto-detected credential paths; KuCoin, Binance, and BitMEX have documented manual CCXT setup paths; Kraken, Binance, KuCoin, BitMEX, Bybit, and OKX have documented backtesting examples. Lumibot does not claim blanket support for every CCXT exchange.
 
 ## Select Backtesting Data Sources
@@ -497,6 +498,7 @@ Crypto futures/perpetual backtests can route `Asset.AssetType.CRYPTO_FUTURE` thr
 | Polygon     | Yes   | Yes            | No        | No                        |
 | Tradier     | Yes   | Yes            | No        | No                        |
 | Polymarket  | Yes   | N/A            | N/A       | N/A                       |
+| Kalshi (live) | Yes | N/A            | N/A       | N/A                       |
 | Pandas*     | Yes   | Yes            | Yes       | Yes                       |
 
 *Pandas loads CSV files in Yahoo dataframe format, which can contain dividends.

--- a/docs/BROKER_ORDER_SEMANTICS.md
+++ b/docs/BROKER_ORDER_SEMANTICS.md
@@ -2,9 +2,35 @@
 
 > Notes on live broker behavior that affect backtesting semantics (extended hours, order types, and “market closed / no data” handling).
 
-**Last Updated:** 2026-09-06
+**Last Updated:** 2026-09-10
 **Status:** Active
 **Audience:** Developers, AI Agents
+
+## Kalshi live prediction contracts
+
+Kalshi uses `prediction_contract` assets with the market ticker as the symbol.
+All prices and order sides refer to YES: buy increases signed YES quantity and
+sell decreases it. Negative positions are NO contracts. Polymarket's distinct
+outcome-token identifiers are not reused or inferred from a Kalshi ticker.
+
+Only simple limit orders are supported, with explicit `gtc`, `ioc`, `fok` or
+`gtd` (future timezone-aware expiration). The provider's V2 endpoint requires a
+price, so `market` raises instead of being silently simulated. `day`, stops,
+trailing/smart limits, bracket/OCO/OTO/multileg, and custom provider parameters
+are unsupported. Price modification uses amend; quantity changes require a new
+order. Plural submission remains the broker base's independent-order behavior.
+
+Kalshi integer cents and fixed-point strings are normalized at the adapter.
+LumiBot account value is available cash plus the provider's positions value.
+Prediction-contract fills use the existing cash-refresh behavior rather than
+stock short-sale arithmetic. Fill notifications are reconciled against REST
+cumulative quantity/notional and delivered once through `_process_trade_event`.
+The adapter retains sub-cent fill averages despite the generic Order setter's
+cent rounding. The existing `CustomStream` owns notification dispatch and REST
+repair after disconnects. There is no Kalshi backtesting adapter in this change.
+
+See `KALSHI_BROKER_ARCHITECTURE.md` and `docsrc/brokers.kalshi.rst` for tests,
+credentials, endpoint mappings, limits and user examples.
 
 ---
 

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -11,6 +11,24 @@ This page documents environment variables used by LumiBot, with an emphasis on *
   - `docsrc/environment_variables.rst` (public docs), and
   - this file (engineering notes) when it helps contributors.
 
+## Kalshi
+
+Use `TRADING_BROKER=KALSHI` and `IS_BACKTESTING=false`. Runtime credentials are
+`KALSHI_API_KEY_ID` plus either `KALSHI_PRIVATE_KEY` (inline RSA PEM, takes precedence,
+accepts actual or escaped newlines) or `KALSHI_PRIVATE_KEY_PATH`. `KALSHI_IS_DEMO`
+defaults to `true`; `false` selects production and requires production credentials.
+`KALSHI_SUBACCOUNT` defaults to 0 (accepted values 0–63). No URL override is exposed.
+`DATA_SOURCE=KALSHI` selects public data independently. `LUMIBOT_CONNECT_STREAM=false`
+is useful for read-only one-shot clients; live strategies normally keep streaming.
+
+Real API tests use only `KALSHI_TEST_API_KEY_ID` and `KALSHI_TEST_PRIVATE_KEY` or
+`KALSHI_TEST_PRIVATE_KEY_PATH`, with mandatory `KALSHI_TEST_IS_DEMO=true`.
+`KALSHI_TEST_ENABLE_ORDER_MUTATIONS=true` explicitly enables Demo mutations;
+`KALSHI_TEST_ENABLE_FILL=true` enables the additional one-contract fill test.
+`KALSHI_TEST_TICKER` optionally overrides the private, test-only current-market
+selector. These are authorization gates for tests that perform external actions,
+not switches for disabling the offline test suite. See `KALSHI_BROKER_ARCHITECTURE.md`.
+
 ## Backtesting selection + dates
 
 ### `ALPACA_NEWS_API_KEY` / `ALPACA_NEWS_API_SECRET`

--- a/docs/KALSHI_BROKER_ARCHITECTURE.md
+++ b/docs/KALSHI_BROKER_ARCHITECTURE.md
@@ -1,0 +1,232 @@
+# Kalshi live broker architecture and qualification
+
+Standard LumiBot live trading and data contracts, with staged Demo qualification.
+
+Last Updated: 2026-09-10
+Status: Implemented; authenticated Demo qualification pending
+Audience: Contributors, maintainers, and integration testers
+
+## Overview
+
+The integration implements the existing `Broker`, `DataSource` and `CustomStream`
+contracts. It adds no asset type or public strategy method. `prediction_contract`
+assets use Kalshi market tickers; buy/sell and every order/quote/bar price refer to
+YES. Signed positions represent net YES (positive) and NO (negative). Polymarket
+uses the same asset type but distinct outcome tokens, so its token identifiers
+and wallet logic must not be copied into Kalshi.
+
+## Boundaries
+
+- `lumibot/tools/kalshi_client.py`: private RSA-PSS/SHA-256 signing, fixed-point
+  validation, HTTP requests, pagination, bounded read retries and sanitized errors.
+- `lumibot/data_sources/kalshi_data.py`: asset/quote validation, market prices,
+  quotes, OHLCV normalization, history chunking and archived-market fallback.
+- `lumibot/brokers/kalshi.py`: balances, signed positions, order validation,
+  state parsing, submit/cancel/amend and lifecycle reconciliation. `KalshiStream`
+  derives from the existing `CustomStream`.
+- `lumibot/credentials.py` and lazy package exports: standard selection through
+  `TRADING_BROKER=KALSHI`; exported object is `BROKER`.
+
+The official generated Python SDK is not a dependency: its release inspected at
+implementation time requires Python 3.13, while LumiBot supports 3.10 and later.
+The adapter uses existing `httpx`, with direct `cryptography` and `websockets`
+dependencies. Provider wire models stay as dictionaries at the private boundary;
+strategies receive LumiBot objects.
+
+## Method and endpoint map
+
+| Existing LumiBot contract | Kalshi path (under `/trade-api/v2`) |
+|---|---|
+| `_get_balances_at_broker` → `get_cash`, `get_portfolio_value` | GET `/portfolio/balance` |
+| `_pull_position(s)` → `get_position(s)` | GET `/portfolio/positions`, paginated |
+| `_pull_broker_all_orders` → `get_orders` | GET `/portfolio/orders`, paginated |
+| `_pull_broker_order` → `get_order` | GET `/portfolio/orders/{id}`, historical order pagination after 404 |
+| `_submit_order` → `submit_order` | POST `/portfolio/events/orders` |
+| `cancel_order`, inherited `cancel_orders` | DELETE `/portfolio/events/orders/{id}` |
+| `_modify_order` → `modify_order` | POST `/portfolio/events/orders/{id}/amend` |
+| Internal fill reconciliation | GET `/portfolio/fills`, historical fills when needed |
+| `get_last_price`, `get_last_prices` | GET `/markets/{ticker}`; plural reads preserve failed assets as `None` |
+| `get_quote` | GET `/markets/{ticker}` → LumiBot `Quote` |
+| `get_historical_prices` | GET `/markets/candlesticks`, then `/historical/markets/{ticker}/candlesticks` for archived markets |
+| `get_historical_prices_for_assets` | Existing `DataSource.get_bars` dispatch and per-asset errors |
+| `get_chains`, `get_historical_account_value` | Empty result; unsupported provider features |
+
+The preferred strategy `submit_order` accepts one order or a list. The broker's
+inherited plural path submits independent orders concurrently. It is not atomic.
+`submit_orders` and strategy `get_bars` remain existing deprecated aliases.
+There is no `create_orders` or `get_quotes` addition.
+
+## Authentication and values
+
+Inline `KALSHI_PRIVATE_KEY` takes precedence over `KALSHI_PRIVATE_KEY_PATH`.
+The timestamp is milliseconds; sign `timestamp + METHOD + full path`, excluding
+query parameters. The signer uses RSA-PSS with SHA-256 and a 32-byte salt. No
+private key, raw response body, signed header or unsanitized WebSocket exception
+is logged. Demo is the default; explicit `KALSHI_IS_DEMO=false` selects production.
+Subaccount 0 is the default; reads/writes that support account scope receive it.
+
+Prefer `balance_dollars` when provided, otherwise divide `balance` cents by 100.
+Divide `portfolio_value` cents by 100 for positions value. Return the ordinary
+broker tuple `(cash, positions_value, cash + positions_value)`.
+
+Prices use dollar `Decimal` values at the wire boundary. Quantities use 0.01
+contract precision. A market's published price ranges determine valid tick
+increments. Trade candles contain actual OHLCV; null-trade periods are omitted,
+not synthesized from bids/asks. Bars use timezone-aware period-end timestamps
+and exclude incomplete periods. The requested time window can contain fewer
+traded bars than `length` on sparse markets.
+
+## Order support and limits
+
+Simple LIMIT orders support GTC, IOC, FOK and GTD. GTD maps to provider GTC with
+a future expiration. `day` and unpriced MARKET requests fail explicitly. Stops,
+trailing/smart limits, bracket/OCO/OTO/multileg, custom provider parameters,
+scalar/MVE markets, and non-USD quotes are unsupported. Price modification uses
+the broker's current order quantity; this API does not change quantity.
+
+A non-marketable limit can become marketable if the market changes. An IOC can
+partially fill and then cancel. A cancel/amend can race an execution. Tests and
+callers must inspect fills and positions, not assume cancellation means no fill.
+
+## Lifecycle invariants
+
+1. A successful submit attaches the provider ID to the original LumiBot `Order`
+   and emits NEW through `_process_trade_event`.
+2. A transport/5xx/409 ambiguity retains the original client ID. Pending
+   submissions are matched back to that original object during reconciliation.
+3. Order and fill WebSocket messages enqueue an order-ID update on `CustomStream`.
+   The dispatcher reads authoritative order/fill state and applies only the
+   cumulative quantity/notional delta. This deliberately tolerates duplicates,
+   out-of-order delivery and a lagging order view. The order and deduplicated
+   fill quantities must agree before a delta is applied; either endpoint can lag.
+4. REST fills are deduplicated by provider fill ID. Partial and final events carry
+   incremental quantity, not cumulative quantity. Fees and sub-cent average
+   prices are retained on the normal Order.
+5. A canceled order with partial fills emits the fill delta before cancellation.
+   A missing broad-list order is looked up directly; disappearance is not a fill
+   or cancellation. Unknown states stay unknown.
+6. Historical account orders are imported without callbacks for old executions.
+   Use a dedicated account/subaccount for a strategy; no cross-strategy ownership
+   scheme or external platform identity is added.
+7. Reconnect, subscription recovery and queue overflow request REST repair.
+   Both `user_orders` and `fill` acknowledgements are required before the stream
+   reports subscribed, and reconnect does not reuse earlier acknowledgements.
+   Periodic reconciliation continues during a WebSocket outage. API errors are
+   surfaced/logged without private payloads; no mutation is blindly retried.
+8. Live cash/portfolio value use the broker refresh contract. Prediction-market
+   fills already bypass equity short-sale cash arithmetic in StrategyExecutor.
+
+## Qualification layers
+
+### Offline suite (normal deployment tests)
+
+```text
+python -m pytest tests/test_kalshi_client.py tests/test_kalshi_data.py tests/test_kalshi_broker.py tests/test_kalshi_stream.py tests/test_kalshi_credentials.py tests/test_kalshi_demo_safety.py -m "not apitest" --cov=lumibot.brokers.kalshi --cov=lumibot.data_sources.kalshi_data --cov=lumibot.tools.kalshi_client --cov-report=term-missing
+```
+
+Tests verify signing independently with the RSA public key, credential precedence,
+request routing, retry boundaries, redaction, numeric validation, pagination,
+historical range/archival rules, order capability matrices, signed positions,
+cash arithmetic, errors, imported history, partial/final/canceled states, duplicate
+fills, uncertain submit recovery, stream shutdown/reconnect, and actual Strategy
+singular/plural accessors. The target is at least 90% line coverage on new modules,
+with meaningful error/lifecycle branches covered. Existing broker/lifecycle tests
+must remain unchanged in behavior. Only the central provider marker gate is
+extended so Kalshi API tests do not require Polygon/Theta credentials.
+
+### Demo read-only suite
+
+Public Demo price/quote/history checks can run first without any credentials:
+
+```text
+python -m pytest tests/test_kalshi_public_apitest.py -m kalshi -v
+```
+
+Provide **separate test secrets**: `KALSHI_TEST_API_KEY_ID`,
+`KALSHI_TEST_PRIVATE_KEY` or `KALSHI_TEST_PRIVATE_KEY_PATH`, and mandatory
+`KALSHI_TEST_IS_DEMO=true`. There is no production-credential fallback.
+
+```text
+python -m pytest tests/test_kalshi_apitest.py -m "kalshi and not kalshi_demo_mutation and not kalshi_demo_fill" -v
+```
+
+### Demo submit/modify/cancel suite
+
+Additionally enable `KALSHI_TEST_ENABLE_ORDER_MUTATIONS=true`:
+
+```text
+python -m pytest tests/test_kalshi_apitest.py -m kalshi_demo_mutation -v
+```
+
+The test-only market selector finds an open binary market with enough time before
+close, liquidity and valid non-crossing test prices. It does not export a new
+LumiBot method. `KALSHI_TEST_TICKER` is an optional troubleshooting override.
+The test submits a one-contract GTC, reads it, changes price, cancels it, and
+checks non-crossing IOC/FOK behavior. Cleanup is mandatory and failures are visible.
+Mutation tests require the selected market to have no initial position. They
+reconcile uncertain submissions, cancel outstanding test orders, and attempt to
+close accidental fills with at most three IOC requests. No closing order exceeds
+the current position or the total contracts opened by that test. An unresolved
+submission/cancellation stops automated closing and fails with a manual-inspection
+warning. These separate test environment flags are explicit safety authorization
+for account mutations, not a workaround for a failing offline suite.
+
+### Demo fill suite
+
+Also enable `KALSHI_TEST_ENABLE_FILL=true`:
+
+```text
+python -m pytest tests/test_kalshi_apitest.py -m kalshi_demo_fill -v
+```
+
+This deliberately buys at most one Demo contract, checks fills/positions/cash and
+stream subscription, then closes the resulting position. It never uses production
+hosts. It skips an already-held market to preserve existing positions. An inability
+to close is a test failure that requires inspecting the Demo account.
+
+### CI and release
+
+The existing main unit jobs exclude `apitest`, so offline coverage runs there.
+The dedicated Kalshi workflow runs offline tests for Kalshi changes and offers a
+manual Demo read-only/mutation/fill selection using repository environment secrets.
+Secrets are not exposed to forked PRs. Demo tests cannot be called passed when
+credentials are missing or the tests skip. PR/release evidence must state separately
+which offline, existing-broker and Demo checks actually ran.
+
+## Scope after this PR
+
+Backtesting, public market discovery/books, provider order groups/batches,
+advanced order emulation, OAuth and hosted platform onboarding remain separate
+work. The transport, data-source and broker boundaries leave backtesting possible
+later without claiming that it already works.
+
+## Implementation verification (2026-09-10)
+
+- Windows Python 3.12 offline contracts including the Demo safety harness:
+  171 passed with 93.39% combined
+  statement/branch coverage across the three new runtime modules.
+- Demo-harness safety tests: 8 passed, including unknown submissions, incomplete
+  cancellation, partial cleanup, unexpected inventory, and bounded retries.
+- Existing Alpaca, Tradier, Polymarket, credentials and broker/strategy lifecycle
+  regression selection: 184 passed, 3 skipped, 7 deselected.
+- Real public Demo market-data test: 1 passed. The selected open market returned
+  zero traded hourly candles; populated OHLCV normalization is verified offline,
+  not yet against a populated real Demo response.
+- Authenticated Demo tests: 4 skipped because separate test credentials were
+  unavailable. Authentication, account values, positions, orders, authenticated
+  streaming and trading are **not yet certified against a real Demo account**.
+- Scoped Ruff checks passed. Sphinx generated the Kalshi page with no Kalshi-page
+  warnings; the full docs build still reports pre-existing autodoc/indentation
+  warnings and errors in other providers' documentation.
+- Full repository CI and the Python 3.10/3.11 matrix require hosted validation.
+  Do not treat this evidence as a production-trading or release qualification.
+
+## Official sources
+
+- [REST/OpenAPI specification](https://docs.kalshi.com/openapi.yaml)
+- [WebSocket/AsyncAPI specification](https://docs.kalshi.com/asyncapi.yaml)
+- [Authentication](https://docs.kalshi.com/getting_started/quick_start_authenticated_requests)
+- [API environments](https://docs.kalshi.com/getting_started/api_environments)
+- [Create order V2](https://docs.kalshi.com/api-reference/orders/create-order-v2)
+- [Historical data](https://docs.kalshi.com/getting_started/historical_data)
+- [SDK policy](https://docs.kalshi.com/sdks/overview)

--- a/docsrc/_extra/sitemap.xml
+++ b/docsrc/_extra/sitemap.xml
@@ -205,6 +205,10 @@
     <lastmod>2024-11-01</lastmod>
   </url>
   <url>
+    <loc>https://lumibot.lumiwealth.com/brokers.kalshi.html</loc>
+    <lastmod>2026-09-10</lastmod>
+  </url>
+  <url>
     <loc>https://lumibot.lumiwealth.com/brokers.polymarket.html</loc>
     <lastmod>2026-07-02</lastmod>
   </url>

--- a/docsrc/brokers.kalshi.rst
+++ b/docsrc/brokers.kalshi.rst
@@ -1,0 +1,226 @@
+Kalshi
+======
+
+Kalshi is a live broker and data source for binary prediction contracts. It uses
+the normal LumiBot ``Asset``, ``Order``, ``Position``, strategy methods, and order
+lifecycle. Kalshi backtesting is not included.
+
+Account and API key setup
+--------------------------------
+
+1. Create a separate `Kalshi Demo account <https://demo.kalshi.co/>`_ to test
+   without real money. Production accounts are created at `Kalshi <https://kalshi.com/>`_.
+2. In that environment's account settings, open the API keys section and create
+   an API key. Save the key ID and the downloaded RSA private key securely.
+   Follow Kalshi's `authenticated request guide <https://docs.kalshi.com/getting_started/quick_start_authenticated_requests>`_
+   if the account settings change.
+3. Set the environment variables below in your local environment or secret manager.
+   Demo keys and production keys are separate and cannot be interchanged.
+4. Start with the read-only example. Check the account balances before enabling
+   any strategy that submits orders.
+
+.. code-block:: text
+
+   IS_BACKTESTING=false
+   TRADING_BROKER=KALSHI
+   KALSHI_IS_DEMO=true
+   KALSHI_API_KEY_ID=<your-demo-key-id>
+   KALSHI_PRIVATE_KEY_PATH=<path-to-your-private-key.pem>
+
+Alternatively, set ``KALSHI_PRIVATE_KEY`` to the PEM key itself. It accepts real
+newlines or escaped ``\n`` sequences. The inline value takes precedence over
+``KALSHI_PRIVATE_KEY_PATH``. This supports secret managers that inject a key into
+the process environment without writing a file. Do not commit either the key or
+an environment file containing it.
+
+``KALSHI_IS_DEMO`` defaults to ``true``. Explicitly set it to ``false`` only when
+using a production account and intentionally trading real money. An invalid
+boolean value raises an error. ``KALSHI_SUBACCOUNT`` defaults to ``0`` and accepts
+integers from 0 to 63. Balance, position, order-list, and fill requests are scoped
+to the selected subaccount.
+
+``DATA_SOURCE=KALSHI`` is optional when the broker is already Kalshi. The broker
+creates and shares its Kalshi data source automatically. Public market data can
+also be read with ``KalshiData`` without account credentials.
+
+Connection and account values
+-----------------------------
+
+The standard credentials loader exports the configured broker as ``BROKER``:
+
+.. code-block:: python
+
+   from lumibot.credentials import BROKER
+   from lumibot.strategies import Strategy
+
+   class AccountCheck(Strategy):
+       def on_trading_iteration(self):
+           pass
+
+   strategy = AccountCheck(
+       broker=BROKER, analyze_backtest=False,
+       synchronize_broker_on_start=False,
+   )
+   try:
+       if not strategy.update_broker_balances():
+           raise RuntimeError("Kalshi account balance request failed")
+       print("Cash:", strategy.get_cash())
+       print("Total portfolio value:", strategy.get_portfolio_value())
+       print("Positions:", strategy.get_positions())
+       print("Orders:", strategy.get_orders())
+   finally:
+       BROKER.cleanup_streams()
+
+For a one-shot read-only script, ``LUMIBOT_CONNECT_STREAM=false`` avoids starting
+the background stream. Trading strategies should retain the default streaming
+behavior. See ``lumibot/example_strategies/kalshi_account_check.py`` for a
+read-only entry point.
+
+``get_cash()`` is available USD cash. Kalshi reports positions value separately
+from cash; LumiBot's ``get_portfolio_value()`` is their sum. Dollar fixed-point
+fields are preferred over legacy integer-cent fields. The historical account
+value method returns an empty dictionary because Kalshi does not expose that
+series through this integration.
+
+Assets, YES and NO
+--------------------------------
+
+.. code-block:: python
+
+   from lumibot.entities import Asset
+
+   contract = Asset("<KALSHI-MARKET-TICKER>", asset_type="prediction_contract")
+
+Use a **market ticker**, not an event or series ticker. Copy the ticker for a
+specific binary market from Kalshi's market details or documented API. This
+integration adds no public market-search method.
+
+The existing prediction-contract asset type is shared with Polymarket, but the
+identifiers differ: Polymarket uses an outcome token; Kalshi uses one market
+ticker and a signed YES position. Positive quantity means YES, negative means
+NO. A ``buy`` increases YES exposure; a ``sell`` decreases it and may establish
+NO exposure. Selling is not automatically restricted to closing a holding.
+
+All last prices, quotes, candles, limit prices, and fill prices use the YES price
+in dollars from 0 to 1. To buy NO at a maximum cost of 0.40, submit a **sell** at
+a YES limit price of 0.60. Read account balances from the broker; ordinary stock
+short-sale cash arithmetic does not describe collateralized NO contracts.
+
+Quantities can have up to two decimal places and prices up to four; each market
+also has its own price ranges/tick increments. The adapter checks the market's
+published rules before submitting. Only binary, non-multivariate markets are
+supported in this version.
+
+Supported orders
+----------------
+
+.. list-table:: Order support
+   :header-rows: 1
+   :widths: 30 70
+
+   * - LumiBot request
+     - Behavior
+   * - Limit, ``gtc``
+     - Rests until filled or canceled.
+   * - Limit, ``ioc``
+     - Fills available quantity immediately and cancels the remainder.
+   * - Limit, ``fok``
+     - Fills the entire requested quantity immediately or cancels it.
+   * - Limit, ``gtd``
+     - Requires a future, timezone-aware ``good_till_date``.
+   * - Market
+     - Unsupported; the current Kalshi V2 create endpoint requires a price.
+   * - ``day`` time in force
+     - Unsupported. Set ``gtc``, ``ioc``, ``fok``, or ``gtd`` explicitly.
+   * - Stop, stop-limit, trailing-stop, smart-limit
+     - Unsupported; raises before submission.
+   * - Bracket, OCO, OTO, multileg
+     - Unsupported; there is no emulation using independent legs.
+
+The LumiBot default time in force is ``day``, so **always specify the supported
+time in force explicitly**. Unsupported order types/classes and custom provider
+parameters raise an actionable error before an order request is sent.
+
+Inside a normal strategy method:
+
+.. code-block:: python
+
+   # Choose a currently tradable ticker and a deliberate price first.
+   order = self.create_order(
+       contract, 1, "buy", order_type="limit",
+       limit_price=0.25, time_in_force="gtc",
+   )
+   self.submit_order(order)
+   current = self.get_order(order.identifier)
+   self.modify_order(order, limit_price=0.24)
+   self.cancel_order(order)
+
+``modify_order`` supports limit-price changes only. Quantity changes require
+canceling and creating a new order. Modification can execute immediately if the
+new price crosses the market. ``cancel_order`` always contacts Kalshi, including
+when the local status is already ``CANCELLING``.
+
+Plural methods and lifecycle
+--------------------------------
+
+- ``submit_order([first, second])`` uses LumiBot's existing independent-order
+  submission. It is not an atomic package; one order can succeed while another
+  fails. ``submit_orders`` remains available as the existing deprecated alias.
+- ``cancel_orders([first, second])`` and ``cancel_open_orders()`` use the normal
+  broker helpers.
+- ``get_position(asset)``, ``get_positions()``, ``get_order(identifier)``, and
+  ``get_orders()`` use Kalshi account state with pagination.
+- ``get_last_price(asset)``, ``get_last_prices(assets)``, ``get_quote(asset)``,
+  ``get_historical_prices(...)`` and ``get_historical_prices_for_assets(...)``
+  use the standard data-source contract.
+- There is no new ``create_orders()`` or ``get_quotes()`` method.
+
+Authenticated ``user_orders`` and ``fill`` WebSocket messages wake the existing
+``CustomStream`` dispatcher. The adapter reconciles the corresponding order and
+cumulative fills through REST and emits normal LumiBot new, partial-fill, fill,
+cancel, modified, and error events. Duplicate messages do not repeat fills.
+Disconnects trigger reconnect/subscription recovery and periodic REST repair.
+Normal order wait helpers and strategy callbacks use those same events.
+
+Use a dedicated account/subaccount for a strategy. Orders already present on
+startup are imported without announcing old fills as new strategy executions.
+An uncertain submit response retains its client order ID and is reconciled
+against later broker state. Do not create a replacement order merely because
+a request timed out; verify the first order's outcome.
+
+Historical prices
+-----------------
+
+``minute``/``1minute``, ``hour``/``1hour``/``60minute``, and ``day``/``1day``
+are supported. Timeshift must be a ``timedelta``. Bars contain traded YES OHLC
+prices and contract volume, with a timezone-aware period-end index. The current
+incomplete period is excluded. Intervals without trades are omitted, so sparse
+markets can return fewer rows than requested. Bid/ask values are not substituted
+for missing trades. Archived markets use Kalshi's historical candlestick path.
+
+The existing plural historical path preserves a result or error for each asset.
+Plural last-price reads return ``None`` for unavailable assets while preserving
+successful prices in the normal ``AssetsMapping`` result.
+Unsupported timesteps, non-prediction assets, foreign exchanges, and non-USD
+quotes raise clear errors. ``get_chains`` returns ``{}``.
+
+Troubleshooting and verification
+----------------------------------------
+
+- **Authentication failure:** verify the Demo/production setting, key ID, RSA
+  PEM key, and system clock. Signing requires a millisecond timestamp.
+- **Price validation failure:** use the market's current price range/tick size.
+- **No candles:** verify the ticker, timeframe, and that trades occurred. Empty
+  candles do not mean a trade price of zero.
+- **Order status temporarily pending:** order/fill REST views can lag the
+  matching engine. The stream and polling reconciliation retry consistent reads.
+- **Rate limits or transport errors:** safe GETs retry with bounded backoff.
+  Order mutations are not automatically retried.
+- **WebSocket disconnect:** allow outbound HTTPS/WSS access to Kalshi's
+  `documented API hosts <https://docs.kalshi.com/getting_started/api_environments>`_.
+
+Offline tests run without credentials. Demo read-only, order mutation, and fill
+tests are separate ``apitest`` tiers. See ``docs/KALSHI_BROKER_ARCHITECTURE.md``
+for exact commands and test credential settings. Mutation tests never use
+production hosts. A test-only selector chooses a current contract so the tests
+do not depend on one market staying open forever.

--- a/docsrc/brokers.rst
+++ b/docsrc/brokers.rst
@@ -30,6 +30,7 @@ Broker setup is easier on `BotSpot <https://botspot.trade/sales?showLogin=1&utm_
    brokers.ccxt
    brokers.interactive_brokers
    brokers.interactive_brokers_legacy
+   brokers.kalshi
    brokers.polymarket
    brokers.projectx
    brokers.schwab

--- a/docsrc/environment_variables.rst
+++ b/docsrc/environment_variables.rst
@@ -9,6 +9,39 @@ LumiBot supports configuring many behaviors via environment variables. This page
 
    **Never commit secrets** (API keys, passwords, AWS secret keys) into any repo or docs. Document variable names and semantics only.
 
+Kalshi live broker
+------------------
+
+Select ``TRADING_BROKER=KALSHI`` and ``IS_BACKTESTING=false``. See :doc:`brokers.kalshi`.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Variable
+     - Meaning
+   * - ``KALSHI_API_KEY_ID``
+     - Required account API key identifier.
+   * - ``KALSHI_PRIVATE_KEY``
+     - Inline RSA PEM private key. Real or escaped newlines are accepted. Takes precedence over the path.
+   * - ``KALSHI_PRIVATE_KEY_PATH``
+     - Local PEM file path; used when the inline key is absent.
+   * - ``KALSHI_IS_DEMO``
+     - ``true`` (default) or ``false``. Demo and production credentials are separate.
+   * - ``KALSHI_SUBACCOUNT``
+     - Account scope, integer 0–63; default 0.
+
+``DATA_SOURCE=KALSHI`` optionally selects standalone Kalshi market data.
+``LUMIBOT_CONNECT_STREAM=false`` is available for one-shot read-only checks.
+
+The opt-in ``apitest`` suite uses separate ``KALSHI_TEST_API_KEY_ID``,
+``KALSHI_TEST_PRIVATE_KEY`` or ``KALSHI_TEST_PRIVATE_KEY_PATH`` credentials and
+requires ``KALSHI_TEST_IS_DEMO=true``. It never falls back to runtime credentials.
+``KALSHI_TEST_ENABLE_ORDER_MUTATIONS=true`` enables Demo submit/modify/cancel tests;
+``KALSHI_TEST_ENABLE_FILL=true`` additionally enables the one-contract Demo fill
+test. ``KALSHI_TEST_TICKER`` optionally overrides the test-only contract selector.
+Production hosts are prohibited in those tests.
+
 Backtesting configuration
 -------------------------
 

--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -419,6 +419,15 @@ quotes, inspect market rules and resolution status, backtest historical Polymark
 
 Start with the full setup and reference guide: :doc:`brokers.polymarket`.
 
+Kalshi Live Trading
+-------------------
+
+Kalshi supports live binary prediction contracts through the normal broker and
+data-source interfaces: account values, positions, orders, limit GTC/IOC/FOK/GTD,
+price modification, cancellation, streaming, quotes and historical prices.
+Start with :doc:`brokers.kalshi`. This integration does not provide Kalshi
+backtesting or unpriced market orders.
+
 Compared With Backtesting Libraries
 -----------------------------------
 

--- a/lumibot/brokers/__init__.py
+++ b/lumibot/brokers/__init__.py
@@ -11,6 +11,7 @@ _NAME_TO_MODULE = {
     "ExampleBroker": "example_broker",
     "InteractiveBrokers": "interactive_brokers",
     "InteractiveBrokersREST": "interactive_brokers_rest",
+    "Kalshi": "kalshi",
     "ProjectX": "projectx",
     "Polymarket": "polymarket",
     "Schwab": "schwab",

--- a/lumibot/brokers/kalshi.py
+++ b/lumibot/brokers/kalshi.py
@@ -1,0 +1,589 @@
+"""Kalshi live broker using LumiBot orders, positions and lifecycle dispatch."""
+
+from __future__ import annotations
+
+import json
+import queue
+import random
+import threading
+import time
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from lumibot.brokers.broker import Broker
+from lumibot.data_sources.kalshi_data import KalshiData
+from lumibot.entities import Asset, Order, Position
+from lumibot.tools.kalshi_client import KalshiAPIError, KalshiClient, decimal_value
+from lumibot.trading_builtins import CustomStream
+
+
+class KalshiStream(CustomStream):
+    """Existing queue dispatcher, with authenticated WS wakeups and REST repair.
+
+    Order/fill notifications wake reconciliation on this stream's dispatcher.
+    REST cumulative fills are authoritative, so dropped, duplicated or reordered
+    WebSocket messages cannot double-count executions.
+    """
+
+    UPDATE = "kalshi_update"
+
+    def __init__(self, broker, *, websocket_factory=None):
+        super().__init__()
+        self.broker = broker
+        self._websocket_factory = websocket_factory
+        self._reader = None
+        self._socket = None
+        self._subscriptions = set()
+        self._repair = threading.Event()
+        self._repair.set()
+
+    def _receive(self, message):
+        kind = message.get("type")
+        if kind == "error":
+            raise KalshiAPIError("Kalshi WebSocket rejected a subscription")
+        if kind == "subscribed":
+            self._repair.set()
+            self._subscriptions.add((message.get("msg") or {}).get("channel"))
+            if {"user_orders", "fill"} <= self._subscriptions:
+                self.broker._stream_established()
+        if kind in ("user_order", "fill"):
+            row = message.get("msg") or {}
+            if row.get("order_id"):
+                try:
+                    self._queue.put_nowait((self.UPDATE, {"identifier": row["order_id"]}))
+                except queue.Full:
+                    self._repair.set()
+
+    def _read_websocket(self):
+        from websockets.sync.client import connect
+
+        factory = self._websocket_factory or connect
+        attempt = 0
+        while not self._stop_event.is_set():
+            try:
+                client = self.broker._client
+                with factory(
+                    client.ws_url,
+                    additional_headers=client.auth_headers("GET", client.WS_PATH),
+                    open_timeout=10,
+                    close_timeout=2,
+                    ping_interval=20,
+                    ping_timeout=20,
+                ) as socket:
+                    self._socket = socket
+                    self._subscriptions.clear()
+                    socket.send(
+                        json.dumps({"id": 1, "cmd": "subscribe", "params": {"channels": ["user_orders", "fill"]}})
+                    )
+                    self._repair.set()
+                    while not self._stop_event.is_set():
+                        try:
+                            message = socket.recv(timeout=1)
+                        except TimeoutError:
+                            continue
+                        self._receive(json.loads(message))
+                        attempt = 0
+            except Exception:
+                if not self._stop_event.is_set():
+                    # Exceptions from websocket libraries can contain signed
+                    # handshake headers. Log no exception text or traceback.
+                    self.broker.logger.warning("Kalshi stream disconnected; reconciling and reconnecting")
+                    self._repair.set()
+                    self._stop_event.wait(min(30, 0.5 * 2 ** min(attempt, 6)) + random.random() * 0.25)
+                    attempt += 1
+            finally:
+                self._socket = None
+                self.broker._is_stream_subscribed = False
+
+    def _run(self):
+        self._thread = threading.current_thread()
+        self._reader = threading.Thread(target=self._read_websocket, name="Kalshi-websocket", daemon=True)
+        self._reader.start()
+        last_poll = 0.0
+        while not self._stop_event.is_set():
+            try:
+                event, payload = self._queue.get(timeout=0.2)
+                try:
+                    self._process_queue_event(event, payload)
+                finally:
+                    self._queue.task_done()
+            except queue.Empty:
+                pass
+            except Exception:
+                self._repair.set()
+                self.broker.logger.warning("Kalshi order update deferred to REST reconciliation")
+            now = time.monotonic()
+            if self._repair.is_set() or now - last_poll >= self.broker.polling_interval:
+                self._repair.clear()
+                last_poll = now
+                try:
+                    if self.broker._strategy_name:
+                        self.broker.sync_orders(self.broker._strategy_name)
+                        self.broker.sync_positions(self.broker._strategy_name)
+                except Exception:
+                    self.broker.logger.warning("Kalshi REST reconciliation failed; retrying next polling interval")
+
+    def stop(self):
+        self._stop_event.set()
+        if self._socket is not None:
+            self._socket.close()
+        if self._reader and self._reader is not threading.current_thread():
+            self._reader.join(timeout=3)
+        if self._thread is not threading.current_thread():
+            super().stop()
+
+
+class Kalshi(Broker):
+    """Live Kalshi event markets. All prices and order sides refer to YES."""
+
+    NAME = "Kalshi"
+    _TIF = {
+        "gtc": "good_till_canceled",
+        "gtd": "good_till_canceled",
+        "ioc": "immediate_or_cancel",
+        "fok": "fill_or_kill",
+    }
+
+    def __init__(
+        self, config=None, data_source=None, *, connect_stream=True, max_workers=4, polling_interval=5, client=None
+    ):
+        config = config or {}
+        subaccount = config.get("SUBACCOUNT", config.get("KALSHI_SUBACCOUNT", 0))
+        if isinstance(subaccount, bool) or str(subaccount) not in {str(n) for n in range(64)}:
+            raise ValueError("KALSHI_SUBACCOUNT must be an integer from 0 to 63")
+        self.subaccount = int(subaccount)
+        self.polling_interval = max(1.0, float(polling_interval))
+        self._client = client if client is not None else KalshiClient(config, require_auth=True)
+        self._owns_client = client is None
+        self._reconcile_lock = threading.RLock()
+        self._pending_submissions = {}
+        data_source = data_source or KalshiData(client=self._client)
+        self._kalshi_data = data_source if isinstance(data_source, KalshiData) else KalshiData(client=self._client)
+        if isinstance(data_source, KalshiData) and data_source._client.is_demo != self._client.is_demo:
+            raise ValueError("Kalshi broker and data source must use the same environment")
+        # Pass no credential dictionary into Broker's generic config/logging path.
+        super().__init__(
+            name=self.NAME,
+            data_source=data_source,
+            config={"MARKET": "24/7"},
+            connect_stream=connect_stream,
+            max_workers=max_workers,
+            start_orders_thread=False,
+        )
+
+    def _get_balances_at_broker(self, quote_asset, strategy):
+        if quote_asset is not None and quote_asset.symbol != "USD":
+            raise ValueError("Kalshi account balances are denominated in USD")
+        row = self._client.request("GET", "/portfolio/balance", params={"subaccount": self.subaccount})
+        cash = (
+            decimal_value(row["balance_dollars"], "balance")
+            if row.get("balance_dollars") is not None
+            else decimal_value(row["balance"], "balance") / 100
+        )
+        positions = decimal_value(row["portfolio_value"], "portfolio_value") / 100
+        return float(cash), float(positions), float(cash + positions)
+
+    def get_historical_account_value(self):
+        """Kalshi does not expose historical equity through this broker contract."""
+        return {}
+
+    def _pull_positions(self, strategy):
+        name = self._strategy_name_from_input(strategy)
+        rows = self._client.pages(
+            "/portfolio/positions",
+            "market_positions",
+            params={"subaccount": self.subaccount, "limit": 1000, "count_filter": "position"},
+        )
+        positions = []
+        for row in rows:
+            quantity = decimal_value(row.get("position_fp", row.get("position")), "position")
+            if quantity == 0:
+                continue
+            asset = Asset(row["ticker"], asset_type=Asset.AssetType.PREDICTION_CONTRACT, precision="0.01")
+            exposure = row.get("market_exposure_dollars")
+            avg = decimal_value(exposure) / abs(quantity) if exposure is not None else None
+            # Preserve signed YES inventory; NO contracts are negative. Cost and
+            # value of a NO holding use its complementary price, not -YES price.
+            position = Position(name, asset, quantity, avg_fill_price=float(avg) if avg is not None else None)
+            position._raw = row
+            positions.append(position)
+        return positions
+
+    def _pull_position(self, strategy, asset):
+        KalshiData._validate_asset(asset)
+        return next((position for position in self._pull_positions(strategy) if position.asset == asset), None)
+
+    def _pull_broker_all_orders(self):
+        return list(
+            self._client.pages("/portfolio/orders", "orders", params={"subaccount": self.subaccount, "limit": 1000})
+        )
+
+    def _pull_broker_order(self, identifier):
+        try:
+            row = self._client.request("GET", f"/portfolio/orders/{self._client.path_id(identifier)}")["order"]
+        except KalshiAPIError as exc:
+            if exc.status_code != 404:
+                raise
+            # The historical API has no order-ID filter; explicit old-ID reads
+            # must paginate history. Normal synchronization stays on live data.
+            row = next(
+                (
+                    r
+                    for r in self._client.pages("/historical/orders", "orders", params={"limit": 1000})
+                    if str(r.get("order_id")) == str(identifier)
+                ),
+                None,
+            )
+        if row is not None and row.get("subaccount_number", 0) != self.subaccount:
+            return None
+        return row
+
+    @staticmethod
+    def _side(row):
+        book_side = row.get("book_side")
+        if book_side is None:
+            outcome = row.get("outcome_side")
+            if outcome in ("yes", "no"):
+                book_side = "bid" if outcome == "yes" else "ask"
+            elif row.get("side") in ("yes", "no") and row.get("action") in ("buy", "sell"):
+                book_side = "bid" if (row["side"] == "yes") == (row["action"] == "buy") else "ask"
+        if book_side not in ("bid", "ask"):
+            raise KalshiAPIError("Kalshi order has an unknown direction")
+        return Order.OrderSide.BUY if book_side == "bid" else Order.OrderSide.SELL
+
+    @staticmethod
+    def _counts(row):
+        filled = decimal_value(row.get("fill_count_fp", row.get("fill_count", 0)), "fill count")
+        remaining = decimal_value(row.get("remaining_count_fp", row.get("remaining_count", 0)), "remaining count")
+        initial = decimal_value(
+            row.get("initial_count_fp", row.get("initial_count", filled + remaining)), "initial count"
+        )
+        if min(filled, remaining, initial) < 0 or filled > initial or filled + remaining > initial:
+            raise KalshiAPIError("Kalshi returned inconsistent order quantities")
+        return filled, remaining, initial
+
+    def _parse_broker_order(self, response, strategy_name, strategy_object=None):
+        filled, remaining, initial = self._counts(response)
+        state = response.get("status")
+        status = {
+            "resting": Order.OrderStatus.NEW,
+            "executed": Order.OrderStatus.FILLED,
+            "canceled": Order.OrderStatus.CANCELED,
+            "rejected": Order.OrderStatus.ERROR,
+        }.get(state, Order.OrderStatus.UNKNOWN)
+        if state == "resting" and filled:
+            status = Order.OrderStatus.PARTIALLY_FILLED
+        price = KalshiData._number(response, "yes_price_dollars", legacy="yes_price", scale=100)
+        order = Order(
+            strategy_name,
+            Asset(response["ticker"], asset_type=Asset.AssetType.PREDICTION_CONTRACT, precision="0.01"),
+            initial,
+            self._side(response),
+            order_type=response.get("type", "limit"),
+            limit_price=price,
+            identifier=str(response["order_id"]),
+            status=status,
+            time_in_force={v: k for k, v in self._TIF.items() if k != "gtd"}.get(response.get("time_in_force"), "gtc"),
+        )
+        order.update_raw(response)
+        order.broker_create_date = response.get("created_time")
+        order.broker_update_date = response.get("last_update_time")
+        order._kalshi_client_order_id = response.get("client_order_id")
+        return order
+
+    def _order_payload(self, order):
+        KalshiData._validate_asset(order.asset, order.quote, order.exchange)
+        if order.order_class not in (None, "", Order.OrderClass.SIMPLE) or order.child_orders:
+            raise ValueError(
+                "Kalshi supports simple orders only; bracket, OCO, OTO and multileg orders are unsupported"
+            )
+        if order.order_type != Order.OrderType.LIMIT:
+            raise ValueError("Kalshi supports limit orders only; use an explicit limit price and GTC, IOC, FOK or GTD")
+        side = {Order.OrderSide.BUY: "bid", Order.OrderSide.SELL: "ask"}.get(order.side)
+        if side is None:
+            raise ValueError("Kalshi order side must be 'buy' or 'sell' in YES-contract terms")
+        quantity = decimal_value(order.quantity, "quantity")
+        price = decimal_value(order.limit_price, "limit price")
+        if quantity <= 0 or quantity % Decimal("0.01"):
+            raise ValueError("Kalshi quantity must be positive, in increments of 0.01 contracts")
+        if not 0 < price < 1 or price % Decimal("0.0001"):
+            raise ValueError("Kalshi limit price must be between 0 and 1 USD with at most four decimal places")
+        tif = str(order.time_in_force).lower()
+        if tif not in self._TIF:
+            raise ValueError("Kalshi time_in_force must be gtc, ioc, fok or gtd; day is unsupported")
+        if order.custom_params:
+            raise ValueError("Kalshi custom order parameters are unsupported in this integration")
+        payload = {
+            "ticker": order.asset.symbol,
+            "side": side,
+            "count": f"{quantity:.2f}",
+            "price": f"{price:.4f}",
+            "time_in_force": self._TIF[tif],
+            "self_trade_prevention_type": "taker_at_cross",
+            "subaccount": self.subaccount,
+        }
+        if tif == "gtd":
+            expiration = order.good_till_date
+            if not isinstance(expiration, datetime) or expiration.tzinfo is None:
+                raise ValueError("Kalshi GTD requires a timezone-aware good_till_date")
+            if expiration.timestamp() <= time.time():
+                raise ValueError("Kalshi good_till_date must be in the future")
+            payload["expiration_time"] = int(expiration.timestamp())
+        elif order.good_till_date is not None:
+            raise ValueError("Kalshi good_till_date requires time_in_force='gtd'")
+        market = self._kalshi_data._market(order.asset)
+        if market.get("market_type") != "binary" or market.get("mve_collection_ticker"):
+            raise ValueError("Kalshi V1 supports binary, non-multivariate markets only")
+        if market.get("status") not in ("active", "open"):
+            raise ValueError("Kalshi market is not open for trading")
+        ranges = market.get("price_ranges", [])
+        valid = False
+        for band in ranges:
+            start, end, step = (decimal_value(band[k], "price range") for k in ("start", "end", "step"))
+            if step > 0 and start <= price <= end and (price - start) % step == 0:
+                valid = True
+                break
+        if not valid:
+            raise ValueError("Kalshi limit price does not match the market's published price ranges/tick size")
+        return payload
+
+    def _submit_order(self, order):
+        if order.was_transmitted():
+            raise ValueError("Kalshi order is already submitted; use modify_order or create a new order")
+        payload = self._order_payload(order)
+        # Retain this ID on an uncertain outcome. Retrying the same Order object
+        # cannot accidentally invent a second idempotency key.
+        client_id = getattr(order, "_kalshi_client_order_id", None) or str(uuid.uuid4())
+        order._kalshi_client_order_id = client_id
+        payload["client_order_id"] = client_id
+        with self._reconcile_lock:
+            self._pending_submissions[client_id] = order
+            try:
+                response = self._client.request("POST", "/portfolio/events/orders", json=payload)
+            except KalshiAPIError as exc:
+                if exc.status_code is not None and 400 <= exc.status_code < 500 and exc.status_code != 409:
+                    self._pending_submissions.pop(client_id, None)
+                    self._process_trade_event(order, self.ERROR_ORDER, error=exc)
+                else:
+                    order.status = Order.OrderStatus.UNKNOWN
+                    order.error_message = "Kalshi submission outcome unknown; reconcile client_order_id before retrying"
+                raise
+            order.identifier = str(response["order_id"])
+            order.update_raw(response)
+            self._pending_submissions.pop(client_id, None)
+            order._kalshi_fill_count = Decimal(0)
+            order._kalshi_fill_notional = Decimal(0)
+            self._process_trade_event(order, self.NEW_ORDER)
+            self._invalidate_order_caches()
+        # A failed follow-up read must not turn an accepted submit into a failed
+        # submit that a caller might retry. Periodic/WS reconciliation repairs it.
+        self._refresh_after_mutation(order)
+        return order
+
+    def _refresh_after_mutation(self, order):
+        try:
+            self._reconcile_order(order.identifier)
+        except Exception:
+            self.logger.warning("Kalshi accepted order mutation; status refresh deferred to reconciliation")
+
+    def cancel_order(self, order):
+        if not order.identifier:
+            raise ValueError("Kalshi cancellation requires a broker order identifier")
+        self._client.request(
+            "DELETE",
+            f"/portfolio/events/orders/{self._client.path_id(order.identifier)}",
+            params={"subaccount": self.subaccount, "market_ticker": order.asset.symbol},
+        )
+        # Local CANCELLING is not terminal and must never suppress this request.
+        self._refresh_after_mutation(order)
+
+    def _modify_order(self, order, limit_price=None, stop_price=None):
+        if stop_price is not None or limit_price is None:
+            raise ValueError("Kalshi modify_order supports limit_price only")
+        with self._reconcile_lock:
+            snapshot = self._pull_broker_order(order.identifier)
+            if snapshot is None:
+                raise KalshiAPIError("Kalshi order was not found for modification")
+            candidate = self._parse_broker_order(snapshot, order.strategy)
+            candidate.limit_price = limit_price
+            candidate.time_in_force = order.time_in_force
+            candidate.good_till_date = order.good_till_date
+            validated = self._order_payload(candidate)
+            updated_id = str(uuid.uuid4())
+            payload = {key: validated[key] for key in ("ticker", "side", "price", "count")}
+            payload.update(client_order_id=snapshot.get("client_order_id"), updated_client_order_id=updated_id)
+            self._client.request(
+                "POST",
+                f"/portfolio/events/orders/{self._client.path_id(order.identifier)}/amend",
+                params={"subaccount": self.subaccount},
+                json=payload,
+            )
+            order.limit_price = limit_price
+            order._kalshi_client_order_id = updated_id
+            self._process_trade_event(order, self.MODIFIED_ORDER)
+        self._refresh_after_mutation(order)
+        return order
+
+    def _fill_totals(self, row):
+        identifier = row["order_id"]
+        fills = list(
+            self._client.pages(
+                "/portfolio/fills",
+                "fills",
+                params={"order_id": identifier, "subaccount": self.subaccount, "limit": 1000},
+            )
+        )
+        expected, _, _ = self._counts(row)
+        if sum(decimal_value(f.get("count_fp", f.get("count", 0))) for f in fills) < expected:
+            fills.extend(
+                f
+                for f in self._client.pages(
+                    "/historical/fills", "fills", params={"ticker": row["ticker"], "limit": 1000}
+                )
+                if f.get("order_id") == identifier and f.get("subaccount_number", 0) == self.subaccount
+            )
+        unique = {}
+        for fill in fills:
+            if fill.get("order_id") != identifier:
+                raise KalshiAPIError("Kalshi fill did not match the requested order")
+            key = fill.get("fill_id", fill.get("trade_id"))
+            if not key:
+                raise KalshiAPIError("Kalshi fill is missing its identifier")
+            unique[key] = fill
+        count, notional, fees = Decimal(0), Decimal(0), Decimal(0)
+        for fill in unique.values():
+            quantity = decimal_value(fill.get("count_fp", fill.get("count")), "fill count")
+            price = decimal_value(fill["yes_price_dollars"], "fill price")
+            if quantity <= 0 or not 0 <= price <= 1:
+                raise KalshiAPIError("Kalshi returned an invalid fill")
+            count += quantity
+            notional += quantity * price
+            fees += decimal_value(fill.get("fee_cost", 0), "fee")
+        # Either REST view can lead the other. Applying fills newer than the
+        # order snapshot can prematurely complete an order or seed imported
+        # history with a fill checkpoint ahead of its lifecycle state.
+        if count != expected:
+            raise KalshiAPIError("Kalshi fills are not yet consistent with the order; retry reconciliation")
+        return count, notional, fees
+
+    def _apply_snapshot(self, row, strategy_name):
+        parsed = self._parse_broker_order(row, strategy_name)
+        filled, _, initial = self._counts(row)
+        tracked = self.get_tracked_order(parsed.identifier)
+        if tracked is None:
+            tracked = self._pending_submissions.pop(row.get("client_order_id"), None)
+            if tracked is not None:
+                tracked.identifier = parsed.identifier
+                tracked.update_raw(row)
+                tracked._kalshi_fill_count = Decimal(0)
+                tracked._kalshi_fill_notional = Decimal(0)
+                self._process_trade_event(tracked, self.NEW_ORDER)
+        if tracked is None:
+            # Existing account history is imported without announcing historical
+            # fills as new executions to today's strategy.
+            tracked = parsed
+            parsed_status = parsed.status
+            count, notional, fees = self._fill_totals(row) if filled else (Decimal(0), Decimal(0), Decimal(0))
+            self._process_new_order(tracked)
+            if filled:
+                tracked.add_transaction(float(notional / count), count)
+                tracked._avg_fill_price = float(notional / count)
+            tracked._kalshi_fill_count, tracked._kalshi_fill_notional = count, notional
+            tracked.trade_cost = float(fees)
+            self._new_orders.remove(tracked.identifier, key="identifier")
+            tracked.status = parsed_status
+            if row.get("status") == "executed":
+                tracked.set_filled()
+                self._filled_orders.append(tracked)
+            elif row.get("status") == "canceled":
+                tracked.set_canceled()
+                self._canceled_orders.append(tracked)
+            elif row.get("status") == "rejected":
+                tracked.set_error(KalshiAPIError("Kalshi rejected the order"))
+                self._error_orders.append(tracked)
+            elif filled:
+                tracked.set_partially_filled()
+                self._partially_filled_orders.append(tracked)
+            else:
+                self._new_orders.append(tracked)
+            self._invalidate_order_caches()
+            return tracked
+        old_count = getattr(tracked, "_kalshi_fill_count", Decimal(0))
+        if filled < old_count:
+            return tracked  # Stale REST/WS snapshot; never roll back fills.
+        tracked.quantity = initial
+        tracked.limit_price = parsed.limit_price
+        tracked.update_raw(row)
+        if filled > old_count:
+            count, notional, fees = self._fill_totals(row)
+            if count > initial:
+                raise KalshiAPIError("Kalshi fills exceed order size")
+            delta = count - old_count
+            price = (notional - getattr(tracked, "_kalshi_fill_notional", Decimal(0))) / delta
+            event = self.FILLED_ORDER if count == initial else self.PARTIALLY_FILLED_ORDER
+            # The generic average-price setter rounds to cents. Kalshi supports
+            # sub-cent prices; retain the provider's exact average on this Order.
+            tracked._avg_fill_price = float(notional / count)
+            tracked.trade_cost = float(fees)
+            tracked._kalshi_fill_count, tracked._kalshi_fill_notional = count, notional
+            self._process_trade_event(tracked, event, price=price, filled_quantity=delta)
+            self.sync_positions(tracked.strategy)
+        terminal = getattr(tracked, "_kalshi_terminal_event", None)
+        if (
+            row.get("status") == "canceled"
+            and not tracked.is_filled()
+            and tracked.status != self.CANCELED_ORDER
+            and terminal != self.CANCELED_ORDER
+        ):
+            tracked._kalshi_terminal_event = self.CANCELED_ORDER
+            self._process_trade_event(tracked, self.CANCELED_ORDER)
+        elif row.get("status") == "rejected" and tracked.status != self.ERROR_ORDER and terminal != self.ERROR_ORDER:
+            tracked._kalshi_terminal_event = self.ERROR_ORDER
+            self._process_trade_event(tracked, self.ERROR_ORDER, error=KalshiAPIError("Kalshi rejected the order"))
+        elif parsed.status == Order.OrderStatus.UNKNOWN:
+            tracked.status = Order.OrderStatus.UNKNOWN
+            self.logger.warning("Kalshi returned an unknown order status")
+        self._invalidate_order_caches()
+        return tracked
+
+    def _reconcile_order(self, identifier):
+        with self._reconcile_lock:
+            row = self._pull_broker_order(identifier)
+            if row is None:
+                return None
+            tracked = self.get_tracked_order(identifier)
+            name = tracked.strategy if tracked is not None else self._strategy_name
+            if not name:
+                return None
+            return self._apply_snapshot(row, name)
+
+    def sync_orders(self, strategy):
+        """Override the existing sync hook so REST repair emits fill deltas."""
+        name = self._strategy_name_from_input(strategy)
+        with self._reconcile_lock:
+            rows = self._pull_broker_all_orders()
+            identifiers = set()
+            for row in rows:
+                identifiers.add(str(row["order_id"]))
+                tracked = self.get_tracked_order(str(row["order_id"]))
+                self._apply_snapshot(row, tracked.strategy if tracked else name)
+            for order in list(self.get_active_tracked_orders(name)):
+                if order.identifier not in identifiers:
+                    self._reconcile_order(order.identifier)
+
+    def _get_stream_object(self):
+        return KalshiStream(self)
+
+    def _register_stream_events(self):
+        @self.stream.add_action(KalshiStream.UPDATE)
+        def update(identifier):
+            self._reconcile_order(identifier)
+
+    def _run_stream(self):
+        self.stream.run(self.name)
+
+    def cleanup_streams(self):
+        super().cleanup_streams()
+        if getattr(self, "_owns_client", False):
+            self._client.close()

--- a/lumibot/credentials.py
+++ b/lumibot/credentials.py
@@ -59,6 +59,7 @@ _BROKER_CLASS_NAMES = {
     "Bitunix",
     "ProjectX",
     "Polymarket",
+    "Kalshi",
 }
 
 
@@ -380,6 +381,15 @@ ALPACA_TEST_CONFIG = {  # Paper trading!
     "PAPER": True
 }
 
+# Kalshi binary prediction markets (Demo by default)
+KALSHI_CONFIG = {
+    "API_KEY_ID": os.environ.get("KALSHI_API_KEY_ID"),
+    "PRIVATE_KEY": os.environ.get("KALSHI_PRIVATE_KEY"),
+    "PRIVATE_KEY_PATH": os.environ.get("KALSHI_PRIVATE_KEY_PATH"),
+    "IS_DEMO": os.environ.get("KALSHI_IS_DEMO", "true"),
+    "SUBACCOUNT": os.environ.get("KALSHI_SUBACCOUNT", "0"),
+}
+
 # Polymarket International CLOB Configuration
 POLYMARKET_CONFIG = {
     "PRIVATE_KEY": os.environ.get("POLYMARKET_PRIVATE_KEY"),
@@ -646,6 +656,9 @@ def _build_default_live_credentials():
             broker = _broker_class("Schwab")(SCHWAB_CONFIG, connect_stream=connect_stream)
         elif broker_name == "bitunix":
             broker = _broker_class("Bitunix")(BITUNIX_CONFIG, connect_stream=connect_stream)
+        elif broker_name == "kalshi":
+            broker = _broker_class("Kalshi")(KALSHI_CONFIG, connect_stream=connect_stream)
+            data_source = broker.data_source
         elif broker_name in ("polymarket", "polymarket_clob"):
             from .data_sources import PolymarketData
 
@@ -812,6 +825,10 @@ def _build_default_live_credentials():
                 data_source = SchwabData(account_number=SCHWAB_CONFIG["SCHWAB_ACCOUNT_NUMBER"])
                 if broker and broker.name.lower() == "schwab" and hasattr(broker, "client"):
                     data_source.set_client(broker.client)
+            elif data_name == "kalshi":
+                from .data_sources import KalshiData
+
+                data_source = broker.data_source if broker and broker.name == "Kalshi" else KalshiData(KALSHI_CONFIG)
             elif data_name in ("polymarket", "polymarket_clob"):
                 from .data_sources import PolymarketData
 
@@ -931,6 +948,9 @@ elif not is_backtesting or is_backtesting.lower() == "false":
             broker = _broker_class("Schwab")(SCHWAB_CONFIG, connect_stream=connect_stream)
         elif trading_broker_name.lower() == "bitunix":
             broker = _broker_class("Bitunix")(BITUNIX_CONFIG, connect_stream=connect_stream)
+        elif trading_broker_name.lower() == "kalshi":
+            broker = _broker_class("Kalshi")(KALSHI_CONFIG, connect_stream=connect_stream)
+            data_source = broker.data_source
         elif trading_broker_name.lower() in ("polymarket", "polymarket_clob"):
             from .data_sources import PolymarketData
 
@@ -1118,6 +1138,10 @@ elif not is_backtesting or is_backtesting.lower() == "false":
                 # If broker is also Schwab, share the client
                 if broker and broker.name.lower() == "schwab" and hasattr(broker, "client"):
                     data_source.set_client(broker.client)
+            elif data_source_name.lower() == "kalshi":
+                from .data_sources import KalshiData
+
+                data_source = broker.data_source if broker and broker.name == "Kalshi" else KalshiData(KALSHI_CONFIG)
             elif data_source_name.lower() in ("polymarket", "polymarket_clob"):
                 from .data_sources import PolymarketData
 

--- a/lumibot/data_sources/__init__.py
+++ b/lumibot/data_sources/__init__.py
@@ -16,6 +16,7 @@ _NAME_TO_MODULE = {
     "ExampleBrokerData": "example_broker_data",
     "InteractiveBrokersData": "interactive_brokers_data",
     "InteractiveBrokersRESTData": "interactive_brokers_rest_data",
+    "KalshiData": "kalshi_data",
     "NoDataFound": "exceptions",
     "PandasData": "pandas_data",
     "PolarsData": "polars_data",

--- a/lumibot/data_sources/kalshi_data.py
+++ b/lumibot/data_sources/kalshi_data.py
@@ -1,0 +1,198 @@
+"""Kalshi price data through the existing LumiBot DataSource interface."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+
+from lumibot.data_sources.data_source import DataSource
+from lumibot.entities import Asset, AssetsMapping, Bars, Quote
+from lumibot.tools.kalshi_client import KalshiAPIError, KalshiClient, decimal_value
+
+
+class KalshiData(DataSource):
+    SOURCE = "KALSHI"
+    MIN_TIMESTEP = "minute"
+    _INTERVALS = {
+        "minute": 1,
+        "1minute": 1,
+        "1m": 1,
+        "hour": 60,
+        "1hour": 60,
+        "60minute": 60,
+        "1h": 60,
+        "day": 1440,
+        "1day": 1440,
+        "1440minute": 1440,
+        "1d": 1440,
+    }
+
+    def __init__(self, config=None, *, client=None, **kwargs):
+        super().__init__(**kwargs)
+        self.name = "kalshi"
+        self._client = client if client is not None else KalshiClient(config)
+        self._owns_client = client is None
+
+    @staticmethod
+    def _validate_asset(asset, quote=None, exchange=None):
+        if not isinstance(asset, Asset) or asset.asset_type != Asset.AssetType.PREDICTION_CONTRACT:
+            raise ValueError("Kalshi requires an Asset with asset_type='prediction_contract' and a market ticker")
+        if not asset.symbol or asset.multiplier != 1:
+            raise ValueError("Kalshi prediction contracts require a ticker and multiplier=1")
+        if quote is not None and (quote.symbol != "USD" or quote.asset_type != Asset.AssetType.FOREX):
+            raise ValueError("Kalshi only supports USD quotes")
+        if exchange is not None and str(exchange).upper() != "KALSHI":
+            raise ValueError("Kalshi does not support routing to another exchange")
+        return asset.symbol
+
+    @staticmethod
+    def _number(row, field, *, legacy=None, scale=1):
+        value = row.get(field)
+        if value is not None:
+            return float(decimal_value(value, field))
+        if legacy and row.get(legacy) is not None:
+            return float(decimal_value(row[legacy], legacy) / scale)
+        return None
+
+    def _market(self, asset):
+        ticker = self._validate_asset(asset)
+        payload = self._client.request("GET", f"/markets/{self._client.path_id(ticker)}", authenticated=False)
+        market = payload.get("market")
+        if not isinstance(market, dict) or market.get("ticker") != ticker:
+            raise KalshiAPIError("Kalshi returned an invalid market response")
+        return market
+
+    def get_chains(self, asset, quote=None):
+        return {}
+
+    def get_last_price(self, asset, quote=None, exchange=None):
+        self._validate_asset(asset, quote, exchange)
+        return self._number(self._market(asset), "last_price_dollars", legacy="last_price", scale=100)
+
+    def get_last_prices(self, assets, quote=None, exchange=None):
+        # Preserve the existing AssetsMapping contract while keeping one failed
+        # ticker from discarding successful reads for the other assets.
+        result = {}
+        for asset in assets:
+            try:
+                result[asset] = self.get_last_price(asset, quote=quote, exchange=exchange)
+            except (KalshiAPIError, ValueError):
+                result[asset] = None
+                logging.getLogger(__name__).warning("Kalshi last-price read unavailable for a requested asset")
+        return AssetsMapping(result)
+
+    def get_quote(self, asset, quote=None, exchange=None):
+        self._validate_asset(asset, quote, exchange)
+        market = self._market(asset)
+        return Quote(
+            asset=asset,
+            price=self._number(market, "last_price_dollars", legacy="last_price", scale=100),
+            bid=self._number(market, "yes_bid_dollars", legacy="yes_bid", scale=100),
+            ask=self._number(market, "yes_ask_dollars", legacy="yes_ask", scale=100),
+            bid_size=self._number(market, "yes_bid_size_fp"),
+            ask_size=self._number(market, "yes_ask_size_fp"),
+            volume=self._number(market, "volume_fp", legacy="volume"),
+            timestamp=datetime.now(timezone.utc),
+            raw_data=market,
+        )
+
+    def _candlesticks(self, ticker, start, end, interval):
+        params = {"start_ts": start, "end_ts": end, "period_interval": interval}
+        try:
+            payload = self._client.request(
+                "GET",
+                "/markets/candlesticks",
+                params={**params, "market_tickers": ticker},
+                authenticated=False,
+            )
+        except KalshiAPIError as exc:
+            if exc.status_code != 404:
+                raise
+            payload = {"markets": []}
+        markets = payload.get("markets")
+        if not isinstance(markets, list):
+            raise KalshiAPIError("Kalshi candlestick response is missing markets")
+        for market in markets:
+            if market.get("market_ticker", market.get("ticker")) == ticker:
+                return market["candlesticks"]
+        # Archived markets disappear from the live endpoint. A candle's date
+        # alone cannot identify archival: Kalshi archives by settlement time.
+        historical = self._client.request(
+            "GET",
+            f"/historical/markets/{self._client.path_id(ticker)}/candlesticks",
+            params=params,
+            authenticated=False,
+        )
+        return historical["candlesticks"]
+
+    def get_historical_prices(
+        self,
+        asset,
+        length,
+        timestep="",
+        timeshift=None,
+        quote=None,
+        exchange=None,
+        include_after_hours=True,
+        **kwargs,
+    ):
+        ticker = self._validate_asset(asset, quote, exchange)
+        if isinstance(length, bool) or not isinstance(length, int) or length <= 0:
+            raise ValueError("Kalshi history length must be a positive integer")
+        interval = self._INTERVALS.get((timestep or "minute").lower())
+        if interval is None:
+            raise ValueError("Kalshi historical prices support minute, hour, and day timesteps")
+        if timeshift is not None and not isinstance(timeshift, timedelta):
+            raise ValueError("Kalshi history timeshift must be a timedelta")
+        end_dt = self.get_datetime(adjust_for_delay=True) - (timeshift or timedelta())
+        end = int(end_dt.timestamp())
+        step = interval * 60
+        end = (end // step) * step
+        start = end - (length - 1) * step
+        rows = []
+        raw = []
+        # Bound each response below the API's 10,000-candle aggregate limit.
+        for window_start in range(start, end + 1, 4999 * step):
+            candles = self._candlesticks(ticker, window_start, min(end, window_start + 4998 * step), interval)
+            if not isinstance(candles, list):
+                raise KalshiAPIError("Kalshi returned invalid candlesticks")
+            raw.extend(candles)
+            for candle in candles:
+                ts = int(candle["end_period_ts"])
+                if not start <= ts <= end:
+                    continue
+                prices = candle.get("price") or {}
+                values = {
+                    name: self._number(prices, f"{name}_dollars", legacy=name, scale=100)
+                    for name in ("open", "high", "low", "close")
+                }
+                # No trades means null OHLC. Never invent executions from bid/ask
+                # candles or carry a prior close forward as a traded candle.
+                if any(value is None for value in values.values()):
+                    continue
+                rows.append(
+                    {
+                        "datetime": datetime.fromtimestamp(ts, timezone.utc),
+                        **values,
+                        "volume": self._number(candle, "volume_fp", legacy="volume") or 0,
+                    }
+                )
+        if rows:
+            frame = pd.DataFrame(rows).set_index("datetime").sort_index()
+            frame = frame[~frame.index.duplicated(keep="last")].tail(length)
+        else:
+            frame = pd.DataFrame(
+                columns=["open", "high", "low", "close", "volume"],
+                index=pd.DatetimeIndex([], tz="UTC", name="datetime"),
+            )
+        return Bars(frame, self.SOURCE, asset, quote=quote, raw=raw)
+
+    # The base get_bars implements plural Strategy history, including per-asset
+    # failures. Reuse that dispatcher instead of adding another public method.
+
+    def shutdown(self):
+        super().shutdown()
+        if self._owns_client:
+            self._client.close()

--- a/lumibot/example_strategies/kalshi_account_check.py
+++ b/lumibot/example_strategies/kalshi_account_check.py
@@ -1,0 +1,25 @@
+"""Read Kalshi cash, portfolio value, positions and orders without submitting."""
+
+from lumibot.strategies import Strategy
+
+
+class KalshiAccountCheck(Strategy):
+    def on_trading_iteration(self):
+        pass
+
+
+if __name__ == "__main__":
+    from lumibot.credentials import BROKER
+
+    if BROKER is None or BROKER.name != "Kalshi":
+        raise SystemExit("Set TRADING_BROKER=KALSHI and configure Kalshi credentials")
+    strategy = KalshiAccountCheck(broker=BROKER, analyze_backtest=False, synchronize_broker_on_start=False)
+    try:
+        if not strategy.update_broker_balances():
+            raise SystemExit("Kalshi balance check failed; check credentials and environment")
+        print("Cash:", strategy.get_cash())
+        print("Total portfolio value:", strategy.get_portfolio_value())
+        print("Positions:", strategy.get_positions())
+        print("Orders:", strategy.get_orders())
+    finally:
+        BROKER.cleanup_streams()

--- a/lumibot/tools/kalshi_client.py
+++ b/lumibot/tools/kalshi_client.py
@@ -1,0 +1,171 @@
+"""Internal Kalshi REST transport. Public trading behavior belongs to the broker."""
+
+from __future__ import annotations
+
+import base64
+import os
+import time
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from urllib.parse import quote, urlsplit
+
+import httpx
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+from lumibot.brokers.broker import LumibotBrokerAPIError
+
+
+class KalshiAPIError(LumibotBrokerAPIError):
+    """Sanitized provider error; response bodies may contain account information."""
+
+    def __init__(self, message, *, status_code=None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def decimal_value(value, name="value"):
+    """Parse provider fixed-point numbers without accepting NaN or infinity."""
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        raise ValueError(f"Kalshi {name} must be a finite number") from None
+    if not result.is_finite():
+        raise ValueError(f"Kalshi {name} must be a finite number")
+    return result
+
+
+def config_bool(value, name):
+    if isinstance(value, bool):
+        return value
+    if str(value).lower() in ("true", "1"):
+        return True
+    if str(value).lower() in ("false", "0"):
+        return False
+    raise ValueError(f"{name} must be true or false")
+
+
+class KalshiClient:
+    """Small signed HTTP client shared by the broker and its data source.
+
+    Only GET requests are retried automatically. An uncertain order response is
+    surfaced to the caller; resubmitting with a new client ID could trade twice.
+    """
+
+    API_PATH = "/trade-api/v2"
+    WS_PATH = "/trade-api/ws/v2"
+    PRODUCTION_URL = "https://external-api.kalshi.com"
+    DEMO_URL = "https://external-api.demo.kalshi.co"
+    PRODUCTION_WS = "wss://external-api-ws.kalshi.com/trade-api/ws/v2"
+    DEMO_WS = "wss://external-api-ws.demo.kalshi.co/trade-api/ws/v2"
+
+    def __init__(self, config=None, *, http_client=None, require_auth=False, clock=time.time, sleep=time.sleep):
+        config = config or {}
+
+        def setting(key, default=None):
+            return config.get(key, config.get(f"KALSHI_{key}", os.environ.get(f"KALSHI_{key}", default)))
+
+        self.is_demo = config_bool(setting("IS_DEMO", True), "KALSHI_IS_DEMO")
+        self.base_url = self.DEMO_URL if self.is_demo else self.PRODUCTION_URL
+        self.ws_url = self.DEMO_WS if self.is_demo else self.PRODUCTION_WS
+        self.api_key_id = setting("API_KEY_ID")
+        self._private_key = None
+        key = setting("PRIVATE_KEY")
+        key_path = setting("PRIVATE_KEY_PATH")
+        if key or key_path:
+            try:
+                pem = key.replace("\\n", "\n").encode() if key else Path(key_path).read_bytes()
+                self._private_key = serialization.load_pem_private_key(pem, password=None)
+                if not isinstance(self._private_key, rsa.RSAPrivateKey):
+                    raise ValueError("RSA key required")
+            except (OSError, ValueError, TypeError):
+                raise ValueError(
+                    "Invalid Kalshi RSA private key; check KALSHI_PRIVATE_KEY or KALSHI_PRIVATE_KEY_PATH"
+                ) from None
+        self._clock, self._sleep = clock, sleep
+        self._owns_http = http_client is None
+        self._http = http_client or httpx.Client(timeout=15, follow_redirects=False)
+        if require_auth:
+            self.require_auth()
+
+    def require_auth(self):
+        if not self.api_key_id or self._private_key is None:
+            raise ValueError("Kalshi requires KALSHI_API_KEY_ID and KALSHI_PRIVATE_KEY (or KALSHI_PRIVATE_KEY_PATH)")
+
+    def auth_headers(self, method, path):
+        self.require_auth()
+        timestamp = str(int(self._clock() * 1000))
+        message = (timestamp + method.upper() + urlsplit(path).path).encode()
+        signature = self._private_key.sign(
+            message,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=hashes.SHA256().digest_size),
+            hashes.SHA256(),
+        )
+        return {
+            "KALSHI-ACCESS-KEY": self.api_key_id,
+            "KALSHI-ACCESS-TIMESTAMP": timestamp,
+            "KALSHI-ACCESS-SIGNATURE": base64.b64encode(signature).decode(),
+        }
+
+    def request(self, method, path, *, params=None, json=None, authenticated=True):
+        method = method.upper()
+        if not path.startswith("/") or "?" in path or "://" in path:
+            raise ValueError("Kalshi request path must be relative; pass query parameters separately")
+        full_path = self.API_PATH + path
+        for attempt in range(3):
+            headers = self.auth_headers(method, full_path) if authenticated else {}
+            try:
+                response = self._http.request(
+                    method,
+                    self.base_url + full_path,
+                    params=params,
+                    json=json,
+                    headers=headers,
+                )
+            except httpx.TransportError:
+                if method == "GET" and attempt < 2:
+                    self._sleep(0.25 * 2**attempt)
+                    continue
+                raise KalshiAPIError("Kalshi request failed in transport; order outcome may be unknown") from None
+            if response.status_code in (429, 500, 502, 503, 504) and method == "GET" and attempt < 2:
+                self._sleep(0.25 * 2**attempt)
+                continue
+            if response.status_code >= 300:
+                raise KalshiAPIError(
+                    f"Kalshi {method} request failed (HTTP {response.status_code})",
+                    status_code=response.status_code,
+                )
+            if response.status_code == 204:
+                return {}
+            try:
+                result = response.json()
+            except ValueError:
+                raise KalshiAPIError("Kalshi returned invalid JSON") from None
+            if not isinstance(result, dict):
+                raise KalshiAPIError("Kalshi returned an invalid response object")
+            return result
+
+    def pages(self, path, key, *, params=None, authenticated=True):
+        params = dict(params or {})
+        seen = set()
+        while True:
+            payload = self.request("GET", path, params=params, authenticated=authenticated)
+            rows = payload.get(key)
+            if not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows):
+                raise KalshiAPIError(f"Kalshi response is missing the {key} list")
+            yield from rows
+            cursor = payload.get("cursor")
+            if not cursor:
+                return
+            if cursor in seen:
+                raise KalshiAPIError("Kalshi pagination repeated a cursor")
+            seen.add(cursor)
+            params["cursor"] = cursor
+
+    @staticmethod
+    def path_id(value):
+        return quote(str(value), safe="")
+
+    def close(self):
+        if self._owns_http:
+            self._http.close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,9 @@ markers =
     polymarket: marks tests that require Polymarket CLOB credentials or live market data
     polymarket_credentials: marks Polymarket tests that require authenticated CLOB credentials
     polymarket_live_trading: marks Polymarket tests that can submit/cancel live orders when explicitly enabled
+    kalshi: Kalshi Demo API tests (no Polygon or Theta credentials required)
+    kalshi_demo_mutation: opt-in Kalshi Demo submit/modify/cancel tests
+    kalshi_demo_fill: opt-in Kalshi Demo fill and position reconciliation tests
     acceptance_backtest: full Strategy Library acceptance backtests (ThetaData, prod-like flags)
 
 # Exclude the warnings issued by underlying library that we can't fix

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,8 @@ setuptools.setup(
         "requests-oauthlib",
         "boto3>=1.40.64",
         "httpx",
+        "cryptography>=41",
+        "websockets>=15,<16",
     ],
     # Include configuration files, and only include ThetaTerminal.jar if present
     package_data={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -345,11 +345,14 @@ def pytest_runtest_setup(item: pytest.Item):
     requires_theta = item.get_closest_marker("thetadata") is not None
     requires_ibkr = item.get_closest_marker("ibkr") is not None
     requires_polymarket = item.get_closest_marker("polymarket") is not None
+    # Kalshi has independent Demo credentials. Do not apply unrelated legacy
+    # Polygon/Theta gates to this newly supported broker's API tests.
+    requires_kalshi = item.get_closest_marker("kalshi") is not None
     requires_polymarket_credentials = item.get_closest_marker("polymarket_credentials") is not None
     requires_polymarket_live_trading = item.get_closest_marker("polymarket_live_trading") is not None
 
     # Determine which providers are required
-    if requires_ibkr or requires_polymarket:
+    if requires_ibkr or requires_polymarket or requires_kalshi:
         need_polygon = False
         need_theta = False
     elif requires_polygon or requires_theta:

--- a/tests/test_kalshi_apitest.py
+++ b/tests/test_kalshi_apitest.py
@@ -1,0 +1,221 @@
+"""Opt-in real Demo API qualification; never uses production credentials."""
+
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from lumibot.entities import Asset
+from lumibot.strategies import Strategy
+from lumibot.tools.kalshi_client import decimal_value
+
+pytestmark = [pytest.mark.apitest, pytest.mark.kalshi]
+
+
+class DemoCheck(Strategy):
+    def on_trading_iteration(self):
+        pass
+
+
+@pytest.fixture
+def demo(request, monkeypatch):
+    key_id = os.environ.get("KALSHI_TEST_API_KEY_ID")
+    pem = os.environ.get("KALSHI_TEST_PRIVATE_KEY")
+    path = os.environ.get("KALSHI_TEST_PRIVATE_KEY_PATH")
+    if not key_id or not (pem or path):
+        pytest.skip("Configure separate KALSHI_TEST_API_KEY_ID and KALSHI_TEST_PRIVATE_KEY or _PATH")
+    if os.environ.get("KALSHI_TEST_IS_DEMO", "").lower() != "true":
+        pytest.fail("KALSHI_TEST_IS_DEMO=true is required; production API testing is forbidden")
+    mutations = request.node.get_closest_marker("kalshi_demo_mutation") is not None
+    fills = request.node.get_closest_marker("kalshi_demo_fill") is not None
+    if (mutations or fills) and os.environ.get("KALSHI_TEST_ENABLE_ORDER_MUTATIONS", "").lower() != "true":
+        pytest.skip("Demo order mutation tests require KALSHI_TEST_ENABLE_ORDER_MUTATIONS=true")
+    if fills and os.environ.get("KALSHI_TEST_ENABLE_FILL", "").lower() != "true":
+        pytest.skip("Demo fill tests require KALSHI_TEST_ENABLE_FILL=true")
+    # Test the real standard credentials factory, with an explicit complete
+    # Demo-only config. Never fall back to the developer's production settings.
+    monkeypatch.setenv("LUMIBOT_LAZY_CREDENTIALS", "true")
+    monkeypatch.setenv("LUMIBOT_CONNECT_STREAM", "true" if mutations or fills else "false")
+    import lumibot.credentials as credentials
+
+    monkeypatch.setattr(credentials, "trading_broker_name", "kalshi")
+    monkeypatch.setattr(credentials, "data_source_name", None)
+    monkeypatch.setattr(
+        credentials,
+        "KALSHI_CONFIG",
+        {
+            "API_KEY_ID": key_id,
+            "PRIVATE_KEY": pem,
+            "PRIVATE_KEY_PATH": path,
+            "IS_DEMO": True,
+            "SUBACCOUNT": 0,
+        },
+    )
+    broker, source = credentials._build_default_live_credentials()
+    assert broker._client.is_demo and ".demo.kalshi.co" in broker._client.base_url
+    strategy = DemoCheck(broker=broker, analyze_backtest=False, synchronize_broker_on_start=False)
+    try:
+        yield strategy
+    finally:
+        broker.cleanup_streams()
+        source.shutdown()
+
+
+def _eligible_contract(strategy):
+    """Test fixture only: pick a fresh tradable ticker, never a public API."""
+    client = strategy.broker._client
+    override = os.environ.get("KALSHI_TEST_TICKER")
+    rows = client.pages("/markets", "markets", params={"status": "open", "limit": 1000}, authenticated=False)
+    if override:
+        rows = [client.request("GET", f"/markets/{client.path_id(override)}", authenticated=False)["market"]]
+    for index, market in enumerate(rows):
+        if index >= 5000:
+            break
+        if market.get("market_type") != "binary" or market.get("mve_collection_ticker"):
+            continue
+        close = datetime.fromisoformat(market["close_time"].replace("Z", "+00:00"))
+        if close < datetime.now(timezone.utc) + timedelta(hours=1):
+            continue
+        ask = decimal_value(market.get("yes_ask_dollars", "0"))
+        bid = decimal_value(market.get("yes_bid_dollars", "0"))
+        if not Decimal("0.03") < ask < Decimal("0.95") or bid <= 0:
+            continue
+        for band in market.get("price_ranges", []):
+            start, end, step = (decimal_value(band[k]) for k in ("start", "end", "step"))
+            low = max(start, step)
+            if step > 0 and low + step < min(ask, end) and low > 0:
+                return Asset(market["ticker"], asset_type="prediction_contract"), float(low), float(low + step)
+    pytest.skip("No eligible liquid, unexpired Demo contract was found; retry or set KALSHI_TEST_TICKER")
+
+
+def _wait(strategy, order, predicate, timeout=20):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        current = strategy.get_order(order.identifier)
+        if current is not None and predicate(current):
+            return current
+        time.sleep(0.25)
+    pytest.fail("Kalshi Demo order did not reach the expected state within 20 seconds")
+
+
+def _cleanup_demo_orders_and_position(strategy, asset, orders, maximum_quantity):
+    """Only for tests that established the selected market was initially empty.
+
+    Recover an uncertain submit by client ID before canceling. Closing attempts
+    are bounded and never continue after an uncertain close submission.
+    """
+    strategy.broker.sync_orders(strategy.name)
+    errors = []
+    for obj in orders:
+        try:
+            if not obj.was_transmitted():
+                if getattr(obj, "_kalshi_client_order_id", None) in strategy.broker._pending_submissions:
+                    raise RuntimeError("Demo submit outcome remains unknown; inspect the Demo account")
+                continue
+            current = strategy.get_order(obj.identifier)
+            if current is None:
+                raise RuntimeError("Demo test order could not be located for cleanup")
+            if current.is_active():
+                strategy.cancel_order(obj)
+                _wait(strategy, obj, lambda value: value.is_canceled() or value.is_filled())
+        except (Exception, pytest.fail.Exception) as exc:
+            errors.append(type(exc).__name__)
+    # Never let one failed cancellation prevent attempts on the remaining orders.
+    # Do not trade against unresolved open orders or unexpected preexisting size.
+    if errors:
+        pytest.fail("Demo order cleanup incomplete; inspect open orders before closing positions")
+    for _ in range(3):
+        position = strategy.get_position(asset)
+        if position is None or position.quantity == 0:
+            return
+        if not 0 < position.quantity <= maximum_quantity:
+            pytest.fail("Unexpected Demo position size; manual cleanup required")
+        bid = strategy.get_quote(asset).bid
+        if bid is None or bid <= 0:
+            pytest.fail("No executable Demo bid for cleanup; manual cleanup required")
+        close = strategy.create_order(asset, position.quantity, "sell", limit_price=bid, time_in_force="ioc")
+        strategy.submit_order(close)
+        _wait(strategy, close, lambda value: value.is_filled() or value.is_canceled())
+    remaining = strategy.get_position(asset)
+    assert remaining is None or remaining.quantity == 0, "Demo cleanup left a position; close it manually"
+
+
+def test_demo_authentication_cash_positions_orders(demo):
+    assert demo.update_broker_balances()
+    assert demo.get_cash() >= 0
+    assert demo.get_portfolio_value() >= demo.get_cash()
+    positions = demo.get_positions()
+    assert isinstance(positions, list)
+    for position in positions:
+        if position.asset.asset_type == "prediction_contract":
+            assert demo.get_position(position.asset).quantity == position.quantity
+    orders = demo.get_orders()
+    for obj in orders[:3]:
+        assert demo.get_order(obj.identifier).identifier == obj.identifier
+
+
+def test_demo_price_quote_and_singular_plural_history(demo):
+    asset, _, _ = _eligible_contract(demo)
+    assert 0 <= demo.get_last_price(asset) <= 1
+    assert 0 <= demo.get_last_prices([asset])[asset] <= 1
+    quote = demo.get_quote(asset)
+    assert 0 <= quote.bid <= quote.ask <= 1
+    assert demo.get_historical_prices(asset, 5, timestep="hour") is not None
+    assert demo.get_historical_prices_for_assets([asset], 5, timestep="hour")[asset] is not None
+
+
+@pytest.mark.kalshi_demo_mutation
+def test_demo_submit_read_modify_cancel_and_ioc_fok(demo):
+    asset, low, modified = _eligible_contract(demo)
+    initial = demo.get_position(asset)
+    if initial is not None and initial.quantity:
+        pytest.skip("Selected Demo market already has a position; select an empty market")
+    created = []
+    try:
+        obj = demo.create_order(asset, 1, "buy", limit_price=low, time_in_force="gtc")
+        created.append(obj)
+        demo.submit_order(obj)
+        _wait(demo, obj, lambda current: current.is_active())
+        assert any(o.identifier == obj.identifier for o in demo.get_orders())
+        demo.modify_order(obj, limit_price=modified)
+        _wait(demo, obj, lambda current: abs(current.limit_price - modified) < 0.00001)
+        demo.cancel_order(obj)
+        _wait(demo, obj, lambda current: current.is_canceled())
+        for tif in ("ioc", "fok"):
+            quote = demo.get_quote(asset)
+            if quote.ask <= low:
+                pytest.fail("Demo market moved through the non-marketable test price")
+            obj = demo.create_order(asset, 1, "buy", limit_price=low, time_in_force=tif)
+            created.append(obj)
+            demo.submit_order(obj)
+            _wait(demo, obj, lambda current: current.is_canceled())
+        assert demo.broker._is_stream_subscribed, "Authenticated Kalshi stream did not subscribe"
+    finally:
+        _cleanup_demo_orders_and_position(demo, asset, created, maximum_quantity=len(created))
+        if any(obj.transactions for obj in created):
+            pytest.fail("Demo mutation test unexpectedly filled; cleanup completed, retry at a non-crossing price")
+
+
+@pytest.mark.kalshi_demo_fill
+def test_demo_one_contract_fill_positions_cash_and_cleanup(demo):
+    asset, _, _ = _eligible_contract(demo)
+    initial = demo.get_position(asset)
+    if initial is not None and initial.quantity:
+        pytest.skip("Selected Demo market already has a position; select an empty market")
+    assert demo.update_broker_balances()
+    cash_before = demo.get_cash()
+    buy = demo.create_order(asset, 1, "buy", limit_price=demo.get_quote(asset).ask, time_in_force="ioc")
+    try:
+        demo.submit_order(buy)
+        _wait(demo, buy, lambda obj: obj.is_filled() or obj.is_canceled())
+        assert buy.transactions, "Demo contract lacked executable liquidity"
+        position = demo.get_position(asset)
+        assert position and 0 < position.quantity <= 1
+        assert demo.update_broker_balances()
+        assert demo.get_cash() < cash_before
+        assert demo.get_portfolio_value() >= demo.get_cash()
+        assert demo.broker._is_stream_subscribed
+    finally:
+        _cleanup_demo_orders_and_position(demo, asset, [buy], maximum_quantity=1)

--- a/tests/test_kalshi_broker.py
+++ b/tests/test_kalshi_broker.py
@@ -1,0 +1,558 @@
+"""Offline Kalshi order/account contracts through real LumiBot entities."""
+
+import copy
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from lumibot.brokers import Kalshi
+from lumibot.brokers.kalshi import KalshiStream
+from lumibot.entities import Asset, Order
+from lumibot.strategies import Strategy
+from lumibot.tools.kalshi_client import KalshiAPIError, KalshiClient
+
+ASSET = Asset("TEST-MARKET", asset_type="prediction_contract")
+
+
+class FakeClient:
+    is_demo = True
+    path_id = staticmethod(KalshiClient.path_id)
+
+    def __init__(self):
+        self.calls, self.orders, self.fills, self.positions = [], {}, [], []
+        self.market = {
+            "ticker": ASSET.symbol,
+            "market_type": "binary",
+            "status": "active",
+            "last_price_dollars": "0.4321",
+            "yes_bid_dollars": "0.42",
+            "yes_ask_dollars": "0.44",
+            "price_ranges": [{"start": "0.0000", "end": "1.0000", "step": "0.0001"}],
+        }
+        self.balance = {"balance": 10000, "balance_dollars": "100.1234", "portfolio_value": 500}
+
+    def request(self, method, path, *, params=None, json=None, authenticated=True):
+        self.calls.append((method, path, copy.deepcopy(params), copy.deepcopy(json)))
+        if path == "/portfolio/balance":
+            return copy.deepcopy(self.balance)
+        if path == "/markets/TEST-MARKET":
+            return {"market": copy.deepcopy(self.market)}
+        if path == "/markets/candlesticks":
+            return {"markets": [{"market_ticker": ASSET.symbol, "candlesticks": []}]}
+        if method == "POST" and path == "/portfolio/events/orders":
+            identifier = str(len(self.orders) + 1)
+            self.orders[identifier] = {
+                "ticker": json["ticker"],
+                "order_id": identifier,
+                "client_order_id": json["client_order_id"],
+                "book_side": json["side"],
+                "yes_price_dollars": json["price"],
+                "type": "limit",
+                "initial_count_fp": json["count"],
+                "fill_count_fp": "0.00",
+                "remaining_count_fp": json["count"],
+                "status": "resting",
+                "subaccount_number": json["subaccount"],
+                "time_in_force": json["time_in_force"],
+            }
+            if json["time_in_force"] in ("immediate_or_cancel", "fill_or_kill"):
+                self.orders[identifier].update(status="canceled", remaining_count_fp="0.00")
+            return {"order_id": identifier, "fill_count": "0.00", "remaining_count": json["count"], "ts_ms": 1}
+        if method == "GET" and path.startswith("/portfolio/orders/"):
+            identifier = path.split("/")[-1]
+            if identifier not in self.orders:
+                raise KalshiAPIError("missing", status_code=404)
+            return {"order": copy.deepcopy(self.orders[identifier])}
+        if method == "DELETE":
+            identifier = path.split("/")[-1]
+            self.orders[identifier].update(status="canceled", remaining_count_fp="0.00")
+            return {"order_id": identifier, "reduced_by": "1.00", "ts_ms": 1}
+        if method == "POST" and path.endswith("/amend"):
+            identifier = path.split("/")[-2]
+            self.orders[identifier].update(
+                yes_price_dollars=json["price"], client_order_id=json["updated_client_order_id"]
+            )
+            return {"order_id": identifier, "ts_ms": 1}
+        raise AssertionError((method, path, params, json))
+
+    def pages(self, path, key, *, params=None, authenticated=True):
+        self.calls.append(("GET", path, copy.deepcopy(params), None))
+        if path == "/portfolio/orders":
+            return iter(copy.deepcopy(list(self.orders.values())))
+        if path == "/portfolio/positions":
+            return iter(copy.deepcopy(self.positions))
+        if path == "/portfolio/fills":
+            return iter(copy.deepcopy([f for f in self.fills if f["order_id"] == params["order_id"]]))
+        if path.startswith("/historical/"):
+            return iter([])
+        raise AssertionError(path)
+
+    def fill(self, order, quantity, price="0.4321", *, cancel=False):
+        row = self.orders[order.identifier]
+        filled = Decimal(row["fill_count_fp"]) + Decimal(str(quantity))
+        remaining = Decimal(row["initial_count_fp"]) - filled
+        row.update(
+            fill_count_fp=str(filled),
+            remaining_count_fp=str(remaining),
+            status="executed" if remaining == 0 else "resting",
+        )
+        if cancel:
+            row.update(status="canceled", remaining_count_fp="0.00")
+        self.fills.append(
+            {
+                "fill_id": str(len(self.fills) + 1),
+                "order_id": order.identifier,
+                "count_fp": str(quantity),
+                "yes_price_dollars": price,
+                "fee_cost": "0.0001",
+            }
+        )
+        signed = filled if row["book_side"] == "bid" else -filled
+        self.positions = [{"ticker": ASSET.symbol, "position_fp": str(signed), "market_exposure_dollars": "0.5"}]
+
+
+@pytest.fixture
+def broker():
+    broker = Kalshi(client=FakeClient(), connect_stream=False)
+    broker.set_strategy_name("test")
+    # A live strategy has an executor subscriber. Exercise that normal contract
+    # rather than invoking the base broker's missing-subscriber error path.
+    broker._add_subscriber(
+        SimpleNamespace(
+            name="test",
+            add_event=Mock(),
+            NEW_ORDER="new",
+            CANCELED_ORDER="canceled",
+            PARTIALLY_FILLED_ORDER="partial_fill",
+            FILLED_ORDER="fill",
+            ERROR_ORDER="error",
+        )
+    )
+    yield broker
+    broker.cleanup_streams()
+
+
+def order(**kwargs):
+    options = dict(
+        strategy="test", asset=ASSET, quantity=2, side="buy", limit_price=0.4, order_type="limit", time_in_force="gtc"
+    )
+    options.update(kwargs)
+    return Order(**options)
+
+
+@pytest.mark.parametrize("side,book_side", [("buy", "bid"), ("sell", "ask")])
+@pytest.mark.parametrize("tif", ["gtc", "ioc", "fok", "gtd"])
+def test_supported_order_combinations(broker, side, book_side, tif):
+    obj = order(
+        side=side,
+        time_in_force=tif,
+        good_till_date=datetime.now(timezone.utc) + timedelta(days=1) if tif == "gtd" else None,
+    )
+    result = broker.submit_order(obj)
+    assert result is obj
+    submit = next(call for call in broker._client.calls if call[0] == "POST")
+    assert submit[3]["side"] == book_side
+    assert submit[3]["price"] == "0.4000"
+    assert submit[3]["count"] == "2.00"
+    assert ("expiration_time" in submit[3]) == (tif == "gtd")
+    assert obj.was_transmitted()
+    assert obj.status == (Order.OrderStatus.CANCELED if tif in ("ioc", "fok") else Order.OrderStatus.NEW)
+
+
+def test_balance_units_and_total_equity(broker):
+    assert broker._get_balances_at_broker(Asset("USD", asset_type="forex"), None) == (100.1234, 5, 105.1234)
+    del broker._client.balance["balance_dollars"]
+    assert broker._get_balances_at_broker(None, None) == (100, 5, 105)
+    with pytest.raises(ValueError, match="USD"):
+        broker._get_balances_at_broker(Asset("EUR", asset_type="forex"), None)
+    assert broker.get_historical_account_value() == {}
+
+
+@pytest.mark.parametrize("quantity", ["2.25", "-2.25", "0.00"])
+def test_signed_positions_and_lookup(broker, quantity):
+    broker._client.positions = [{"ticker": ASSET.symbol, "position_fp": quantity, "market_exposure_dollars": "1.125"}]
+    positions = broker._pull_positions("test")
+    if Decimal(quantity):
+        assert Decimal(str(positions[0].quantity)) == Decimal(quantity)
+        assert broker._pull_position("test", ASSET).avg_fill_price == 0.5
+    else:
+        assert positions == []
+        assert broker._pull_position("test", ASSET) is None
+
+
+@pytest.mark.parametrize("kind", ["market", "stop", "stop_limit", "trailing_stop", "smart_limit"])
+def test_unsupported_order_types_send_no_requests(broker, kind):
+    obj = order()
+    obj.order_type = kind
+    with pytest.raises(ValueError, match="limit orders only"):
+        broker.submit_order(obj)
+    assert broker._client.calls == []
+
+
+@pytest.mark.parametrize("kind", ["bracket", "oco", "oto", "multileg"])
+def test_unsupported_order_classes_send_no_requests(broker, kind):
+    obj = order()
+    obj.order_class = kind
+    with pytest.raises(ValueError, match="simple orders"):
+        broker.submit_order(obj)
+    assert broker._client.calls == []
+
+
+@pytest.mark.parametrize(
+    "field,value,match",
+    [
+        ("time_in_force", "day", "time_in_force"),
+        ("limit_price", 1.0, "limit price"),
+        ("limit_price", 0.0, "limit price"),
+        ("limit_price", 0.12345, "four decimal"),
+        ("limit_price", float("nan"), "finite"),
+        ("quantity", 0.001, "increments"),
+        ("custom_params", {"post_only": True}, "custom"),
+    ],
+)
+def test_invalid_order_parameters_fail_before_network(broker, field, value, match):
+    obj = order()
+    setattr(obj, field, value)
+    with pytest.raises(ValueError, match=match):
+        broker.submit_order(obj)
+    assert broker._client.calls == []
+
+
+def test_gtd_requires_future_aware_expiration(broker):
+    for expiration in [None, datetime(2030, 1, 1), datetime(2000, 1, 1, tzinfo=timezone.utc)]:
+        with pytest.raises(ValueError, match="Kalshi"):
+            broker.submit_order(order(time_in_force="gtd", good_till_date=expiration))
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"status": "closed"},
+        {"market_type": "scalar"},
+        {"mve_collection_ticker": "MULTI"},
+        {"price_ranges": [{"start": "0", "end": "1", "step": "0.03"}]},
+        {"price_ranges": []},
+    ],
+)
+def test_market_rules_reject_without_submitting(broker, change):
+    broker._client.market.update(change)
+    with pytest.raises(ValueError, match="Kalshi"):
+        broker.submit_order(order())
+    assert all(call[0] != "POST" for call in broker._client.calls)
+
+
+def test_modify_and_cancel_follow_provider_and_lifecycle(broker):
+    obj = broker.submit_order(order())
+    broker.modify_order(obj, limit_price=0.4123)
+    assert obj.limit_price == 0.4123
+    assert broker._pull_order(obj.identifier, "test").limit_price == 0.4123
+    amend = next(c for c in broker._client.calls if c[1].endswith("/amend"))
+    assert amend[3]["count"] == "2.00"
+    with pytest.raises(ValueError, match="limit_price only"):
+        broker.modify_order(obj, stop_price=0.2)
+    obj.status = Order.OrderStatus.CANCELLING
+    broker.cancel_order(obj)
+    assert obj.status == Order.OrderStatus.CANCELED
+    assert obj._closed_event.is_set()
+    assert any(c[0] == "DELETE" for c in broker._client.calls)
+
+
+def test_duplicate_and_out_of_order_fills_are_counted_once(broker):
+    obj = broker.submit_order(order())
+    broker._client.fill(obj, 0.75)
+    broker._reconcile_order(obj.identifier)
+    assert obj.status == Order.OrderStatus.PARTIALLY_FILLED
+    assert obj.get_fill_price() == 0.4321
+    stale = copy.deepcopy(broker._client.orders[obj.identifier])
+    broker._client.fill(obj, 1.25, "0.4567")
+    broker._client.fills.append(copy.deepcopy(broker._client.fills[0]))
+    broker._reconcile_order(obj.identifier)
+    broker._reconcile_order(obj.identifier)
+    broker._apply_snapshot(stale, "test")
+    assert obj.status == Order.OrderStatus.FILLED
+    assert sum(Decimal(str(t.quantity)) for t in obj.transactions) == Decimal("2.00")
+    assert obj.get_fill_price() == pytest.approx((0.75 * 0.4321 + 1.25 * 0.4567) / 2)
+    assert obj.trade_cost == pytest.approx(0.0002)
+    assert obj._closed_event.is_set()
+    assert broker.get_tracked_position("test", ASSET).quantity == 2
+
+
+def test_partial_fill_then_cancel_keeps_fill_and_terminal_callback(broker):
+    obj = broker.submit_order(order())
+    broker._client.fill(obj, 0.75, cancel=True)
+    broker._reconcile_order(obj.identifier)
+    assert obj.status == Order.OrderStatus.CANCELED
+    assert len(obj.transactions) == 1
+    assert obj.transactions[0].quantity == 0.75
+    assert broker.get_tracked_position("test", ASSET).quantity == 0.75
+
+
+def test_order_status_waits_for_authoritative_fills(broker):
+    obj = broker.submit_order(order())
+    row = broker._client.orders[obj.identifier]
+    row.update(fill_count_fp="2.00", remaining_count_fp="0.00", status="executed")
+    with pytest.raises(KalshiAPIError, match="not yet consistent"):
+        broker._reconcile_order(obj.identifier)
+    assert not obj.is_filled()
+    assert not obj.transactions
+
+
+def test_imported_history_does_not_emit_old_fill_callbacks(broker):
+    obj = broker.submit_order(order())
+    broker._client.fill(obj, 2)
+    fresh = Kalshi(client=broker._client, connect_stream=False)
+    try:
+        fresh._on_filled_order = Mock()
+        fresh.sync_orders("new-strategy")
+        pulled = fresh.get_tracked_order(obj.identifier)
+        assert pulled.status == Order.OrderStatus.FILLED
+        assert sum(t.quantity for t in pulled.transactions) == 2
+        fresh._on_filled_order.assert_not_called()
+    finally:
+        fresh.cleanup_streams()
+
+
+@pytest.mark.parametrize("imported", [False, True])
+def test_fills_ahead_of_order_snapshot_wait_for_consistent_state(broker, imported):
+    obj = broker.submit_order(order())
+    broker._client.fill(obj, 0.75)
+    stale = copy.deepcopy(broker._client.orders[obj.identifier])
+    broker._client.fill(obj, 1.25)
+    target = Kalshi(client=broker._client, connect_stream=False) if imported else broker
+    try:
+        with pytest.raises(KalshiAPIError, match="not yet consistent"):
+            target._apply_snapshot(stale, "test")
+        assert not obj.transactions
+        target._apply_snapshot(broker._client.orders[obj.identifier], "test")
+        tracked = target.get_tracked_order(obj.identifier)
+        assert tracked.is_filled()
+        assert sum(t.quantity for t in tracked.transactions) == 2
+        assert tracked._closed_event.is_set()
+    finally:
+        if imported:
+            target.cleanup_streams()
+
+
+def test_inherited_plural_submit_cancel_and_atomic_rejection(broker):
+    orders = broker.submit_orders([order(), order(side="sell")])
+    assert len(orders) == 2
+    broker.cancel_orders(orders)
+    assert all(obj.status == Order.OrderStatus.CANCELED for obj in orders)
+    with pytest.raises(NotImplementedError, match="atomic"):
+        broker.submit_orders([order()], is_multileg=True)
+
+
+@pytest.mark.parametrize("status", [None, 409, 500])
+def test_uncertain_submission_preserves_client_id(broker, status):
+    original = broker._client.request
+    ids = []
+
+    def fail(method, path, **kwargs):
+        if method == "POST":
+            ids.append(kwargs["json"]["client_order_id"])
+            raise KalshiAPIError("uncertain", status_code=status)
+        return original(method, path, **kwargs)
+
+    broker._client.request = fail
+    obj = order()
+    for _ in range(2):
+        with pytest.raises(KalshiAPIError):
+            broker.submit_order(obj)
+    assert ids[0] == ids[1]
+    assert obj.status == Order.OrderStatus.UNKNOWN
+
+
+def test_rejected_submission_emits_error(broker):
+    original = broker._client.request
+
+    def reject(method, path, **kwargs):
+        if method == "POST":
+            raise KalshiAPIError("rejected", status_code=400)
+        return original(method, path, **kwargs)
+
+    broker._client.request = reject
+    obj = order()
+    with pytest.raises(KalshiAPIError):
+        broker.submit_order(obj)
+    assert obj.status == Order.OrderStatus.ERROR
+    assert obj._closed_event.is_set()
+
+
+def test_stream_dispatch_and_overflow_request_reconciliation(broker):
+    broker.stream = KalshiStream(broker)
+    broker._register_stream_events()
+    obj = broker.submit_order(order())
+    broker._client.fill(obj, 2)
+    broker.stream._receive({"type": "fill", "msg": {"order_id": obj.identifier}})
+    event, payload = broker.stream._queue.get_nowait()
+    broker.stream._process_queue_event(event, payload)
+    broker.stream._queue.task_done()
+    assert obj.is_filled()
+    broker.stream._repair.clear()
+    for _ in range(101):
+        broker.stream._receive({"type": "fill", "msg": {"order_id": obj.identifier}})
+    assert broker.stream._repair.is_set()
+    with pytest.raises(KalshiAPIError, match="subscription"):
+        broker.stream._receive({"type": "error"})
+
+
+class ContractStrategy(Strategy):
+    def initialize(self):
+        self.sleeptime = "1M"
+
+    def on_trading_iteration(self):
+        pass
+
+
+def test_real_strategy_singular_plural_and_order_accessors(broker):
+    strategy = ContractStrategy(broker=broker, analyze_backtest=False, synchronize_broker_on_start=False)
+    assert strategy.update_broker_balances()
+    assert strategy.get_cash() == 100.1234
+    assert strategy.get_portfolio_value() == 105.1234
+    first = strategy.create_order(ASSET, 1, "buy", limit_price=0.4, time_in_force="gtc")
+    second = strategy.create_order(ASSET, 1, "sell", limit_price=0.4, time_in_force="gtc")
+    strategy.submit_order([first, second])
+    assert strategy.get_order(first.identifier).identifier == first.identifier
+    assert len(strategy.get_orders()) == 2
+    assert strategy.get_last_price(ASSET) == 0.4321
+    assert strategy.get_last_prices([ASSET])[ASSET] == 0.4321
+    assert strategy.get_quote(ASSET).bid == 0.42
+    assert strategy.get_historical_prices(ASSET, 2).df.empty
+    assert strategy.get_historical_prices_for_assets([ASSET], 2)[ASSET].df.empty
+    strategy.modify_order(first, limit_price=0.41)
+    strategy.cancel_orders([first, second])
+    assert all(obj.status == Order.OrderStatus.CANCELED for obj in strategy.get_orders())
+    assert strategy.get_position(ASSET) is None
+    assert all(p.asset.symbol == "USD" for p in strategy.get_positions())
+
+
+def test_lost_submit_response_recovers_original_order_and_fill(broker):
+    original = broker._client.request
+
+    def lose_response(method, path, **kwargs):
+        response = original(method, path, **kwargs)
+        if method == "POST":
+            raise KalshiAPIError("response lost")
+        return response
+
+    broker._client.request = lose_response
+    obj = order()
+    with pytest.raises(KalshiAPIError):
+        broker.submit_order(obj)
+    broker._client.request = original
+    broker.sync_orders("test")
+    assert broker.get_tracked_order("1") is obj
+    assert obj.identifier == "1"
+    assert obj.was_transmitted()
+    assert not broker._pending_submissions
+    broker._client.fill(obj, 2)
+    broker.sync_orders("test")
+    assert obj.is_filled()
+    assert len(obj.transactions) == 1
+    with pytest.raises(ValueError, match="already submitted"):
+        broker.submit_order(obj)
+
+
+@pytest.mark.parametrize(
+    "row,side",
+    [
+        ({"book_side": "bid"}, "buy"),
+        ({"book_side": "ask"}, "sell"),
+        ({"outcome_side": "yes"}, "buy"),
+        ({"outcome_side": "no"}, "sell"),
+        ({"action": "buy", "side": "yes"}, "buy"),
+        ({"action": "sell", "side": "yes"}, "sell"),
+        ({"action": "buy", "side": "no"}, "sell"),
+        ({"action": "sell", "side": "no"}, "buy"),
+    ],
+)
+def test_current_and_legacy_order_direction(broker, row, side):
+    assert broker._side(row) == side
+
+
+def test_unknown_direction_and_inconsistent_counts_rejected(broker):
+    with pytest.raises(KalshiAPIError, match="direction"):
+        broker._side({"side": "unknown"})
+    for counts in [("2", "1", "2"), ("-1", "1", "1"), ("3", "0", "2")]:
+        with pytest.raises(KalshiAPIError, match="quantities"):
+            broker._counts(dict(zip(("fill_count_fp", "remaining_count_fp", "initial_count_fp"), counts)))
+
+
+def test_get_order_404_searches_history_and_preserves_account_scope(broker):
+    assert broker._pull_broker_order("absent") is None
+    assert any(call[1] == "/historical/orders" for call in broker._client.calls)
+    obj = broker.submit_order(order())
+    broker._client.orders[obj.identifier]["subaccount_number"] = 3
+    assert broker._pull_broker_order(obj.identifier) is None
+    broker._client.request = Mock(side_effect=KalshiAPIError("unavailable", status_code=503))
+    with pytest.raises(KalshiAPIError):
+        broker._pull_broker_order("one")
+
+
+def test_unknown_provider_status_is_not_assumed_filled(broker):
+    obj = broker.submit_order(order())
+    broker._client.orders[obj.identifier]["status"] = "future_state"
+    broker._reconcile_order(obj.identifier)
+    assert obj.status == Order.OrderStatus.UNKNOWN
+    assert not obj.transactions
+
+
+def test_read_failure_after_accepted_submit_does_not_raise_or_resubmit(broker):
+    original = broker._client.request
+
+    def get_fails(method, path, **kwargs):
+        if path.startswith("/portfolio/orders/"):
+            raise KalshiAPIError("temporary", status_code=503)
+        return original(method, path, **kwargs)
+
+    broker._client.request = get_fails
+    obj = broker.submit_order(order())
+    assert obj.was_transmitted()
+    assert obj.status == Order.OrderStatus.NEW
+    assert len(broker._client.orders) == 1
+
+
+@pytest.mark.parametrize("subaccount", [-1, 64, True, 1.5, "bad"])
+def test_bad_subaccount_rejected_before_connection(subaccount):
+    with pytest.raises(ValueError, match="SUBACCOUNT"):
+        Kalshi({"SUBACCOUNT": subaccount}, client=FakeClient(), connect_stream=False)
+
+
+def test_cancel_events_held_during_sync_are_not_duplicated(broker):
+    obj = broker.submit_order(order())
+    broker._hold_trade_events = True
+    broker.cancel_order(obj)
+    broker._reconcile_order(obj.identifier)
+    assert len(broker._held_trades) == 1
+    broker._hold_trade_events = False
+    broker.process_held_trades()
+    assert obj.is_canceled()
+
+
+def test_external_partial_order_is_seeded_then_only_new_fill_notifies(broker):
+    obj = broker.submit_order(order())
+    broker._client.fill(obj, 0.5)
+    fresh = Kalshi(client=broker._client, connect_stream=False)
+    fresh._add_subscriber(
+        SimpleNamespace(
+            name="test",
+            add_event=Mock(),
+            PARTIALLY_FILLED_ORDER="partial_fill",
+            FILLED_ORDER="fill",
+            NEW_ORDER="new",
+            CANCELED_ORDER="cancel",
+        )
+    )
+    try:
+        fresh.sync_orders("test")
+        tracked = fresh.get_tracked_order(obj.identifier)
+        assert tracked.status == Order.OrderStatus.PARTIALLY_FILLED
+        broker._client.fill(obj, 1.5)
+        fresh.sync_orders("test")
+        assert tracked.is_filled()
+        assert [float(t.quantity) for t in tracked.transactions] == [0.5, 1.5]
+    finally:
+        fresh.cleanup_streams()

--- a/tests/test_kalshi_client.py
+++ b/tests/test_kalshi_client.py
@@ -1,0 +1,191 @@
+"""Offline transport contracts: sign independently, never send real orders."""
+
+import base64
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+
+from lumibot.tools.kalshi_client import KalshiAPIError, KalshiClient, decimal_value
+
+
+@pytest.fixture(scope="module")
+def key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def pem(key):
+    return key.private_bytes(
+        serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8, serialization.NoEncryption()
+    ).decode()
+
+
+def test_signing_matches_public_key_and_excludes_query(key):
+    client = KalshiClient({"API_KEY_ID": "unit-test", "PRIVATE_KEY": pem(key)}, clock=lambda: 1700000000.123)
+    headers = client.auth_headers("get", "/trade-api/v2/portfolio/orders?limit=100")
+    assert headers["KALSHI-ACCESS-TIMESTAMP"] == "1700000000123"
+    key.public_key().verify(
+        base64.b64decode(headers["KALSHI-ACCESS-SIGNATURE"]),
+        b"1700000000123GET/trade-api/v2/portfolio/orders",
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=32),
+        hashes.SHA256(),
+    )
+    client.close()
+
+
+def test_inline_key_wins_over_path_and_supports_escaped_newlines(key):
+    client = KalshiClient(
+        {"API_KEY_ID": "test", "PRIVATE_KEY": pem(key).replace("\n", "\\n"), "PRIVATE_KEY_PATH": "does-not-exist"},
+        require_auth=True,
+    )
+    assert client.is_demo
+    assert client.auth_headers("POST", client.API_PATH + "/portfolio/events/orders")
+    client.close()
+
+
+def test_key_path_loading(key, tmp_path):
+    path = tmp_path / "generated-test-key.pem"
+    path.write_text(pem(key))
+    client = KalshiClient({"API_KEY_ID": "test", "PRIVATE_KEY": None, "PRIVATE_KEY_PATH": str(path)}, require_auth=True)
+    assert client.auth_headers("GET", client.WS_PATH)
+    client.close()
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"PRIVATE_KEY": "secret-do-not-echo"},
+        {"PRIVATE_KEY_PATH": "private-do-not-echo-path", "PRIVATE_KEY": None},
+        {"PRIVATE_KEY": pem(ec.generate_private_key(ec.SECP256R1()))},
+    ],
+)
+def test_invalid_key_errors_do_not_disclose_inputs(config):
+    with pytest.raises(ValueError) as error:
+        KalshiClient(config)
+    assert "secret-do-not-echo" not in str(error.value)
+    assert "private-do-not-echo-path" not in str(error.value)
+
+
+def test_missing_auth_is_explicit(monkeypatch):
+    for name in ("API_KEY_ID", "PRIVATE_KEY", "PRIVATE_KEY_PATH"):
+        monkeypatch.delenv("KALSHI_" + name, raising=False)
+    with pytest.raises(ValueError, match="KALSHI_API_KEY_ID"):
+        KalshiClient(require_auth=True)
+
+
+@pytest.mark.parametrize(
+    "value,result", [(True, True), (False, False), ("TRUE", True), ("false", False), (1, True), (0, False)]
+)
+def test_environment_selection(value, result):
+    client = KalshiClient({"IS_DEMO": value})
+    assert client.is_demo == result
+    assert client.base_url == (client.DEMO_URL if result else client.PRODUCTION_URL)
+    client.close()
+
+
+@pytest.mark.parametrize("value", ["yes", "prod", "", None, 3])
+def test_invalid_environment_fails_closed(value):
+    with pytest.raises(ValueError, match="IS_DEMO"):
+        KalshiClient({"IS_DEMO": value})
+
+
+@pytest.mark.parametrize("value", ["NaN", "Infinity", "-Infinity", None, "bad"])
+def test_non_finite_fields_rejected(value):
+    with pytest.raises(ValueError, match="finite"):
+        decimal_value(value)
+
+
+@pytest.mark.parametrize("method", ["POST", "DELETE"])
+@pytest.mark.parametrize("status", [401, 403, 409, 429, 500, 503])
+def test_mutations_are_not_automatically_retried(method, status):
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        return httpx.Response(status, json={"message": "private-account-data"})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        client = KalshiClient(http_client=http)
+        with pytest.raises(KalshiAPIError) as error:
+            client.request(method, "/test", authenticated=False)
+    assert len(calls) == 1
+    assert error.value.status_code == status
+    assert "private-account-data" not in str(error.value)
+
+
+@pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
+def test_safe_read_retries_are_bounded(status):
+    calls, sleeps = [], []
+
+    def handler(request):
+        calls.append(request)
+        return httpx.Response(status if len(calls) < 3 else 200, json={"balance": 100})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        client = KalshiClient(http_client=http, sleep=sleeps.append)
+        assert client.request("GET", "/portfolio/balance", authenticated=False)["balance"] == 100
+    assert len(calls) == 3
+    assert sleeps == [0.25, 0.5]
+
+
+@pytest.mark.parametrize("method,calls_expected", [("GET", 3), ("POST", 1)])
+def test_transport_errors_do_not_leak_request(method, calls_expected):
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        raise httpx.ConnectError("secret exception body", request=request)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        client = KalshiClient(http_client=http, sleep=lambda _: None)
+        with pytest.raises(KalshiAPIError, match="transport") as error:
+            client.request(method, "/test", authenticated=False)
+    assert "secret" not in str(error.value)
+    assert len(calls) == calls_expected
+
+
+def test_pages_follow_cursor_and_reject_loops():
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        return httpx.Response(200, json={"orders": [{"order_id": len(calls)}], "cursor": "same"})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        client = KalshiClient(http_client=http)
+        iterator = client.pages("/orders", "orders", authenticated=False)
+        assert next(iterator)["order_id"] == 1
+        assert next(iterator)["order_id"] == 2
+        with pytest.raises(KalshiAPIError, match="cursor"):
+            next(iterator)
+    assert calls[1].url.params["cursor"] == "same"
+
+
+@pytest.mark.parametrize("body", [b"not-json", b"[]", b"null"])
+def test_invalid_responses(body):
+    with httpx.Client(transport=httpx.MockTransport(lambda r: httpx.Response(200, content=body))) as http:
+        with pytest.raises(KalshiAPIError):
+            KalshiClient(http_client=http).request("GET", "/test", authenticated=False)
+
+
+@pytest.mark.parametrize("path", ["https://another-host/test", "//another-host?key=x", "/test?x=y", "test"])
+def test_invalid_path_cannot_redirect_credentials(path):
+    with pytest.raises(ValueError, match="path"):
+        KalshiClient().request("GET", path)
+
+
+def test_authenticated_request_uses_full_api_path(key):
+    def handler(request):
+        key.public_key().verify(
+            base64.b64decode(request.headers["KALSHI-ACCESS-SIGNATURE"]),
+            (request.headers["KALSHI-ACCESS-TIMESTAMP"] + "GET/trade-api/v2/portfolio/orders").encode(),
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=32),
+            hashes.SHA256(),
+        )
+        assert request.url.params["limit"] == "100"
+        return httpx.Response(200, json={"orders": []})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        client = KalshiClient({"API_KEY_ID": "unit", "PRIVATE_KEY": pem(key)}, http_client=http)
+        assert client.request("GET", "/portfolio/orders", params={"limit": 100}) == {"orders": []}

--- a/tests/test_kalshi_credentials.py
+++ b/tests/test_kalshi_credentials.py
@@ -1,0 +1,62 @@
+"""Exercise eager/lazy standard credentials loading in isolated interpreters."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+@pytest.mark.parametrize("lazy", ["true", "false"])
+def test_standard_environment_constructs_kalshi_without_network(lazy):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8, serialization.NoEncryption()
+    ).decode()
+    env = dict(os.environ)
+    env.update(
+        TRADING_BROKER="KALSHI",
+        DATA_SOURCE="KALSHI",
+        IS_BACKTESTING="false",
+        KALSHI_API_KEY_ID="generated-unit-test",
+        KALSHI_PRIVATE_KEY=pem,
+        KALSHI_IS_DEMO="true",
+        KALSHI_SUBACCOUNT="0",
+        LUMIBOT_CONNECT_STREAM="false",
+        LUMIBOT_LAZY_CREDENTIALS=lazy,
+        LUMIBOT_DISABLE_DOTENV="1",
+        LUMIBOT_DISABLE_DOTENV_LOCAL="1",
+    )
+    code = """
+from unittest.mock import patch
+with patch('httpx.Client.request', side_effect=AssertionError('unexpected network call')):
+    import lumibot.credentials as credentials
+    from lumibot.brokers import Kalshi
+    from lumibot.data_sources import KalshiData
+    broker = credentials.BROKER
+    assert isinstance(broker, Kalshi)
+    assert isinstance(credentials.DATA_SOURCE, KalshiData)
+    assert broker.data_source is credentials.DATA_SOURCE
+    assert broker._client.is_demo
+    assert not hasattr(broker, 'stream')
+    broker.cleanup_streams()
+"""
+    result = subprocess.run([sys.executable, "-c", code], env=env, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stderr
+
+
+def test_public_lazy_exports_do_not_import_kalshi_until_requested():
+    # Other providers already have lazy-export tests. This isolates the new names.
+    code = """
+import sys
+import lumibot.brokers as brokers
+import lumibot.data_sources as data
+assert 'Kalshi' in dir(brokers)
+assert 'KalshiData' in dir(data)
+assert 'lumibot.brokers.kalshi' not in sys.modules
+assert 'lumibot.data_sources.kalshi_data' not in sys.modules
+"""
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stderr

--- a/tests/test_kalshi_data.py
+++ b/tests/test_kalshi_data.py
@@ -1,0 +1,202 @@
+"""Price, quote and bar contracts, including inherited plural reads."""
+
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+
+from lumibot.data_sources import KalshiData
+from lumibot.entities import Asset, Bars, Quote
+from lumibot.tools.kalshi_client import KalshiAPIError, KalshiClient
+
+ASSET = Asset("TEST-MARKET", asset_type="prediction_contract")
+NOW = datetime(2026, 1, 1, 12, tzinfo=timezone.utc)
+
+
+def candle(ts, price="0.4321"):
+    return {
+        "end_period_ts": ts,
+        "price": {name + "_dollars": price for name in ("open", "high", "low", "close")},
+        "volume_fp": "1.25",
+    }
+
+
+@pytest.fixture
+def data():
+    market = {
+        "ticker": ASSET.symbol,
+        "last_price_dollars": "0.4321",
+        "yes_bid_dollars": "0.42",
+        "yes_ask_dollars": "0.44",
+        "yes_bid_size_fp": "12.50",
+        "yes_ask_size_fp": "8.25",
+        "volume_fp": "100.50",
+    }
+
+    def handler(request):
+        if request.url.path.endswith("/candlesticks"):
+            end = int(request.url.params["end_ts"])
+            step = int(request.url.params["period_interval"]) * 60
+            return httpx.Response(
+                200,
+                json={"markets": [{"market_ticker": ASSET.symbol, "candlesticks": [candle(end), candle(end - step)]}]},
+            )
+        return httpx.Response(200, json={"market": market})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    source = KalshiData(client=KalshiClient(http_client=http))
+    source.get_datetime = lambda **_: NOW
+    yield source
+    source.shutdown()
+    http.close()
+
+
+def test_last_and_quote_preserve_subcent_and_fractional_values(data):
+    assert data.get_last_price(ASSET) == 0.4321
+    quote = data.get_quote(ASSET)
+    assert isinstance(quote, Quote)
+    assert (quote.bid, quote.ask, quote.mid_price) == (0.42, 0.44, 0.43)
+    assert (quote.bid_size, quote.ask_size, quote.price, quote.volume) == (12.5, 8.25, 0.4321, 100.5)
+    assert data.get_last_prices([ASSET])[ASSET] == 0.4321
+
+
+@pytest.mark.parametrize(
+    "timestep,minutes", [("minute", 1), ("1minute", 1), ("hour", 60), ("60minute", 60), ("day", 1440), ("1day", 1440)]
+)
+def test_candles_return_real_ohlcv_in_chronological_order(data, timestep, minutes):
+    result = data.get_historical_prices(ASSET, 2, timestep=timestep)
+    assert isinstance(result, Bars)
+    assert len(result.df) == 2
+    assert result.df.index.is_monotonic_increasing
+    assert result.df.iloc[-1]["close"] == 0.4321
+    assert result.df.iloc[-1]["volume"] == 1.25
+    assert result.df.index[-1] - result.df.index[0] == timedelta(minutes=minutes)
+
+
+def test_timeshift_excludes_future_data(data):
+    result = data.get_historical_prices(ASSET, 2, timeshift=timedelta(hours=1))
+    assert result.df.index[-1].timestamp() == (NOW - timedelta(hours=1)).timestamp()
+
+
+def test_inherited_plural_history_preserves_individual_errors(data):
+    stock = Asset("WRONG-TYPE")
+    results = data.get_bars([ASSET, stock], 2, sleep_time=0)
+    assert isinstance(results[ASSET], Bars)
+    assert results[stock] is None
+    assert stock in results.errors
+
+
+def test_plural_last_prices_preserve_success_and_failure(data):
+    stock = Asset("WRONG-TYPE")
+    result = data.get_last_prices([stock, ASSET])
+    assert result[stock] is None
+    assert result[ASSET] == 0.4321
+    assert result[ASSET.symbol] == 0.4321
+
+
+@pytest.mark.parametrize(
+    "payload", [{}, {"markets": {}}, {"markets": [{"market_ticker": ASSET.symbol, "candlesticks": {}}]}]
+)
+def test_malformed_candlestick_collections_are_rejected(payload):
+    with httpx.Client(transport=httpx.MockTransport(lambda _: httpx.Response(200, json=payload))) as http:
+        with pytest.raises(KalshiAPIError, match="candlestick"):
+            KalshiData(client=KalshiClient(http_client=http)).get_historical_prices(ASSET, 2)
+
+
+@pytest.mark.parametrize("status", [404, 403])
+def test_history_only_falls_back_on_not_found(status):
+    calls = []
+
+    def handler(request):
+        calls.append(request.url.path)
+        if "/historical/" in request.url.path:
+            return httpx.Response(200, json={"candlesticks": []})
+        return httpx.Response(status)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        source = KalshiData(client=KalshiClient(http_client=http))
+        if status == 404:
+            assert source.get_historical_prices(ASSET, 2).df.empty
+            assert len(calls) == 2
+        else:
+            with pytest.raises(KalshiAPIError):
+                source.get_historical_prices(ASSET, 2)
+            assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "asset", [Asset("SPY"), "TEST-MARKET", Asset("TEST", asset_type="prediction_contract", multiplier=2)]
+)
+def test_invalid_assets(data, asset):
+    with pytest.raises(ValueError):
+        data.get_last_price(asset)
+
+
+@pytest.mark.parametrize("length", [0, -1, 1.2, True, None])
+def test_invalid_history_length(data, length):
+    with pytest.raises(ValueError, match="length"):
+        data.get_historical_prices(ASSET, length)
+
+
+@pytest.mark.parametrize("timestep", ["second", "5minute", "week"])
+def test_unsupported_timestep(data, timestep):
+    with pytest.raises(ValueError, match="timesteps"):
+        data.get_historical_prices(ASSET, 2, timestep=timestep)
+
+
+def test_wrong_quote_exchange_and_timeshift(data):
+    with pytest.raises(ValueError, match="USD"):
+        data.get_quote(ASSET, quote=Asset("EUR", asset_type="forex"))
+    with pytest.raises(ValueError, match="exchange"):
+        data.get_quote(ASSET, exchange="NYSE")
+    with pytest.raises(ValueError, match="timedelta"):
+        data.get_historical_prices(ASSET, 2, timeshift=1)
+    assert data.get_chains(ASSET) == {}
+
+
+def test_archived_history_fallback_and_null_trade_candles():
+    calls = []
+
+    def handler(request):
+        calls.append(request.url.path)
+        if request.url.path.endswith("/markets/candlesticks"):
+            return httpx.Response(200, json={"markets": []})
+        ts = int(request.url.params["end_ts"])
+        return httpx.Response(200, json={"candlesticks": [candle(ts, None)]})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        source = KalshiData(client=KalshiClient(http_client=http))
+        result = source.get_historical_prices(ASSET, 2)
+        assert result.df.empty
+        assert calls[-1].endswith("/historical/markets/TEST-MARKET/candlesticks")
+
+
+def test_long_history_is_chunked_without_gaps_or_duplicates():
+    windows = []
+
+    def handler(request):
+        start, end = int(request.url.params["start_ts"]), int(request.url.params["end_ts"])
+        windows.append((start, end))
+        return httpx.Response(
+            200,
+            json={
+                "markets": [
+                    {"market_ticker": ASSET.symbol, "candlesticks": [candle(ts) for ts in range(start, end + 1, 60)]}
+                ]
+            },
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        source = KalshiData(client=KalshiClient(http_client=http))
+        result = source.get_historical_prices(ASSET, 10001)
+        assert len(windows) == 3
+        assert len(result.df) == 10001
+        assert all(a[1] + 60 == b[0] for a, b in zip(windows, windows[1:]))
+
+
+def test_market_mismatch_and_missing_data_are_not_silently_substituted():
+    with httpx.Client(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={"market": {"ticker": "WRONG"}}))
+    ) as http:
+        with pytest.raises(KalshiAPIError, match="market"):
+            KalshiData(client=KalshiClient(http_client=http)).get_last_price(ASSET)

--- a/tests/test_kalshi_demo_safety.py
+++ b/tests/test_kalshi_demo_safety.py
@@ -1,0 +1,83 @@
+"""Offline safety checks for the opt-in Demo test cleanup harness."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tests.test_kalshi_apitest import _cleanup_demo_orders_and_position
+
+
+def strategy():
+    obj = Mock(name="demo-strategy")
+    obj.broker._pending_submissions = {}
+    obj.get_position.return_value = None
+    return obj
+
+
+def test_empty_demo_cleanup_never_submits():
+    demo = strategy()
+    _cleanup_demo_orders_and_position(demo, "asset", [], 1)
+    demo.broker.sync_orders.assert_called_once()
+    demo.submit_order.assert_not_called()
+
+
+def test_demo_cleanup_cancels_remaining_orders_after_one_cancellation_fails():
+    demo = strategy()
+    orders = [Mock(identifier="first"), Mock(identifier="second")]
+    demo.cancel_order.side_effect = [RuntimeError("temporary"), None]
+    demo.get_order.return_value.is_canceled.return_value = True
+    with pytest.raises(pytest.fail.Exception, match="cleanup incomplete"):
+        _cleanup_demo_orders_and_position(demo, "asset", orders, 2)
+    assert demo.cancel_order.call_count == 2
+    demo.submit_order.assert_not_called()
+
+
+def test_demo_cleanup_stops_on_an_uncertain_submission():
+    demo = strategy()
+    order = Mock(_kalshi_client_order_id="pending")
+    order.was_transmitted.return_value = False
+    demo.broker._pending_submissions = {"pending": order}
+    with pytest.raises(pytest.fail.Exception, match="cleanup incomplete"):
+        _cleanup_demo_orders_and_position(demo, "asset", [order], 1)
+    demo.submit_order.assert_not_called()
+    demo.get_position.assert_not_called()
+
+
+@pytest.mark.parametrize("quantity", [-1, 2])
+def test_demo_cleanup_rejects_unexpected_inventory(quantity):
+    demo = strategy()
+    demo.get_position.return_value = SimpleNamespace(quantity=quantity)
+    with pytest.raises(pytest.fail.Exception, match="Unexpected Demo position"):
+        _cleanup_demo_orders_and_position(demo, "asset", [], 1)
+    demo.submit_order.assert_not_called()
+
+
+def test_demo_cleanup_partial_closes_use_only_remaining_position():
+    demo = strategy()
+    demo.get_position.side_effect = [SimpleNamespace(quantity=1), SimpleNamespace(quantity=0.5), None]
+    demo.get_quote.return_value.bid = 0.2
+    demo.get_order.return_value.is_filled.return_value = True
+    _cleanup_demo_orders_and_position(demo, "asset", [], 1)
+    assert [call.args[1] for call in demo.create_order.call_args_list] == [1, 0.5]
+    assert demo.submit_order.call_count == 2
+
+
+def test_demo_cleanup_has_a_finite_retry_bound():
+    demo = strategy()
+    demo.get_position.return_value = SimpleNamespace(quantity=1)
+    demo.get_quote.return_value.bid = 0.2
+    demo.get_order.return_value.is_canceled.return_value = True
+    with pytest.raises(AssertionError, match="left a position"):
+        _cleanup_demo_orders_and_position(demo, "asset", [], 1)
+    assert demo.submit_order.call_count == 3
+
+
+def test_demo_cleanup_never_retries_an_uncertain_close():
+    demo = strategy()
+    demo.get_position.return_value = SimpleNamespace(quantity=1)
+    demo.get_quote.return_value.bid = 0.2
+    demo.submit_order.side_effect = RuntimeError("unknown submit outcome")
+    with pytest.raises(RuntimeError, match="unknown submit outcome"):
+        _cleanup_demo_orders_and_position(demo, "asset", [], 1)
+    demo.submit_order.assert_called_once()

--- a/tests/test_kalshi_public_apitest.py
+++ b/tests/test_kalshi_public_apitest.py
@@ -1,0 +1,49 @@
+"""Read-only real Demo market-data contracts; no API keys or orders."""
+
+from itertools import islice
+
+import pytest
+
+from lumibot.data_sources import KalshiData
+from lumibot.entities import Asset, Bars, Quote
+
+pytestmark = [pytest.mark.apitest, pytest.mark.kalshi]
+
+
+def test_public_demo_prices_quotes_and_history(record_property):
+    source = KalshiData(config={"IS_DEMO": True, "API_KEY_ID": None, "PRIVATE_KEY": None, "PRIVATE_KEY_PATH": None})
+    try:
+        markets = source._client.pages(
+            "/markets", "markets", params={"status": "open", "limit": 1000}, authenticated=False
+        )
+        market = next(
+            (
+                row
+                for row in islice(markets, 5000)
+                if row.get("market_type") == "binary"
+                and not row.get("mve_collection_ticker")
+                and row.get("last_price_dollars") is not None
+            ),
+            None,
+        )
+        if market is None:
+            pytest.skip("No open binary Demo contract available for read-only market-data qualification")
+        asset = Asset(market["ticker"], asset_type="prediction_contract")
+        record_property("market_ticker", asset.symbol)
+        assert 0 <= source.get_last_price(asset) <= 1
+        assert 0 <= source.get_last_prices([asset])[asset] <= 1
+        quote = source.get_quote(asset)
+        assert isinstance(quote, Quote)
+        for price in (quote.bid, quote.ask):
+            assert price is None or 0 <= price <= 1
+        bars = source.get_historical_prices(asset, 24, timestep="hour")
+        assert isinstance(bars, Bars)
+        assert bars.df.index.tz is not None
+        assert bars.df.index.is_monotonic_increasing
+        assert bars.df[["open", "high", "low", "close"]].map(lambda price: 0 <= price <= 1).all().all()
+        record_property("traded_hourly_bars", len(bars.df))
+        result = source.get_bars([asset], 24, timestep="hour", sleep_time=0)
+        assert isinstance(result[asset], Bars)
+        assert not result.errors
+    finally:
+        source.shutdown()

--- a/tests/test_kalshi_stream.py
+++ b/tests/test_kalshi_stream.py
@@ -1,0 +1,197 @@
+"""Deterministic WebSocket lifecycle checks using the existing stream class."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from lumibot.brokers.kalshi import KalshiStream
+from lumibot.trading_builtins import CustomStream
+
+
+class Socket:
+    def __init__(self, stream, messages):
+        self.stream, self.messages = stream, iter(messages)
+        self.sent = []
+        self.closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.closed = True
+
+    def send(self, message):
+        self.sent.append(json.loads(message))
+
+    def recv(self, timeout):
+        try:
+            value = next(self.messages)
+        except StopIteration:
+            self.stream._stop_event.set()
+            raise TimeoutError()
+        if isinstance(value, Exception):
+            raise value
+        return json.dumps(value)
+
+    def close(self):
+        self.closed = True
+
+
+def make_stream():
+    client = SimpleNamespace(
+        ws_url="wss://example.invalid/trade-api/ws/v2",
+        WS_PATH="/trade-api/ws/v2",
+        auth_headers=Mock(return_value={"KALSHI-ACCESS-KEY": "test"}),
+    )
+    broker = SimpleNamespace(
+        _client=client,
+        _stream_established=Mock(),
+        logger=Mock(),
+        _strategy_name="test",
+        polling_interval=1,
+        sync_orders=Mock(),
+        sync_positions=Mock(),
+    )
+    return KalshiStream(broker)
+
+
+def test_stream_uses_custom_stream_and_signed_subscription():
+    stream = make_stream()
+    assert isinstance(stream, CustomStream)
+    socket = Socket(
+        stream,
+        [
+            {"type": "subscribed", "msg": {"channel": "user_orders"}},
+            {"type": "subscribed", "msg": {"channel": "fill"}},
+            {"type": "user_order", "msg": {"order_id": "one"}},
+            {"type": "fill", "msg": {"order_id": "one"}},
+        ],
+    )
+    factory = Mock(return_value=socket)
+    stream._websocket_factory = factory
+    stream._read_websocket()
+    assert socket.sent == [{"id": 1, "cmd": "subscribe", "params": {"channels": ["user_orders", "fill"]}}]
+    assert stream._queue.qsize() == 2
+    stream.broker._client.auth_headers.assert_called_once_with("GET", "/trade-api/ws/v2")
+    assert factory.call_args.kwargs["additional_headers"] == {"KALSHI-ACCESS-KEY": "test"}
+    assert socket.closed
+
+
+def test_idle_receive_timeout_keeps_same_connection():
+    stream = make_stream()
+    socket = Socket(stream, [TimeoutError(), TimeoutError(), {"type": "subscribed"}])
+    stream._websocket_factory = Mock(return_value=socket)
+    stream._read_websocket()
+    assert stream._websocket_factory.call_count == 1
+    stream.broker.logger.warning.assert_not_called()
+
+
+def test_stream_requires_both_subscription_acknowledgements():
+    stream = make_stream()
+    stream._receive({"type": "subscribed", "msg": {"channel": "user_orders"}})
+    stream.broker._stream_established.assert_not_called()
+    stream._receive({"type": "subscribed", "msg": {"channel": "fill"}})
+    stream.broker._stream_established.assert_called_once()
+
+
+def test_reconnect_does_not_reuse_previous_subscription_acknowledgement():
+    stream = make_stream()
+    first = Socket(stream, [{"type": "subscribed", "msg": {"channel": "user_orders"}}, RuntimeError()])
+    second = Socket(stream, [{"type": "subscribed", "msg": {"channel": "fill"}}])
+    stream._websocket_factory = Mock(side_effect=[first, second])
+    stream._read_websocket()
+    stream.broker._stream_established.assert_not_called()
+    assert stream.broker._is_stream_subscribed is False
+
+
+def test_disconnect_reconnects_resigns_resubscribes_without_leaking_error(monkeypatch):
+    stream = make_stream()
+    first = Socket(stream, [RuntimeError("secret signed headers must not leak")])
+    second = Socket(stream, [{"type": "subscribed"}])
+    stream._websocket_factory = Mock(side_effect=[first, second])
+    stream._read_websocket()
+    assert stream._websocket_factory.call_count == 2
+    assert stream.broker._client.auth_headers.call_count == 2
+    assert len(first.sent) == len(second.sent) == 1
+    assert stream._repair.is_set()
+    assert "secret" not in str(stream.broker.logger.warning.call_args_list)
+
+
+def test_subscription_error_triggers_reconnect():
+    stream = make_stream()
+    stream._websocket_factory = Mock(
+        side_effect=[
+            Socket(stream, [{"type": "error", "msg": {"msg": "private error"}}]),
+            Socket(stream, [{"type": "subscribed"}]),
+        ]
+    )
+    stream._read_websocket()
+    assert stream._websocket_factory.call_count == 2
+    assert "private error" not in str(stream.broker.logger.warning.call_args_list)
+
+
+def test_dispatch_loop_processes_updates_and_periodic_repair():
+    stream = make_stream()
+    stream._read_websocket = Mock()
+    updates = []
+
+    @stream.add_action(stream.UPDATE)
+    def update(identifier):
+        updates.append(identifier)
+
+    stream._receive({"type": "fill", "msg": {"order_id": "one"}})
+    stream.broker.sync_positions.side_effect = lambda _: stream._stop_event.set()
+    stream._run()
+    assert updates == ["one"]
+    stream.broker.sync_orders.assert_called_once_with("test")
+    stream.broker.sync_positions.assert_called_once_with("test")
+    assert stream._queue.unfinished_tasks == 0
+
+
+def test_dispatch_failure_requests_rest_repair():
+    stream = make_stream()
+    stream._read_websocket = Mock()
+
+    @stream.add_action(stream.UPDATE)
+    def update(identifier):
+        raise ValueError("bad event")
+
+    stream._receive({"type": "fill", "msg": {"order_id": "one"}})
+    stream.broker.sync_positions.side_effect = lambda _: stream._stop_event.set()
+    stream._run()
+    stream.broker.sync_orders.assert_called_once()
+    assert stream._queue.unfinished_tasks == 0
+
+
+def test_poll_error_does_not_crash_dispatcher():
+    stream = make_stream()
+    stream._read_websocket = Mock()
+
+    def fail(_):
+        stream._stop_event.set()
+        raise ValueError("temporary")
+
+    stream.broker.sync_orders.side_effect = fail
+    stream._run()
+    assert stream.broker.logger.warning.called
+
+
+def test_stop_closes_socket_and_workers():
+    stream = make_stream()
+    socket = Socket(stream, [])
+    stream._socket = socket
+    stream._reader = Mock()
+    stream._thread = Mock()
+    stream._thread.is_alive.return_value = True
+    stream.stop()
+    assert socket.closed
+    assert stream._stop_event.is_set()
+    stream._reader.join.assert_called_once()
+    stream._thread.join.assert_called_once()
+
+
+def test_irrelevant_or_incomplete_messages_do_not_create_events():
+    stream = make_stream()
+    for message in [{}, {"type": "ticker"}, {"type": "fill", "msg": {}}]:
+        stream._receive(message)
+    assert stream._queue.empty()


### PR DESCRIPTION
## Summary

Add Kalshi as a normal LumiBot live broker and data source using the existing
`Broker`, `DataSource`, `CustomStream`, `Asset`, `Order`, `Position` and Strategy
contracts. This is a dedicated feature branch based on `dev`; no package version,
release marker, shared entity, or other broker implementation is changed.

**Draft qualification status:** local offline checks and all four authenticated
Demo tests passed (Demo suite on unchanged rerun). Hosted CI and maintainer review
remain required. Do not interpret this PR as production-trading certification.

## Implemented

- Standard `TRADING_BROKER=KALSHI` credentials wiring, including eager/lazy
  imports, shared data source, inline RSA PEM or private-key file, Demo default,
  explicit production selection, and subaccount scoping.
- Cash and portfolio value, singular/plural positions and orders, order-by-ID
  reads, pagination, and archived-order lookup.
- Standard create/submit/cancel flows and limit-price modification. Simple limit
  GTC, IOC, FOK and GTD orders; provider tick rules and fixed-point precision.
- Existing singular/plural last prices, quotes, historical OHLCV and multi-asset
  history contracts, archived-market fallback, and per-asset failures.
- Signed YES inventory using the existing `prediction_contract` asset type.
  Kalshi market tickers are not Polymarket outcome-token identifiers.
- Authenticated order/fill WebSockets through `CustomStream`, REST repair,
  reconnect/resubscribe, fill deduplication, consistent order/fill snapshots,
  partial-fill/cancel reconciliation and uncertain-submit recovery.
- Detailed public RST and engineering Markdown docs, environment references,
  README broker/data table entries, changelog and a read-only Strategy example.
- Offline contracts, explicit Demo read-only/order/fill test tiers, a test-only
  current-contract selector, bounded cleanup, and a Python 3.10/3.11/3.12 CI matrix.

## Explicit limits

The current Kalshi V2 create endpoint requires a price: unpriced market orders
raise an actionable error instead of being silently emulated. Stops, smart or
trailing limits, bracket/OCO/OTO/multileg, `day` TIF, quantity modification,
scalar/MVE markets and custom provider parameters are unsupported.

No Kalshi backtesting, public discovery/order-book API, new asset type, new public
Strategy method, hosted-platform onboarding, OAuth or release/deployment is added.

## Audit fixes

- Isolate inconsistent order/fill snapshots so other orders and positions still
  reconcile; incomplete refreshes are retried, not cached as successful.
- Recover unknown order statuses when a supported status returns, without
  duplicate fill callbacks or reopening terminal orders.
- Use the existing broker direct-read hook from `Strategy.get_order()` when a
  live order ID remains untracked after refresh. Kalshi seeds archived history
  without replaying old callbacks. Cached reads, backtests, strategy ownership,
  returned identifiers and sanitized lookup failures have regression coverage.
- Add 21 audit regression cases and include them in the dedicated CI matrix.
- Recognize an explicit insufficient-volume FOK HTTP 409 as terminal rejection,
  not UNKNOWN. Preserve only the allowlisted provider code, leave unknown conflicts
  fail-closed, and add 18 offline regressions including the Demo cleanup path.

## Verification (2026-09-14)

- **210 offline Kalshi tests passed**, with **93.89% combined statement/branch
  coverage** across the broker, data source and internal transport. Coverage gate: 90%.
- **269 existing-broker/lifecycle/entity regression tests passed**, 3 skipped,
  7 deselected: Alpaca, Tradier, Polymarket, broker initialization, position sync,
  fill ownership/priority, live Strategy order accessors and credential isolation.
- **4 authenticated Demo tests passed on unchanged rerun**: account reads, market
  data, submit/read/modify/cancel, IOC/FOK, one-contract buy/close, cash/positions,
  stream subscription and cleanup. A separate final read found zero open orders
  and zero nonzero prediction positions. No production calls were made.
- The first full Demo run had **3 passes and one direct-lookup failure before
  modification**. It did not recur on unchanged rerun; this remains a recorded
  intermittent read/visibility observation, not a proven fixed defect.
- A populated real Demo hourly bar was observed. The public-data smoke had
  previously passed; minute data remained empty. Forced real disconnect recovery
  and every possible parameter combination are not certified by these runs.
- Scoped Ruff and the repository public-secret hygiene check passed.
- Editable checkout builds and dependency consistency checks passed on Windows
  Python 3.12 during initial implementation. Sphinx generated the new Kalshi page
  without Kalshi-page warnings then; updated Kalshi RST parsed successfully today.
  Existing unrelated provider autodoc/indentation diagnostics remain in the full
  documentation build. The complete repository CI suite was not run locally.

## Remaining qualification before ready-for-review

- [x] Configure separate local Demo credentials; no credentials in this PR or repository.
- [x] Verify authentication, cash/account value, positions and order reads.
- [x] Run Demo submit/read/modify/cancel and IOC/FOK tests.
- [x] Run bounded Demo fill/position/cash/subscription qualification and confirm cleanup.
- [x] Observe populated real hourly historical data.
- [ ] Review hosted CI results and the intermittent direct-lookup observation.

Commands, safety gates, endpoint mappings and limitations are documented in
`docs/KALSHI_BROKER_ARCHITECTURE.md` and `docsrc/brokers.kalshi.rst`.
