### PR TITLE
Preserve newer broker positions during overlapping refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@
 - Corrected README and package license labels to match the existing GPLv3 LICENSE file; the license text is unchanged.
 
 ### Fixed
+- Overlapping broker position reads no longer let an older response delete,
+  resurrect, or overwrite a newer applied snapshot. Network reads remain outside
+  the tracker lock, and a failed newer request does not discard older success.
 - Failed or malformed Bitunix position snapshots preserve tracked positions
   and remain retryable instead of making the account appear flat. Successful
   empty broker snapshots now remove every stale non-cash position.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Overlapping broker position reads no longer let an older response delete,
   resurrect, or overwrite a newer applied snapshot. Network reads remain outside
   the tracker lock, and a failed newer request does not discard older success.
+  Positions added during a read also keep their newer fields and strategy owner.
 - Failed or malformed Bitunix position snapshots preserve tracked positions
   and remain retryable instead of making the account appear flat. Successful
   empty broker snapshots now remove every stale non-cash position.

--- a/docs/BROKER_ORDER_SEMANTICS.md
+++ b/docs/BROKER_ORDER_SEMANTICS.md
@@ -323,3 +323,14 @@ Maintain a small table in this doc (append-only) for each broker:
 - order type
 - expected behavior (accept/hold/reject; eligible-to-fill)
 - last verified date + environment (paper/live)
+
+### Overlapping position refreshes
+
+The shared broker assigns a sequence number before each position read and applies
+a completed snapshot under the tracker lock. Once a newer request has applied, an
+older response is ignored in full: it cannot prune, resurrect, or change positions.
+A failed newer read does not invalidate an older successful response. Network I/O
+runs outside the tracker lock so fills and strategy accessors can still proceed.
+The existing pre-read position identity check continues to protect new local fills
+from stale pruning. This ordering is local request ordering; it cannot establish
+the exchange's internal snapshot timestamp or historical incident cause.

--- a/docs/BROKER_ORDER_SEMANTICS.md
+++ b/docs/BROKER_ORDER_SEMANTICS.md
@@ -332,5 +332,6 @@ older response is ignored in full: it cannot prune, resurrect, or change positio
 A failed newer read does not invalidate an older successful response. Network I/O
 runs outside the tracker lock so fills and strategy accessors can still proceed.
 The existing pre-read position identity check continues to protect new local fills
-from stale pruning. This ordering is local request ordering; it cannot establish
+from stale pruning and same-asset field/owner overwrites. The next fresh read
+reconciles those positions normally. This ordering is local request ordering; it cannot establish
 the exchange's internal snapshot timestamp or historical incident cause.

--- a/docsrc/brokers.bitunix.rst
+++ b/docsrc/brokers.bitunix.rst
@@ -54,6 +54,8 @@ An explicitly successful empty snapshot removes all stale non-cash positions.
 Concurrent polling and strategy reads preserve the latest successfully applied
 request: an older response cannot remove, resurrect, or overwrite its positions.
 Failed reads remain retryable and do not discard another successful response.
+Positions added locally during a pending read retain their fields and ownership
+until the next fresh snapshot.
 Polling reports the failure and retries on its next cycle. Strategy code using
 fresh ``get_position()`` or ``get_positions()`` reads should allow the error to
 stop that decision, rather than treating it as permission to open a position.

--- a/docsrc/brokers.bitunix.rst
+++ b/docsrc/brokers.bitunix.rst
@@ -51,6 +51,9 @@ rejected request, or malformed position raises ``LumibotBrokerAPIError`` and
 leaves tracked positions unchanged. A failed read does not mean the account is
 flat and is not cached as a successful refresh; a later read can retry.
 An explicitly successful empty snapshot removes all stale non-cash positions.
+Concurrent polling and strategy reads preserve the latest successfully applied
+request: an older response cannot remove, resurrect, or overwrite its positions.
+Failed reads remain retryable and do not discard another successful response.
 Polling reports the failure and retries on its next cycle. Strategy code using
 fresh ``get_position()`` or ``get_positions()`` reads should allow the error to
 stop that decision, rather than treating it as permission to open a position.

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -1080,6 +1080,10 @@ class Broker(ABC):
                 position_lumi = position_lumi[0] if len(position_lumi) > 0 else None
 
                 if position_lumi:
