### PR TITLE
Preserve broker positions across failed snapshot refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@
 - Corrected README and package license labels to match the existing GPLv3 LICENSE file; the license text is unchanged.
 
 ### Fixed
+- Failed or malformed Bitunix position snapshots preserve tracked positions
+  and remain retryable instead of making the account appear flat. Successful
+  empty broker snapshots now remove every stale non-cash position.
 - Strategy variable backups retain `Asset` objects across scheduled-file and
   database restarts, including nested instruments and option underlyings.
 - Bitunix reduce-only closes no longer request a leverage change from a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 - Failed or malformed Bitunix position snapshots preserve tracked positions
   and remain retryable instead of making the account appear flat. Successful
   empty broker snapshots now remove every stale non-cash position.
+  Ambiguous same-symbol active positions are rejected instead of overwriting
+  each other according to response order.
 - Strategy variable backups retain `Asset` objects across scheduled-file and
   database restarts, including nested instruments and option underlyings.
 - Bitunix reduce-only closes no longer request a leverage change from a

--- a/docs/BROKER_ORDER_SEMANTICS.md
+++ b/docs/BROKER_ORDER_SEMANTICS.md
@@ -102,10 +102,26 @@ limit or inclusive timestamp cursor:
 - Bitunix fractional closes convert both quantity and fraction to Decimal.
   A rounded partial close can leave a real residual position. No changes to
   the shared base-broker close or history-pagination paths are needed.
