### PR TITLE
Preserve Bitunix leverage when closing positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@
 - Corrected README and package license labels to match the existing GPLv3 LICENSE file; the license text is unchanged.
 
 ### Fixed
+- Bitunix reduce-only closes no longer request a leverage change from a
+  reconstructed asset's default, preserving the existing position's leverage
+  for full and fractional closes, including after broker restarts.
 - A failed tool attempt followed by a successful retry of the same tool is
   classified as recovered. Unrecovered or final tool failures still produce a
   structured ``tool_error`` outcome.

--- a/docs/BROKER_ORDER_SEMANTICS.md
+++ b/docs/BROKER_ORDER_SEMANTICS.md
@@ -86,6 +86,10 @@ limit or inclusive timestamp cursor:
 - Preserve constructor leverage for `CRYPTO_FUTURE` as for `FUTURE`. This is
   desired leverage, not proof that the exchange accepted the leverage change;
   the existing warning behavior for leverage API failures remains.
+- Apply desired leverage only to opening orders. Reduce-only full and partial
+  closes must not call the leverage API or update the local leverage cache,
+  even when a reconstructed asset defaults to 1x or a restart clears the cache.
+  Position identification, HEDGE validation, and quantity rules still apply.
 - Only submit after HEDGE initialization is confirmed. Failures leave the
   initialization flag unset and block the order, so a later submission retries.
   Never infer ONE_WAY mode from a failed mode-change request.

--- a/docsrc/brokers.bitunix.rst
+++ b/docsrc/brokers.bitunix.rst
@@ -49,7 +49,10 @@ Setting Leverage for Bitunix Orders
 Specify leverage in the ``CRYPTO_FUTURE`` Asset constructor or set its
 ``leverage`` attribute before creating an order. The constructor preserves the
 requested leverage; its default is 1. LumiBot requests that leverage from
-Bitunix before submitting the order. If the exchange rejects the leverage
+Bitunix before submitting an opening order. Reduce-only orders, including full
+and fractional ``close_position`` calls, preserve the existing exchange leverage
+without requesting a leverage change. This also applies after a restart when
+the local leverage cache is empty. If the exchange rejects an opening leverage
 change, LumiBot logs a warning; the Asset value does not confirm the exchange's
 actual leverage.
 

--- a/lumibot/brokers/bitunix.py
+++ b/lumibot/brokers/bitunix.py
@@ -394,10 +394,11 @@ class Bitunix(Broker):
                     "Allowing reduce-only close because the live %s position confirms HEDGE mode",
                     symbol,
                 )
-            # Ensure desired leverage is set
+            # Only opening orders set leverage. Reconstructed close assets may
+            # default to 1x, which must not change an existing position's margin.
             leverage = order.asset.leverage
             try:
-                if self.current_leverage.get(symbol) != leverage:
+                if not reduce_only and self.current_leverage.get(symbol) != leverage:
                     lev_resp = self.api.change_leverage(
                         symbol=symbol, leverage=leverage, margin_coin=self.get_quote_asset().symbol
                     )  # Use quote_asset.symbol

--- a/tests/test_bitunix_place_order_params.py
+++ b/tests/test_bitunix_place_order_params.py
@@ -275,6 +275,32 @@ def test_close_position_fraction_reaches_wire(submission, quantity, wire_side):
     assert body["side"] == wire_side
 
 
+@pytest.mark.parametrize("quantity,wire_side", [("0.02", "BUY"), ("-0.02", "SELL")])
+@pytest.mark.parametrize("fraction", [0.4, 1.0])
+@pytest.mark.parametrize("cached_leverage", [None, 10])
+def test_close_position_preserves_exchange_leverage(submission, quantity, wire_side, fraction, cached_leverage):
+    broker, client, request = submission
+    # Reconstructed assets default to 1x; closing must not apply that default
+    # to an existing position, including after a restart with an empty cache.
+    asset = Asset("BTCUSDT", Asset.AssetType.CRYPTO_FUTURE)
+    broker.get_tracked_position = MagicMock(return_value=Position("test-strategy", asset, Decimal(quantity)))
+    broker.submit_order = broker._submit_order
+    if cached_leverage is not None:
+        broker.current_leverage[asset.symbol] = cached_leverage
+    previous_leverage = broker.current_leverage.copy()
+
+    order = broker.close_position("test-strategy", asset, fraction=fraction)
+
+    client.change_leverage.assert_not_called()
+    assert broker.current_leverage == previous_leverage
+    assert order.status == Order.OrderStatus.SUBMITTED
+    body = json.loads(request.call_args.kwargs["data"])
+    assert body["tradeSide"] == "CLOSE"
+    assert body["side"] == wire_side
+    assert body["positionId"] == ("test-long" if wire_side == "BUY" else "test-short")
+    assert Decimal(body["qty"]) == abs(Decimal(quantity)) * Decimal(str(fraction))
+
+
 def test_close_without_matching_position_fails_closed(submission):
     broker, client, request = submission
     client.get_positions.return_value = {"code": 0, "data": []}


### PR DESCRIPTION
Closing a Bitunix position can reset its leverage to 1x when the close asset is reconstructed with its default leverage, including after a restart with an empty cache. This can change margin requirements or cause the close to fail before the exchange accepts it.

Apply leverage changes only to opening orders. Partial and full closes preserve existing exchange leverage while retaining quantity validation, HEDGE-mode safeguards and the matching position ID.

Validation: eight new regressions failed before the fix and pass afterward. Both Bitunix test files pass (61 tests), covering long/short positions, partial/full closes and empty/populated leverage caches through the real adapter/client serialization path with intercepted HTTP. Fatal-error lint, syntax checks, public repository hygiene and the focused Sphinx build pass. Existing opening-order leverage behavior remains covered.

Targets the active 4.5.92 source branch because this repository has no remote main branch. This is a scoped source repair; it does not publish a package or qualify a deployment. Live exchange recovery remains unverified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Bitunix reduce-only orders now preserve the existing exchange leverage for full and partial position closes.
  - Closing positions no longer triggers an unnecessary leverage change, including after broker restarts or when local leverage information is unavailable.
  - Opening orders continue to apply the requested leverage before submission.

- **Documentation**
  - Updated Bitunix order behavior documentation to clarify leverage handling for opening and reduce-only orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->