+                    # A streamed fill added while the read was in flight is
+                    # newer than this snapshot, including its fields and owner.
+                    if id(position_lumi) not in positions_before_snapshot:
+                        continue
                     self._sync_position_fields_from_broker(position_lumi, position)
 
                     # No current brokers have any way to distinguish between strategies for an open position.

--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -461,6 +461,8 @@ class Broker(ABC):
         # Shared Variables between threads
         self.name = name
         self._lock = RLock()
+        self._positions_snapshot_started = 0
+        self._positions_snapshot_applied = 0
         self._stop_event = threading.Event()  # Add stop event for clean shutdown
         self._runtime_telemetry = None
         # PERF: Backtesting is single-threaded, but SafeList lock acquisition shows up as
@@ -1051,60 +1053,68 @@ class Broker(ABC):
         """
         Sync the broker positions with the lumibot positions. Remove any lumibot positions that are not at the broker.
         """
-        # Only positions that existed before the broker snapshot began are
-        # eligible for stale pruning. A fill can add a local position while the
-        # remote read is in flight; absence from that older snapshot must not
-        # delete the newly observed fill.
-        positions_before_snapshot = {id(position) for position in self._filled_positions.get_list()}
+        # Sequence requests under the tracker lock, but never hold it across
+        # network I/O: fills and newer accessor reads must remain able to run.
+        with self._lock:
+            self._positions_snapshot_started += 1
+            snapshot_id = self._positions_snapshot_started
+            # Only pre-existing positions are eligible for stale pruning.
+            positions_before_snapshot = {id(position) for position in self._filled_positions.get_list()}
         positions_broker = self._pull_positions(strategy)
-        for position in positions_broker:
-            # Check if the position is None
-            if position is None:
-                continue
+        with self._lock:
+            # A slow response cannot erase or overwrite a newer applied snapshot.
+            # Failed newer reads do not supersede an older successful response.
+            if snapshot_id < self._positions_snapshot_applied:
+                return
+            for position in positions_broker:
+                # Check if the position is None
+                if position is None:
+                    continue
 
-            # Check against existing position.
-            position_lumi = [
-                pos_lumi
-                for pos_lumi in self._filled_positions.get_list()
-                if pos_lumi.asset == position.asset
-            ]
-            position_lumi = position_lumi[0] if len(position_lumi) > 0 else None
+                # Check against existing position.
+                position_lumi = [
+                    pos_lumi
+                    for pos_lumi in self._filled_positions.get_list()
+                    if pos_lumi.asset == position.asset
+                ]
+                position_lumi = position_lumi[0] if len(position_lumi) > 0 else None
 
-            if position_lumi:
-                self._sync_position_fields_from_broker(position_lumi, position)
+                if position_lumi:
+                    self._sync_position_fields_from_broker(position_lumi, position)
 
-                # No current brokers have any way to distinguish between strategies for an open position.
-                # Therefore, we will just update the strategy to the current strategy.
-                # This is added here because with initial polling, no strategy is set for the positions so we
-                # can create ones that have no strategy attached. This will ensure that all stored positions have a
-                # strategy with subsequent updates.
-                if strategy:
-                    strategy_name = strategy.name if not isinstance(strategy, str) else strategy
-                    if position_lumi.strategy != strategy_name:
-                        position_lumi.strategy = strategy_name
-                        self._filled_positions.revision += 1
-            else:
-                # Add to positions in lumibot, position does not exist
-                # in lumibot.
-                if position.quantity != 0.0:
-                    self._filled_positions.append(position)
+                    # No current brokers have any way to distinguish between strategies for an open position.
+                    # Therefore, we will just update the strategy to the current strategy.
+                    # This is added here because with initial polling, no strategy is set for the positions so we
+                    # can create ones that have no strategy attached. This will ensure that all stored positions have a
+                    # strategy with subsequent updates.
+                    if strategy:
+                        strategy_name = strategy.name if not isinstance(strategy, str) else strategy
+                        if position_lumi.strategy != strategy_name:
+                            position_lumi.strategy = strategy_name
+                            self._filled_positions.revision += 1
+                else:
+                    # Add to positions in lumibot, position does not exist
+                    # in lumibot.
+                    if position.quantity != 0.0:
+                        self._filled_positions.append(position)
 