+- Position snapshots are atomic: reject a failed response or any row lacking a
+  usable symbol, recognized position side, or finite quantity/entry price.
+  Raise `LumibotBrokerAPIError` before returning any partial list, preserving
+  tracked positions and allowing the next refresh to retry. Bitunix cannot
+  represent an unknown side without guessing its signed exposure.
+- Shared stale-position pruning iterates a copy of the tracker list, so an
+  explicitly successful empty snapshot removes every stale non-cash position.
+  The existing pre-snapshot identity guard still protects fills added while the
+  remote read is in flight. Snapshot failure and an empty account remain
+  distinct; neither implies a customer strategy's own variables are reconciled.
 
 Sources: [place order](https://www.bitunix.com/api-docs/futures/trade/place_order.html),
 [pair metadata](https://www.bitunix.com/api-docs/futures/market/get_trading_pairs.html),
 [position mode](https://www.bitunix.com/api-docs/futures/account/change_position_mode.html).
+
+Position snapshot contract:
+[pending positions](https://www.bitunix.com/api-docs/futures/position/get_pending_positions.html).
+`tests/test_bitunix_position_snapshot.py` exercises the real broker and client
+with intercepted transport, including rejected/malformed snapshots, preserved
+state, retry, valid empty accounts, and signed long/short positions.
 
 Regression evidence: `tests/test_bitunix_place_order_params.py` intercepts
 HTTP transport and exercises the real broker/client serialization path,
@@ -131,6 +147,8 @@ LumiBot should not fail an entire order, position, or balance refresh because on
 - Warn instead of raising for unknown broker asset/order/status/side values.
 - Skip only truly unrepresentable rows, such as no usable symbol/instrument identifier or non-numeric quantity.
 - If a Schwab position refresh is degraded by skipped rows, update parsed rows but do not remove tracked positions just because they were absent from the partial parse.
+- Bitunix position sync requires an atomic snapshot and raises on unrepresentable
+  rows instead of returning a partial list that would authorize stale pruning.
 - Never write cash or portfolio value as `0` because a broker balance refresh failed. `get_cash()` and `get_portfolio_value()` return `None` on failed fresh reads and leave cached internal values unchanged.
 
 This policy is intentionally different from order mutation behavior. Submit, cancel, and modify failures still fail loudly. The resilience policy applies to reading/parsing broker state, not hiding failed state-changing requests.

--- a/docs/BROKER_ORDER_SEMANTICS.md
+++ b/docs/BROKER_ORDER_SEMANTICS.md
@@ -107,6 +107,10 @@ limit or inclusive timestamp cursor:
   Raise `LumibotBrokerAPIError` before returning any partial list, preserving
   tracked positions and allowing the next refresh to retry. Bitunix cannot
   represent an unknown side without guessing its signed exposure.
+- Reject multiple nonzero rows for the same asset, including opposite-side
+  HEDGE positions. The shared tracker identifies positions by asset and cannot
+  represent both independently; publishing them would make exposure depend on
+  response order. Zero-quantity rows do not create this ambiguity.
 - Shared stale-position pruning iterates a copy of the tracker list, so an
   explicitly successful empty snapshot removes every stale non-cash position.
   The existing pre-snapshot identity guard still protects fills added while the

--- a/docsrc/brokers.bitunix.rst
+++ b/docsrc/brokers.bitunix.rst
@@ -55,6 +55,11 @@ Polling reports the failure and retries on its next cycle. Strategy code using
 fresh ``get_position()`` or ``get_positions()`` reads should allow the error to
 stop that decision, rather than treating it as permission to open a position.
 
+The tracker supports one active position per symbol. Multiple nonzero rows for
+the same symbol, including simultaneous long and short HEDGE positions, raise
+the same error and preserve tracked state. They cannot be represented as
+independent positions by this adapter. Zero-quantity rows are ignored.
+
 Setting Leverage for Bitunix Orders
 -----------------------------------
 

--- a/docsrc/brokers.bitunix.rst
+++ b/docsrc/brokers.bitunix.rst
@@ -43,6 +43,18 @@ Set the following environment variables in your `.env` file or system environmen
     BITUNIX_API_KEY=your_bitunix_api_key
     BITUNIX_API_SECRET=your_bitunix_api_secret
 
+Position Refresh Failures
+----------------------------
+
+Position reads require a complete successful response. A transport error,
+rejected request, or malformed position raises ``LumibotBrokerAPIError`` and
+leaves tracked positions unchanged. A failed read does not mean the account is
+flat and is not cached as a successful refresh; a later read can retry.
+An explicitly successful empty snapshot removes all stale non-cash positions.
+Polling reports the failure and retries on its next cycle. Strategy code using
+fresh ``get_position()`` or ``get_positions()`` reads should allow the error to
+stop that decision, rather than treating it as permission to open a position.
+
 Setting Leverage for Bitunix Orders
 -----------------------------------
 

--- a/lumibot/brokers/bitunix.py
+++ b/lumibot/brokers/bitunix.py
@@ -214,38 +214,47 @@ class Bitunix(Broker):
         return cash, positions_value, net_liquidation
 
     def _pull_positions(self, strategy) -> list[Position]:
-        """
-        Retrieves FUTURES positions.
-        Futures positions are fetched from the open positions endpoint.
+        """Return a complete futures snapshot or raise without publishing partial state.
+
+        A successful empty list means the account is flat. An unreadable response
+        must raise instead, because shared position sync prunes absent assets.
         """
         positions = []
         Position = _position_class()
-        strategy_name = strategy.name if strategy else ""
+        strategy_name = self._strategy_name_from_input(strategy) or ""
 
         try:
             resp = self.api.get_positions()
-            if resp and resp.get("code") == 0:
-                for p in resp.get("data", []):
-                    sym = p.get("symbol", "")
-                    # qty is now under "qty"
-                    qty = Decimal(str(p.get("qty", "0")))
-                    # Position responses use LONG/SHORT; retain older BUY/SELL responses too.
-                    side = p.get("side", "").upper()
-                    if side in ("SELL", "SHORT"):
-                        qty = -abs(qty)
-                    else:
-                        qty = abs(qty)
-                    # entry price is avgOpenPrice (fallback to entryValue)
-                    entry = Decimal(str(p.get("avgOpenPrice", p.get("entryValue", "0"))))
-                    if qty != 0 and sym:
-                        asset = Asset(sym, Asset.AssetType.CRYPTO_FUTURE)
-                        pos = Position(strategy_name, asset, qty)
-                        pos.avg_fill_price = entry
-                        pos._raw = p
-                        positions.append(pos)
-        except Exception as e:
-            logger.warning("Error fetching futures positions: %s", e)
-            logger.debug(_format_exc())
+            if not isinstance(resp, dict) or resp.get("code") != 0:
+                raise LumibotBrokerAPIError("Bitunix position snapshot request failed")
+            rows = resp.get("data")
+            if not isinstance(rows, list):
+                raise LumibotBrokerAPIError("Bitunix position snapshot must contain a list")
+            for p in rows:
+                if not isinstance(p, dict):
+                    raise LumibotBrokerAPIError("Invalid Bitunix position row")
+                sym = p.get("symbol")
+                side = p.get("side")
+                if not isinstance(sym, str) or not sym.strip() or not isinstance(side, str):
+                    raise LumibotBrokerAPIError("Invalid Bitunix position identity")
+                side = side.upper()
+                if side not in ("LONG", "SHORT", "BUY", "SELL"):
+                    raise LumibotBrokerAPIError("Invalid Bitunix position side")
+                qty = Decimal(str(p["qty"]))
+                entry = Decimal(str(p.get("avgOpenPrice", p.get("entryValue", "0"))))
+                if not qty.is_finite() or not entry.is_finite():
+                    raise LumibotBrokerAPIError("Non-finite Bitunix position quantity or entry price")
+                qty = -abs(qty) if side in ("SELL", "SHORT") else abs(qty)
+                if qty != 0:
+                    asset = Asset(sym, Asset.AssetType.CRYPTO_FUTURE)
+                    pos = Position(strategy_name, asset, qty)
+                    pos.avg_fill_price = entry
+                    pos._raw = p
+                    positions.append(pos)
+        except LumibotBrokerAPIError:
+            raise
+        except Exception as exc:
+            raise LumibotBrokerAPIError("Unable to read complete Bitunix position snapshot") from exc
         return positions
 
     def _map_side_to_bitunix(self, side: Order.OrderSide) -> str:

--- a/lumibot/brokers/bitunix.py
+++ b/lumibot/brokers/bitunix.py
@@ -220,6 +220,7 @@ class Bitunix(Broker):
         must raise instead, because shared position sync prunes absent assets.
         """
         positions = []
+        seen_assets = set()
         Position = _position_class()
         strategy_name = self._strategy_name_from_input(strategy) or ""
 
@@ -247,6 +248,11 @@ class Bitunix(Broker):
                 qty = -abs(qty) if side in ("SELL", "SHORT") else abs(qty)
                 if qty != 0:
                     asset = Asset(sym, Asset.AssetType.CRYPTO_FUTURE)
+                    if asset in seen_assets:
+                        raise LumibotBrokerAPIError(
+                            "Multiple active Bitunix positions for one symbol cannot be represented safely"
+                        )
+                    seen_assets.add(asset)
                     pos = Position(strategy_name, asset, qty)
                     pos.avg_fill_price = entry
                     pos._raw = p

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -1091,7 +1091,9 @@ class Broker(ABC):
 
         # Now iterate through lumibot positions.
         # Remove lumibot position if not at the broker.
-        for position in self._filled_positions.get_list():
+        # get_list() exposes the live list; removing from it while iterating
+        # skips consecutive stale positions.
+        for position in list(self._filled_positions.get_list()):
             found = False
             for position_broker in positions_broker:
                 if position_broker.asset == position.asset:

--- a/tests/test_bitunix_position_snapshot.py
+++ b/tests/test_bitunix_position_snapshot.py
@@ -1,0 +1,139 @@
+"""Position refresh must not turn an unreadable broker snapshot into flat state."""
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lumibot.brokers.bitunix import Bitunix
+from lumibot.brokers.broker import LumibotBrokerAPIError
+from lumibot.entities import Asset, Position
+from lumibot.strategies import Strategy
+from lumibot.tools.bitunix_helpers import BitUnixClient
+
+
+def row(symbol="BTCUSDT", qty="0.5", side="SHORT", **overrides):
+    return {"symbol": symbol, "qty": qty, "side": side, "avgOpenPrice": "51000", **overrides}
+
+
+@pytest.fixture
+def broker():
+    # Real client and broker; intercept transport so no account or order is touched.
+    client = BitUnixClient(api_key="test_api_key", secret_key="test_api_secret")
+    client._request = MagicMock()
+    with patch("lumibot.brokers.bitunix.BitUnixClient", return_value=client), patch(
+        "lumibot.brokers.bitunix.BitunixData"
+    ) as data:
+        data.return_value.client_symbols = set()
+        result = Bitunix({"API_KEY": "test_api_key", "API_SECRET": "test_api_secret"}, connect_stream=False)
+    result._filled_positions.append(
+        Position("test_strategy", Asset("BTCUSDT", Asset.AssetType.CRYPTO_FUTURE), Decimal("-0.25"))
+    )
+    result._filled_positions.append(
+        Position("test_strategy", Asset("ETHUSDT", Asset.AssetType.CRYPTO_FUTURE), Decimal("2"))
+    )
+    return result
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        {},
+        {"code": 10001, "data": []},
+        {"code": 0},
+        {"code": 0, "data": None},
+        {"code": 0, "data": {}},
+        {"code": 0, "data": [row(), None]},
+        {"code": 0, "data": [row(), row("ETHUSDT", qty="invalid")]},
+        {"code": 0, "data": [row(), row("ETHUSDT", qty="NaN")]},
+        {"code": 0, "data": [row(), row("ETHUSDT", qty="Infinity")]},
+        {"code": 0, "data": [row(), row("ETHUSDT", side="unknown")]},
+        {"code": 0, "data": [row(), row(symbol="")]},
+        {"code": 0, "data": [row(), {"symbol": "ETHUSDT", "side": "LONG"}]},
+        {"code": 0, "data": [row(), row("ETHUSDT", avgOpenPrice="NaN")]},
+    ],
+)
+def test_failed_snapshot_preserves_all_positions_and_refresh_retry(broker, response):
+    before = [(p.asset, p.quantity) for p in broker._filled_positions.get_list()]
+    revision = broker._filled_positions.revision
+    broker.api._request.return_value = response
+    error = None
+    try:
+        broker.refresh_positions(SimpleNamespace(name="test_strategy"), ttl_seconds=60)
+    except LumibotBrokerAPIError as exc:
+        error = exc
+    assert [(p.asset, p.quantity) for p in broker._filled_positions.get_list()] == before
+    assert broker._filled_positions.revision == revision
+    assert error is not None
+
+    # Failed reads must not populate the success throttle or suppress recovery.
+    broker.api._request.return_value = {"code": 0, "data": [row()]}
+    broker.refresh_positions(SimpleNamespace(name="test_strategy"), ttl_seconds=60)
+    assert len(broker._filled_positions.get_list()) == 1
+    assert broker._filled_positions.get_list()[0].quantity == Decimal("-0.5")
+    assert broker.api._request.call_count == 2
+
+
+def test_transport_failure_preserves_positions(broker):
+    before = broker._filled_positions.get_list()
+    broker.api._request.side_effect = TimeoutError("unavailable")
+    with pytest.raises(LumibotBrokerAPIError):
+        broker.sync_positions(SimpleNamespace(name="test_strategy"))
+    assert broker._filled_positions.get_list() == before
+
+
+def test_successful_empty_snapshot_removes_stale_positions(broker):
+    cash = Position("test_strategy", broker.get_quote_asset(), Decimal("1000"))
+    broker._filled_positions.append(cash)
+    broker.api._request.return_value = {"code": 0, "data": []}
+    broker.sync_positions(SimpleNamespace(name="test_strategy"))
+    assert broker._filled_positions.get_list() == [cash]
+
+
+@pytest.mark.parametrize("side, expected", [("LONG", "0.5"), ("BUY", "0.5"), ("SHORT", "-0.5"), ("SELL", "-0.5")])
+def test_valid_snapshot_preserves_side_and_zero_quantity_contract(broker, side, expected):
+    broker.api._request.return_value = {"code": 0, "data": [row(side=side), row("ETHUSDT", qty="0")]}
+    broker.sync_positions(None)
+    positions = broker._filled_positions.get_list()
+    assert len(positions) == 1
+    assert positions[0].quantity == Decimal(expected)
+    assert positions[0].avg_fill_price == Decimal("51000")
+    broker.api._request.assert_called_once_with(method="GET", endpoint="/api/v1/futures/position/get_pending_positions")
+
+
+def test_public_strategy_position_read_fails_then_recovers(broker):
+    strategy = object.__new__(Strategy)
+    strategy._name = "test_strategy"
+    strategy.broker = broker
+    asset = broker._filled_positions.get_list()[0].asset
+    broker.api._request.return_value = {"code": 10001}
+    with pytest.raises(LumibotBrokerAPIError):
+        strategy.get_position(asset)
+    assert broker.get_tracked_position(strategy.name, asset).quantity == Decimal("-0.25")
+
+    broker.api._request.return_value = {"code": 0, "data": [row()]}
+    assert strategy.get_position(asset).quantity == Decimal("-0.5")
+
+
+def test_polling_cycle_reports_failure_and_next_cycle_recovers(broker, caplog):
+    broker.stream = broker._get_stream_object()
+    broker._register_stream_events()
+    before = [(p.asset, p.quantity) for p in broker._filled_positions.get_list()]
+    broker.api._request.return_value = {"code": 10001}
+    broker.stream._poll()
+    assert "Bitunix position snapshot request failed" in caplog.text
+    assert [(p.asset, p.quantity) for p in broker._filled_positions.get_list()] == before
+
+    broker.api._request.side_effect = [{"code": 0, "data": []}, {"code": 0, "data": {"orderList": []}}]
+    broker.stream._poll()
+    assert broker._filled_positions.get_list() == []
+
+
+def test_direct_position_read_accepts_strategy_name(broker):
+    broker.api._request.return_value = {"code": 0, "data": [row()]}
+    asset = broker._filled_positions.get_list()[0].asset
+    position = broker._pull_position("test_strategy", asset)
+    assert position.strategy == "test_strategy"
+    assert position.quantity == Decimal("-0.5")

--- a/tests/test_bitunix_position_snapshot.py
+++ b/tests/test_bitunix_position_snapshot.py
@@ -77,11 +77,13 @@ def test_failed_snapshot_preserves_all_positions_and_refresh_retry(broker, respo
 
 
 def test_transport_failure_preserves_positions(broker):
-    before = broker._filled_positions.get_list()
+    before = [(p.asset, p.quantity) for p in broker._filled_positions.get_list()]
+    revision = broker._filled_positions.revision
     broker.api._request.side_effect = TimeoutError("unavailable")
     with pytest.raises(LumibotBrokerAPIError):
         broker.sync_positions(SimpleNamespace(name="test_strategy"))
-    assert broker._filled_positions.get_list() == before
+    assert [(p.asset, p.quantity) for p in broker._filled_positions.get_list()] == before
+    assert broker._filled_positions.revision == revision
 
 
 def test_successful_empty_snapshot_removes_stale_positions(broker):

--- a/tests/test_bitunix_position_snapshot.py
+++ b/tests/test_bitunix_position_snapshot.py
@@ -53,6 +53,9 @@ def broker():
         {"code": 0, "data": [row(), row(symbol="")]},
         {"code": 0, "data": [row(), {"symbol": "ETHUSDT", "side": "LONG"}]},
         {"code": 0, "data": [row(), row("ETHUSDT", avgOpenPrice="NaN")]},
+        {"code": 0, "data": [row(side="LONG"), row(side="SHORT")]},
+        {"code": 0, "data": [row(side="SHORT"), row(side="LONG")]},
+        {"code": 0, "data": [row(side="LONG"), row(side="LONG")]},
     ],
 )
 def test_failed_snapshot_preserves_all_positions_and_refresh_retry(broker, response):
@@ -139,3 +142,13 @@ def test_direct_position_read_accepts_strategy_name(broker):
     position = broker._pull_position("test_strategy", asset)
     assert position.strategy == "test_strategy"
     assert position.quantity == Decimal("-0.5")
+
+
+@pytest.mark.parametrize("zero_first", [True, False])
+def test_zero_quantity_row_does_not_make_active_position_ambiguous(broker, zero_first):
+    rows = [row(qty="0", side="LONG"), row(side="SHORT")]
+    broker.api._request.return_value = {"code": 0, "data": rows if zero_first else rows[::-1]}
+    broker.sync_positions(None)
+    positions = broker._filled_positions.get_list()
+    assert len(positions) == 1
+    assert positions[0].quantity == Decimal("-0.5")


### PR DESCRIPTION
A failed Bitunix position read was returned as an empty or partial snapshot, allowing shared synchronization to erase known positions. Reject unreadable snapshots atomically with `LumibotBrokerAPIError`, preserve tracked state, and allow the next refresh to retry. Successful empty snapshots now remove every stale non-cash position by iterating a stable copy instead of mutating the traversed list.

Validation: 123 focused tests pass, including the real Bitunix client/broker path with intercepted transport, public Strategy position reads, polling failure/recovery, malformed rows, long/short signs, cash preservation, concurrent-fill protection, and rejection of ambiguous same-symbol active positions. Initial regressions: 16 failures and 4 passes. Review added three failing duplicate-position cases, now passing; zero-quantity rows remain supported. Changed Bitunix code and new tests pass Ruff F/I; shared broker's nine existing annotation diagnostics are identical to baseline. Focused Sphinx content build and public leak check pass.

No exchange orders, live account reads, package publication, or downstream deployment. This repairs source behavior; it does not establish a historical incident's cause or prove deployed recovery. Target is the existing active version branch; its separate release PR remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bitunix position updates now preserve tracked positions when responses fail or contain invalid data, allowing later retries.
  * Successful empty snapshots correctly clear stale non-cash positions.
  * Conflicting active positions for the same symbol are rejected to prevent inaccurate account state.
  * Position synchronization now removes all applicable stale positions reliably.

* **Documentation**
  * Added guidance on Bitunix position refresh failures, snapshot validation, retry behavior, and supported position scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->