-        # Now iterate through lumibot positions.
-        # Remove lumibot position if not at the broker.
-        # get_list() exposes the live list; removing from it while iterating
-        # skips consecutive stale positions.
-        for position in list(self._filled_positions.get_list()):
-            found = False
-            for position_broker in positions_broker:
-                if position_broker.asset == position.asset:
-                    found = True
-                    break
-            if (
-                not found
-                and id(position) in positions_before_snapshot
-                and (position.asset not in self.quote_assets)
-            ):
-                self._filled_positions.remove(position)
+            # Now iterate through lumibot positions.
+            # Remove lumibot position if not at the broker.
+            # get_list() exposes the live list; removing from it while iterating
+            # skips consecutive stale positions.
+            for position in list(self._filled_positions.get_list()):
+                found = False
+                for position_broker in positions_broker:
+                    if position_broker.asset == position.asset:
+                        found = True
+                        break
+                if (
+                    not found
+                    and id(position) in positions_before_snapshot
+                    and (position.asset not in self.quote_assets)
+                ):
+                    self._filled_positions.remove(position)
+            self._positions_snapshot_applied = snapshot_id
 
     def refresh_positions(self, strategy, ttl_seconds: float = 0.0):
         """Refresh live broker positions with a short throttle.

--- a/tests/test_bitunix_position_snapshot.py
+++ b/tests/test_bitunix_position_snapshot.py
@@ -1,6 +1,8 @@
 """Position refresh must not turn an unreadable broker snapshot into flat state."""
 
+from concurrent.futures import ThreadPoolExecutor
 from decimal import Decimal
+from threading import Event, current_thread
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -152,3 +154,61 @@ def test_zero_quantity_row_does_not_make_active_position_ambiguous(broker, zero_
     positions = broker._filled_positions.get_list()
     assert len(positions) == 1
     assert positions[0].quantity == Decimal("-0.5")
+
+
+@pytest.mark.parametrize(
+    "older_rows, newer_response, expected_quantity",
+    [
+        ([], {"code": 0, "data": [row(qty="1.5")]}, "-1.5"),
+        ([row(qty="0.75")], {"code": 0, "data": [row(qty="1.5")]}, "-1.5"),
+        ([row(qty="0.75")], {"code": 0, "data": []}, None),
+        ([row(qty="0.75")], {"code": 10001}, "-0.75"),
+        ([], {"code": 10001}, None),
+    ],
+    ids=["stale-delete", "stale-quantity", "stale-resurrection", "newer-fails", "newer-fails-empty"],
+)
+def test_older_refresh_preserves_newer_success_but_survives_newer_failure(
+    broker, older_rows, newer_response, expected_quantity
+):
+    """A slow poll must not overwrite a newer successful accessor refresh."""
+    old_read_started = Event()
+    release_old_read = Event()
+    old_thread_name = []
+
+    def transport(**kwargs):
+        if current_thread().name in old_thread_name:
+            old_read_started.set()
+            assert release_old_read.wait(5), "test failed to release older read"
+            return {"code": 0, "data": older_rows}
+        return newer_response
+
+    def old_refresh():
+        old_thread_name.append(current_thread().name)
+        broker.sync_positions(None)
+
+    broker.api._request.side_effect = transport
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        older = pool.submit(old_refresh)
+        try:
+            assert old_read_started.wait(5), "older refresh did not start"
+            strategy = object.__new__(Strategy)
+            strategy._name = "test_strategy"
+            strategy.broker = broker
+            asset = Asset("BTCUSDT", Asset.AssetType.CRYPTO_FUTURE)
+            if newer_response["code"] != 0:
+                with pytest.raises(LumibotBrokerAPIError):
+                    strategy.get_position(asset)
+            else:
+                strategy.get_position(asset)
+                revision_after_newer = broker._filled_positions.revision
+        finally:
+            release_old_read.set()
+        older.result(timeout=5)
+
+    remaining = broker.get_tracked_position("test_strategy", Asset("BTCUSDT", Asset.AssetType.CRYPTO_FUTURE))
+    if expected_quantity is None:
+        assert remaining is None
+    else:
+        assert remaining.quantity == Decimal(expected_quantity)
+    if newer_response["code"] == 0:
+        assert broker._filled_positions.revision == revision_after_newer

--- a/tests/test_bitunix_position_snapshot.py
+++ b/tests/test_bitunix_position_snapshot.py
@@ -176,6 +176,7 @@ def test_older_refresh_preserves_newer_success_but_survives_newer_failure(
     old_thread_name = []
 
     def transport(**kwargs):
+        """Hold only the older request so the public accessor can finish first."""
         if current_thread().name in old_thread_name:
             old_read_started.set()
             assert release_old_read.wait(5), "test failed to release older read"
@@ -183,6 +184,7 @@ def test_older_refresh_preserves_newer_success_but_survives_newer_failure(
         return newer_response
 
     def old_refresh():
+        """Identify the background polling thread before starting its read."""
         old_thread_name.append(current_thread().name)
         broker.sync_positions(None)
 
@@ -200,7 +202,7 @@ def test_older_refresh_preserves_newer_success_but_survives_newer_failure(
                     strategy.get_position(asset)
             else:
                 strategy.get_position(asset)
-                revision_after_newer = broker._filled_positions.revision
+            revision_after_newer = broker._filled_positions.revision
         finally:
             release_old_read.set()
         older.result(timeout=5)

--- a/tests/test_broker_sync_positions.py
+++ b/tests/test_broker_sync_positions.py
@@ -105,3 +105,32 @@ def test_sync_positions_does_not_prune_position_added_after_snapshot_started():
     broker.sync_positions(_Strategy())
 
     assert broker._filled_positions.get_list() == [new_fill]
+
+
+def test_sync_positions_preserves_fields_on_position_added_during_read():
+    """A streamed fill takes precedence over a same-asset in-flight snapshot."""
+    broker = _BrokerForSyncTest([])
+    new_fill = _stock_position(quantity=2, current_price=220.0, market_value=440.0, pnl=1.0)
+    new_fill.strategy = "fill-owner"
+    stale_snapshot = _stock_position(quantity=1, current_price=210.0, market_value=210.0, pnl=-10.0)
+
+    def pull_positions_with_interleaved_fill(strategy):
+        broker._filled_positions.append(new_fill)
+        return [stale_snapshot]
+
+    broker._pull_positions = pull_positions_with_interleaved_fill
+    broker.sync_positions(_Strategy())
+
+    assert broker._filled_positions.get_list() == [new_fill]
+    assert new_fill.quantity == 2
+    assert new_fill.current_price == 220.0
+    assert new_fill.market_value == 440.0
+    assert new_fill.pnl == 1.0
+    assert new_fill.strategy == "fill-owner"
+
+    # The next fresh snapshot may reconcile that now-existing position normally.
+    broker._pull_positions = lambda strategy: [stale_snapshot]
+    broker.sync_positions(_Strategy())
+    assert new_fill.quantity == 1
+    assert new_fill.current_price == 210.0
+    assert new_fill.strategy == _Strategy.name


### PR DESCRIPTION
Background polling and strategy position reads can finish out of order. An older response could delete a position refreshed by a newer read, revert its quantity, or resurrect a closed position.

Sequence shared broker reads and apply their results under the tracker lock. Ignore responses older than the latest successfully applied request. Keep network I/O outside the lock, preserve new-fill fields and ownership as well as pruning protection, and allow older success when a newer request fails.

Validation: 125 related tests pass, including five deterministic threaded cases through the real Bitunix client and public Strategy accessor with intercepted transport; the original race failed before the fix. A separate red regression confirmed stale same-asset updates overwrote newly streamed position fields; it now verifies preservation and reconciliation on the next fresh snapshot. Covers shared tracking, Schwab and cloud snapshots. Test lint/format, changed-line public hygiene and focused Sphinx content build pass. The shared broker has 12 unchanged baseline lint findings.

Targets the active 4.5.92 source branch. Package publication and downstream runtime recovery remain separate; no live orders or customer deployment changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved broker position refresh reliability when multiple updates overlap.
  - Newer position data now takes precedence over older, delayed responses.
  - Positions added during an in-progress refresh retain their latest quantities, pricing, profit/loss, and strategy ownership.
  - Failed refreshes no longer overwrite valid existing position data.
  - Subsequent successful refreshes continue to reconcile positions normally.

- **Documentation**
  - Added guidance describing overlapping position refresh behavior and position refresh failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->